### PR TITLE
feat: add node deletion functionality with confirmation dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code SlashCommands and Sub-Agents",
-  "version": "0.3.0",
-  "publisher": "breaking-break",
+  "version": "0.3.1",
+  "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {
     "type": "git",

--- a/src/extension/commands/export-workflow.ts
+++ b/src/extension/commands/export-workflow.ts
@@ -14,6 +14,7 @@ import {
   validateClaudeFileFormat,
 } from '../services/export-service';
 import type { FileService } from '../services/file-service';
+import { validateAIGeneratedWorkflow } from '../utils/validate-workflow';
 
 /**
  * Export workflow to .claude format
@@ -30,6 +31,13 @@ export async function handleExportWorkflow(
   requestId?: string
 ): Promise<void> {
   try {
+    // Validate workflow structure before export
+    const validationResult = validateAIGeneratedWorkflow(payload.workflow);
+    if (!validationResult.valid) {
+      const errorMessages = validationResult.errors.map((err) => err.message).join('\n');
+      throw new Error(`Workflow validation failed:\n${errorMessages}`);
+    }
+
     // Check if files already exist (unless overwrite is confirmed)
     if (!payload.overwriteExisting) {
       const existingFiles = await checkExistingFiles(payload.workflow, fileService);

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "0.1.4",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "0.1.4",
+      "version": "0.3.1",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -14,8 +14,13 @@ import { PropertyPanel } from './components/PropertyPanel';
 import { Toolbar } from './components/Toolbar';
 import { Tour } from './components/Tour';
 import { WorkflowEditor } from './components/WorkflowEditor';
+import { ConfirmDialog } from './components/dialogs/ConfirmDialog';
+import { useTranslation } from './i18n/i18n-context';
+import { useWorkflowStore } from './stores/workflow-store';
 
 const App: React.FC = () => {
+  const { t } = useTranslation();
+  const { pendingDeleteNodeIds, confirmDeleteNodes, cancelDeleteNodes } = useWorkflowStore();
   const [error, setError] = useState<ErrorPayload | null>(null);
   const [runTour, setRunTour] = useState(false);
   const [tourKey, setTourKey] = useState(0); // Used to force Tour component remount
@@ -98,6 +103,17 @@ const App: React.FC = () => {
 
       {/* Interactive Tour */}
       <Tour key={tourKey} run={runTour} onFinish={handleTourFinish} />
+
+      {/* Delete Confirmation Dialog for Delete key */}
+      <ConfirmDialog
+        isOpen={pendingDeleteNodeIds.length > 0}
+        title={t('dialog.deleteNode.title')}
+        message={t('dialog.deleteNode.message')}
+        confirmLabel={t('dialog.deleteNode.confirm')}
+        cancelLabel={t('dialog.deleteNode.cancel')}
+        onConfirm={confirmDeleteNodes}
+        onCancel={cancelDeleteNodes}
+      />
     </div>
   );
 };

