### PR TITLE
fix: add missing conventional-changelog-conventionalcommits dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/vscode": "^1.80.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.3.8",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "semantic-release": "^24.2.0",
         "typescript": "^5.3.0"
       },
@@ -1721,6 +1722,19 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
       "integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/vscode": "^1.80.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.3.8",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "semantic-release": "^24.2.0",
     "typescript": "^5.3.0"
   }


### PR DESCRIPTION
## 問題

semantic-releaseの実行時に以下のエラーが発生していました:

```
Error: Cannot find module 'conventional-changelog-conventionalcommits'
```

## 原因

`.releaserc.json` で `"preset": "conventionalcommits"` を指定していましたが、このプリセットに必要な `conventional-changelog-conventionalcommits` パッケージがインストールされていませんでした。

## 修正内容

- `conventional-changelog-conventionalcommits@^8.0.0` を devDependencies に追加
- package-lock.json を更新

## テスト

この修正により、semantic-releaseが正常に動作するようになります。

## 関連

- エラーが発生したPR: #49
- semantic-release公式ドキュメント: https://semantic-release.gitbook.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>