### PR TITLE
Release v1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code Slash Commands, Sub Agents, and Agent Skills",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -131,5 +131,6 @@ export const getTourLocale = (t: (key: string) => string) => ({
   close: t('tour.button.close'),
   last: t('tour.button.finish'),
   next: t('tour.button.next'),
+  nextLabelWithProgress: t('tour.button.next'), // Used when showProgress is enabled
   skip: t('tour.button.skip'),
 });

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -174,21 +174,21 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Tour
   'tour.welcome':
-    'Welcome to Claude Code Workflow Studio!\n\nThis tour will guide you through creating your first workflow.',
+    "Welcome to Claude Code Workflow Studio!\n\nThis tour will introduce the key features and show you where everything is. Let's get familiar with the basics before creating your first workflow.",
   'tour.nodePalette':
     'The Node Palette contains various nodes you can use in your workflow.\n\nClick on Prompt, Sub-Agent, AskUserQuestion, If/Else, Switch, and other nodes to add them to the canvas.',
   'tour.addPrompt':
-    'Click the "Prompt" button to add your first node.\n\nA Prompt node is a template that supports variables and is the basic building block of workflows.',
+    'This "Prompt" button lets you add Prompt nodes to the canvas.\n\nA Prompt node is a template that supports variables and is the basic building block of workflows.',
   'tour.canvas':
     'This is the canvas. Drag nodes to adjust their position and drag handles to connect nodes.\n\nStart and End nodes are already placed.',
   'tour.propertyPanel':
     'The Property Panel lets you configure the selected node.\n\nYou can edit node name, prompt, model selection, and more.',
   'tour.addAskUserQuestion':
-    'Now add an "AskUserQuestion" node.\n\nThis node lets you branch the workflow based on user selection.',
+    'The "AskUserQuestion" node lets you branch the workflow based on user selection.\n\nYou can add it to the canvas using this button.',
   'tour.connectNodes':
     'Connect nodes to create your workflow.\n\nDrag from the output handle (⚪) on the right of a node to the input handle on the left of another node.',
   'tour.workflowName':
-    'Name your workflow.\n\nYou can use letters, numbers, hyphens, and underscores.',
+    'This is where you name your workflow.\n\nYou can use letters, numbers, hyphens, and underscores.',
   'tour.saveWorkflow':
     'Click the "Save" button to save your workflow as JSON in the `.vscode/workflows/` directory.\n\nYou can load and continue editing later.',
   'tour.loadWorkflow':
@@ -204,7 +204,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.back': 'Back',
   'tour.button.close': 'Close',
   'tour.button.finish': 'Finish',
-  'tour.button.next': 'Next',
+  'tour.button.next': 'Next ({step}/{steps})',
   'tour.button.skip': 'Skip',
 
   // AI Generation Dialog

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -174,21 +174,21 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Tour
   'tour.welcome':
-    'Claude Code Workflow Studioへようこそ！\n\nこのツアーでは、初めてのワークフロー作成を通じて、基本的な使い方をご案内します。',
+    'Claude Code Workflow Studioへようこそ！\n\nこのツアーでは、各機能の場所と役割をご紹介します。基本的な使い方を理解して、ワークフロー作成を始めましょう。',
   'tour.nodePalette':
     'ノードパレットには、ワークフローで使用できる様々なノードが用意されています。\n\nPrompt、Sub-Agent、AskUserQuestion、If/Else、Switchなどのノードをクリックしてキャンバスに追加できます。',
   'tour.addPrompt':
-    '「Prompt」ボタンをクリックして、最初のノードを追加してみましょう。\n\nPromptノードは変数を使用できるテンプレートで、ワークフローの基本的な構成要素です。',
+    'この「Prompt」ボタンから、Promptノードをキャンバスに追加できます。\n\nPromptノードは変数を使用できるテンプレートで、ワークフローの基本的な構成要素です。',
   'tour.canvas':
     'ここがキャンバスです。ノードをドラッグして配置を調整し、ハンドルをドラッグしてノード間を接続できます。\n\n既にStartノードとEndノードが配置されています。',
   'tour.propertyPanel':
     'プロパティパネルでは、選択したノードの詳細設定を行います。\n\nノード名、プロンプト、モデル選択などを編集できます。',
   'tour.addAskUserQuestion':
