### PR TITLE
fix: sync webview package.json after semantic-release completes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,21 +37,6 @@ jobs:
           cd src/webview
           npm ci
 
-      - name: Build extension
-        run: npm run build
-
-      - name: Package extension
-        run: |
-          npm install -g @vscode/vsce
-          vsce package
-
-      - name: Sync webview package.json version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          cd src/webview
-          npm version $VERSION --no-git-tag-version --allow-same-version
-          npm install
-
       - name: Semantic Release
         id: semantic_release
         env:
@@ -61,6 +46,46 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: npx semantic-release
+
+      - name: Sync webview package.json version
+        if: steps.semantic_release.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the new version from semantic-release
+          NEW_VERSION=$(node -p "require('./package.json').version")
+
+          # Update webview package.json
+          cd src/webview
+          npm version $NEW_VERSION --no-git-tag-version --allow-same-version
+          npm install
+
+          # Commit the webview version sync
+          cd ../..
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/webview/package.json src/webview/package-lock.json
+          git commit --amend --no-edit
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }} --force
+
+      - name: Build extension with new version
+        if: steps.semantic_release.outcome == 'success'
+        run: npm run build
+
+      - name: Package extension with new version
+        if: steps.semantic_release.outcome == 'success'
+        run: |
+          npm install -g @vscode/vsce
+          vsce package
+
+      - name: Upload VSIX to release
+        if: steps.semantic_release.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          VSIX_FILE=$(ls *.vsix)
+          gh release upload "v${NEW_VERSION}" "${VSIX_FILE}" --clobber
 
       - name: Sync version to main branch
         if: github.ref == 'refs/heads/production' && steps.semantic_release.outcome == 'success'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -70,15 +70,7 @@
       }
     ],
     [
-      "@semantic-release/github",
-      {
-        "assets": [
-          {
-            "path": "*.vsix",
-            "label": "VSCode Extension Package"
-          }
-        ]
-      }
+      "@semantic-release/github"
     ]
   ]
 }


### PR DESCRIPTION
## 問題

semantic-releaseの実行後、`package.json` はバージョンアップされますが、`src/webview/package.json` がバージョンアップされていませんでした。

## 原因

現在のワークフローでは、webview のバージョン同期が semantic-release の**前**に実行されていました:

1. webview バージョン同期 (古いバージョンで同期)
2. semantic-release (ルートの package.json のみ更新)
3. webview は古いバージョンのまま

## 修正内容

webview のバージョン同期ステップを semantic-release の**後**に移動しました:

1. semantic-release (ルートの package.json を更新)
2. **webview バージョン同期** (新しいバージョンで同期)
3. `git commit --amend` でリリースコミットに webview の変更を含める
4. force push でリリースコミットを更新

### 変更後のフロー

```yaml
- Semantic Release (package.json → 2.1.0)
- Sync webview version (src/webview/package.json → 2.1.0)
- git commit --amend (リリースコミットに追加)
- git push --force (更新)
```

## テスト

この修正により、次回のリリースから両方の package.json が同じバージョンに更新されます。

## 関連

- CLAUDE.md の Version Update Procedure に記載されている通り、両方の package.json を同時に更新する必要があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>