--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -14,13 +14,53 @@ import { useWorkflowStore } from '../stores/workflow-store';
  */
 export const NodePalette: React.FC = () => {
   const { t } = useTranslation();
-  const { addNode } = useWorkflowStore();
+  const { addNode, nodes } = useWorkflowStore();
+
+  /**
+   * 既存のノードと重ならない位置を計算する
+   * @param defaultX デフォルトのX座標
+   * @param defaultY デフォルトのY座標
+   * @returns 重複しない位置 {x, y}
+   */
+  const calculateNonOverlappingPosition = (
+    defaultX: number,
+    defaultY: number
+  ): { x: number; y: number } => {
+    let newX = defaultX;
+    let newY = defaultY;
+    const OVERLAP_THRESHOLD = 50; // 50px以内なら重複と判定
+    const OFFSET_X = 100; // 重複時の右オフセット
+    const OFFSET_Y = 80; // 重複時の下オフセット
+    const MAX_ATTEMPTS = 20; // 最大試行回数
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      // 現在の位置と重複するノードがあるかチェック
+      const hasOverlap = nodes.some((node) => {
+        const dx = Math.abs(node.position.x - newX);
+        const dy = Math.abs(node.position.y - newY);
+        return dx < OVERLAP_THRESHOLD && dy < OVERLAP_THRESHOLD;
+      });
+
+      if (!hasOverlap) {
+        // 重複がなければこの位置を返す
+        return { x: newX, y: newY };
+      }
+
+      // 重複があれば斜め下にオフセット
+      newX += OFFSET_X;
+      newY += OFFSET_Y;
+    }
+
+    // 最大試行回数に達した場合でも最後の位置を返す
+    return { x: newX, y: newY };
+  };
 
   const handleAddSubAgent = () => {
+    const position = calculateNonOverlappingPosition(250, 100);
     const newNode = {
       id: `agent-${Date.now()}`,
       type: 'subAgent' as const,
-      position: { x: 250, y: 100 },
+      position,
       data: {
         description: t('default.newSubAgent'),
         prompt: t('default.enterPrompt'),
@@ -32,10 +72,11 @@ export const NodePalette: React.FC = () => {
   };
 
   const handleAddAskUserQuestion = () => {
+    const position = calculateNonOverlappingPosition(250, 300);
     const newNode = {
       id: `question-${Date.now()}`,
       type: 'askUserQuestion' as const,
-      position: { x: 250, y: 300 },
+      position,
       data: {
         questionText: t('default.newQuestion'),
         options: [
@@ -49,10 +90,11 @@ export const NodePalette: React.FC = () => {
   };
 
   const handleAddPromptNode = () => {
+    const position = calculateNonOverlappingPosition(350, 200);
     const newNode = {
       id: `prompt-${Date.now()}`,
       type: 'prompt' as const,
-      position: { x: 350, y: 200 },
+      position,
       data: {
         label: t('default.newPrompt'),
         prompt: t('default.promptTemplate'),
@@ -62,11 +104,25 @@ export const NodePalette: React.FC = () => {
     addNode(newNode);
   };
 
+  const handleAddEndNode = () => {
+    const position = calculateNonOverlappingPosition(600, 200);
+    const newNode = {
+      id: `end-${Date.now()}`,
+      type: 'end' as const,
+      position,
+      data: {
+        label: 'End',
+      },
+    };
+    addNode(newNode);
+  };
+
   const handleAddBranch = () => {
+    const position = calculateNonOverlappingPosition(250, 250);
     const newNode = {
       id: `branch-${Date.now()}`,
       type: 'branch' as const,
-      position: { x: 250, y: 250 },
+      position,
       data: {
         branchType: 'conditional' as const,
         branches: [
@@ -80,10 +136,11 @@ export const NodePalette: React.FC = () => {
   };
 
   const handleAddIfElse = () => {
+    const position = calculateNonOverlappingPosition(250, 250);
     const newNode = {
       id: `ifelse-${Date.now()}`,
       type: 'ifElse' as const,
-      position: { x: 250, y: 250 },
+      position,
       data: {
         evaluationTarget: '',
         branches: [
@@ -97,10 +154,11 @@ export const NodePalette: React.FC = () => {
   };
 
   const handleAddSwitch = () => {
+    const position = calculateNonOverlappingPosition(250, 280);
     const newNode = {
       id: `switch-${Date.now()}`,
       type: 'switch' as const,
-      position: { x: 250, y: 280 },
+      position,
       data: {
         evaluationTarget: '',
         branches: [
@@ -360,6 +418,45 @@ export const NodePalette: React.FC = () => {
           }}
         >
           {t('node.askUserQuestion.description')}
+        </div>
+      </button>
+
+      {/* End Node Button */}
+      <button
+        type="button"
+        onClick={handleAddEndNode}
+        data-tour="add-end-button"
+        style={{
+          width: '100%',
+          padding: '12px',
+          marginBottom: '12px',
+          backgroundColor: 'var(--vscode-button-background)',
+          color: 'var(--vscode-button-foreground)',
+          border: '1px solid var(--vscode-button-border)',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          fontSize: '13px',
+          fontWeight: 500,
+          textAlign: 'left',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+        }}
+      >
+        <div style={{ fontWeight: 600 }}>{t('node.end.title')}</div>
+        <div
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+          }}
+        >
+          {t('node.end.description')}
         </div>
       </button>
 

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -66,9 +66,19 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour }) => {
       await saveWorkflow(workflow);
       console.log('Workflow saved successfully:', workflowName);
     } catch (error) {
+      // Translate error messages
+      let errorMessage = t('toolbar.error.validationFailed');
+      if (error instanceof Error) {
+        if (error.message.includes('at least one End node')) {
+          errorMessage = t('toolbar.error.missingEndNode');
+        } else {
+          errorMessage = error.message;
+        }
+      }
+
       onError({
         code: 'VALIDATION_ERROR',
-        message: error instanceof Error ? error.message : t('toolbar.error.validationFailed'),
+        message: errorMessage,
         details: error,
       });
     } finally {
@@ -163,9 +173,19 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour }) => {
         payload: { workflow },
       });
     } catch (error) {
+      // Translate error messages
+      let errorMessage = t('toolbar.error.validationFailed');
+      if (error instanceof Error) {
+        if (error.message.includes('at least one End node')) {
+          errorMessage = t('toolbar.error.missingEndNode');
+        } else {
+          errorMessage = error.message;
+        }
+      }
+
       onError({
         code: 'VALIDATION_ERROR',
-        message: error instanceof Error ? error.message : t('toolbar.error.validationFailed'),
+        message: errorMessage,
         details: error,
       });
       setIsExporting(false);

--- a/src/webview/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/webview/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,167 @@
+/**
+ * ConfirmDialog Component
+ *
+ * シンプルな確認ダイアログコンポーネント
+ */
+
+import type React from 'react';
+import { useEffect, useRef } from 'react';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * 確認ダイアログコンポーネント
+ */
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // ダイアログが開いたときに自動的にフォーカス
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 9999,
+      }}
+      onClick={onCancel}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          onCancel();
+        }
+      }}
+      aria-label="Close dialog overlay"
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        style={{
+          backgroundColor: 'var(--vscode-editor-background)',
+          border: '1px solid var(--vscode-panel-border)',
+          borderRadius: '4px',
+          padding: '24px',
+          minWidth: '400px',
+          maxWidth: '600px',
+          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+          outline: 'none',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        aria-labelledby="dialog-title"
+      >
+        {/* Title */}
+        <div
+          id="dialog-title"
+          style={{
+            fontSize: '16px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '16px',
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Message */}
+        <div
+          style={{
+            fontSize: '13px',
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: '24px',
+            lineHeight: '1.5',
+          }}
+        >
+          {message}
+        </div>
+
+        {/* Buttons */}
+        <div
+          style={{
+            display: 'flex',
+            gap: '8px',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{
+              padding: '6px 16px',
+              backgroundColor: 'var(--vscode-button-secondaryBackground)',
+              color: 'var(--vscode-button-secondaryForeground)',
+              border: 'none',
+              borderRadius: '2px',
+              cursor: 'pointer',
+              fontSize: '13px',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor =
+                'var(--vscode-button-secondaryHoverBackground)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryBackground)';
+            }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            style={{
+              padding: '6px 16px',
+              backgroundColor: 'var(--vscode-errorForeground)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '2px',
+              cursor: 'pointer',
+              fontSize: '13px',
+              fontWeight: 500,
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.opacity = '0.9';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.opacity = '1';
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/src/webview/src/components/nodes/AskUserQuestionNode.tsx
+++ b/src/webview/src/components/nodes/AskUserQuestionNode.tsx
@@ -8,6 +8,7 @@
 import type { AskUserQuestionData } from '@shared/types/workflow-definition';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * AskUserQuestionNode Component
@@ -25,6 +26,7 @@ export const AskUserQuestionNodeComponent: React.FC<NodeProps<AskUserQuestionDat
       <div
         className={`ask-user-question-node ${selected ? 'selected' : ''}`}
         style={{
+          position: 'relative',
           padding: '12px',
           borderRadius: '8px',
           border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
@@ -33,6 +35,8 @@ export const AskUserQuestionNodeComponent: React.FC<NodeProps<AskUserQuestionDat
           maxWidth: '300px',
         }}
       >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/src/webview/src/components/nodes/BranchNode.tsx
+++ b/src/webview/src/components/nodes/BranchNode.tsx
@@ -7,6 +7,7 @@
 import type { BranchNodeData } from '@shared/types/workflow-definition';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * BranchNode Component
@@ -26,6 +27,7 @@ export const BranchNodeComponent: React.FC<NodeProps<BranchNodeData>> = React.me
       <div
         className={`branch-node ${selected ? 'selected' : ''}`}
         style={{
+          position: 'relative',
           padding: '12px',
           borderRadius: '8px',
           border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
@@ -34,6 +36,8 @@ export const BranchNodeComponent: React.FC<NodeProps<BranchNodeData>> = React.me
           maxWidth: '300px',
         }}
       >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/src/webview/src/components/nodes/DeleteButton.tsx
+++ b/src/webview/src/components/nodes/DeleteButton.tsx
@@ -1,0 +1,83 @@
+/**
+ * DeleteButton Component
+ *
+ * ノード削除ボタンコンポーネント
+ * ノードが選択されている時のみ表示される
+ */
+
+import type React from 'react';
+import { useWorkflowStore } from '../../stores/workflow-store';
+
+interface DeleteButtonProps {
+  nodeId: string;
+  selected: boolean;
+}
+
+/**
+ * 削除ボタンコンポーネント
+ *
+ * @param nodeId - 削除対象のノードID
+ * @param selected - ノードが選択されているかどうか
+ */
+export const DeleteButton: React.FC<DeleteButtonProps> = ({ nodeId, selected }) => {
+  const { requestDeleteNode } = useWorkflowStore();
+
+  if (!selected) {
+    return null;
+  }
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // ノードの選択イベントを防ぐ
+    requestDeleteNode(nodeId);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleButtonClick}
+      className="nodrag nopan" // ReactFlowのドラッグ・パンを無効化
+      style={{
+        position: 'absolute',
+        top: '2px',
+        right: '2px',
+        width: '18px',
+        height: '18px',
+        borderRadius: '3px',
+        backgroundColor: 'var(--vscode-errorForeground)',
+        color: 'white',
+        border: 'none',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '14px',
+        fontWeight: 'bold',
+        padding: 0,
+        zIndex: 10,
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.backgroundColor = 'var(--vscode-errorForeground)';
+        e.currentTarget.style.opacity = '0.8';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.opacity = '1';
+      }}
+      title="Delete node"
+    >
+      <svg
+        width="8"
+        height="8"
+        viewBox="0 0 8 8"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ display: 'block' }}
+        aria-labelledby="delete-icon-title"
+      >
+        <title id="delete-icon-title">Delete</title>
+        <path d="M1 1L7 7M7 1L1 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </button>
+  );
+};
+
+export default DeleteButton;

--- a/src/webview/src/components/nodes/EndNode.tsx
+++ b/src/webview/src/components/nodes/EndNode.tsx
@@ -14,6 +14,7 @@
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import type { EndNodeData } from '../../types/node-types';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * EndNodeコンポーネント
@@ -21,13 +22,14 @@ import type { EndNodeData } from '../../types/node-types';
  * @param data - ノードデータ（label: カスタムラベル）
  * @param selected - ノードが選択されているかどうか
  */
-export const EndNode: React.FC<NodeProps<EndNodeData>> = React.memo(({ data, selected }) => {
+export const EndNode: React.FC<NodeProps<EndNodeData>> = React.memo(({ id, data, selected }) => {
   // ラベルのデフォルト値
   const label = data.label || 'End';
 
   return (
     <div
       style={{
+        position: 'relative',
         padding: '12px',
         borderRadius: '8px',
         border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : '#ef4444'}`,
@@ -35,6 +37,9 @@ export const EndNode: React.FC<NodeProps<EndNodeData>> = React.memo(({ data, sel
         minWidth: '120px',
       }}
     >
+      {/* Delete Button */}
+      <DeleteButton nodeId={id} selected={selected} />
+
       {/* Node Header */}
       <div
         style={{

--- a/src/webview/src/components/nodes/IfElseNode.tsx
+++ b/src/webview/src/components/nodes/IfElseNode.tsx
@@ -8,6 +8,7 @@
 import type { IfElseNodeData } from '@shared/types/workflow-definition';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * IfElseNode Component
@@ -28,6 +29,7 @@ export const IfElseNodeComponent: React.FC<NodeProps<IfElseNodeData>> = React.me
       <div
         className={`ifelse-node ${selected ? 'selected' : ''}`}
         style={{
+          position: 'relative',
           padding: '12px',
           borderRadius: '8px',
           border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
@@ -36,6 +38,8 @@ export const IfElseNodeComponent: React.FC<NodeProps<IfElseNodeData>> = React.me
           maxWidth: '280px',
         }}
       >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/src/webview/src/components/nodes/PromptNode.tsx
+++ b/src/webview/src/components/nodes/PromptNode.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import type { PromptNodeData } from '../../types/node-types';
 import { extractVariables } from '../../utils/template-utils';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * PromptNodeコンポーネント
@@ -22,120 +23,125 @@ import { extractVariables } from '../../utils/template-utils';
  * @param data - ノードデータ（label, prompt, variables）
  * @param selected - ノードが選択されているかどうか
  */
-export const PromptNode: React.FC<NodeProps<PromptNodeData>> = React.memo(({ data, selected }) => {
-  // ラベルのデフォルト値
-  const label = data.label || 'Prompt';
+export const PromptNode: React.FC<NodeProps<PromptNodeData>> = React.memo(
+  ({ id, data, selected }) => {
+    // ラベルのデフォルト値
+    const label = data.label || 'Prompt';
 
-  // プロンプトから変数を抽出
-  const variables = extractVariables(data.prompt);
+    // プロンプトから変数を抽出
+    const variables = extractVariables(data.prompt);
 
-  // プロンプトのプレビュー（最初の100文字）
-  const previewText =
-    data.prompt.length > 100 ? `${data.prompt.substring(0, 100)}...` : data.prompt;
+    // プロンプトのプレビュー（最初の100文字）
+    const previewText =
+      data.prompt.length > 100 ? `${data.prompt.substring(0, 100)}...` : data.prompt;
 
-  return (
-    <div
-      style={{
-        padding: '12px',
-        borderRadius: '8px',
-        border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : '#3b82f6'}`,
-        backgroundColor: 'var(--vscode-editor-background)',
-        minWidth: '200px',
-        maxWidth: '300px',
-      }}
-    >
-      {/* Node Header */}
+    return (
       <div
         style={{
-          fontSize: '11px',
-          fontWeight: 600,
-          color: 'var(--vscode-descriptionForeground)',
-          marginBottom: '8px',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
+          position: 'relative',
+          padding: '12px',
+          borderRadius: '8px',
+          border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : '#3b82f6'}`,
+          backgroundColor: 'var(--vscode-editor-background)',
+          minWidth: '200px',
+          maxWidth: '300px',
         }}
       >
-        Prompt
-      </div>
-
-      {/* Label */}
-      <div
-        style={{
-          fontSize: '13px',
-          color: 'var(--vscode-foreground)',
-          marginBottom: '8px',
-          fontWeight: 500,
-        }}
-      >
-        {label}
-      </div>
-
-      {/* Prompt Preview */}
-      {data.prompt && (
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
+        {/* Node Header */}
         <div
           style={{
             fontSize: '11px',
+            fontWeight: 600,
             color: 'var(--vscode-descriptionForeground)',
-            backgroundColor: 'var(--vscode-textBlockQuote-background)',
-            border: '1px solid var(--vscode-textBlockQuote-border)',
-            borderRadius: '4px',
-            padding: '8px',
             marginBottom: '8px',
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            maxHeight: '60px',
-            overflow: 'hidden',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
           }}
         >
-          {previewText}
+          Prompt
         </div>
-      )}
 
-      {/* Variables Badge */}
-      {variables.length > 0 && (
+        {/* Label */}
         <div
           style={{
-            fontSize: '10px',
-            color: 'var(--vscode-descriptionForeground)',
-            backgroundColor: 'var(--vscode-badge-background)',
-            padding: '2px 6px',
-            borderRadius: '3px',
-            display: 'inline-block',
+            fontSize: '13px',
+            color: 'var(--vscode-foreground)',
+            marginBottom: '8px',
+            fontWeight: 500,
           }}
         >
-          {variables.length} variable{variables.length !== 1 ? 's' : ''}
+          {label}
         </div>
-      )}
 
-      {/* Input Handle */}
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="in"
-        style={{
-          width: '12px',
-          height: '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          border: '2px solid var(--vscode-button-foreground)',
-        }}
-      />
+        {/* Prompt Preview */}
+        {data.prompt && (
+          <div
+            style={{
+              fontSize: '11px',
+              color: 'var(--vscode-descriptionForeground)',
+              backgroundColor: 'var(--vscode-textBlockQuote-background)',
+              border: '1px solid var(--vscode-textBlockQuote-border)',
+              borderRadius: '4px',
+              padding: '8px',
+              marginBottom: '8px',
+              fontFamily: 'monospace',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              maxHeight: '60px',
+              overflow: 'hidden',
+            }}
+          >
+            {previewText}
+          </div>
+        )}
 
-      {/* Output Handle */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="out"
-        style={{
-          width: '12px',
-          height: '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          border: '2px solid var(--vscode-button-foreground)',
-        }}
-      />
-    </div>
-  );
-});
+        {/* Variables Badge */}
+        {variables.length > 0 && (
+          <div
+            style={{
+              fontSize: '10px',
+              color: 'var(--vscode-descriptionForeground)',
+              backgroundColor: 'var(--vscode-badge-background)',
+              padding: '2px 6px',
+              borderRadius: '3px',
+              display: 'inline-block',
+            }}
+          >
+            {variables.length} variable{variables.length !== 1 ? 's' : ''}
+          </div>
+        )}
+
+        {/* Input Handle */}
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="in"
+          style={{
+            width: '12px',
+            height: '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            border: '2px solid var(--vscode-button-foreground)',
+          }}
+        />
+
+        {/* Output Handle */}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="out"
+          style={{
+            width: '12px',
+            height: '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            border: '2px solid var(--vscode-button-foreground)',
+          }}
+        />
+      </div>
+    );
+  }
+);
 
 PromptNode.displayName = 'PromptNode';
 

--- a/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -8,16 +8,18 @@
 import type { SubAgentData } from '@shared/types/workflow-definition';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * SubAgentNode Component
  */
 export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.memo(
-  ({ data, selected }) => {
+  ({ id, data, selected }) => {
     return (
       <div
         className={`sub-agent-node ${selected ? 'selected' : ''}`}
         style={{
+          position: 'relative',
           padding: '12px',
           borderRadius: '8px',
           border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
@@ -26,6 +28,8 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
           maxWidth: '300px',
         }}
       >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/src/webview/src/components/nodes/SwitchNode.tsx
+++ b/src/webview/src/components/nodes/SwitchNode.tsx
@@ -8,6 +8,7 @@
 import type { SwitchNodeData } from '@shared/types/workflow-definition';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
+import { DeleteButton } from './DeleteButton';
 
 /**
  * SwitchNode Component
@@ -25,6 +26,7 @@ export const SwitchNodeComponent: React.FC<NodeProps<SwitchNodeData>> = React.me
       <div
         className={`switch-node ${selected ? 'selected' : ''}`}
         style={{
+          position: 'relative',
           padding: '12px',
           borderRadius: '8px',
           border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
@@ -33,6 +35,8 @@ export const SwitchNodeComponent: React.FC<NodeProps<SwitchNodeData>> = React.me
           maxWidth: '300px',
         }}
       >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -19,6 +19,7 @@ export interface WebviewTranslationKeys {
   'toolbar.error.workflowNameRequiredForExport': string;
   'toolbar.error.selectWorkflowToLoad': string;
   'toolbar.error.validationFailed': string;
+  'toolbar.error.missingEndNode': string;
 
   // Node Palette
   'palette.title': string;
@@ -31,6 +32,8 @@ export interface WebviewTranslationKeys {
   'node.prompt.description': string;
   'node.subAgent.title': string;
   'node.subAgent.description': string;
+  'node.end.title': string;
+  'node.end.description': string;
   'node.branch.title': string;
   'node.branch.description': string;
   'node.branch.deprecationNotice': string;
@@ -190,4 +193,10 @@ export interface WebviewTranslationKeys {
   'ai.error.parseError': string;
   'ai.error.validationError': string;
   'ai.error.unknown': string;
+
+  // Delete Confirmation Dialog
+  'dialog.deleteNode.title': string;
+  'dialog.deleteNode.message': string;
+  'dialog.deleteNode.confirm': string;
+  'dialog.deleteNode.cancel': string;
 }

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -21,6 +21,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.workflowNameRequiredForExport': 'Workflow name is required for export',
   'toolbar.error.selectWorkflowToLoad': 'Please select a workflow to load',
   'toolbar.error.validationFailed': 'Workflow validation failed',
+  'toolbar.error.missingEndNode': 'Workflow must have at least one End node',
 
   // Node Palette
   'palette.title': 'Node Palette',
@@ -33,6 +34,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'node.prompt.description': 'Template with variables',
   'node.subAgent.title': 'Sub-Agent',
   'node.subAgent.description': 'Execute a specialized task',
+  'node.end.title': 'End',
+  'node.end.description': 'Workflow termination point',
   'node.branch.title': 'Branch',
   'node.branch.description': 'Conditional branching logic',
   'node.branch.deprecationNotice': 'Deprecated. Please migrate to If/Else or Switch nodes',
@@ -81,7 +84,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.startNodeDescription':
     'Start node marks the beginning of the workflow. It cannot be deleted and has no editable properties.',
   'property.endNodeDescription':
-    'End node marks the completion of the workflow. It cannot be deleted and has no editable properties.',
+    'End node marks the completion of the workflow. At least one End node is required for export.',
   'property.unknownNodeType': 'Unknown node type:',
 
   // Sub-Agent properties
@@ -212,4 +215,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'ai.error.parseError': 'Generation failed - please try again or rephrase your description',
   'ai.error.validationError': 'Generated workflow failed validation',
   'ai.error.unknown': 'An unexpected error occurred. Please try again.',
+
+  // Delete Confirmation Dialog
+  'dialog.deleteNode.title': 'Delete Node',
+  'dialog.deleteNode.message': 'Are you sure you want to delete this node?',
+  'dialog.deleteNode.confirm': 'Delete',
+  'dialog.deleteNode.cancel': 'Cancel',
 };

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -21,6 +21,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.workflowNameRequiredForExport': 'エクスポートにはワークフロー名が必要です',
   'toolbar.error.selectWorkflowToLoad': '読み込むワークフローを選択してください',
   'toolbar.error.validationFailed': 'ワークフローの検証に失敗しました',
+  'toolbar.error.missingEndNode': 'ワークフローには最低1つのEndノードが必要です',
 
   // Node Palette
   'palette.title': 'ノードパレット',
@@ -33,6 +34,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'node.prompt.description': '変数を使用できるテンプレート',
   'node.subAgent.title': 'Sub-Agent',
   'node.subAgent.description': '専門タスクを実行',
+  'node.end.title': 'End',
+  'node.end.description': 'ワークフロー終了地点',
   'node.branch.title': 'Branch',
   'node.branch.description': '条件分岐ロジック',
   'node.branch.deprecationNotice': '廃止予定。If/ElseまたはSwitchノードへの移行を推奨します',
@@ -81,7 +84,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.startNodeDescription':
     'Startノードはワークフローの開始地点です。削除できず、編集可能なプロパティはありません。',
   'property.endNodeDescription':
-    'Endノードはワークフローの終了地点です。削除できず、編集可能なプロパティはありません。',
+    'Endノードはワークフローの終了地点です。編集可能なプロパティはありません。エクスポート時に最低1つのEndノードが必要です。',
   'property.unknownNodeType': '不明なノードタイプ:',
 
   // Sub-Agent properties
@@ -213,4 +216,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'ai.error.parseError': '生成に失敗しました - もう一度試すか、説明を言い換えてください',
   'ai.error.validationError': '生成されたワークフローの検証に失敗しました',
   'ai.error.unknown': '予期しないエラーが発生しました。もう一度お試しください。',
+
+  // Delete Confirmation Dialog
+  'dialog.deleteNode.title': 'ノードを削除',
+  'dialog.deleteNode.message': 'このノードを削除してもよろしいですか？',
+  'dialog.deleteNode.confirm': '削除',
+  'dialog.deleteNode.cancel': 'キャンセル',
 };

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -21,6 +21,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.workflowNameRequiredForExport': '내보내기에는 워크플로 이름이 필요합니다',
   'toolbar.error.selectWorkflowToLoad': '불러올 워크플로를 선택하세요',
   'toolbar.error.validationFailed': '워크플로 검증에 실패했습니다',
+  'toolbar.error.missingEndNode': '워크플로에는 최소 1개의 End 노드가 필요합니다',
 
   // Node Palette
   'palette.title': '노드 팔레트',
@@ -33,6 +34,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'node.prompt.description': '변수가 있는 템플릿',
   'node.subAgent.title': 'Sub-Agent',
   'node.subAgent.description': '전문 작업 실행',
+  'node.end.title': 'End',
+  'node.end.description': '워크플로 종료 지점',
   'node.branch.title': 'Branch',
   'node.branch.description': '조건 분기 로직',
   'node.branch.deprecationNotice':
@@ -213,4 +216,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'ai.error.parseError': '생성에 실패했습니다 - 다시 시도하거나 설명을 다시 작성하세요',
   'ai.error.validationError': '생성된 워크플로 검증에 실패했습니다',
   'ai.error.unknown': '예기치 않은 오류가 발생했습니다. 다시 시도하세요.',
+
+  // Delete Confirmation Dialog
+  'dialog.deleteNode.title': '노드 삭제',
+  'dialog.deleteNode.message': '이 노드를 삭제하시겠습니까?',
+  'dialog.deleteNode.confirm': '삭제',
+  'dialog.deleteNode.cancel': '취소',
 };

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -21,6 +21,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.workflowNameRequiredForExport': '导出需要工作流名称',
   'toolbar.error.selectWorkflowToLoad': '请选择要加载的工作流',
   'toolbar.error.validationFailed': '工作流验证失败',
+  'toolbar.error.missingEndNode': '工作流必须至少包含一个End节点',
 
   // Node Palette
   'palette.title': '节点面板',
@@ -33,6 +34,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'node.prompt.description': '带变量的模板',
   'node.subAgent.title': 'Sub-Agent',
   'node.subAgent.description': '执行专门任务',
+  'node.end.title': 'End',
+  'node.end.description': '工作流结束点',
   'node.branch.title': 'Branch',
   'node.branch.description': '条件分支逻辑',
   'node.branch.deprecationNotice': '已弃用。请迁移到If/Else或Switch节点',
@@ -200,4 +203,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'ai.error.parseError': '生成失败 - 请重试或重新表述您的描述',
   'ai.error.validationError': '生成的工作流验证失败',
   'ai.error.unknown': '发生意外错误。请重试。',
+
+  // Delete Confirmation Dialog
+  'dialog.deleteNode.title': '删除节点',
+  'dialog.deleteNode.message': '确定要删除此节点吗？',
+  'dialog.deleteNode.confirm': '删除',
+  'dialog.deleteNode.cancel': '取消',
 };

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -21,6 +21,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.workflowNameRequiredForExport': '匯出需要工作流名稱',
   'toolbar.error.selectWorkflowToLoad': '請選擇要載入的工作流',
   'toolbar.error.validationFailed': '工作流驗證失敗',
+  'toolbar.error.missingEndNode': '工作流必須至少包含一個End節點',
 
   // Node Palette
   'palette.title': '節點面板',
@@ -33,6 +34,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'node.prompt.description': '帶變數的範本',
   'node.subAgent.title': 'Sub-Agent',
   'node.subAgent.description': '執行專門任務',
+  'node.end.title': 'End',
+  'node.end.description': '工作流程結束點',
   'node.branch.title': 'Branch',
   'node.branch.description': '條件分支邏輯',
   'node.branch.deprecationNotice': '已棄用。請遷移到If/Else或Switch節點',
@@ -200,4 +203,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'ai.error.parseError': '產生失敗 - 請重試或重新表述您的描述',
   'ai.error.validationError': '產生的工作流驗證失敗',
   'ai.error.unknown': '發生意外錯誤。請重試。',
+
+  // Delete Confirmation Dialog
+  'dialog.deleteNode.title': '刪除節點',
+  'dialog.deleteNode.message': '確定要刪除此節點嗎？',
+  'dialog.deleteNode.confirm': '刪除',
+  'dialog.deleteNode.cancel': '取消',
 };

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -47,7 +47,7 @@ export function serializeWorkflow(
     id: `workflow-${Date.now()}`,
     name: workflowName,
     description: workflowDescription,
-    version: '0.3.0',
+    version: '0.3.1',
     nodes: workflowNodes,
     connections,
     createdAt: new Date(),
@@ -136,6 +136,22 @@ export function validateWorkflow(workflow: Workflow): void {
   // Validate connections
   for (const connection of workflow.connections) {
     validateConnection(connection, workflow.nodes);
+  }
+
+  // Validate Start/End nodes
+  const startNodes = workflow.nodes.filter((n) => n.type === 'start');
+  const endNodes = workflow.nodes.filter((n) => n.type === 'end');
+
+  if (startNodes.length === 0) {
+    throw new Error('Workflow must have at least one Start node');
+  }
+
+  if (startNodes.length > 1) {
+    throw new Error('Workflow must have exactly one Start node');
+  }
+
+  if (endNodes.length === 0) {
+    throw new Error('Workflow must have at least one End node');
   }
 }
 


### PR DESCRIPTION
## Summary
- ノード選択時に削除ボタン（×）を表示
- DeleteキーまたはXボタンでノード削除時に確認ダイアログを表示
- 確認ダイアログの自動フォーカス機能
- Startノードの削除を防止
- 5言語対応（en, ja, ko, zh-CN, zh-TW）

## 主な変更内容
- `DeleteButton`コンポーネントの追加（8x8 SVGアイコン使用）
- `ConfirmDialog`コンポーネントの追加（自動フォーカス、キーボードナビゲーション対応）
- `workflow-store.ts`に削除確認ロジックを追加（`requestDeleteNode`, `confirmDeleteNodes`, `cancelDeleteNodes`）
- すべてのノードコンポーネント（Start以外）に`DeleteButton`を統合
- 翻訳キーの追加（全5言語）

## Test plan
- [x] ノード選択時に×ボタンが表示される
- [x] ×ボタンクリックで確認ダイアログが表示される
- [x] Deleteキー押下で確認ダイアログが表示される
- [x] 確認ダイアログが自動的にフォーカスされる
- [x] ダイアログがドラッグされない（ReactFlow外に配置）
- [x] Startノードは削除できない
- [x] lint/formatエラーなし

## Version
0.3.0 → 0.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)