-    '次に「AskUserQuestion」ノードを追加してみましょう。\n\nこのノードを使うと、ユーザーの選択に応じてワークフローを分岐できます。',
+    '「AskUserQuestion」ノードは、ユーザーの選択に応じてワークフローを分岐させるために使用します。\n\nこのボタンからキャンバスに追加できます。',
   'tour.connectNodes':
     'ノードを接続してワークフローを作りましょう。\n\nノードの右側の出力ハンドル(⚪)を別のノードの左側の入力ハンドルにドラッグして接続します。',
   'tour.workflowName':
-    'ワークフローに名前を付けます。\n\n英数字、ハイフン、アンダースコアが使用できます。',
+    'ここでワークフローに名前を付けることができます。\n\n英数字、ハイフン、アンダースコアが使用できます。',
   'tour.saveWorkflow':
     '「保存」ボタンをクリックすると、ワークフローが`.vscode/workflows/`ディレクトリにJSON形式で保存されます。\n\n後で読み込んで編集を続けることができます。',
   'tour.loadWorkflow':
@@ -204,7 +204,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.back': '戻る',
   'tour.button.close': '閉じる',
   'tour.button.finish': '完了',
-  'tour.button.next': '次へ',
+  'tour.button.next': '次へ ({step}/{steps})',
   'tour.button.skip': 'スキップ',
 
   // AI Generation Dialog

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -176,21 +176,21 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Tour
   'tour.welcome':
-    'Claude Code Workflow Studio에 오신 것을 환영합니다!\n\n이 투어는 첫 워크플로우 생성 방법을 안내합니다.',
+    'Claude Code Workflow Studio에 오신 것을 환영합니다!\n\n이 투어에서는 주요 기능의 위치와 역할을 소개합니다. 첫 워크플로우를 만들기 전에 기본 사항을 익혀보세요.',
   'tour.nodePalette':
     '노드 팔레트에는 워크플로우에서 사용할 수 있는 다양한 노드가 있습니다.\n\nPrompt, Sub-Agent, AskUserQuestion, If/Else, Switch 등의 노드를 클릭하여 캔버스에 추가할 수 있습니다.',
   'tour.addPrompt':
-    '"Prompt" 버튼을 클릭하여 첫 번째 노드를 추가하세요.\n\nPrompt 노드는 변수를 지원하는 템플릿으로 워크플로우의 기본 구성 요소입니다.',
+    '이 "Prompt" 버튼으로 캔버스에 Prompt 노드를 추가할 수 있습니다.\n\nPrompt 노드는 변수를 지원하는 템플릿으로 워크플로우의 기본 구성 요소입니다.',
   'tour.canvas':
     '여기가 캔버스입니다. 노드를 드래그하여 위치를 조정하고 핸들을 드래그하여 노드를 연결할 수 있습니다.\n\n시작 및 종료 노드가 이미 배치되어 있습니다.',
   'tour.propertyPanel':
     '속성 패널에서 선택한 노드를 구성할 수 있습니다.\n\n노드 이름, 프롬프트, 모델 선택 등을 편집할 수 있습니다.',
   'tour.addAskUserQuestion':
-    '이제 "AskUserQuestion" 노드를 추가하세요.\n\n이 노드를 사용하면 사용자 선택에 따라 워크플로우를 분기할 수 있습니다.',
+    '"AskUserQuestion" 노드는 사용자 선택에 따라 워크플로우를 분기하는 데 사용됩니다.\n\n이 버튼으로 캔버스에 추가할 수 있습니다.',
   'tour.connectNodes':
     '노드를 연결하여 워크플로우를 만드세요.\n\n노드 오른쪽의 출력 핸들(⚪)에서 다른 노드 왼쪽의 입력 핸들로 드래그하세요.',
   'tour.workflowName':
