### PR TITLE
feat: Add multilingual support for UI and exported workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ All operations run locally within VSCode. No network communication means zero ri
 
 ⚙️ **Intuitive Property Panel** - Configure all node settings in a dedicated right-side panel
 
+🌐 **Multilingual Support** - Both the Visual Editor UI and exported workflows automatically adapt to your VSCode language (English/Japanese/Korean/Simplified Chinese/Traditional Chinese supported)
+
 ## Getting Started
 
 ### Installation
@@ -107,6 +109,8 @@ Generates ready-to-use files:
 - `.claude/agents/*.md` - Sub-Agent definitions
 - `.claude/commands/*.md` - SlashCommand to execute the workflow
 
+**Internationalization**: The Visual Editor UI and all exported files automatically adapt to your VSCode display language setting (`vscode.env.language`). Supported languages: English (default), Japanese, Korean, Simplified Chinese (zh-CN), and Traditional Chinese (zh-TW/zh-HK). This ensures both the editing experience and generated workflows are accessible for international teams regardless of their location.
+
 ## Usage Examples
 
 ### Example 1: Data Analysis Pipeline
@@ -137,6 +141,9 @@ A: The extension will detect conflicts and ask for confirmation before overwriti
 
 **Q: How many nodes can I add?**
 A: Up to 50 nodes per workflow. Most workflows use 3-10 nodes.
+
+**Q: What languages are supported?**
+A: Both the Visual Editor UI and exported workflows automatically use your VSCode display language setting. Currently supported: English (default), Japanese, Korean, Simplified Chinese (zh-CN), and Traditional Chinese (zh-TW/zh-HK). The extension detects `vscode.env.language` and displays all UI elements and generates documentation in the appropriate language. This includes toolbar buttons, node palette, property panel labels, and all exported files.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -2,21 +2,14 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code SlashCommands and Sub-Agents",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "breaking-break",
   "icon": "resources/icon.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/breaking-brake/cc-wf-studio"
   },
-  "keywords": [
-    "claude",
-    "claude-code",
-    "workflow",
-    "visual-editor",
-    "automation",
-    "ai"
-  ],
+  "keywords": ["claude", "claude-code", "workflow", "visual-editor", "automation", "ai"],
   "engines": {
     "vscode": "^1.80.0"
   },

--- a/src/extension/i18n/i18n-service.ts
+++ b/src/extension/i18n/i18n-service.ts
@@ -1,0 +1,117 @@
+/**
+ * Claude Code Workflow Studio - i18n Service
+ *
+ * Handles internationalization for workflow exports
+ * Detects VSCode locale and provides translations
+ */
+
+import * as vscode from 'vscode';
+import type { TranslationKeys } from './translation-keys';
+import { enTranslations } from './translations/en';
+import { jaTranslations } from './translations/ja';
+import { koTranslations } from './translations/ko';
+import { zhCNTranslations } from './translations/zh-CN';
+import { zhTWTranslations } from './translations/zh-TW';
+
+type Translations = typeof enTranslations;
+
+/**
+ * Get current locale from VSCode
+ *
+ * @returns Locale code (e.g., 'en', 'ja', 'zh-CN', 'zh-TW')
+ */
+export function getCurrentLocale(): string {
+  // Get VSCode's display language
+  return vscode.env.language;
+}
+
+/**
+ * Get translations for the current locale
+ *
+ * @returns Translation object for current locale (defaults to English)
+ */
+export function getTranslations(): Translations {
+  const locale = getCurrentLocale();
+  const languageCode = locale.split('-')[0];
+
+  // Check full locale first (e.g., zh-CN, zh-TW)
+  if (locale === 'zh-CN') {
+    return zhCNTranslations;
+  }
+  if (locale === 'zh-TW' || locale === 'zh-HK') {
+    return zhTWTranslations;
+  }
+
+  // Check language code (e.g., ja, ko)
+  switch (languageCode) {
+    case 'ja':
+      return jaTranslations;
+    case 'ko':
+      return koTranslations;
+    case 'zh':
+      // Default to Simplified Chinese if no region specified
+      return zhCNTranslations;
+    default:
+      return enTranslations;
+  }
+}
+
+/**
+ * Translate a key to the current locale
+ *
+ * @param key - Translation key
+ * @param params - Optional parameters for string interpolation
+ * @returns Translated string
+ */
+export function translate<K extends keyof TranslationKeys>(
+  key: K,
+  params?: Record<string, string | number>
+): string {
+  const translations = getTranslations();
+  let text = translations[key] as string;
+
+  // Handle nested keys (e.g., 'mermaid.start')
+  if (text === undefined) {
+    const parts = (key as string).split('.');
+    // biome-ignore lint/suspicious/noExplicitAny: Dynamic nested property access requires any
+    let current: any = translations;
+
+    for (const part of parts) {
+      current = current[part];
+      if (current === undefined) {
+        // Fallback to English if translation is missing
+        current = enTranslations;
+        for (const part of parts) {
+          current = current[part];
+          if (current === undefined) {
+            return key as string;
+          }
+        }
+        break;
+      }
+    }
+
+    text = current as string;
+  }
+
+  // Replace parameters (e.g., {{name}} -> value)
+  if (params) {
+    for (const [paramKey, paramValue] of Object.entries(params)) {
+      text = text.replace(`{{${paramKey}}}`, String(paramValue));
+    }
+  }
+
+  return text;
+}
+
+/**
+ * Get shorthand translation function for a specific namespace
+ *
+ * @returns Translation function
+ */
+export function useTranslation() {
+  return {
+    t: translate,
+    locale: getCurrentLocale(),
+  };
+}

--- a/src/extension/i18n/translation-keys.ts
+++ b/src/extension/i18n/translation-keys.ts
@@ -1,0 +1,44 @@
+/**
+ * Claude Code Workflow Studio - Translation Keys Type Definition
+ *
+ * Defines the structure of translation keys for type safety
+ */
+
+export interface TranslationKeys {
+  // Mermaid flowchart labels
+  'mermaid.start': string;
+  'mermaid.end': string;
+  'mermaid.question': string;
+  'mermaid.conditionalBranch': string;
+
+  // Workflow execution guide
+  'guide.title': string;
+  'guide.intro': string;
+  'guide.nodeTypesTitle': string;
+  'guide.nodeTypes.subAgent': string;
+  'guide.nodeTypes.askUserQuestion': string;
+  'guide.nodeTypes.branch': string;
+  'guide.nodeTypes.prompt': string;
+
+  // Prompt node details
+  'promptNode.title': string;
+  'promptNode.availableVariables': string;
+  'promptNode.variableNotSet': string;
+
+  // AskUserQuestion node details
+  'askNode.title': string;
+  'askNode.selectionMode': string;
+  'askNode.aiSuggestions': string;
+  'askNode.multiSelect': string;
+  'askNode.singleSelect': string;
+  'askNode.options': string;
+  'askNode.noDescription': string;
+  'askNode.multiSelectExplanation': string;
+
+  // Branch node details
+  'branchNode.title': string;
+  'branchNode.binary': string;
+  'branchNode.multiple': string;
+  'branchNode.conditions': string;
+  'branchNode.executionMethod': string;
+}

--- a/src/extension/i18n/translations/en.ts
+++ b/src/extension/i18n/translations/en.ts
@@ -1,0 +1,51 @@
+/**
+ * Claude Code Workflow Studio - English Translations
+ */
+
+import type { TranslationKeys } from '../translation-keys';
+
+export const enTranslations: TranslationKeys = {
+  // Mermaid flowchart labels
+  'mermaid.start': 'Start',
+  'mermaid.end': 'End',
+  'mermaid.question': 'Question',
+  'mermaid.conditionalBranch': 'Conditional Branch',
+
+  // Workflow execution guide
+  'guide.title': '## Workflow Execution Guide',
+  'guide.intro':
+    'Follow the Mermaid flowchart above to execute the workflow. Each node type has specific execution methods as described below.',
+  'guide.nodeTypesTitle': '### Execution Methods by Node Type',
+  'guide.nodeTypes.subAgent': '- **Rectangle nodes**: Execute Sub-Agents using the Task tool',
+  'guide.nodeTypes.askUserQuestion':
+    '- **Diamond nodes (AskUserQuestion:...)**: Use the AskUserQuestion tool to prompt the user and branch based on their response',
+  'guide.nodeTypes.branch':
+    '- **Diamond nodes (Branch/Switch:...)**: Automatically branch based on the results of previous processing (see details section)',
+  'guide.nodeTypes.prompt':
+    '- **Rectangle nodes (Prompt nodes)**: Execute the prompts described in the details section below',
+
+  // Prompt node details
+  'promptNode.title': '### Prompt Node Details',
+  'promptNode.availableVariables': '**Available variables:**',
+  'promptNode.variableNotSet': '(not set)',
+
+  // AskUserQuestion node details
+  'askNode.title': '### AskUserQuestion Node Details',
+  'askNode.selectionMode': '**Selection mode:**',
+  'askNode.aiSuggestions':
+    'AI Suggestions (AI generates options dynamically based on context and presents them to the user)',
+  'askNode.multiSelect': '**Multi-select:** Enabled (user can select multiple options)',
+  'askNode.singleSelect': 'Single Select (branches based on the selected option)',
+  'askNode.options': '**Options:**',
+  'askNode.noDescription': '(no description)',
+  'askNode.multiSelectExplanation':
+    'Multi-select enabled (a list of selected options is passed to the next node)',
+
+  // Branch node details
+  'branchNode.title': '### Branch Node Details',
+  'branchNode.binary': 'Binary Branch',
+  'branchNode.multiple': 'Multiple Branch',
+  'branchNode.conditions': '**Branch conditions:**',
+  'branchNode.executionMethod':
+    '**Execution method**: Evaluate the results of the previous processing and automatically select the appropriate branch based on the conditions above.',
+};

