### PR TITLE
feat: 初回ユーザー向けインタラクティブツアー機能を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio",
-  "version": "1.0.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio",
-      "version": "1.0.0",
+      "version": "0.1.4",
       "devDependencies": {
         "@biomejs/biome": "^1.4.1",
         "@types/node": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code SlashCommands and Sub-Agents",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "breaking-break",
   "icon": "resources/icon.png",
   "repository": {

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -63,6 +63,25 @@ export function registerOpenEditorCommand(
     // Set webview HTML content
     currentPanel.webview.html = getWebviewContent(currentPanel.webview, context.extensionUri);
 
+    // Check if this is the first launch and send initial state
+    const hasLaunchedBefore = context.globalState.get<boolean>('hasLaunchedBefore', false);
+    if (!hasLaunchedBefore) {
+      // Mark as launched
+      context.globalState.update('hasLaunchedBefore', true);
+    }
+
+    // Send initial state to webview after a short delay to ensure webview is ready
+    setTimeout(() => {
+      if (currentPanel) {
+        currentPanel.webview.postMessage({
+          type: 'INITIAL_STATE',
+          payload: {
+            isFirstLaunch: !hasLaunchedBefore,
+          },
+        });
+      }
+    }, 500);
+
     // Handle messages from webview
     currentPanel.webview.onDidReceiveMessage(
       async (message: WebviewMessage) => {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -52,6 +52,10 @@ export interface WorkflowListPayload {
   }>;
 }
 
+export interface InitialStatePayload {
+  isFirstLaunch: boolean;
+}
+
 // ============================================================================
 // Webview → Extension Payloads
 // ============================================================================
@@ -89,7 +93,8 @@ export type ExtensionMessage =
   | Message<SaveSuccessPayload, 'SAVE_SUCCESS'>
   | Message<ExportSuccessPayload, 'EXPORT_SUCCESS'>
   | Message<ErrorPayload, 'ERROR'>
-  | Message<WorkflowListPayload, 'WORKFLOW_LIST_LOADED'>;
+  | Message<WorkflowListPayload, 'WORKFLOW_LIST_LOADED'>
+  | Message<InitialStatePayload, 'INITIAL_STATE'>;
 
 // ============================================================================
 // Webview → Extension Messages

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "1.0.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "1.0.0",
+      "version": "0.1.4",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-joyride": "^2.9.3",
         "reactflow": "^11.10.0",
         "zustand": "^4.4.0"
       },
@@ -54,6 +55,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -695,6 +697,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
+      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==",
+      "license": "MIT"
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -1543,15 +1551,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
-      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1652,6 +1659,7 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -1776,6 +1784,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -1892,7 +1901,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -1952,6 +1960,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2018,6 +2027,12 @@
         }
       }
     },
+    "node_modules/deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -2029,6 +2044,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/diff-sequences": {
@@ -2278,6 +2302,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-lite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-1.2.1.tgz",
+      "integrity": "sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -2536,6 +2566,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -2634,6 +2673,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -2678,6 +2728,23 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2704,6 +2771,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2716,6 +2784,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2724,11 +2793,89 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-floater": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+      "integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "is-lite": "^0.8.2",
+        "popper.js": "^1.16.0",
+        "prop-types": "^15.8.1",
+        "tree-changes": "^0.9.1"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA==",
+      "license": "MIT"
+    },
+    "node_modules/react-floater/node_modules/is-lite": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+      "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
+      "license": "MIT"
+    },
+    "node_modules/react-floater/node_modules/tree-changes": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+      "integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.1.1",
+        "is-lite": "^0.8.2"
+      }
+    },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.9.3.tgz",
+      "integrity": "sha512-1+Mg34XK5zaqJ63eeBhqdbk7dlGCFp36FXwsEvgpjqrtyywX2C6h9vr3jgxP0bGHCw8Ilsp/nRDzNVq6HJ3rNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "deep-diff": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "is-lite": "^1.2.1",
+        "react-floater": "^0.7.9",
+        "react-innertext": "^1.1.5",
+        "react-is": "^16.13.1",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "tree-changes": "^0.11.2",
+        "type-fest": "^4.27.0"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-joyride/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -2844,6 +2991,18 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3020,6 +3179,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/tree-changes": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.11.3.tgz",
+      "integrity": "sha512-r14mvDZ6tqz8PRQmlFKjhUVngu4VZ9d92ON3tp0EGpFBE6PAHOq8Bx8m8ahbNoGE3uI/npjYcJiqVydyOiYXag==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "is-lite": "^1.2.1"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -3028,6 +3197,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3097,6 +3278,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3180,6 +3362,7 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-joyride": "^2.9.3",
     "reactflow": "^11.10.0",
     "zustand": "^4.4.0"
   },

