### PR TITLE
fix(webview): resolve React dependency conflicts

### DIFF
--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.2",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^19.2.0",
+        "react-dom": "^18.2.0",
         "react-joyride": "^2.9.3",
         "reactflow": "^11.10.0",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
-        "@types/react-dom": "^19.2.2",
+        "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^5.1.0",
         "@vitest/ui": "^4.0.6",
         "typescript": "^5.3.0",
@@ -1749,13 +1749,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
-      "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.2.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2510,15 +2510,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-innertext": {
@@ -2670,10 +2671,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/scroll": {
       "version": "3.0.1",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^19.2.0",
+    "react-dom": "^18.2.0",
     "react-joyride": "^2.9.3",
     "reactflow": "^11.10.0",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
-    "@types/react-dom": "^19.2.2",
+    "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^5.1.0",
     "@vitest/ui": "^4.0.6",
     "typescript": "^5.3.0",


### PR DESCRIPTION
## Summary
- Downgrade react-dom from ^19.2.0 to ^18.2.0
- Downgrade @types/react-dom from ^19.2.2 to ^18.2.0
- Keep react and @types/react at ^18.2.0 for compatibility

## Background
Dependency resolution was failing due to `react-joyride@2.9.3` requiring `react@15-18` and `react-dom@15-18`. The library does not yet support React 19.

## Test Plan
- [x] Dependencies install successfully with `npm install`
- [x] Build completes without errors
- [x] No TypeScript compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)