### PR TITLE
Release v2.0.1: ClaudeCode CLI実行ディレクトリ修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code Slash Commands, Sub Agents, and Agent Skills",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {

--- a/src/extension/commands/ai-generation.ts
+++ b/src/extension/commands/ai-generation.ts
@@ -31,12 +31,14 @@ import { validateAIGeneratedWorkflow } from '../utils/validate-workflow';
  * @param webview - The webview to send response messages to
  * @param extensionPath - The extension's root path
  * @param requestId - The request ID for correlation
+ * @param workspaceRoot - The workspace root path for CLI execution
  */
 export async function handleGenerateWorkflow(
   payload: GenerateWorkflowPayload,
   webview: vscode.Webview,
   extensionPath: string,
-  requestId: string
+  requestId: string,
+  workspaceRoot?: string
 ): Promise<void> {
   const startTime = Date.now();
 
@@ -99,7 +101,7 @@ export async function handleGenerateWorkflow(
 
     // Step 3: Execute Claude Code CLI (pass requestId for cancellation support)
     const timeout = payload.timeoutMs ?? 60000;
-    const cliResult = await executeClaudeCodeCLI(prompt, timeout, requestId);
+    const cliResult = await executeClaudeCodeCLI(prompt, timeout, requestId, workspaceRoot);
 
     if (!cliResult.success || !cliResult.output) {
       // CLI execution failed

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -166,11 +166,13 @@ export function registerOpenEditorCommand(
           case 'GENERATE_WORKFLOW':
             // AI-assisted workflow generation
             if (message.payload) {
+              const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
               await handleGenerateWorkflow(
                 message.payload,
                 webview,
                 context.extensionPath,
-                message.requestId || ''
+                message.requestId || '',
+                workspaceRoot
               );
             } else {
               webview.postMessage({
@@ -256,11 +258,13 @@ export function registerOpenEditorCommand(
           case 'REFINE_WORKFLOW':
             // AI-assisted workflow refinement
             if (message.payload) {
+              const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
               await handleRefineWorkflow(
                 message.payload,
                 webview,
                 message.requestId || '',
-                context.extensionPath
+                context.extensionPath,
+                workspaceRoot
               );
             } else {
               webview.postMessage({

--- a/src/extension/commands/workflow-refinement.ts
+++ b/src/extension/commands/workflow-refinement.ts
@@ -27,12 +27,14 @@ import { refineWorkflow } from '../services/refinement-service';
  * @param webview - Webview to send response messages to
  * @param requestId - Request ID for correlation
  * @param extensionPath - VSCode extension path for schema loading
+ * @param workspaceRoot - The workspace root path for CLI execution
  */
 export async function handleRefineWorkflow(
   payload: RefineWorkflowPayload,
   webview: vscode.Webview,
   requestId: string,
-  extensionPath: string
+  extensionPath: string,
+  workspaceRoot?: string
 ): Promise<void> {
   const {
     workflowId,
@@ -82,7 +84,8 @@ export async function handleRefineWorkflow(
       extensionPath,
       useSkills,
       timeoutMs,
-      requestId
+      requestId,
+      workspaceRoot
     );
 
     if (!result.success || !result.refinedWorkflow) {

--- a/src/extension/services/refinement-service.ts
+++ b/src/extension/services/refinement-service.ts
@@ -144,6 +144,7 @@ const MAX_REFINEMENT_TIMEOUT_MS = 90000;
  * @param useSkills - Whether to include skills in refinement (default: true)
  * @param timeoutMs - Timeout in milliseconds (default: 90000)
  * @param requestId - Optional request ID for cancellation support
+ * @param workspaceRoot - The workspace root path for CLI execution
  * @returns Refinement result with success status and refined workflow or error
  */
 export async function refineWorkflow(
@@ -153,7 +154,8 @@ export async function refineWorkflow(
   extensionPath: string,
   useSkills = true,
   timeoutMs = MAX_REFINEMENT_TIMEOUT_MS,
-  requestId?: string
+  requestId?: string,
+  workspaceRoot?: string
 ): Promise<RefinementResult> {
   const startTime = Date.now();
 
@@ -253,7 +255,7 @@ export async function refineWorkflow(
     );
 
     // Step 4: Execute Claude Code CLI
-    const cliResult = await executeClaudeCodeCLI(prompt, timeoutMs, requestId);
+    const cliResult = await executeClaudeCodeCLI(prompt, timeoutMs, requestId, workspaceRoot);
 
     if (!cliResult.success || !cliResult.output) {
       // CLI execution failed

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -301,7 +301,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton.tooltip': 'Clear conversation history and start fresh',
   'refinement.chat.useSkillsCheckbox': 'Include Skills',
   'refinement.chat.claudeMdTip':
-    '💡 Tip: Add workflow-specific rules and constraints to `~/.claude/CLAUDE.md` for more accurate AI edits',
+    '💡 Tip: Add workflow-specific rules and constraints to CLAUDE.md for more accurate AI edits',
   'refinement.chat.refining': 'AI is refining workflow... This may take up to 120 seconds.',
   'refinement.chat.progressTime': '{elapsed}s / {max}s',
   'refinement.chat.characterCount': '{count} / {max} characters',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -300,7 +300,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton.tooltip': '会話履歴をクリアして最初からやり直します',
   'refinement.chat.useSkillsCheckbox': 'Skillを含める',
   'refinement.chat.claudeMdTip':
-    '💡 Tip: ワークフロー固有のルールや制約を`~/.claude/CLAUDE.md` に記載すると、AIがより的確な編集を行えます',
+    '💡 Tip: ワークフロー固有のルールや制約をCLAUDE.mdに記載すると、AIがより的確な編集を行えます',
   'refinement.chat.refining': 'AIがワークフローを改善中... 最大120秒かかる場合があります。',
   'refinement.chat.progressTime': '{elapsed}秒 / {max}秒',
   'refinement.chat.characterCount': '{count} / {max} 文字',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -301,7 +301,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton.tooltip': '대화 기록을 지우고 처음부터 시작합니다',
   'refinement.chat.useSkillsCheckbox': 'Skill 포함',
   'refinement.chat.claudeMdTip':
-    '💡 팁: `~/.claude/CLAUDE.md` 에 워크플로별 규칙과 제약을 추가하면AI가 더 정확한 편집을 수행합니다',
+    '💡 팁: CLAUDE.md 에 워크플로별 규칙과 제약을 추가하면AI가 더 정확한 편집을 수행합니다',
   'refinement.chat.refining': 'AI가 워크플로를 개선하는 중... 최대 120초가 소요될 수 있습니다.',
   'refinement.chat.progressTime': '{elapsed}초 / {max}초',
   'refinement.chat.characterCount': '{count} / {max} 자',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -290,7 +290,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton.tooltip': '清除对话历史记录并重新开始',
   'refinement.chat.useSkillsCheckbox': '包含Skill',
   'refinement.chat.claudeMdTip':
-    '💡 提示：在 `~/.claude/CLAUDE.md` 中添加工作流特定的规则和约束，AI可以进行更准确的编辑',
+    '💡 提示：在 CLAUDE.md 中添加工作流特定的规则和约束，AI可以进行更准确的编辑',
   'refinement.chat.refining': 'AI正在优化工作流... 最多可能需要120秒。',
   'refinement.chat.progressTime': '{elapsed}秒 / {max}秒',
   'refinement.chat.characterCount': '{count} / {max} 字符',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -290,7 +290,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton.tooltip': '清除對話歷史記錄並重新開始',
   'refinement.chat.useSkillsCheckbox': '包含Skill',
   'refinement.chat.claudeMdTip':
-    '💡 提示：在 `~/.claude/CLAUDE.md` 中新增工作流程特定的規則和約束，AI可以進行更準確的編輯',
+    '💡 提示：在 CLAUDE.md 中新增工作流程特定的規則和約束，AI可以進行更準確的編輯',
   'refinement.chat.refining': 'AI正在優化工作流程... 最多可能需要120秒。',
   'refinement.chat.progressTime': '{elapsed}秒 / {max}秒',
   'refinement.chat.characterCount': '{count} / {max} 字元',


### PR DESCRIPTION
## リリース内容

v2.0.1 - ClaudeCode CLI実行ディレクトリ修正

## 主な変更

### 🐛 バグ修正
- **ClaudeCode CLIをワークスペースルートで実行するように修正**
  - 修正前: `claude`コマンドがルートディレクトリ(/)で実行されていた
  - 修正後: ワークスペースルートで実行され、プロジェクト固有のCLAUDE.mdや.gitignoreが正しく参照される

### 🎨 UI改善
- リファインメントパネルのTipメッセージを更新（5言語対応）
  - 修正前: `~/.claude/CLAUDE.md`
  - 修正後: `CLAUDE.md`

## 影響範囲

- AIワークフロー生成機能
- AIワークフロー編集(リファインメント)機能
- リファインメントパネルのTip表示

## 関連PR

- #39 - fix: ClaudeCode CLIをワークスペースルートで実行するように修正

## テスト済み

- [x] AIワークフロー生成が正しいディレクトリで実行される
- [x] AIワークフロー編集が正しいディレクトリで実行される
- [x] ログに正しいcwdが表示される
- [x] UI文言が更新される