--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -124,6 +124,7 @@ export const NodePalette: React.FC = () => {
       <button
         type="button"
         onClick={handleAddPromptNode}
+        data-tour="add-prompt-button"
         style={{
           width: '100%',
           padding: '12px',
@@ -162,6 +163,7 @@ export const NodePalette: React.FC = () => {
       <button
         type="button"
         onClick={handleAddSubAgent}
+        data-tour="add-subagent-button"
         style={{
           width: '100%',
           padding: '12px',
@@ -253,6 +255,7 @@ export const NodePalette: React.FC = () => {
       <button
         type="button"
         onClick={handleAddAskUserQuestion}
+        data-tour="add-askuserquestion-button"
         style={{
           width: '100%',
           padding: '12px',

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -19,6 +19,7 @@ import { useWorkflowStore } from '../stores/workflow-store';
 
 interface ToolbarProps {
   onError: (error: { code: string; message: string; details?: unknown }) => void;
+  onStartTour: () => void;
 }
 
 interface WorkflowListItem {
@@ -28,7 +29,7 @@ interface WorkflowListItem {
   updatedAt: string;
 }
 
-export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
+export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour }) => {
   const { t } = useTranslation();
   const { nodes, edges, setNodes, setEdges } = useWorkflowStore();
   const [workflowName, setWorkflowName] = useState('my-workflow');
@@ -195,6 +196,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
         onChange={(e) => setWorkflowName(e.target.value)}
         placeholder={t('toolbar.workflowNamePlaceholder')}
         className="nodrag"
+        data-tour="workflow-name-input"
         style={{
           flex: 1,
           padding: '4px 8px',
@@ -211,6 +213,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
         type="button"
         onClick={handleSave}
         disabled={isSaving}
+        data-tour="save-button"
         style={{
           padding: '4px 12px',
           backgroundColor: 'var(--vscode-button-background)',
@@ -231,6 +234,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
         type="button"
         onClick={handleExport}
         disabled={isExporting}
+        data-tour="export-button"
         style={{
           padding: '4px 12px',
           backgroundColor: 'var(--vscode-button-secondaryBackground)',
@@ -316,6 +320,34 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError }) => {
         }}
       >
         ↻
+      </button>
+
+      {/* Divider */}
+      <div
+        style={{
+          width: '1px',
+          height: '20px',
+          backgroundColor: 'var(--vscode-panel-border)',
+        }}
+      />
+
+      {/* Help Button */}
+      <button
+        type="button"
+        onClick={onStartTour}
+        title="Start Tour"
+        data-tour="help-button"
+        style={{
+          padding: '4px 8px',
+          backgroundColor: 'var(--vscode-button-secondaryBackground)',
+          color: 'var(--vscode-button-secondaryForeground)',
+          border: 'none',
+          borderRadius: '2px',
+          cursor: 'pointer',
+          fontSize: '13px',
+        }}
+      >
+        ?
       </button>
     </div>
   );

--- a/src/webview/src/components/Tour.tsx
+++ b/src/webview/src/components/Tour.tsx
@@ -1,0 +1,60 @@
+/**
+ * Claude Code Workflow Studio - Interactive Tour Component
+ *
+ * Provides a guided tour for first-time users using react-joyride
+ */
+
+import type React from 'react';
+import { useCallback } from 'react';
+import Joyride, { type CallBackProps, EVENTS, STATUS } from 'react-joyride';
+import { getTourLocale, getTourSteps, tourStyles } from '../constants/tour-steps';
+import { useTranslation } from '../i18n/i18n-context';
+
+interface TourProps {
+  run: boolean;
+  onFinish: () => void;
+}
+
+/**
+ * Tour Component
+ *
+ * Displays an interactive overlay tour that guides users through the application
+ */
+export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
+  const { t } = useTranslation();
+
+  const handleJoyrideCallback = useCallback(
+    (data: CallBackProps) => {
+      const { status, type } = data;
+
+      // Tour finished or skipped
+      if (([STATUS.FINISHED, STATUS.SKIPPED] as string[]).includes(status)) {
+        onFinish();
+      }
+
+      // Handle tour close event
+      if (type === EVENTS.TOUR_END || type === EVENTS.STEP_AFTER) {
+        // Optional: Add analytics or state updates here
+      }
+    },
+    [onFinish]
+  );
+
+  return (
+    <Joyride
+      steps={getTourSteps((key) => t(key as keyof typeof t))}
+      run={run}
+      continuous
+      showProgress
+      showSkipButton
+      spotlightPadding={10}
+      disableOverlayClose
+      disableCloseOnEsc={false}
+      scrollToFirstStep
+      scrollOffset={100}
+      styles={tourStyles}
+      locale={getTourLocale((key) => t(key as keyof typeof t))}
+      callback={handleJoyrideCallback}
+    />
+  );
+};

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -1,0 +1,123 @@
+/**
+ * Claude Code Workflow Studio - Tour Steps Definition
+ *
+ * Defines interactive tour steps for first-time users
+ */
+
+import type { Step } from 'react-joyride';
+
+/**
+ * Tour steps configuration
+ * Each step guides users through creating their first workflow
+ */
+export const getTourSteps = (t: (key: string) => string): Step[] => [
+  {
+    target: 'body',
+    content: t('tour.welcome'),
+    placement: 'center',
+    disableBeacon: true,
+  },
+  {
+    target: '.node-palette',
+    content: t('tour.nodePalette'),
+    placement: 'right',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="add-prompt-button"]',
+    content: t('tour.addPrompt'),
+    placement: 'right',
+    disableBeacon: true,
+  },
+  {
+    target: '.react-flow',
+    content: t('tour.canvas'),
+    placement: 'center',
+    disableBeacon: true,
+  },
+  {
+    target: '.property-panel',
+    content: t('tour.propertyPanel'),
+    placement: 'left',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="add-askuserquestion-button"]',
+    content: t('tour.addAskUserQuestion'),
+    placement: 'right',
+    disableBeacon: true,
+  },
+  {
+    target: '.react-flow',
+    content: t('tour.connectNodes'),
+    placement: 'center',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="workflow-name-input"]',
+    content: t('tour.workflowName'),
+    placement: 'bottom',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="save-button"]',
+    content: t('tour.saveWorkflow'),
+    placement: 'bottom',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="export-button"]',
+    content: t('tour.exportWorkflow'),
+    placement: 'bottom',
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour="help-button"]',
+    content: t('tour.helpButton'),
+    placement: 'bottom',
+    disableBeacon: true,
+  },
+];
+
+/**
+ * Tour styles configuration
+ */
+export const tourStyles = {
+  options: {
+    arrowColor: '#fff',
+    backgroundColor: '#fff',
+    overlayColor: 'rgba(0, 0, 0, 0.5)',
+    primaryColor: '#007acc',
+    textColor: '#333',
+    zIndex: 10000,
+  },
+  tooltip: {
+    fontSize: 14,
+    padding: 20,
+  },
+  buttonNext: {
+    backgroundColor: '#007acc',
+    fontSize: 14,
+    padding: '8px 16px',
+  },
+  buttonBack: {
+    color: '#007acc',
+    fontSize: 14,
+    marginRight: 10,
+  },
+  buttonSkip: {
+    color: '#999',
+    fontSize: 14,
+  },
+};
+
+/**
+ * Tour locale configuration
+ */
+export const getTourLocale = (t: (key: string) => string) => ({
+  back: t('tour.button.back'),
+  close: t('tour.button.close'),
+  last: t('tour.button.finish'),
+  next: t('tour.button.next'),
+  skip: t('tour.button.skip'),
+});

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -129,4 +129,24 @@ export interface WebviewTranslationKeys {
   'default.branchFalseCondition': string;
   'default.newBranch': string;
   'default.newCondition': string;
+
+  // Tour
+  'tour.welcome': string;
+  'tour.nodePalette': string;
+  'tour.addPrompt': string;
+  'tour.canvas': string;
+  'tour.propertyPanel': string;
+  'tour.addAskUserQuestion': string;
+  'tour.connectNodes': string;
+  'tour.workflowName': string;
+  'tour.saveWorkflow': string;
+  'tour.exportWorkflow': string;
+  'tour.helpButton': string;
+
+  // Tour buttons
+  'tour.button.back': string;
+  'tour.button.close': string;
+  'tour.button.finish': string;
+  'tour.button.next': string;
+  'tour.button.skip': string;
 }

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -134,4 +134,35 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'default.branchFalseCondition': 'When condition is false',
   'default.newBranch': 'Branch',
   'default.newCondition': 'New condition',
+
+  // Tour
+  'tour.welcome':
+    'Welcome to Claude Code Workflow Studio!\n\nThis tour will guide you through creating your first workflow.',
+  'tour.nodePalette':
+    'The Node Palette contains various nodes you can use in your workflow.\n\nClick on Prompt, Sub-Agent, AskUserQuestion, Branch, and other nodes to add them to the canvas.',
+  'tour.addPrompt':
+    'Click the "Prompt" button to add your first node.\n\nA Prompt node is a template that supports variables and is the basic building block of workflows.',
+  'tour.canvas':
+    'This is the canvas. Drag nodes to adjust their position and drag handles to connect nodes.\n\nStart and End nodes are already placed.',
+  'tour.propertyPanel':
+    'The Property Panel lets you configure the selected node.\n\nYou can edit node name, prompt, model selection, and more.',
+  'tour.addAskUserQuestion':
+    'Now add an "AskUserQuestion" node.\n\nThis node lets you branch the workflow based on user selection.',
+  'tour.connectNodes':
+    'Connect nodes to create your workflow.\n\nDrag from the output handle (⚪) on the right of a node to the input handle on the left of another node.',
+  'tour.workflowName':
+    'Name your workflow.\n\nYou can use letters, numbers, hyphens, and underscores.',
+  'tour.saveWorkflow':
+    'Click the "Save" button to save your workflow as JSON in the `.vscode/workflows/` directory.\n\nYou can load and continue editing later.',
+  'tour.exportWorkflow':
+    'Click the "Export" button to export in a format executable by Claude Code.\n\nSub-Agents go to `.claude/agents/` and SlashCommands to `.claude/commands/`.',
+  'tour.helpButton':
+    'To see this tour again, click the help button (?).\n\nEnjoy creating workflows!',
+
+  // Tour buttons
+  'tour.button.back': 'Back',
+  'tour.button.close': 'Close',
+  'tour.button.finish': 'Finish',
+  'tour.button.next': 'Next',
+  'tour.button.skip': 'Skip',
 };

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -134,4 +134,35 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'default.branchFalseCondition': '条件が偽の場合',
   'default.newBranch': '分岐',
   'default.newCondition': '新しい条件',
+
+  // Tour
+  'tour.welcome':
+    'Claude Code Workflow Studioへようこそ！\n\nこのツアーでは、初めてのワークフロー作成を通じて、基本的な使い方をご案内します。',
+  'tour.nodePalette':
+    'ノードパレットには、ワークフローで使用できる様々なノードが用意されています。\n\nPrompt、Sub-Agent、AskUserQuestion、Branchなどのノードをクリックしてキャンバスに追加できます。',
+  'tour.addPrompt':
+    '「Prompt」ボタンをクリックして、最初のノードを追加してみましょう。\n\nPromptノードは変数を使用できるテンプレートで、ワークフローの基本的な構成要素です。',
+  'tour.canvas':
+    'ここがキャンバスです。ノードをドラッグして配置を調整し、ハンドルをドラッグしてノード間を接続できます。\n\n既にStartノードとEndノードが配置されています。',
+  'tour.propertyPanel':
+    'プロパティパネルでは、選択したノードの詳細設定を行います。\n\nノード名、プロンプト、モデル選択などを編集できます。',
+  'tour.addAskUserQuestion':
+    '次に「AskUserQuestion」ノードを追加してみましょう。\n\nこのノードを使うと、ユーザーの選択に応じてワークフローを分岐できます。',
+  'tour.connectNodes':
+    'ノードを接続してワークフローを作りましょう。\n\nノードの右側の出力ハンドル(⚪)を別のノードの左側の入力ハンドルにドラッグして接続します。',
+  'tour.workflowName':
+    'ワークフローに名前を付けます。\n\n英数字、ハイフン、アンダースコアが使用できます。',
+  'tour.saveWorkflow':
+    '「保存」ボタンをクリックすると、ワークフローが`.vscode/workflows/`ディレクトリにJSON形式で保存されます。\n\n後で読み込んで編集を続けることができます。',
+  'tour.exportWorkflow':
+    '「エクスポート」ボタンをクリックすると、Claude Codeで実行可能な形式にエクスポートされます。\n\nSub-Agentは`.claude/agents/`に、SlashCommandは`.claude/commands/`に出力されます。',
+  'tour.helpButton':
+    'このツアーをもう一度見たい場合は、ヘルプボタン(?)をクリックしてください。\n\nそれでは、ワークフロー作成を楽しんでください！',
+
+  // Tour buttons
+  'tour.button.back': '戻る',
+  'tour.button.close': '閉じる',
+  'tour.button.finish': '完了',
+  'tour.button.next': '次へ',
+  'tour.button.skip': 'スキップ',
 };

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -134,4 +134,35 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'default.branchFalseCondition': '조건이 거짓일 때',
   'default.newBranch': '분기',
   'default.newCondition': '새 조건',
+
+  // Tour
+  'tour.welcome':
+    'Claude Code Workflow Studio에 오신 것을 환영합니다!\n\n이 투어는 첫 워크플로우 생성 방법을 안내합니다.',
+  'tour.nodePalette':
+    '노드 팔레트에는 워크플로우에서 사용할 수 있는 다양한 노드가 있습니다.\n\nPrompt, Sub-Agent, AskUserQuestion, Branch 등의 노드를 클릭하여 캔버스에 추가할 수 있습니다.',
+  'tour.addPrompt':
+    '"Prompt" 버튼을 클릭하여 첫 번째 노드를 추가하세요.\n\nPrompt 노드는 변수를 지원하는 템플릿으로 워크플로우의 기본 구성 요소입니다.',
+  'tour.canvas':
+    '여기가 캔버스입니다. 노드를 드래그하여 위치를 조정하고 핸들을 드래그하여 노드를 연결할 수 있습니다.\n\n시작 및 종료 노드가 이미 배치되어 있습니다.',
+  'tour.propertyPanel':
+    '속성 패널에서 선택한 노드를 구성할 수 있습니다.\n\n노드 이름, 프롬프트, 모델 선택 등을 편집할 수 있습니다.',
+  'tour.addAskUserQuestion':
+    '이제 "AskUserQuestion" 노드를 추가하세요.\n\n이 노드를 사용하면 사용자 선택에 따라 워크플로우를 분기할 수 있습니다.',
+  'tour.connectNodes':
+    '노드를 연결하여 워크플로우를 만드세요.\n\n노드 오른쪽의 출력 핸들(⚪)에서 다른 노드 왼쪽의 입력 핸들로 드래그하세요.',
+  'tour.workflowName':
+    '워크플로우에 이름을 지정하세요.\n\n문자, 숫자, 하이픈 및 밑줄을 사용할 수 있습니다.',
+  'tour.saveWorkflow':
+    '"저장" 버튼을 클릭하면 워크플로우가 `.vscode/workflows/` 디렉터리에 JSON으로 저장됩니다.\n\n나중에 로드하여 계속 편집할 수 있습니다.',
+  'tour.exportWorkflow':
+    '"내보내기" 버튼을 클릭하면 Claude Code에서 실행 가능한 형식으로 내보내집니다.\n\nSub-Agent는 `.claude/agents/`로, SlashCommand는 `.claude/commands/`로 이동합니다.',
+  'tour.helpButton':
+    '이 투어를 다시 보려면 도움말 버튼(?)을 클릭하세요.\n\n워크플로우 생성을 즐기세요!',
+
+  // Tour buttons
+  'tour.button.back': '뒤로',
+  'tour.button.close': '닫기',
+  'tour.button.finish': '완료',
+  'tour.button.next': '다음',
+  'tour.button.skip': '건너뛰기',
 };

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -131,4 +131,31 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'default.branchFalseCondition': '条件为假时',
   'default.newBranch': '分支',
   'default.newCondition': '新条件',
+
+  // Tour
+  'tour.welcome': '欢迎使用Claude Code Workflow Studio！\n\n本导览将指导您创建第一个工作流。',
+  'tour.nodePalette':
+    '节点面板包含可在工作流中使用的各种节点。\n\n点击Prompt、Sub-Agent、AskUserQuestion、Branch等节点将其添加到画布。',
+  'tour.addPrompt': '点击"Prompt"按钮添加第一个节点。\n\nPrompt节点是支持变量的模板，是工作流的基本构建块。',
+  'tour.canvas':
+    '这是画布。拖动节点调整位置，拖动手柄连接节点。\n\n已经放置了开始和结束节点。',
+  'tour.propertyPanel':
+    '属性面板可以配置所选节点。\n\n您可以编辑节点名称、提示、模型选择等。',
+  'tour.addAskUserQuestion':
+    '现在添加"AskUserQuestion"节点。\n\n此节点允许根据用户选择分支工作流。',
+  'tour.connectNodes':
+    '连接节点以创建工作流。\n\n从节点右侧的输出手柄(⚪)拖动到另一个节点左侧的输入手柄。',
+  'tour.workflowName': '为工作流命名。\n\n可以使用字母、数字、连字符和下划线。',
+  'tour.saveWorkflow':
+    '点击"保存"按钮将工作流以JSON格式保存到`.vscode/workflows/`目录。\n\n稍后可以加载并继续编辑。',
+  'tour.exportWorkflow':
+    '点击"导出"按钮以Claude Code可执行的格式导出。\n\nSub-Agent导出到`.claude/agents/`，SlashCommand导出到`.claude/commands/`。',
+  'tour.helpButton': '要再次查看此导览，请点击帮助按钮(?)。\n\n享受创建工作流的乐趣！',
+
+  // Tour buttons
+  'tour.button.back': '返回',
+  'tour.button.close': '关闭',
+  'tour.button.finish': '完成',
+  'tour.button.next': '下一步',
+  'tour.button.skip': '跳过',
 };

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -131,4 +131,31 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'default.branchFalseCondition': '條件為偽時',
   'default.newBranch': '分支',
   'default.newCondition': '新條件',
