### PR TITLE
fix: production→main同期でリリースコミットが含まれない問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Fetch latest production branch (after semantic-release created the release commit)
+          git fetch origin production
+
           # Fetch latest main branch
           git fetch origin main:main
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -237,13 +237,16 @@ chore(release): 2.1.0 [skip ci]
 
 productionブランチでリリースが成功した後:
 
-1. mainブランチをフェッチ
-2. mainブランチにチェックアウト
-3. productionブランチの変更をマージ (`chore: sync version from production [skip ci]`)
-4. mainブランチにプッシュ
+1. **productionブランチをフェッチ** (semantic-releaseが作成したリリースコミットを取得)
+2. mainブランチをフェッチ
+3. mainブランチにチェックアウト
+4. productionブランチの変更をマージ (`chore: sync version from production [skip ci]`)
+5. mainブランチにプッシュ
 
 これにより、**mainとproductionの両方が同じバージョン**になります。
 `[skip ci]` により、このマージコミットでCIが再実行されることを防ぎます。
+
+**重要**: semantic-releaseがproductionブランチにリリースコミットを作成した後、必ず `git fetch origin production` を実行してから同期を行います。これにより、ワークフロー開始時にチェックアウトされた古い状態ではなく、最新のリリースコミットが含まれた状態でマージされます。
 
 ## 参考資料
 


### PR DESCRIPTION
## 問題

Semantic Releaseがproductionブランチでリリースコミットを作成した後、mainブランチへの同期が正しく動作していなかった。

### 原因

`Sync version to main branch`ステップで`origin/production`をマージしていたが、このrefはワークフロー開始時にチェックアウトされた古い状態を指していた。semantic-releaseがリリースコミットを作成した**後**の状態が反映されていなかった。

## 修正内容

### .github/workflows/release.yml

semantic-releaseがリリースコミットを作成した後、`git fetch origin production`を実行してから同期を行うように修正:

```yaml
# Fetch latest production branch (after semantic-release created the release commit)
git fetch origin production

# Fetch latest main branch
git fetch origin main:main

# Checkout main and merge production
git checkout main
git merge origin/production --no-edit -m "chore: sync version from production [skip ci]"
```

### docs/release-automation.md

ブランチ同期の仕組みのドキュメントを更新し、productionブランチのフェッチが必要であることを明記。

## テスト方法

1. このPRをmainブランチにマージ
2. mainからproductionへPRを作成してマージ
3. Semantic Release Actionsが動作し、リリースが作成される
4. 自動的にmainブランチにもバージョンが同期されることを確認

## 関連Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)