--- a/src/extension/i18n/translations/ja.ts
+++ b/src/extension/i18n/translations/ja.ts
@@ -1,0 +1,50 @@
+/**
+ * Claude Code Workflow Studio - Japanese Translations
+ */
+
+import type { TranslationKeys } from '../translation-keys';
+
+export const jaTranslations: TranslationKeys = {
+  // Mermaid flowchart labels
+  'mermaid.start': '開始',
+  'mermaid.end': '終了',
+  'mermaid.question': '質問',
+  'mermaid.conditionalBranch': '条件分岐',
+
+  // Workflow execution guide
+  'guide.title': '## ワークフロー実行ガイド',
+  'guide.intro':
+    '上記のMermaidフローチャートに従ってワークフローを実行してください。各ノードタイプの実行方法は以下の通りです。',
+  'guide.nodeTypesTitle': '### ノードタイプ別実行方法',
+  'guide.nodeTypes.subAgent': '- **四角形のノード**: Taskツールを使用してSub-Agentを実行します',
+  'guide.nodeTypes.askUserQuestion':
+    '- **ひし形のノード(AskUserQuestion:...)**: AskUserQuestionツールを使用してユーザーに質問し、回答に応じて分岐します',
+  'guide.nodeTypes.branch':
+    '- **ひし形のノード(Branch/Switch:...)**: 前処理の結果に応じて自動的に分岐します(詳細セクション参照)',
+  'guide.nodeTypes.prompt':
+    '- **四角形のノード(Promptノード)**: 以下の詳細セクションに記載されたプロンプトを実行します',
+
+  // Prompt node details
+  'promptNode.title': '### Promptノード詳細',
+  'promptNode.availableVariables': '**使用可能な変数:**',
+  'promptNode.variableNotSet': '(未設定)',
+
+  // AskUserQuestion node details
+  'askNode.title': '### AskUserQuestionノード詳細',
+  'askNode.selectionMode': '**選択モード:**',
+  'askNode.aiSuggestions': 'AI提案(AIが文脈に基づいて選択肢を動的に生成し、ユーザーに提示します)',
+  'askNode.multiSelect': '**複数選択:** 有効(ユーザーは複数の選択肢を選べます)',
+  'askNode.singleSelect': '単一選択(選択された選択肢に応じて分岐します)',
+  'askNode.options': '**選択肢:**',
+  'askNode.noDescription': '(説明なし)',
+  'askNode.multiSelectExplanation':
+    '複数選択可能(選択された選択肢のリストが次のノードに渡されます)',
+
+  // Branch node details
+  'branchNode.title': '### Branchノード詳細',
+  'branchNode.binary': '2分岐',
+  'branchNode.multiple': '複数分岐',
+  'branchNode.conditions': '**分岐条件:**',
+  'branchNode.executionMethod':
+    '**実行方法**: 前段の処理結果を評価し、上記の条件に基づいて自動的に適切な分岐を選択してください。',
+};

--- a/src/extension/i18n/translations/ko.ts
+++ b/src/extension/i18n/translations/ko.ts
@@ -1,0 +1,50 @@
+/**
+ * Claude Code Workflow Studio - Korean Translations
+ */
+
+import type { TranslationKeys } from '../translation-keys';
+
+export const koTranslations: TranslationKeys = {
+  // Mermaid flowchart labels
+  'mermaid.start': '시작',
+  'mermaid.end': '종료',
+  'mermaid.question': '질문',
+  'mermaid.conditionalBranch': '조건 분기',
+
+  // Workflow execution guide
+  'guide.title': '## 워크플로 실행 가이드',
+  'guide.intro':
+    '위의 Mermaid 플로우차트를 따라 워크플로를 실행하세요. 각 노드 유형의 실행 방법은 아래에 설명되어 있습니다.',
+  'guide.nodeTypesTitle': '### 노드 유형별 실행 방법',
+  'guide.nodeTypes.subAgent': '- **사각형 노드**: Task 도구를 사용하여 서브 에이전트 실행',
+  'guide.nodeTypes.askUserQuestion':
+    '- **다이아몬드 노드(AskUserQuestion:...)**: AskUserQuestion 도구를 사용하여 사용자에게 질문하고 응답에 따라 분기',
+  'guide.nodeTypes.branch':
+    '- **다이아몬드 노드(Branch/Switch:...)**: 이전 처리 결과에 따라 자동으로 분기(세부 정보 섹션 참조)',
+  'guide.nodeTypes.prompt':
+    '- **사각형 노드(Prompt 노드)**: 아래 세부 정보 섹션에 설명된 프롬프트 실행',
+
+  // Prompt node details
+  'promptNode.title': '### Prompt 노드 세부 정보',
+  'promptNode.availableVariables': '**사용 가능한 변수:**',
+  'promptNode.variableNotSet': '(설정되지 않음)',
+
+  // AskUserQuestion node details
+  'askNode.title': '### AskUserQuestion 노드 세부 정보',
+  'askNode.selectionMode': '**선택 모드:**',
+  'askNode.aiSuggestions':
+    'AI 제안(AI가 컨텍스트를 기반으로 옵션을 동적으로 생성하여 사용자에게 제시)',
+  'askNode.multiSelect': '**다중 선택:** 활성화됨(사용자가 여러 옵션을 선택할 수 있음)',
+  'askNode.singleSelect': '단일 선택(선택한 옵션에 따라 분기)',
+  'askNode.options': '**옵션:**',
+  'askNode.noDescription': '(설명 없음)',
+  'askNode.multiSelectExplanation': '다중 선택 활성화됨(선택한 옵션 목록이 다음 노드로 전달됨)',
+
+  // Branch node details
+  'branchNode.title': '### Branch 노드 세부 정보',
+  'branchNode.binary': '이진 분기',
+  'branchNode.multiple': '다중 분기',
+  'branchNode.conditions': '**분기 조건:**',
+  'branchNode.executionMethod':
+    '**실행 방법**: 이전 처리 결과를 평가하고 위의 조건에 따라 적절한 분기를 자동으로 선택합니다.',
+};

--- a/src/extension/i18n/translations/zh-CN.ts
+++ b/src/extension/i18n/translations/zh-CN.ts
@@ -1,0 +1,47 @@
+/**
+ * Claude Code Workflow Studio - Simplified Chinese Translations
+ */
+
+import type { TranslationKeys } from '../translation-keys';
+
+export const zhCNTranslations: TranslationKeys = {
+  // Mermaid flowchart labels
+  'mermaid.start': '开始',
+  'mermaid.end': '结束',
+  'mermaid.question': '问题',
+  'mermaid.conditionalBranch': '条件分支',
+
+  // Workflow execution guide
+  'guide.title': '## 工作流执行指南',
+  'guide.intro': '按照上方的Mermaid流程图执行工作流。每种节点类型的执行方法如下所述。',
+  'guide.nodeTypesTitle': '### 各节点类型的执行方法',
+  'guide.nodeTypes.subAgent': '- **矩形节点**：使用Task工具执行子代理',
+  'guide.nodeTypes.askUserQuestion':
+    '- **菱形节点（AskUserQuestion:...）**：使用AskUserQuestion工具提示用户并根据其响应进行分支',
+  'guide.nodeTypes.branch':
+    '- **菱形节点（Branch/Switch:...）**：根据先前处理的结果自动分支（参见详细信息部分）',
+  'guide.nodeTypes.prompt': '- **矩形节点（Prompt节点）**：执行下面详细信息部分中描述的提示',
+
+  // Prompt node details
+  'promptNode.title': '### Prompt节点详细信息',
+  'promptNode.availableVariables': '**可用变量：**',
+  'promptNode.variableNotSet': '（未设置）',
+
+  // AskUserQuestion node details
+  'askNode.title': '### AskUserQuestion节点详细信息',
+  'askNode.selectionMode': '**选择模式：**',
+  'askNode.aiSuggestions': 'AI建议（AI根据上下文动态生成选项并呈现给用户）',
+  'askNode.multiSelect': '**多选：** 已启用（用户可以选择多个选项）',
+  'askNode.singleSelect': '单选（根据所选选项进行分支）',
+  'askNode.options': '**选项：**',
+  'askNode.noDescription': '（无描述）',
+  'askNode.multiSelectExplanation': '多选已启用（所选选项列表将传递到下一个节点）',
+
+  // Branch node details
+  'branchNode.title': '### Branch节点详细信息',
+  'branchNode.binary': '二分支',
+  'branchNode.multiple': '多分支',
+  'branchNode.conditions': '**分支条件：**',
+  'branchNode.executionMethod':
+    '**执行方法**：评估先前处理的结果，并根据上述条件自动选择适当的分支。',
+};

--- a/src/extension/i18n/translations/zh-TW.ts
+++ b/src/extension/i18n/translations/zh-TW.ts
@@ -1,0 +1,47 @@
+/**
+ * Claude Code Workflow Studio - Traditional Chinese Translations
+ */
+
+import type { TranslationKeys } from '../translation-keys';
+
+export const zhTWTranslations: TranslationKeys = {
+  // Mermaid flowchart labels
+  'mermaid.start': '開始',
+  'mermaid.end': '結束',
+  'mermaid.question': '問題',
+  'mermaid.conditionalBranch': '條件分支',
+
+  // Workflow execution guide
+  'guide.title': '## 工作流執行指南',
+  'guide.intro': '按照上方的Mermaid流程圖執行工作流。每種節點類型的執行方法如下所述。',
+  'guide.nodeTypesTitle': '### 各節點類型的執行方法',
+  'guide.nodeTypes.subAgent': '- **矩形節點**：使用Task工具執行子代理',
+  'guide.nodeTypes.askUserQuestion':
+    '- **菱形節點（AskUserQuestion:...）**：使用AskUserQuestion工具提示用戶並根據其響應進行分支',
+  'guide.nodeTypes.branch':
+    '- **菱形節點（Branch/Switch:...）**：根據先前處理的結果自動分支（參見詳細資訊部分）',
+  'guide.nodeTypes.prompt': '- **矩形節點（Prompt節點）**：執行下面詳細資訊部分中描述的提示',
+
+  // Prompt node details
+  'promptNode.title': '### Prompt節點詳細資訊',
+  'promptNode.availableVariables': '**可用變數：**',
+  'promptNode.variableNotSet': '（未設置）',
+
+  // AskUserQuestion node details
+  'askNode.title': '### AskUserQuestion節點詳細資訊',
+  'askNode.selectionMode': '**選擇模式：**',
+  'askNode.aiSuggestions': 'AI建議（AI根據上下文動態生成選項並呈現給用戶）',
+  'askNode.multiSelect': '**多選：** 已啟用（用戶可以選擇多個選項）',
+  'askNode.singleSelect': '單選（根據所選選項進行分支）',
+  'askNode.options': '**選項：**',
+  'askNode.noDescription': '（無描述）',
+  'askNode.multiSelectExplanation': '多選已啟用（所選選項列表將傳遞到下一個節點）',
+
+  // Branch node details
+  'branchNode.title': '### Branch節點詳細資訊',
+  'branchNode.binary': '二分支',
+  'branchNode.multiple': '多分支',
+  'branchNode.conditions': '**分支條件：**',
+  'branchNode.executionMethod':
+    '**執行方法**：評估先前處理的結果，並根據上述條件自動選擇適當的分支。',
+};

--- a/src/extension/webview-content.ts
+++ b/src/extension/webview-content.ts
@@ -6,6 +6,7 @@
  */
 
 import * as vscode from 'vscode';