+
+  // Tour
+  'tour.welcome': '歡迎使用Claude Code Workflow Studio！\n\n本導覽將指導您建立第一個工作流程。',
+  'tour.nodePalette':
+    '節點面板包含可在工作流程中使用的各種節點。\n\n點擊Prompt、Sub-Agent、AskUserQuestion、Branch等節點將其新增到畫布。',
+  'tour.addPrompt': '點擊「Prompt」按鈕新增第一個節點。\n\nPrompt節點是支援變數的範本，是工作流程的基本建置區塊。',
+  'tour.canvas':
+    '這是畫布。拖曳節點調整位置，拖曳手柄連接節點。\n\n已經放置了開始和結束節點。',
+  'tour.propertyPanel':
+    '屬性面板可以設定所選節點。\n\n您可以編輯節點名稱、提示、模型選擇等。',
+  'tour.addAskUserQuestion':
+    '現在新增「AskUserQuestion」節點。\n\n此節點允許根據使用者選擇分支工作流程。',
+  'tour.connectNodes':
+    '連接節點以建立工作流程。\n\n從節點右側的輸出手柄(⚪)拖曳到另一個節點左側的輸入手柄。',
+  'tour.workflowName': '為工作流程命名。\n\n可以使用字母、數字、連字號和底線。',
+  'tour.saveWorkflow':
+    '點擊「儲存」按鈕將工作流程以JSON格式儲存到`.vscode/workflows/`目錄。\n\n稍後可以載入並繼續編輯。',
+  'tour.exportWorkflow':
+    '點擊「匯出」按鈕以Claude Code可執行的格式匯出。\n\nSub-Agent匯出到`.claude/agents/`，SlashCommand匯出到`.claude/commands/`。',
+  'tour.helpButton': '要再次檢視此導覽，請點擊說明按鈕(?)。\n\n享受建立工作流程的樂趣！',
+
+  // Tour buttons
+  'tour.button.back': '返回',
+  'tour.button.close': '關閉',
+  'tour.button.finish': '完成',
+  'tour.button.next': '下一步',
+  'tour.button.skip': '略過',
 };

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -47,7 +47,7 @@ export function serializeWorkflow(
     id: `workflow-${Date.now()}`,
     name: workflowName,
     description: workflowDescription,
-    version: '0.1.4',
+    version: '0.1.5',
     nodes: workflowNodes,
     connections,
     createdAt: new Date(),


### PR DESCRIPTION
## 概要

初回ユーザー向けのインタラクティブなツアー機能を実装しました。

## 主な変更内容

### 🎯 実装した機能

- **オーバーレイ型ツアー**: react-joyrideを使用した視覚的なガイド
- **初回起動時の自動表示**: 初めて拡張機能を開いた際に自動的にツアーが開始
- **11ステップのガイド**: ワークフロー作成の基本を段階的に案内
  1. ウェルカムメッセージ
  2. ノードパレットの説明
  3. Promptノードの追加（初心者向けに最適）
  4. キャンバスの使い方
  5. プロパティパネルの説明
  6. AskUserQuestionノードの追加
  7. ノード接続方法
  8. ワークフロー名の入力
  9. 保存機能
  10. エクスポート機能
  11. ヘルプボタンの説明
- **ヘルプボタン（?）**: ツールバーに追加、いつでもツアーを再起動可能
- **完全多言語対応**: 5言語対応（日本語・英語・韓国語・中国語簡体字・繁体字）

### 📁 変更ファイル

**新規作成:**
- `src/webview/src/components/Tour.tsx` - Tourコンポーネント
- `src/webview/src/constants/tour-steps.ts` - ツアーステップ定義

**変更:**
- `src/extension/commands/open-editor.ts` - 初回起動判定機能
- `src/webview/src/App.tsx` - Tourコンポーネントの統合
- `src/webview/src/components/Toolbar.tsx` - ヘルプボタン追加
- `src/webview/src/components/NodePalette.tsx` - data-tour属性追加
- `src/webview/src/i18n/**/*.ts` - 全言語の翻訳ファイル更新
- `package.json` - react-joyride依存関係追加

### 🔧 技術スタック

- **react-joyride**: オーバーレイ型ツアーライブラリ
- **ExtensionContext.globalState**: 初回起動判定
- **既存のi18nシステム**: 翻訳の統合

## テスト方法

1. F5キーで拡張機能をデバッグモードで起動
2. コマンドパレットから「Claude Code Workflow Studio: Open Editor」を実行
3. 初回起動時にツアーが自動的に開始されることを確認
4. ツールバーの「?」ボタンからツアーを再起動できることを確認
5. VSCodeの表示言語を変更してツアーが適切な言語で表示されることを確認

## スクリーンショット

（必要に応じて追加予定）

## チェックリスト

- [x] コードはビルドが通る
- [x] 既存の機能に影響を与えない
- [x] 多言語対応が完了している
- [x] 初回起動時にツアーが自動表示される
- [x] ヘルプボタンからツアーを再起動できる

## 関連Issue

N/A（新機能追加）

🤖 Generated with Claude Code