### PR TITLE
fix: remove main branch from release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - production
-      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
## 問題

現在、リリースワークフローが `production` と `main` の両方のブランチで実行されるようになっています。

これにより、mainブランチへマージするたびにリリースが作成されてしまい、意図しないリリース (v2.1.0, v2.1.1) が作成されました。

## 原因

```yaml
on:
  push:
    branches:
      - production
      - main  # ← これが原因
```

## 修正内容

リリースワークフローのトリガーから `main` ブランチを削除し、**productionブランチのみ**でリリースを実行するようにします。

```yaml
on:
  push:
    branches:
      - production  # productionのみ
```

## 期待される動作

- ✅ main へのマージ: リリースは実行されない
- ✅ production へのマージ: リリースが実行される
- ✅ production → main の自動同期: 正常に動作

## 次のステップ

このPRマージ後:
1. v2.1.0, v2.1.1 のタグとリリースを削除
2. PR #52 を再作成 (v2.0.3 → v2.1.0 として)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>