-    '워크플로우에 이름을 지정하세요.\n\n문자, 숫자, 하이픈 및 밑줄을 사용할 수 있습니다.',
+    '여기에서 워크플로우에 이름을 지정할 수 있습니다.\n\n문자, 숫자, 하이픈 및 밑줄을 사용할 수 있습니다.',
   'tour.saveWorkflow':
     '"저장" 버튼을 클릭하면 워크플로우가 `.vscode/workflows/` 디렉터리에 JSON으로 저장됩니다.\n\n나중에 로드하여 계속 편집할 수 있습니다.',
   'tour.loadWorkflow':
@@ -206,7 +206,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.back': '뒤로',
   'tour.button.close': '닫기',
   'tour.button.finish': '완료',
-  'tour.button.next': '다음',
+  'tour.button.next': '다음 ({step}/{steps})',
   'tour.button.skip': '건너뛰기',
 
   // AI Generation Dialog

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -170,18 +170,19 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' 时',
 
   // Tour
-  'tour.welcome': '欢迎使用Claude Code Workflow Studio！\n\n本导览将指导您创建第一个工作流。',
+  'tour.welcome':
+    '欢迎使用Claude Code Workflow Studio！\n\n本导览将介绍主要功能的位置和作用。在创建第一个工作流之前，让我们先熟悉基础知识。',
   'tour.nodePalette':
     '节点面板包含可在工作流中使用的各种节点。\n\n点击Prompt、Sub-Agent、AskUserQuestion、If/Else、Switch等节点将其添加到画布。',
   'tour.addPrompt':
-    '点击"Prompt"按钮添加第一个节点。\n\nPrompt节点是支持变量的模板，是工作流的基本构建块。',
+    '这个"Prompt"按钮可以将Prompt节点添加到画布。\n\nPrompt节点是支持变量的模板，是工作流的基本构建块。',
   'tour.canvas': '这是画布。拖动节点调整位置，拖动手柄连接节点。\n\n已经放置了开始和结束节点。',
   'tour.propertyPanel': '属性面板可以配置所选节点。\n\n您可以编辑节点名称、提示、模型选择等。',
   'tour.addAskUserQuestion':
-    '现在添加"AskUserQuestion"节点。\n\n此节点允许根据用户选择分支工作流。',
+    '"AskUserQuestion"节点用于根据用户选择分支工作流。\n\n可以使用此按钮将其添加到画布。',
   'tour.connectNodes':
     '连接节点以创建工作流。\n\n从节点右侧的输出手柄(⚪)拖动到另一个节点左侧的输入手柄。',
-  'tour.workflowName': '为工作流命名。\n\n可以使用字母、数字、连字符和下划线。',
+  'tour.workflowName': '在这里可以为工作流命名。\n\n可以使用字母、数字、连字符和下划线。',
   'tour.saveWorkflow':
     '点击"保存"按钮将工作流以JSON格式保存到`.vscode/workflows/`目录。\n\n稍后可以加载并继续编辑。',
   'tour.loadWorkflow': '要加载已保存的工作流，请从下拉菜单中选择工作流并点击"加载"按钮。',
@@ -195,7 +196,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.back': '返回',
   'tour.button.close': '关闭',
   'tour.button.finish': '完成',
-  'tour.button.next': '下一步',
+  'tour.button.next': '下一步 ({step}/{steps})',
   'tour.button.skip': '跳过',
 
   // AI Generation Dialog

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -170,18 +170,19 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' 時',
 
   // Tour
-  'tour.welcome': '歡迎使用Claude Code Workflow Studio！\n\n本導覽將指導您建立第一個工作流程。',
+  'tour.welcome':
+    '歡迎使用Claude Code Workflow Studio！\n\n本導覽將介紹主要功能的位置和作用。在建立第一個工作流程之前，讓我們先熟悉基礎知識。',
   'tour.nodePalette':
     '節點面板包含可在工作流程中使用的各種節點。\n\n點擊Prompt、Sub-Agent、AskUserQuestion、If/Else、Switch等節點將其新增到畫布。',
   'tour.addPrompt':
