### PR TITLE
fix: README.mdでGitHub Issue番号として誤認識される問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  <em>✨ AI Refinement #1: "Create a workflow that sends a greeting prompt" – Build workflows from scratch with AI</em>
+  <em>✨ AI Refinement (1): "Create a workflow that sends a greeting prompt" – Build workflows from scratch with AI</em>
 </p>
 
 ---
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <em>✨ AI Refinement #2: "Can you modify it to change the greeting based on the current time?" – Refine iteratively through conversation</em>
+  <em>✨ AI Refinement (2): "Can you modify it to change the greeting based on the current time?" – Refine iteratively through conversation</em>
 </p>
 
 ---


### PR DESCRIPTION
## 概要

README.mdのマーケットプレイスページ表示で、`#1`/`#2` がGitHub Issueリンクとして誤認識される問題を修正しました。

## 変更内容

### Before
```markdown
AI Refinement #1: "Create a workflow..."
AI Refinement #2: "Can you modify it..."
```

### After
```markdown
AI Refinement (1): "Create a workflow..."
AI Refinement (2): "Can you modify it..."
```

## 影響範囲

- README.md:26行目 (AI Refinement Demo 1の説明)
- README.md:37行目 (AI Refinement Demo 2の説明)

## 効果

- マーケットプレイスページでIssueリンクとして誤認識されなくなる
- より自然な補足情報の表記に改善
- 可読性の向上

## チェック項目

- [x] README.mdの該当箇所を修正
- [x] 表記が自然であることを確認
- [x] コミットメッセージが適切

🤖 Generated with [Claude Code](https://claude.com/claude-code)