+import { getCurrentLocale } from './i18n/i18n-service';
 
 /**
  * Generate HTML content for the Webview
@@ -17,6 +18,9 @@ import * as vscode from 'vscode';
 export function getWebviewContent(webview: vscode.Webview, extensionUri: vscode.Uri): string {
   // Generate a nonce for Content Security Policy
   const nonce = getNonce();
+
+  // Get current locale for i18n
+  const locale = getCurrentLocale();
 
   // Get URIs for webview resources
   const scriptUri = webview.asWebviewUri(
@@ -52,6 +56,9 @@ export function getWebviewContent(webview: vscode.Webview, extensionUri: vscode.
 </head>
 <body>
     <div id="root"></div>
+    <script nonce="${nonce}">
+      window.initialLocale = "${locale}";
+    </script>
     <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -6,12 +6,14 @@
  */
 
 import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 
 /**
  * NodePalette Component
  */
 export const NodePalette: React.FC = () => {
+  const { t } = useTranslation();
   const { addNode } = useWorkflowStore();
 
   const handleAddSubAgent = () => {
@@ -20,8 +22,8 @@ export const NodePalette: React.FC = () => {
       type: 'subAgent' as const,
       position: { x: 250, y: 100 },
       data: {
-        description: 'New Sub-Agent',
-        prompt: 'Enter your prompt here',
+        description: t('default.newSubAgent'),
+        prompt: t('default.enterPrompt'),
         model: 'sonnet' as const,
         outputPorts: 1,
       },
@@ -35,10 +37,10 @@ export const NodePalette: React.FC = () => {
       type: 'askUserQuestion' as const,
       position: { x: 250, y: 300 },
       data: {
-        questionText: 'New Question',
+        questionText: t('default.newQuestion'),
         options: [
-          { label: 'Option 1', description: 'First option' },
-          { label: 'Option 2', description: 'Second option' },
+          { label: `${t('default.option')} 1`, description: t('default.firstOption') },
+          { label: `${t('default.option')} 2`, description: t('default.secondOption') },
         ],
         outputPorts: 2,
       },
@@ -52,8 +54,8 @@ export const NodePalette: React.FC = () => {
       type: 'prompt' as const,
       position: { x: 350, y: 200 },
       data: {
-        label: 'New Prompt',
-        prompt: 'Enter your prompt template here.\n\nYou can use variables like {{variableName}}.',
+        label: t('default.newPrompt'),
+        prompt: t('default.promptTemplate'),
         variables: {},
       },
     };
@@ -68,8 +70,8 @@ export const NodePalette: React.FC = () => {
       data: {
         branchType: 'conditional' as const,
         branches: [
-          { label: 'True', condition: '条件が真の場合' },
-          { label: 'False', condition: '条件が偽の場合' },
+          { label: t('default.branchTrue'), condition: t('default.branchTrueCondition') },
+          { label: t('default.branchFalse'), condition: t('default.branchFalseCondition') },
         ],
         outputPorts: 2,
       },
@@ -100,7 +102,7 @@ export const NodePalette: React.FC = () => {
           letterSpacing: '0.5px',
         }}
       >
-        Node Palette
+        {t('palette.title')}
       </div>
 
       {/* Section: Basic Nodes */}
@@ -115,7 +117,7 @@ export const NodePalette: React.FC = () => {
           letterSpacing: '0.5px',
         }}
       >
-        Basic Nodes
+        {t('palette.basicNodes')}
       </div>
 
       {/* Prompt Node Button */}
@@ -145,14 +147,14 @@ export const NodePalette: React.FC = () => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>Prompt</div>
+        <div style={{ fontWeight: 600 }}>{t('node.prompt.title')}</div>
         <div
           style={{
             fontSize: '11px',
             color: 'var(--vscode-descriptionForeground)',
           }}
         >
-          Template with variables
+          {t('node.prompt.description')}
         </div>
       </button>
 
@@ -183,14 +185,14 @@ export const NodePalette: React.FC = () => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>Sub-Agent</div>
+        <div style={{ fontWeight: 600 }}>{t('node.subAgent.title')}</div>
         <div
           style={{
             fontSize: '11px',
             color: 'var(--vscode-descriptionForeground)',
           }}
         >
-          Execute a specialized task
+          {t('node.subAgent.description')}
         </div>
       </button>
 
@@ -206,7 +208,7 @@ export const NodePalette: React.FC = () => {
           letterSpacing: '0.5px',
         }}
       >
-        Control Flow
+        {t('palette.controlFlow')}
       </div>
 
       {/* Branch Node Button */}
@@ -236,14 +238,14 @@ export const NodePalette: React.FC = () => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>Branch</div>
+        <div style={{ fontWeight: 600 }}>{t('node.branch.title')}</div>
         <div
           style={{
             fontSize: '11px',
             color: 'var(--vscode-descriptionForeground)',
           }}
         >
-          Conditional branching logic
+          {t('node.branch.description')}
         </div>
       </button>
 
@@ -274,14 +276,14 @@ export const NodePalette: React.FC = () => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>Ask User Question</div>
+        <div style={{ fontWeight: 600 }}>{t('node.askUserQuestion.title')}</div>
         <div
           style={{
             fontSize: '11px',
             color: 'var(--vscode-descriptionForeground)',
           }}
         >
-          Branch based on user choice
+          {t('node.askUserQuestion.description')}
         </div>
       </button>
 
@@ -298,12 +300,12 @@ export const NodePalette: React.FC = () => {
           lineHeight: '1.5',
         }}
       >
-        <div style={{ fontWeight: 600, marginBottom: '8px' }}>💡 Quick Start</div>
+        <div style={{ fontWeight: 600, marginBottom: '8px' }}>{t('palette.quickStart')}</div>
         <ul style={{ margin: 0, paddingLeft: '16px' }}>
-          <li>Click a node to add it to the canvas</li>
-          <li>Drag nodes to reposition them</li>
-          <li>Connect nodes by dragging from output to input handles</li>
-          <li>Select a node to edit its properties</li>
+          <li>{t('palette.instruction.addNode')}</li>
+          <li>{t('palette.instruction.dragNode')}</li>
+          <li>{t('palette.instruction.connectNodes')}</li>
+          <li>{t('palette.instruction.editProperties')}</li>
         </ul>
       </div>
     </div>

--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@shared/types/workflow-definition';
 import type React from 'react';
 import type { Node } from 'reactflow';
+import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import type { PromptNodeData } from '../types/node-types';
 import { extractVariables } from '../utils/template-utils';
@@ -20,6 +21,7 @@ import { extractVariables } from '../utils/template-utils';
  * PropertyPanel Component
  */
 export const PropertyPanel: React.FC = () => {
+  const { t } = useTranslation();
   const { nodes, selectedNodeId, updateNodeData, setNodes } = useWorkflowStore();
 
   // Find the selected node
@@ -46,7 +48,7 @@ export const PropertyPanel: React.FC = () => {
             marginTop: '24px',
           }}
         >
-          Select a node to edit its properties
+          {t('property.noSelection')}
         </div>
       </div>
     );
@@ -75,7 +77,7 @@ export const PropertyPanel: React.FC = () => {
           letterSpacing: '0.5px',
         }}
       >
-        Properties
+        {t('property.title')}
       </div>
 
       {/* Node Type Badge */}
@@ -91,18 +93,18 @@ export const PropertyPanel: React.FC = () => {
         }}
       >
         {selectedNode.type === 'subAgent'
-          ? 'Sub-Agent'
+          ? t('property.nodeType.subAgent')
           : selectedNode.type === 'askUserQuestion'
-            ? 'Ask User Question'
+            ? t('property.nodeType.askUserQuestion')
             : selectedNode.type === 'branch'
-              ? 'Branch Node'
+              ? t('property.nodeType.branch')
               : selectedNode.type === 'prompt'
-                ? 'Prompt Node'
+                ? t('property.nodeType.prompt')
                 : selectedNode.type === 'start'
-                  ? 'Start Node'
+                  ? t('property.nodeType.start')
                   : selectedNode.type === 'end'
-                    ? 'End Node'
-                    : 'Unknown'}
+                    ? t('property.nodeType.end')
+                    : t('property.nodeType.unknown')}
       </div>
 
       {/* Node Name (only for subAgent, askUserQuestion, branch, and prompt types) */}
@@ -121,7 +123,7 @@ export const PropertyPanel: React.FC = () => {
               marginBottom: '6px',
             }}
           >
-            Node Name
+            {t('property.nodeName')}
           </label>
           <input
             id="node-name-input"
@@ -147,7 +149,7 @@ export const PropertyPanel: React.FC = () => {
               }
             }}
             className="nodrag"
-            placeholder="Enter node name"
+            placeholder={t('property.nodeName.placeholder')}
             style={{
               width: '100%',
               padding: '6px 8px',
@@ -165,7 +167,7 @@ export const PropertyPanel: React.FC = () => {
               marginTop: '4px',
             }}
           >
-            Used for exported file name (e.g., "data-analysis")
+            {t('property.nodeName.help')}
           </div>
         </div>
       )}
@@ -203,8 +205,8 @@ export const PropertyPanel: React.FC = () => {
           }}
         >
           {selectedNode.type === 'start'
-            ? 'Start node marks the beginning of the workflow. It cannot be deleted and has no editable properties.'
-            : 'End node marks the completion of the workflow. It cannot be deleted and has no editable properties.'}
+            ? t('property.startNodeDescription')
+            : t('property.endNodeDescription')}
         </div>
       ) : (
         <div
@@ -217,7 +219,7 @@ export const PropertyPanel: React.FC = () => {
             color: 'var(--vscode-errorForeground)',
           }}
         >
-          Unknown node type: {selectedNode.type}
+          {t('property.unknownNodeType')} {selectedNode.type}
         </div>
       )}
     </div>