-    '點擊「Prompt」按鈕新增第一個節點。\n\nPrompt節點是支援變數的範本，是工作流程的基本建置區塊。',
+    '這個「Prompt」按鈕可以將Prompt節點新增到畫布。\n\nPrompt節點是支援變數的範本，是工作流程的基本建置區塊。',
   'tour.canvas': '這是畫布。拖曳節點調整位置，拖曳手柄連接節點。\n\n已經放置了開始和結束節點。',
   'tour.propertyPanel': '屬性面板可以設定所選節點。\n\n您可以編輯節點名稱、提示、模型選擇等。',
   'tour.addAskUserQuestion':
-    '現在新增「AskUserQuestion」節點。\n\n此節點允許根據使用者選擇分支工作流程。',
+    '「AskUserQuestion」節點用於根據使用者選擇分支工作流程。\n\n可以使用此按鈕將其新增到畫布。',
   'tour.connectNodes':
     '連接節點以建立工作流程。\n\n從節點右側的輸出手柄(⚪)拖曳到另一個節點左側的輸入手柄。',
-  'tour.workflowName': '為工作流程命名。\n\n可以使用字母、數字、連字號和底線。',
+  'tour.workflowName': '在這裡可以為工作流程命名。\n\n可以使用字母、數字、連字號和底線。',
   'tour.saveWorkflow':
     '點擊「儲存」按鈕將工作流程以JSON格式儲存到`.vscode/workflows/`目錄。\n\n稍後可以載入並繼續編輯。',
   'tour.loadWorkflow': '要載入已儲存的工作流程，請從下拉選單中選擇工作流程並點擊「載入」按鈕。',
@@ -195,7 +196,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.back': '返回',
   'tour.button.close': '關閉',
   'tour.button.finish': '完成',
-  'tour.button.next': '下一步',
+  'tour.button.next': '下一步 ({step}/{steps})',
   'tour.button.skip': '略過',
 
   // AI Generation Dialog

--- a/src/webview/vite.config.ts
+++ b/src/webview/vite.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
     // Target modern browsers (VSCode uses Electron)
     target: 'esnext',
     minify: 'esbuild',
+    // Increase chunk size warning limit to 1000 kB (VSCode extension context)
+    chunkSizeWarningLimit: 1000,
   },
   // Resolve configuration
   resolve: {


### PR DESCRIPTION
## リリース v1.0.5

オンボーディングツアーの改善とビルド警告の修正を含むリリースです。

## 主な変更内容

### 🎨 オンボーディングツアーの改善
- ツアー文言を「初めてのワークフロー作成」から「基本機能紹介」に修正
- ユーザーの期待と実際の動作を一致させるため、説明スタイルに統一
- 全5言語対応（en, ja, ko, zh-CN, zh-TW）

### 📊 ステップ進捗表示の改善
- "Step 10 of 13" → "10/13" 形式に変更
- より簡潔で自然な表記に統一
- react-joyrideの`nextLabelWithProgress`キーで対応

### 🔧 ビルド最適化
- Viteのチャンクサイズ警告閾値を1000kBに調整
- ビルド時の不要な警告を抑制

## バージョン
- **1.0.4** → **1.0.5**

## 更新ファイル
- package.json
- src/webview/package.json
- src/webview/package-lock.json
- src/webview/vite.config.ts
- src/webview/src/constants/tour-steps.ts
- 翻訳ファイル5言語分

## マージされたPR
- #34: オンボーディングツアーの文言とステップ表記を改善

## テスト
- ✅ ビルド成功（警告なし）
- ✅ 翻訳ファイルの一貫性確認
- ✅ オンボーディングツアーの動作確認

## コミット
- cab808c: Merge PR #34
- 72d1757: bump version to 1.0.5
- 47fd44e: Viteチャンクサイズ警告閾値調整
- 3673298: オンボーディングツアー改善