### PR TITLE
chore: sync version from production (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## [2.1.0](https://github.com/breaking-brake/cc-wf-studio/compare/v2.0.3...v2.1.0) (2025-11-15)
+
+### Features
+
+* add automatic release workflow with semantic-release ([95e08f5](https://github.com/breaking-brake/cc-wf-studio/commit/95e08f57ffbb810c1cfbddd661c8fcbd4b46ab98))
+* add automatic sync from production to main after release ([b0ed08b](https://github.com/breaking-brake/cc-wf-studio/commit/b0ed08bb8116fa59a64b6c8eef412057a30b7f46))
+
+### Bug Fixes
+
+* add missing conventional-changelog-conventionalcommits dependency ([93b5ead](https://github.com/breaking-brake/cc-wf-studio/commit/93b5ead5dbc37dc314a11a01b57e899f2255d0ef))
+* build and package vsix with correct version after semantic-release ([0ce6ca4](https://github.com/breaking-brake/cc-wf-studio/commit/0ce6ca4e39e7c8853fa969ac0ba71af545bc0661))
+* remove main branch from release workflow trigger ([9c878ef](https://github.com/breaking-brake/cc-wf-studio/commit/9c878effc313fd87bcab71eebc873175e44ae6e3))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code Slash Commands, Sub Agents, and Agent Skills",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 概要

productionブランチのv2.1.0リリースをmainブランチに同期します。

## 背景

Semantic Release Actionsが正常に動作してproductionブランチでv2.1.0がリリースされましたが、自動同期の仕組みに不具合があり、mainブランチへの同期が行われませんでした。

この問題はPR #57で修正済みですが、今回のv2.1.0については手動でPRを作成して同期します。

## 変更内容

- `package.json`: version 2.0.3 → 2.1.0
- `src/webview/package.json`: version 2.0.3 → 2.1.0
- `src/webview/package-lock.json`: version同期
- `CHANGELOG.md`: v2.1.0のリリースノート追加

## マージ後の対応

PR #57をマージした後、次回のリリースからは自動的にmainブランチへ同期されるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)