@@ -231,6 +233,7 @@ const SubAgentProperties: React.FC<{
   node: Node<SubAgentData>;
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
 }> = ({ node, updateNodeData }) => {
+  const { t } = useTranslation();
   const data = node.data;
 
   return (
@@ -247,7 +250,7 @@ const SubAgentProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Description
+          {t('property.description')}
         </label>
         <input
           id="description-input"
@@ -279,7 +282,7 @@ const SubAgentProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Prompt
+          {t('property.prompt')}
         </label>
         <textarea
           id="prompt-textarea"
@@ -313,7 +316,7 @@ const SubAgentProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Model
+          {t('property.model')}
         </label>
         <select
           id="model-select"
@@ -350,14 +353,14 @@ const SubAgentProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Tools (comma-separated)
+          {t('property.tools')}
         </label>
         <input
           id="tools-input"
           type="text"
           value={data.tools || ''}
           onChange={(e) => updateNodeData(node.id, { tools: e.target.value })}
-          placeholder="e.g., Read,Write,Bash"
+          placeholder={t('property.tools.placeholder')}
           className="nodrag"
           style={{
             width: '100%',
@@ -376,7 +379,7 @@ const SubAgentProperties: React.FC<{
             marginTop: '4px',
           }}
         >
-          Leave empty for all tools
+          {t('property.tools.help')}
         </div>
       </div>
     </div>
@@ -397,6 +400,7 @@ const AskUserQuestionProperties: React.FC<{
   node: Node<AskUserQuestionData>;
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
 }> = ({ node, updateNodeData }) => {
+  const { t } = useTranslation();
   const data = node.data;
 
   // Ensure all options have IDs (for backward compatibility)
@@ -415,8 +419,8 @@ const AskUserQuestionProperties: React.FC<{
       ...normalizedOptions,
       {
         id: generateOptionId(),
-        label: `Option ${normalizedOptions.length + 1}`,
-        description: 'New option',
+        label: `${t('default.option')} ${normalizedOptions.length + 1}`,
+        description: t('default.newOption'),
       },
     ];
     updateNodeData(node.id, {
@@ -455,7 +459,7 @@ const AskUserQuestionProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Question
+          {t('property.questionText')}
         </label>
         <textarea
           id="question-text-input"
@@ -506,7 +510,7 @@ const AskUserQuestionProperties: React.FC<{
               cursor: 'pointer',
             }}
           />
-          <span>Multiple Selection</span>
+          <span>{t('property.multiSelect')}</span>
         </label>
         <div
           style={{
@@ -517,8 +521,8 @@ const AskUserQuestionProperties: React.FC<{
           }}
         >
           {data.multiSelect
-            ? 'User can select multiple options (outputs selected list)'
-            : 'User selects one option (branches to corresponding node)'}
+            ? t('property.multiSelect.enabled')
+            : t('property.multiSelect.disabled')}
         </div>
       </div>
 
@@ -553,7 +557,7 @@ const AskUserQuestionProperties: React.FC<{
               cursor: 'pointer',
             }}
           />
-          <span>AI Suggests Options</span>
+          <span>{t('property.aiSuggestions')}</span>
         </label>
         <div
           style={{
@@ -564,8 +568,8 @@ const AskUserQuestionProperties: React.FC<{
           }}
         >
           {data.useAiSuggestions
-            ? 'AI will dynamically generate options based on context'
-            : 'Manually define options below'}
+            ? t('property.aiSuggestions.enabled')
+            : t('property.aiSuggestions.disabled')}
         </div>
       </div>
 
@@ -581,7 +585,7 @@ const AskUserQuestionProperties: React.FC<{
               marginBottom: '6px',
             }}
           >
-            Options ({normalizedOptions.length}/4)
+            {t('property.optionsCount').replace('{count}', normalizedOptions.length.toString())}
           </div>
 
           {normalizedOptions.map((option, index) => (
@@ -598,7 +602,9 @@ const AskUserQuestionProperties: React.FC<{
               <div
                 style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '8px' }}
               >
-                <span style={{ fontSize: '11px', fontWeight: 600 }}>Option {index + 1}</span>
+                <span style={{ fontSize: '11px', fontWeight: 600 }}>
+                  {t('property.optionNumber').replace('{number}', (index + 1).toString())}
+                </span>
                 {normalizedOptions.length > 2 && (
                   <button
                     type="button"
@@ -614,7 +620,7 @@ const AskUserQuestionProperties: React.FC<{
                       cursor: 'pointer',
                     }}
                   >
-                    Remove
+                    {t('property.remove')}
                   </button>
                 )}
               </div>
@@ -622,7 +628,7 @@ const AskUserQuestionProperties: React.FC<{
                 type="text"
                 value={option.label}
                 onChange={(e) => handleUpdateOption(index, 'label', e.target.value)}
-                placeholder="Label"
+                placeholder={t('property.optionLabel.placeholder')}
                 className="nodrag"
                 style={{
                   width: '100%',
@@ -639,7 +645,7 @@ const AskUserQuestionProperties: React.FC<{
                 type="text"
                 value={option.description}
                 onChange={(e) => handleUpdateOption(index, 'description', e.target.value)}
-                placeholder="Description"
+                placeholder={t('property.optionDescription.placeholder')}
                 className="nodrag"
                 style={{
                   width: '100%',
@@ -670,7 +676,7 @@ const AskUserQuestionProperties: React.FC<{
                 fontSize: '12px',
               }}
             >
-              + Add Option
+              {t('property.addOption')}
             </button>
           )}
         </div>
@@ -686,6 +692,7 @@ const PromptProperties: React.FC<{
   node: Node<PromptNodeData>;
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
 }> = ({ node, updateNodeData }) => {
+  const { t } = useTranslation();
   const data = node.data;
 
   // プロンプトから変数を抽出
@@ -705,7 +712,7 @@ const PromptProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Label
+          {t('property.label')}
         </label>
         <input
           id="label-input"
@@ -713,7 +720,7 @@ const PromptProperties: React.FC<{
           value={data.label || ''}
           onChange={(e) => updateNodeData(node.id, { label: e.target.value })}
           className="nodrag"
-          placeholder="Enter label"
+          placeholder={t('property.label.placeholder')}
           style={{
             width: '100%',
             padding: '6px 8px',
@@ -738,7 +745,7 @@ const PromptProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Prompt Template
+          {t('property.promptTemplate')}
         </label>
         <textarea
           id="prompt-textarea"
@@ -746,7 +753,7 @@ const PromptProperties: React.FC<{
           onChange={(e) => updateNodeData(node.id, { prompt: e.target.value })}
           className="nodrag"
           rows={8}
-          placeholder="Enter prompt template with {{variables}}"
+          placeholder={t('property.promptTemplate.placeholder')}
           style={{
             width: '100%',
             padding: '6px 8px',
@@ -766,7 +773,7 @@ const PromptProperties: React.FC<{
             marginTop: '4px',
           }}
         >
-          Use {'{{variableName}}'} syntax for dynamic values
+          {t('property.promptTemplate.help')}
         </div>
       </div>
 
@@ -781,7 +788,7 @@ const PromptProperties: React.FC<{
               marginBottom: '6px',
             }}
           >
-            Detected Variables ({variables.length})
+            {t('property.detectedVariables').replace('{count}', variables.length.toString())}
           </div>
           <div
             style={{
@@ -812,7 +819,7 @@ const PromptProperties: React.FC<{
               marginTop: '4px',
             }}
           >
-            Variables will be substituted at runtime
+            {t('property.variablesSubstituted')}
           </div>
         </div>
       )}
@@ -827,6 +834,7 @@ const BranchProperties: React.FC<{
   node: Node<BranchNodeData>;
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
 }> = ({ node, updateNodeData }) => {
+  const { t } = useTranslation();
   const data = node.data;
 
   // Ensure all branches have IDs (for backward compatibility)
@@ -845,8 +853,8 @@ const BranchProperties: React.FC<{
       ...normalizedBranches,
       {
         id: generateBranchId(),
-        label: `Branch ${normalizedBranches.length + 1}`,
-        condition: '新しい条件',
+        label: `${t('default.newBranch')} ${normalizedBranches.length + 1}`,
+        condition: t('default.newCondition'),
       },
     ];
     updateNodeData(node.id, {
@@ -898,7 +906,7 @@ const BranchProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          Branch Type
+          {t('property.branchType')}
         </label>
         <select
           id="branch-type-select"
@@ -915,8 +923,8 @@ const BranchProperties: React.FC<{
             fontSize: '13px',
           }}
         >
-          <option value="conditional">Conditional (2-way)</option>
-          <option value="switch">Switch (Multi-way)</option>
+          <option value="conditional">{t('property.conditional')}</option>
+          <option value="switch">{t('property.switch')}</option>
         </select>
         <div
           style={{
@@ -925,7 +933,9 @@ const BranchProperties: React.FC<{
             marginTop: '4px',
           }}
         >
-          {data.branchType === 'conditional' ? '2つの分岐（True/False）' : '複数の分岐（2-N分岐）'}
+          {data.branchType === 'conditional'
+            ? t('property.branchType.conditional.help')
+            : t('property.branchType.switch.help')}
         </div>
       </div>
 
@@ -946,7 +956,7 @@ const BranchProperties: React.FC<{
               color: 'var(--vscode-foreground)',
             }}
           >
-            Branches ({normalizedBranches.length})
+            {t('property.branchesCount').replace('{count}', normalizedBranches.length.toString())}
           </div>
           {(data.branchType === 'switch' || normalizedBranches.length < 2) && (
             <button
@@ -962,7 +972,7 @@ const BranchProperties: React.FC<{
                 cursor: 'pointer',
               }}
             >
-              + Add Branch
+              {t('property.addBranch')}
             </button>
           )}
         </div>
@@ -993,7 +1003,7 @@ const BranchProperties: React.FC<{
                   color: 'var(--vscode-descriptionForeground)',
                 }}
               >
-                Branch {index + 1}
+                {t('property.branchNumber').replace('{number}', (index + 1).toString())}
               </span>
               {normalizedBranches.length > 2 && (
                 <button
@@ -1009,7 +1019,7 @@ const BranchProperties: React.FC<{
                     cursor: 'pointer',
                   }}
                 >
-                  Remove
+                  {t('property.remove')}
                 </button>
               )}
             </div>
@@ -1026,7 +1036,7 @@ const BranchProperties: React.FC<{
                   marginBottom: '4px',
                 }}
               >
-                Label
+                {t('property.branchLabel')}
               </label>
               <input
                 id={`branch-label-${index}`}
@@ -1034,7 +1044,7 @@ const BranchProperties: React.FC<{
                 value={branch.label}
                 onChange={(e) => handleUpdateBranch(index, 'label', e.target.value)}
                 className="nodrag"
-                placeholder="e.g., Success, Error"
+                placeholder={t('property.branchLabel.placeholder')}
                 style={{
                   width: '100%',
                   padding: '4px 6px',
@@ -1059,7 +1069,7 @@ const BranchProperties: React.FC<{
                   marginBottom: '4px',
                 }}
               >
-                Condition (自然言語)
+                {t('property.branchCondition')}
               </label>
               <textarea
                 id={`branch-condition-${index}`}
@@ -1067,7 +1077,7 @@ const BranchProperties: React.FC<{
                 onChange={(e) => handleUpdateBranch(index, 'condition', e.target.value)}
                 className="nodrag"
                 rows={2}
-                placeholder="e.g., 前の処理が成功した場合"
+                placeholder={t('property.branchCondition.placeholder')}
                 style={{
                   width: '100%',
                   padding: '4px 6px',
@@ -1090,7 +1100,7 @@ const BranchProperties: React.FC<{
             marginTop: '8px',
           }}
         >
-          Minimum 2 branches required
+          {t('property.minimumBranches')}
         </div>
       </div>
     </div>

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -7,6 +7,7 @@
 import type { Workflow } from '@shared/types/messages';
 import type React from 'react';
 import { useEffect, useState } from 'react';
+import { useTranslation } from '../i18n/i18n-context';
 import { vscode } from '../main';
 import { loadWorkflowList, saveWorkflow } from '../services/vscode-bridge';
 import {
@@ -28,6 +29,7 @@ interface WorkflowListItem {
 }
 
 export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
+  const { t } = useTranslation();
   const { nodes, edges, setNodes, setEdges } = useWorkflowStore();
   const [workflowName, setWorkflowName] = useState('my-workflow');
   const [isSaving, setIsSaving] = useState(false);
@@ -40,7 +42,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
     if (!workflowName.trim()) {
       onError({
         code: 'VALIDATION_ERROR',
-        message: 'Workflow name is required',
+        message: t('toolbar.error.workflowNameRequired'),
       });
       return;
     }
@@ -64,7 +66,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
     } catch (error) {
       onError({
         code: 'VALIDATION_ERROR',
-        message: error instanceof Error ? error.message : 'Workflow validation failed',
+        message: error instanceof Error ? error.message : t('toolbar.error.validationFailed'),
         details: error,
       });
     } finally {
@@ -126,7 +128,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
     if (!selectedWorkflowId) {
       onError({
         code: 'VALIDATION_ERROR',
-        message: 'Please select a workflow to load',
+        message: t('toolbar.error.selectWorkflowToLoad'),
       });
       return;
     }
@@ -142,7 +144,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
     if (!workflowName.trim()) {
       onError({
         code: 'VALIDATION_ERROR',
-        message: 'Workflow name is required for export',
+        message: t('toolbar.error.workflowNameRequiredForExport'),
       });
       return;
     }
@@ -168,7 +170,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
     } catch (error) {
       onError({
         code: 'VALIDATION_ERROR',
-        message: error instanceof Error ? error.message : 'Workflow validation failed',
+        message: error instanceof Error ? error.message : t('toolbar.error.validationFailed'),
         details: error,
       });
       setIsExporting(false);
@@ -191,7 +193,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
         type="text"
         value={workflowName}
         onChange={(e) => setWorkflowName(e.target.value)}
-        placeholder="Workflow name"
+        placeholder={t('toolbar.workflowNamePlaceholder')}
         className="nodrag"
         style={{
           flex: 1,
@@ -221,7 +223,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
           whiteSpace: 'nowrap',
         }}
       >
-        {isSaving ? 'Saving...' : 'Save'}
+        {isSaving ? t('toolbar.saving') : t('toolbar.save')}
       </button>
 
       {/* Export Button */}
@@ -241,7 +243,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
           whiteSpace: 'nowrap',
         }}
       >
-        {isExporting ? 'Exporting...' : 'Export'}
+        {isExporting ? t('toolbar.exporting') : t('toolbar.export')}
       </button>
 
       {/* Divider */}
@@ -268,7 +270,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
           minWidth: '150px',
         }}
       >
-        <option value="">Select workflow...</option>
+        <option value="">{t('toolbar.selectWorkflow')}</option>
         {workflows.map((wf) => (
           <option key={wf.id} value={wf.id}>
             {wf.name}
@@ -293,7 +295,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
           whiteSpace: 'nowrap',
         }}
       >
-        Load
+        {t('toolbar.load')}
       </button>
 
       {/* Refresh List Button */}
@@ -301,7 +303,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
         type="button"
         onClick={handleRefreshList}
         disabled={isLoading}
-        title="Refresh workflow list"
+        title={t('toolbar.refreshList')}
         style={{
           padding: '4px 8px',
           backgroundColor: 'var(--vscode-button-secondaryBackground)',

--- a/src/webview/src/i18n/i18n-context.tsx
+++ b/src/webview/src/i18n/i18n-context.tsx
@@ -1,0 +1,87 @@
+/**
+ * Claude Code Workflow Studio - Webview i18n Context
+ *
+ * Provides translation functionality via React Context
+ */
+
+import type React from 'react';
+import { createContext, useContext, useMemo } from 'react';
+import type { WebviewTranslationKeys } from './translation-keys';
+import { enWebviewTranslations } from './translations/en';
+import { jaWebviewTranslations } from './translations/ja';
+import { koWebviewTranslations } from './translations/ko';
+import { zhCNWebviewTranslations } from './translations/zh-CN';
+import { zhTWWebviewTranslations } from './translations/zh-TW';
+
+type Translations = typeof enWebviewTranslations;
+
+interface I18nContextValue {
+  t: <K extends keyof WebviewTranslationKeys>(key: K) => string;
+  locale: string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+/**
+ * Get translations for a given locale
+ */
+function getTranslations(locale: string): Translations {
+  const languageCode = locale.split('-')[0];
+
+  // Check full locale first (e.g., zh-CN, zh-TW)
+  if (locale === 'zh-CN') {
+    return zhCNWebviewTranslations;
+  }
+  if (locale === 'zh-TW' || locale === 'zh-HK') {
+    return zhTWWebviewTranslations;
+  }
+
+  // Check language code (e.g., ja, ko)
+  switch (languageCode) {
+    case 'ja':
+      return jaWebviewTranslations;
+    case 'ko':
+      return koWebviewTranslations;
+    case 'zh':
+      // Default to Simplified Chinese if no region specified
+      return zhCNWebviewTranslations;
+    default:
+      return enWebviewTranslations;
+  }
+}
+
+interface I18nProviderProps {
+  locale: string;
+  children: React.ReactNode;
+}
+
+/**
+ * I18n Provider Component
+ */
+export const I18nProvider: React.FC<I18nProviderProps> = ({ locale, children }) => {
+  const value = useMemo(() => {
+    const translations = getTranslations(locale);
+
+    return {
+      t: <K extends keyof WebviewTranslationKeys>(key: K): string => {
+        return translations[key] as string;
+      },
+      locale,
+    };
+  }, [locale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+};
+
+/**
+ * Hook to use i18n in components
+ */
+export function useTranslation() {
+  const context = useContext(I18nContext);
+
+  if (!context) {
+    throw new Error('useTranslation must be used within I18nProvider');
+  }
+
+  return context;
+}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -1,0 +1,132 @@
+/**
+ * Claude Code Workflow Studio - Webview Translation Keys
+ */
+
+export interface WebviewTranslationKeys {
+  // Toolbar
+  'toolbar.workflowNamePlaceholder': string;
+  'toolbar.save': string;
+  'toolbar.saving': string;
+  'toolbar.export': string;
+  'toolbar.exporting': string;
+  'toolbar.selectWorkflow': string;
+  'toolbar.load': string;
+  'toolbar.refreshList': string;
+
+  // Toolbar errors
+  'toolbar.error.workflowNameRequired': string;
+  'toolbar.error.workflowNameRequiredForExport': string;
+  'toolbar.error.selectWorkflowToLoad': string;
+  'toolbar.error.validationFailed': string;
+
+  // Node Palette
+  'palette.title': string;
+  'palette.basicNodes': string;
+  'palette.controlFlow': string;
+  'palette.quickStart': string;
+
+  // Node types
+  'node.prompt.title': string;
+  'node.prompt.description': string;
+  'node.subAgent.title': string;
+  'node.subAgent.description': string;
+  'node.branch.title': string;
+  'node.branch.description': string;
+  'node.askUserQuestion.title': string;
+  'node.askUserQuestion.description': string;
+
+  // Quick start instructions
+  'palette.instruction.addNode': string;
+  'palette.instruction.dragNode': string;
+  'palette.instruction.connectNodes': string;
+  'palette.instruction.editProperties': string;
+
+  // Property Panel
+  'property.title': string;
+  'property.noSelection': string;
+
+  // Node type badges
+  'property.nodeType.subAgent': string;
+  'property.nodeType.askUserQuestion': string;
+  'property.nodeType.branch': string;
+  'property.nodeType.prompt': string;
+  'property.nodeType.start': string;
+  'property.nodeType.end': string;
+  'property.nodeType.unknown': string;
+
+  // Common property labels
+  'property.nodeName': string;
+  'property.nodeName.placeholder': string;
+  'property.nodeName.help': string;
+  'property.description': string;
+  'property.prompt': string;
+  'property.model': string;
+  'property.label': string;
+  'property.label.placeholder': string;
+
+  // Start/End node descriptions
+  'property.startNodeDescription': string;
+  'property.endNodeDescription': string;
+  'property.unknownNodeType': string;
+
+  // Sub-Agent properties
+  'property.tools': string;
+  'property.tools.placeholder': string;
+  'property.tools.help': string;
+
+  // AskUserQuestion properties
+  'property.questionText': string;
+  'property.multiSelect': string;
+  'property.multiSelect.enabled': string;
+  'property.multiSelect.disabled': string;
+  'property.aiSuggestions': string;
+  'property.aiSuggestions.enabled': string;
+  'property.aiSuggestions.disabled': string;
+  'property.options': string;
+  'property.optionsCount': string;
+  'property.optionNumber': string;
+  'property.addOption': string;
+  'property.remove': string;
+  'property.optionLabel.placeholder': string;
+  'property.optionDescription.placeholder': string;
+
+  // Prompt properties
+  'property.promptTemplate': string;
+  'property.promptTemplate.placeholder': string;
+  'property.promptTemplate.help': string;
+  'property.detectedVariables': string;
+  'property.variablesSubstituted': string;
+
+  // Branch properties
+  'property.branchType': string;
+  'property.conditional': string;
+  'property.switch': string;
+  'property.branchType.conditional.help': string;
+  'property.branchType.switch.help': string;
+  'property.branches': string;
+  'property.branchesCount': string;
+  'property.branchNumber': string;
+  'property.addBranch': string;
+  'property.branchLabel': string;
+  'property.branchLabel.placeholder': string;
+  'property.branchCondition': string;
+  'property.branchCondition.placeholder': string;
+  'property.minimumBranches': string;
+
+  // Default node labels
+  'default.newSubAgent': string;
+  'default.enterPrompt': string;
+  'default.newQuestion': string;
+  'default.option': string;
+  'default.firstOption': string;
+  'default.secondOption': string;
+  'default.newOption': string;
+  'default.newPrompt': string;
+  'default.promptTemplate': string;
+  'default.branchTrue': string;
+  'default.branchTrueCondition': string;
+  'default.branchFalse': string;
+  'default.branchFalseCondition': string;
+  'default.newBranch': string;
+  'default.newCondition': string;
+}

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -1,0 +1,137 @@
+/**
+ * Claude Code Workflow Studio - Webview English Translations
+ */
+
+import type { WebviewTranslationKeys } from '../translation-keys';
+
+export const enWebviewTranslations: WebviewTranslationKeys = {
+  // Toolbar
+  'toolbar.workflowNamePlaceholder': 'Workflow name',
+  'toolbar.save': 'Save',
+  'toolbar.saving': 'Saving...',
+  'toolbar.export': 'Export',
+  'toolbar.exporting': 'Exporting...',
+  'toolbar.selectWorkflow': 'Select workflow...',
+  'toolbar.load': 'Load',
+  'toolbar.refreshList': 'Refresh workflow list',
+
+  // Toolbar errors
+  'toolbar.error.workflowNameRequired': 'Workflow name is required',
+  'toolbar.error.workflowNameRequiredForExport': 'Workflow name is required for export',
+  'toolbar.error.selectWorkflowToLoad': 'Please select a workflow to load',
+  'toolbar.error.validationFailed': 'Workflow validation failed',
+
+  // Node Palette
+  'palette.title': 'Node Palette',
+  'palette.basicNodes': 'Basic Nodes',
+  'palette.controlFlow': 'Control Flow',
+  'palette.quickStart': '💡 Quick Start',
+
+  // Node types
+  'node.prompt.title': 'Prompt',
+  'node.prompt.description': 'Template with variables',
+  'node.subAgent.title': 'Sub-Agent',
+  'node.subAgent.description': 'Execute a specialized task',
+  'node.branch.title': 'Branch',
+  'node.branch.description': 'Conditional branching logic',
+  'node.askUserQuestion.title': 'Ask User Question',
+  'node.askUserQuestion.description': 'Branch based on user choice',
+
+  // Quick start instructions
+  'palette.instruction.addNode': 'Click a node to add it to the canvas',
+  'palette.instruction.dragNode': 'Drag nodes to reposition them',
+  'palette.instruction.connectNodes': 'Connect nodes by dragging from output to input handles',
+  'palette.instruction.editProperties': 'Select a node to edit its properties',
+
+  // Property Panel
+  'property.title': 'Properties',
+  'property.noSelection': 'Select a node to view its properties',
+
+  // Node type badges
+  'property.nodeType.subAgent': 'Sub-Agent',
+  'property.nodeType.askUserQuestion': 'Ask User Question',
+  'property.nodeType.branch': 'Branch Node',
+  'property.nodeType.prompt': 'Prompt Node',
+  'property.nodeType.start': 'Start Node',
+  'property.nodeType.end': 'End Node',
+  'property.nodeType.unknown': 'Unknown',
+
+  // Common property labels
+  'property.nodeName': 'Node Name',
+  'property.nodeName.placeholder': 'Enter node name',
+  'property.nodeName.help': 'Used for exported file name (e.g., "data-analysis")',
+  'property.description': 'Description',
+  'property.prompt': 'Prompt',
+  'property.model': 'Model',
+  'property.label': 'Label',
+  'property.label.placeholder': 'Enter label',
+
+  // Start/End node descriptions
+  'property.startNodeDescription':
+    'Start node marks the beginning of the workflow. It cannot be deleted and has no editable properties.',
+  'property.endNodeDescription':
+    'End node marks the completion of the workflow. It cannot be deleted and has no editable properties.',
+  'property.unknownNodeType': 'Unknown node type:',
+
+  // Sub-Agent properties
+  'property.tools': 'Tools (comma-separated)',
+  'property.tools.placeholder': 'e.g., Read,Write,Bash',
+  'property.tools.help': 'Leave empty for all tools',
+
+  // AskUserQuestion properties
+  'property.questionText': 'Question',
+  'property.multiSelect': 'Multiple Selection',
+  'property.multiSelect.enabled': 'User can select multiple options (outputs selected list)',
+  'property.multiSelect.disabled': 'User selects one option (branches to corresponding node)',
+  'property.aiSuggestions': 'AI Suggests Options',
+  'property.aiSuggestions.enabled': 'AI will dynamically generate options based on context',
+  'property.aiSuggestions.disabled': 'Manually define options below',
+  'property.options': 'Options',
+  'property.optionsCount': 'Options ({count}/4)',
+  'property.optionNumber': 'Option {number}',
+  'property.addOption': '+ Add Option',
+  'property.remove': 'Remove',
+  'property.optionLabel.placeholder': 'Label',
+  'property.optionDescription.placeholder': 'Description',
+
+  // Prompt properties
+  'property.promptTemplate': 'Prompt Template',
+  'property.promptTemplate.placeholder': 'Enter prompt template with {{variables}}',
+  'property.promptTemplate.help': 'Use {{variableName}} syntax for dynamic values',
+  'property.detectedVariables': 'Detected Variables ({count})',
+  'property.variablesSubstituted': 'Variables will be substituted at runtime',
+
+  // Branch properties
+  'property.branchType': 'Branch Type',
+  'property.conditional': 'Conditional (2-way)',
+  'property.switch': 'Switch (Multi-way)',
+  'property.branchType.conditional.help': '2 branches (True/False)',
+  'property.branchType.switch.help': 'Multiple branches (2-N way)',
+  'property.branches': 'Branches',
+  'property.branchesCount': 'Branches ({count})',
+  'property.branchNumber': 'Branch {number}',
+  'property.addBranch': '+ Add Branch',
+  'property.branchLabel': 'Label',
+  'property.branchLabel.placeholder': 'e.g., Success, Error',
+  'property.branchCondition': 'Condition (natural language)',
+  'property.branchCondition.placeholder': 'e.g., If the previous process succeeded',
+  'property.minimumBranches': 'Minimum 2 branches required',
+
+  // Default node labels
+  'default.newSubAgent': 'New Sub-Agent',
+  'default.enterPrompt': 'Enter your prompt here',
+  'default.newQuestion': 'New Question',
+  'default.option': 'Option',
+  'default.firstOption': 'First option',
+  'default.secondOption': 'Second option',
+  'default.newOption': 'New option',
+  'default.newPrompt': 'New Prompt',
+  'default.promptTemplate':
+    'Enter your prompt template here.\n\nYou can use variables like {{variableName}}.',
+  'default.branchTrue': 'True',
+  'default.branchTrueCondition': 'When condition is true',
+  'default.branchFalse': 'False',
+  'default.branchFalseCondition': 'When condition is false',
+  'default.newBranch': 'Branch',
+  'default.newCondition': 'New condition',
+};

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -1,0 +1,137 @@
+/**
+ * Claude Code Workflow Studio - Webview Japanese Translations
+ */
+
+import type { WebviewTranslationKeys } from '../translation-keys';
+
+export const jaWebviewTranslations: WebviewTranslationKeys = {
+  // Toolbar
+  'toolbar.workflowNamePlaceholder': 'ワークフロー名',
+  'toolbar.save': '保存',
+  'toolbar.saving': '保存中...',
+  'toolbar.export': 'エクスポート',
+  'toolbar.exporting': 'エクスポート中...',
+  'toolbar.selectWorkflow': 'ワークフローを選択...',
+  'toolbar.load': '読み込み',
+  'toolbar.refreshList': 'ワークフローリストを更新',
+
+  // Toolbar errors
+  'toolbar.error.workflowNameRequired': 'ワークフロー名は必須です',
+  'toolbar.error.workflowNameRequiredForExport': 'エクスポートにはワークフロー名が必要です',
+  'toolbar.error.selectWorkflowToLoad': '読み込むワークフローを選択してください',
+  'toolbar.error.validationFailed': 'ワークフローの検証に失敗しました',
+
+  // Node Palette
+  'palette.title': 'ノードパレット',
+  'palette.basicNodes': '基本ノード',
+  'palette.controlFlow': '制御フロー',
+  'palette.quickStart': '💡 クイックスタート',
+
+  // Node types
+  'node.prompt.title': 'Prompt',
+  'node.prompt.description': '変数を使用できるテンプレート',
+  'node.subAgent.title': 'Sub-Agent',
+  'node.subAgent.description': '専門タスクを実行',
+  'node.branch.title': 'Branch',
+  'node.branch.description': '条件分岐ロジック',
+  'node.askUserQuestion.title': 'Ask User Question',
+  'node.askUserQuestion.description': 'ユーザーの選択に基づいて分岐',
+
+  // Quick start instructions
+  'palette.instruction.addNode': 'ノードをクリックしてキャンバスに追加',
+  'palette.instruction.dragNode': 'ノードをドラッグして移動',
+  'palette.instruction.connectNodes': '出力ハンドルから入力ハンドルへドラッグして接続',
+  'palette.instruction.editProperties': 'ノードを選択してプロパティを編集',
+
+  // Property Panel
+  'property.title': 'プロパティ',
+  'property.noSelection': 'ノードを選択してプロパティを表示',
+
+  // Node type badges
+  'property.nodeType.subAgent': 'Sub-Agent',
+  'property.nodeType.askUserQuestion': 'Ask User Question',
+  'property.nodeType.branch': 'Branch Node',
+  'property.nodeType.prompt': 'Prompt Node',
+  'property.nodeType.start': 'Start Node',
+  'property.nodeType.end': 'End Node',
+  'property.nodeType.unknown': '不明',
+
+  // Common property labels
+  'property.nodeName': 'ノード名',
+  'property.nodeName.placeholder': 'ノード名を入力',
+  'property.nodeName.help': 'エクスポート時のファイル名に使用されます（例: "data-analysis"）',
+  'property.description': '説明',
+  'property.prompt': 'プロンプト',
+  'property.model': 'モデル',
+  'property.label': 'ラベル',
+  'property.label.placeholder': 'ラベルを入力',
+
+  // Start/End node descriptions
+  'property.startNodeDescription':
+    'Startノードはワークフローの開始地点です。削除できず、編集可能なプロパティはありません。',
+  'property.endNodeDescription':
+    'Endノードはワークフローの終了地点です。削除できず、編集可能なプロパティはありません。',
+  'property.unknownNodeType': '不明なノードタイプ:',
+
+  // Sub-Agent properties
+  'property.tools': 'ツール（カンマ区切り）',
+  'property.tools.placeholder': '例: Read,Write,Bash',
+  'property.tools.help': '空欄で全てのツールを使用',
+
+  // AskUserQuestion properties
+  'property.questionText': '質問',
+  'property.multiSelect': '複数選択',
+  'property.multiSelect.enabled': 'ユーザーは複数の選択肢を選択可能（選択リストを出力）',
+  'property.multiSelect.disabled': 'ユーザーは1つの選択肢を選択（対応するノードに分岐）',
+  'property.aiSuggestions': 'AI が選択肢を提案',
+  'property.aiSuggestions.enabled': 'AIが文脈に基づいて選択肢を動的に生成します',
+  'property.aiSuggestions.disabled': '以下で選択肢を手動定義',
+  'property.options': '選択肢',
+  'property.optionsCount': '選択肢（{count}/4）',
+  'property.optionNumber': '選択肢 {number}',
+  'property.addOption': '+ 選択肢を追加',
+  'property.remove': '削除',
+  'property.optionLabel.placeholder': 'ラベル',
+  'property.optionDescription.placeholder': '説明',
+
+  // Prompt properties
+  'property.promptTemplate': 'プロンプトテンプレート',
+  'property.promptTemplate.placeholder': '{{variables}}を含むプロンプトテンプレートを入力',
+  'property.promptTemplate.help': '動的な値には{{variableName}}構文を使用',
+  'property.detectedVariables': '検出された変数（{count}）',
+  'property.variablesSubstituted': '変数は実行時に置換されます',
+
+  // Branch properties
+  'property.branchType': '分岐タイプ',
+  'property.conditional': '条件分岐（2分岐）',
+  'property.switch': 'スイッチ（多分岐）',
+  'property.branchType.conditional.help': '2つの分岐（True/False）',
+  'property.branchType.switch.help': '複数の分岐（2-N分岐）',
+  'property.branches': '分岐',
+  'property.branchesCount': '分岐（{count}）',
+  'property.branchNumber': '分岐 {number}',
+  'property.addBranch': '+ 分岐を追加',
+  'property.branchLabel': 'ラベル',
+  'property.branchLabel.placeholder': '例: 成功, エラー',
+  'property.branchCondition': '条件（自然言語）',
+  'property.branchCondition.placeholder': '例: 前の処理が成功した場合',
+  'property.minimumBranches': '最低2つの分岐が必要です',
+
+  // Default node labels
+  'default.newSubAgent': '新しいSub-Agent',
+  'default.enterPrompt': 'ここにプロンプトを入力',
+  'default.newQuestion': '新しい質問',
+  'default.option': '選択肢',
+  'default.firstOption': '最初の選択肢',
+  'default.secondOption': '2番目の選択肢',
+  'default.newOption': '新しい選択肢',
+  'default.newPrompt': '新しいPrompt',
+  'default.promptTemplate':
+    'ここにプロンプトテンプレートを入力してください。\n\n{{variableName}}のように変数を使用できます。',
+  'default.branchTrue': 'True',
+  'default.branchTrueCondition': '条件が真の場合',
+  'default.branchFalse': 'False',
+  'default.branchFalseCondition': '条件が偽の場合',
+  'default.newBranch': '分岐',
+  'default.newCondition': '新しい条件',
+};

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -1,0 +1,137 @@
+/**
+ * Claude Code Workflow Studio - Webview Korean Translations
+ */
+
+import type { WebviewTranslationKeys } from '../translation-keys';
+
+export const koWebviewTranslations: WebviewTranslationKeys = {
+  // Toolbar
+  'toolbar.workflowNamePlaceholder': '워크플로 이름',
+  'toolbar.save': '저장',
+  'toolbar.saving': '저장 중...',
+  'toolbar.export': '내보내기',
+  'toolbar.exporting': '내보내는 중...',
+  'toolbar.selectWorkflow': '워크플로 선택...',
+  'toolbar.load': '불러오기',
+  'toolbar.refreshList': '워크플로 목록 새로고침',
+
+  // Toolbar errors
+  'toolbar.error.workflowNameRequired': '워크플로 이름이 필요합니다',
+  'toolbar.error.workflowNameRequiredForExport': '내보내기에는 워크플로 이름이 필요합니다',
+  'toolbar.error.selectWorkflowToLoad': '불러올 워크플로를 선택하세요',
+  'toolbar.error.validationFailed': '워크플로 검증에 실패했습니다',
+
+  // Node Palette
+  'palette.title': '노드 팔레트',
+  'palette.basicNodes': '기본 노드',
+  'palette.controlFlow': '제어 흐름',
+  'palette.quickStart': '💡 빠른 시작',
+
+  // Node types
+  'node.prompt.title': 'Prompt',
+  'node.prompt.description': '변수가 있는 템플릿',
+  'node.subAgent.title': 'Sub-Agent',
+  'node.subAgent.description': '전문 작업 실행',
+  'node.branch.title': 'Branch',
+  'node.branch.description': '조건 분기 로직',
+  'node.askUserQuestion.title': 'Ask User Question',
+  'node.askUserQuestion.description': '사용자 선택에 따라 분기',
+
+  // Quick start instructions
+  'palette.instruction.addNode': '노드를 클릭하여 캔버스에 추가',
+  'palette.instruction.dragNode': '노드를 드래그하여 재배치',
+  'palette.instruction.connectNodes': '출력에서 입력 핸들로 드래그하여 연결',
+  'palette.instruction.editProperties': '노드를 선택하여 속성 편집',
+
+  // Property Panel
+  'property.title': '속성',
+  'property.noSelection': '노드를 선택하여 속성 보기',
+
+  // Node type badges
+  'property.nodeType.subAgent': 'Sub-Agent',
+  'property.nodeType.askUserQuestion': 'Ask User Question',
+  'property.nodeType.branch': 'Branch Node',
+  'property.nodeType.prompt': 'Prompt Node',
+  'property.nodeType.start': 'Start Node',
+  'property.nodeType.end': 'End Node',
+  'property.nodeType.unknown': '알 수 없음',
+
+  // Common property labels
+  'property.nodeName': '노드 이름',
+  'property.nodeName.placeholder': '노드 이름 입력',
+  'property.nodeName.help': '내보내기 파일 이름으로 사용됨 (예: "data-analysis")',
+  'property.description': '설명',
+  'property.prompt': '프롬프트',
+  'property.model': '모델',
+  'property.label': '레이블',
+  'property.label.placeholder': '레이블 입력',
+
+  // Start/End node descriptions
+  'property.startNodeDescription':
+    'Start 노드는 워크플로의 시작점입니다. 삭제할 수 없으며 편집 가능한 속성이 없습니다.',
+  'property.endNodeDescription':
+    'End 노드는 워크플로의 완료점입니다. 삭제할 수 없으며 편집 가능한 속성이 없습니다.',
+  'property.unknownNodeType': '알 수 없는 노드 유형:',
+
+  // Sub-Agent properties
+  'property.tools': '도구 (쉼표로 구분)',
+  'property.tools.placeholder': '예: Read,Write,Bash',
+  'property.tools.help': '모든 도구를 사용하려면 비워 두세요',
+
+  // AskUserQuestion properties
+  'property.questionText': '질문',
+  'property.multiSelect': '다중 선택',
+  'property.multiSelect.enabled': '사용자가 여러 옵션을 선택할 수 있음 (선택 목록 출력)',
+  'property.multiSelect.disabled': '사용자가 하나의 옵션을 선택 (해당 노드로 분기)',
+  'property.aiSuggestions': 'AI가 옵션 제안',
+  'property.aiSuggestions.enabled': 'AI가 컨텍스트를 기반으로 옵션을 동적으로 생성합니다',
+  'property.aiSuggestions.disabled': '아래에서 옵션을 수동으로 정의',
+  'property.options': '옵션',
+  'property.optionsCount': '옵션 ({count}/4)',
+  'property.optionNumber': '옵션 {number}',
+  'property.addOption': '+ 옵션 추가',
+  'property.remove': '제거',
+  'property.optionLabel.placeholder': '레이블',
+  'property.optionDescription.placeholder': '설명',
+
+  // Prompt properties
+  'property.promptTemplate': '프롬프트 템플릿',
+  'property.promptTemplate.placeholder': '{{variables}}를 포함하는 프롬프트 템플릿 입력',
+  'property.promptTemplate.help': '동적 값에는 {{variableName}} 구문 사용',
+  'property.detectedVariables': '감지된 변수 ({count})',
+  'property.variablesSubstituted': '변수는 런타임에 대체됩니다',
+
+  // Branch properties
+  'property.branchType': '분기 유형',
+  'property.conditional': '조건부 (2방향)',
+  'property.switch': '스위치 (다방향)',
+  'property.branchType.conditional.help': '2개 분기 (True/False)',
+  'property.branchType.switch.help': '다중 분기 (2-N 방향)',
+  'property.branches': '분기',
+  'property.branchesCount': '분기 ({count})',
+  'property.branchNumber': '분기 {number}',
+  'property.addBranch': '+ 분기 추가',
+  'property.branchLabel': '레이블',
+  'property.branchLabel.placeholder': '예: 성공, 오류',
+  'property.branchCondition': '조건 (자연어)',
+  'property.branchCondition.placeholder': '예: 이전 프로세스가 성공한 경우',
+  'property.minimumBranches': '최소 2개의 분기가 필요합니다',
+
+  // Default node labels
+  'default.newSubAgent': '새 Sub-Agent',
+  'default.enterPrompt': '여기에 프롬프트 입력',
+  'default.newQuestion': '새 질문',
+  'default.option': '옵션',
+  'default.firstOption': '첫 번째 옵션',
+  'default.secondOption': '두 번째 옵션',
+  'default.newOption': '새 옵션',
+  'default.newPrompt': '새 Prompt',
+  'default.promptTemplate':
+    '여기에 프롬프트 템플릿을 입력하세요.\n\n{{variableName}}과 같이 변수를 사용할 수 있습니다.',
+  'default.branchTrue': 'True',
+  'default.branchTrueCondition': '조건이 참일 때',
+  'default.branchFalse': 'False',
+  'default.branchFalseCondition': '조건이 거짓일 때',
+  'default.newBranch': '분기',
+  'default.newCondition': '새 조건',
+};

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -1,0 +1,134 @@
+/**
+ * Claude Code Workflow Studio - Webview Simplified Chinese Translations
+ */
+
+import type { WebviewTranslationKeys } from '../translation-keys';
+
+export const zhCNWebviewTranslations: WebviewTranslationKeys = {
+  // Toolbar
+  'toolbar.workflowNamePlaceholder': '工作流名称',
+  'toolbar.save': '保存',
+  'toolbar.saving': '保存中...',
+  'toolbar.export': '导出',
+  'toolbar.exporting': '导出中...',
+  'toolbar.selectWorkflow': '选择工作流...',
+  'toolbar.load': '加载',
+  'toolbar.refreshList': '刷新工作流列表',
+
+  // Toolbar errors
+  'toolbar.error.workflowNameRequired': '工作流名称必填',
+  'toolbar.error.workflowNameRequiredForExport': '导出需要工作流名称',
+  'toolbar.error.selectWorkflowToLoad': '请选择要加载的工作流',
+  'toolbar.error.validationFailed': '工作流验证失败',
+
+  // Node Palette
+  'palette.title': '节点面板',
+  'palette.basicNodes': '基本节点',
+  'palette.controlFlow': '控制流程',
+  'palette.quickStart': '💡 快速入门',
+
+  // Node types
+  'node.prompt.title': 'Prompt',
+  'node.prompt.description': '带变量的模板',
+  'node.subAgent.title': 'Sub-Agent',
+  'node.subAgent.description': '执行专门任务',
+  'node.branch.title': 'Branch',
+  'node.branch.description': '条件分支逻辑',
+  'node.askUserQuestion.title': 'Ask User Question',
+  'node.askUserQuestion.description': '根据用户选择分支',
+
+  // Quick start instructions
+  'palette.instruction.addNode': '点击节点将其添加到画布',
+  'palette.instruction.dragNode': '拖动节点以重新定位',
+  'palette.instruction.connectNodes': '从输出拖动到输入句柄以连接节点',
+  'palette.instruction.editProperties': '选择节点以编辑其属性',
+
+  // Property Panel
+  'property.title': '属性',
+  'property.noSelection': '选择节点以查看其属性',
+
+  // Node type badges
+  'property.nodeType.subAgent': 'Sub-Agent',
+  'property.nodeType.askUserQuestion': 'Ask User Question',
+  'property.nodeType.branch': 'Branch Node',
+  'property.nodeType.prompt': 'Prompt Node',
+  'property.nodeType.start': 'Start Node',
+  'property.nodeType.end': 'End Node',
+  'property.nodeType.unknown': '未知',
+
+  // Common property labels
+  'property.nodeName': '节点名称',
+  'property.nodeName.placeholder': '输入节点名称',
+  'property.nodeName.help': '用于导出的文件名（例如："data-analysis"）',
+  'property.description': '描述',
+  'property.prompt': '提示',
+  'property.model': '模型',
+  'property.label': '标签',
+  'property.label.placeholder': '输入标签',
+
+  // Start/End node descriptions
+  'property.startNodeDescription': 'Start节点标记工作流的开始。它不能被删除且没有可编辑的属性。',
+  'property.endNodeDescription': 'End节点标记工作流的完成。它不能被删除且没有可编辑的属性。',
+  'property.unknownNodeType': '未知节点类型：',
+
+  // Sub-Agent properties
+  'property.tools': '工具（逗号分隔）',
+  'property.tools.placeholder': '例如：Read,Write,Bash',
+  'property.tools.help': '留空表示所有工具',
+
+  // AskUserQuestion properties
+  'property.questionText': '问题',
+  'property.multiSelect': '多选',
+  'property.multiSelect.enabled': '用户可以选择多个选项（输出选择列表）',
+  'property.multiSelect.disabled': '用户选择一个选项（分支到相应节点）',
+  'property.aiSuggestions': 'AI建议选项',
+  'property.aiSuggestions.enabled': 'AI将根据上下文动态生成选项',
+  'property.aiSuggestions.disabled': '在下方手动定义选项',
+  'property.options': '选项',
+  'property.optionsCount': '选项（{count}/4）',
+  'property.optionNumber': '选项 {number}',
+  'property.addOption': '+ 添加选项',
+  'property.remove': '删除',
+  'property.optionLabel.placeholder': '标签',
+  'property.optionDescription.placeholder': '描述',
+
+  // Prompt properties
+  'property.promptTemplate': '提示模板',
+  'property.promptTemplate.placeholder': '输入包含{{variables}}的提示模板',
+  'property.promptTemplate.help': '对动态值使用{{variableName}}语法',
+  'property.detectedVariables': '检测到的变量（{count}）',
+  'property.variablesSubstituted': '变量将在运行时替换',
+
+  // Branch properties
+  'property.branchType': '分支类型',
+  'property.conditional': '条件（双向）',
+  'property.switch': '开关（多向）',
+  'property.branchType.conditional.help': '2个分支（True/False）',
+  'property.branchType.switch.help': '多个分支（2-N向）',
+  'property.branches': '分支',
+  'property.branchesCount': '分支（{count}）',
+  'property.branchNumber': '分支 {number}',
+  'property.addBranch': '+ 添加分支',
+  'property.branchLabel': '标签',
+  'property.branchLabel.placeholder': '例如：成功，错误',
+  'property.branchCondition': '条件（自然语言）',
+  'property.branchCondition.placeholder': '例如：如果前一个过程成功',
+  'property.minimumBranches': '至少需要2个分支',
+
+  // Default node labels
+  'default.newSubAgent': '新Sub-Agent',
+  'default.enterPrompt': '在此输入提示',
+  'default.newQuestion': '新问题',
+  'default.option': '选项',
+  'default.firstOption': '第一个选项',
+  'default.secondOption': '第二个选项',
+  'default.newOption': '新选项',
+  'default.newPrompt': '新Prompt',
+  'default.promptTemplate': '在此输入您的提示模板。\n\n您可以使用{{variableName}}这样的变量。',
+  'default.branchTrue': 'True',
+  'default.branchTrueCondition': '条件为真时',
+  'default.branchFalse': 'False',
+  'default.branchFalseCondition': '条件为假时',
+  'default.newBranch': '分支',
+  'default.newCondition': '新条件',
+};

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -1,0 +1,134 @@
+/**
+ * Claude Code Workflow Studio - Webview Traditional Chinese Translations
+ */
+
+import type { WebviewTranslationKeys } from '../translation-keys';
+
+export const zhTWWebviewTranslations: WebviewTranslationKeys = {
+  // Toolbar
+  'toolbar.workflowNamePlaceholder': '工作流名稱',
+  'toolbar.save': '儲存',
+  'toolbar.saving': '儲存中...',
+  'toolbar.export': '匯出',
+  'toolbar.exporting': '匯出中...',
+  'toolbar.selectWorkflow': '選擇工作流...',
+  'toolbar.load': '載入',
+  'toolbar.refreshList': '重新整理工作流清單',
+
+  // Toolbar errors
+  'toolbar.error.workflowNameRequired': '工作流名稱為必填',
+  'toolbar.error.workflowNameRequiredForExport': '匯出需要工作流名稱',
+  'toolbar.error.selectWorkflowToLoad': '請選擇要載入的工作流',
+  'toolbar.error.validationFailed': '工作流驗證失敗',
+
+  // Node Palette
+  'palette.title': '節點面板',
+  'palette.basicNodes': '基本節點',
+  'palette.controlFlow': '控制流程',
+  'palette.quickStart': '💡 快速入門',
+
+  // Node types
+  'node.prompt.title': 'Prompt',
+  'node.prompt.description': '帶變數的範本',
+  'node.subAgent.title': 'Sub-Agent',
+  'node.subAgent.description': '執行專門任務',
+  'node.branch.title': 'Branch',
+  'node.branch.description': '條件分支邏輯',
+  'node.askUserQuestion.title': 'Ask User Question',
+  'node.askUserQuestion.description': '根據使用者選擇分支',
+
+  // Quick start instructions
+  'palette.instruction.addNode': '點擊節點將其新增到畫布',
+  'palette.instruction.dragNode': '拖動節點以重新定位',
+  'palette.instruction.connectNodes': '從輸出拖動到輸入控點以連接節點',
+  'palette.instruction.editProperties': '選擇節點以編輯其屬性',
+
+  // Property Panel
+  'property.title': '屬性',
+  'property.noSelection': '選擇節點以檢視其屬性',
+
+  // Node type badges
+  'property.nodeType.subAgent': 'Sub-Agent',
+  'property.nodeType.askUserQuestion': 'Ask User Question',
+  'property.nodeType.branch': 'Branch Node',
+  'property.nodeType.prompt': 'Prompt Node',
+  'property.nodeType.start': 'Start Node',
+  'property.nodeType.end': 'End Node',
+  'property.nodeType.unknown': '未知',
+
+  // Common property labels
+  'property.nodeName': '節點名稱',
+  'property.nodeName.placeholder': '輸入節點名稱',
+  'property.nodeName.help': '用於匯出的檔案名稱（例如："data-analysis"）',
+  'property.description': '描述',
+  'property.prompt': '提示',
+  'property.model': '模型',
+  'property.label': '標籤',
+  'property.label.placeholder': '輸入標籤',
+
+  // Start/End node descriptions
+  'property.startNodeDescription': 'Start節點標記工作流的開始。它不能被刪除且沒有可編輯的屬性。',
+  'property.endNodeDescription': 'End節點標記工作流的完成。它不能被刪除且沒有可編輯的屬性。',
+  'property.unknownNodeType': '未知節點類型：',
+
+  // Sub-Agent properties
+  'property.tools': '工具（逗號分隔）',
+  'property.tools.placeholder': '例如：Read,Write,Bash',
+  'property.tools.help': '留空表示所有工具',
+
+  // AskUserQuestion properties
+  'property.questionText': '問題',
+  'property.multiSelect': '多選',
+  'property.multiSelect.enabled': '使用者可以選擇多個選項（輸出選擇清單）',
+  'property.multiSelect.disabled': '使用者選擇一個選項（分支到相應節點）',
+  'property.aiSuggestions': 'AI建議選項',
+  'property.aiSuggestions.enabled': 'AI將根據上下文動態生成選項',
+  'property.aiSuggestions.disabled': '在下方手動定義選項',
+  'property.options': '選項',
+  'property.optionsCount': '選項（{count}/4）',
+  'property.optionNumber': '選項 {number}',
+  'property.addOption': '+ 新增選項',
+  'property.remove': '刪除',
+  'property.optionLabel.placeholder': '標籤',
+  'property.optionDescription.placeholder': '描述',
+
+  // Prompt properties
+  'property.promptTemplate': '提示範本',
+  'property.promptTemplate.placeholder': '輸入包含{{variables}}的提示範本',
+  'property.promptTemplate.help': '對動態值使用{{variableName}}語法',
+  'property.detectedVariables': '偵測到的變數（{count}）',
+  'property.variablesSubstituted': '變數將在執行時替換',
+
+  // Branch properties
+  'property.branchType': '分支類型',
+  'property.conditional': '條件（雙向）',
+  'property.switch': '切換（多向）',
+  'property.branchType.conditional.help': '2個分支（True/False）',
+  'property.branchType.switch.help': '多個分支（2-N向）',
+  'property.branches': '分支',
+  'property.branchesCount': '分支（{count}）',
+  'property.branchNumber': '分支 {number}',
+  'property.addBranch': '+ 新增分支',
+  'property.branchLabel': '標籤',
+  'property.branchLabel.placeholder': '例如：成功，錯誤',
+  'property.branchCondition': '條件（自然語言）',
+  'property.branchCondition.placeholder': '例如：如果前一個過程成功',
+  'property.minimumBranches': '至少需要2個分支',
+
+  // Default node labels
+  'default.newSubAgent': '新Sub-Agent',
+  'default.enterPrompt': '在此輸入提示',
+  'default.newQuestion': '新問題',
+  'default.option': '選項',
+  'default.firstOption': '第一個選項',
+  'default.secondOption': '第二個選項',
+  'default.newOption': '新選項',
+  'default.newPrompt': '新Prompt',
+  'default.promptTemplate': '在此輸入您的提示範本。\n\n您可以使用{{variableName}}這樣的變數。',
+  'default.branchTrue': 'True',
+  'default.branchTrueCondition': '條件為真時',
+  'default.branchFalse': 'False',
+  'default.branchFalseCondition': '條件為偽時',
+  'default.newBranch': '分支',
+  'default.newCondition': '新條件',
+};

--- a/src/webview/src/main.tsx
+++ b/src/webview/src/main.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { I18nProvider } from './i18n/i18n-context';
 import 'reactflow/dist/style.css';
 import './styles/main.css';
 
@@ -28,6 +29,7 @@ interface VSCodeAPI {
 declare global {
   interface Window {
     acquireVsCodeApi?: () => VSCodeAPI;
+    initialLocale?: string;
   }
 }
 
@@ -57,8 +59,13 @@ if (!rootElement) {
 
 const root = ReactDOM.createRoot(rootElement);
 
+// Get locale from Extension (injected via HTML)
+const locale = window.initialLocale || 'en';
+
 root.render(
   <React.StrictMode>
-    <App />
+    <I18nProvider locale={locale}>
+      <App />
+    </I18nProvider>
   </React.StrictMode>
 );

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -47,7 +47,7 @@ export function serializeWorkflow(
     id: `workflow-${Date.now()}`,
     name: workflowName,
     description: workflowDescription,
-    version: '0.1.1',
+    version: '0.1.2',
     nodes: workflowNodes,
     connections,
     createdAt: new Date(),


### PR DESCRIPTION
## Summary
Added comprehensive multilingual support (i18n) for both the Visual Editor UI and exported workflow files.

## Changes
- ✨ Implemented i18n infrastructure for Extension and Webview
- 🌐 Added translations for 5 languages (EN/JA/KO/ZH-CN/ZH-TW)
- 📝 Translated Export service (slash commands and sub-agents)
- 🎨 Translated Visual Editor UI (Toolbar, NodePalette, PropertyPanel)
- 📚 Updated README.md to document multilingual support
- 🔢 Bumped version to 0.1.2

## Supported Languages
- English (default)
- Japanese
- Korean
- Simplified Chinese (zh-CN)
- Traditional Chinese (zh-TW/zh-HK)

## How It Works
The extension automatically detects VSCode's display language setting (`vscode.env.language`) and adapts both the UI and exported files accordingly.

## Test Plan
- [x] Build succeeds without errors
- [x] Extension compiles successfully
- [x] Webview builds successfully
- [x] All translation keys are type-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)