### PR TITLE
docs: add Semantic Release automation guide to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,17 +31,81 @@ npm test && npm run lint
 
 ## Version Update Procedure
 
-When updating the version number, you must update the following files:
+**IMPORTANT: Version updates and releases are fully automated via Semantic Release and GitHub Actions.**
 
-1. **package.json** (root directory)
-   - Update `"version"` field
+### Automated Release Process
 
-2. **src/webview/package.json** (webview directory)
-   - Update `"version"` field
-   - **IMPORTANT**: After updating, run `npm install` in the webview directory to update `package-lock.json`
-   - Command: `cd src/webview && npm install`
+This project uses **Semantic Release** with **GitHub Actions** for fully automated versioning, changelog generation, and publishing.
 
-Both package.json files and the webview's package-lock.json must be committed together for a version update.
+#### Release Workflow (`.github/workflows/release.yml`)
+
+**Trigger**: Push to `production` branch
+
+**Automated Steps**:
+1. **Semantic Release** analyzes commit messages and determines version bump
+2. **Version Update**: Updates `package.json`, `src/webview/package.json`, `src/webview/package-lock.json`
+3. **Changelog Generation**: Automatically updates `CHANGELOG.md`
+4. **Git Commit**: Creates release commit with message `chore(release): ${version} [skip ci]`
+5. **GitHub Release**: Creates GitHub release with release notes
+6. **VSIX Build**: Builds and packages the extension
+7. **VSIX Upload**: Uploads `.vsix` file to GitHub release
+8. **Version Sync**: Merges version changes from `production` to `main` branch
+
+#### Commit Message Convention (Conventional Commits)
+
+The version bump is determined by commit message prefixes:
+
+- `feat:` → **Minor** version bump (e.g., 2.0.0 → 2.1.0)
+- `fix:` → **Patch** version bump (e.g., 2.1.0 → 2.1.1)
+- `perf:` → **Patch** version bump
+- `revert:` → **Patch** version bump
+- **BREAKING CHANGE** in commit body → **Major** version bump (e.g., 2.1.0 → 3.0.0)
+- `docs:`, `style:`, `chore:`, `refactor:`, `test:`, `build:`, `ci:` → No release
+
+**Example commit messages**:
+```bash
+feat: add MCP node integration
+fix: resolve parameter validation issue
+feat!: redesign workflow export format (BREAKING CHANGE)
+```
+
+#### Changelog Sections (`.releaserc.json`)
+
+Generated changelog groups commits by type:
+
+- **Features** (`feat:`)
+- **Bug Fixes** (`fix:`)
+- **Performance Improvements** (`perf:`)
+- **Reverts** (`revert:`)
+- **Code Refactoring** (`refactor:`) - visible
+- **Documentation** (`docs:`) - visible
+- **Styles** (`style:`) - hidden
+- **Tests** (`test:`) - hidden
+- **Build System** (`build:`) - hidden
+- **Continuous Integration** (`ci:`) - hidden
+- **Miscellaneous Chores** (`chore:`) - hidden
+
+#### Automated File Updates
+
+Semantic Release automatically updates:
+- `package.json` (root)
+- `src/webview/package.json`
+- `src/webview/package-lock.json`
+- `CHANGELOG.md`
+
+These files are committed with `[skip ci]` to prevent infinite loops.
+
+#### Manual Version Updates (NOT RECOMMENDED)
+
+**DO NOT manually update version numbers unless absolutely necessary.**
+
+If manual update is required:
+1. Update `package.json` (root directory) - `"version"` field
+2. Update `src/webview/package.json` - `"version"` field
+3. Run `cd src/webview && npm install` to update `package-lock.json`
+4. Commit all three files together
+
+Manual version updates will be overwritten by the next automated release.
 
 ## Code Style
 


### PR DESCRIPTION
## 概要

CLAUDE.mdに自動リリースプロセスの詳細な説明を追加しました。これにより、AIがこのプロジェクトのリリースフローを正しく理解できるようになります。

## 変更内容

### Version Update Procedure セクションを全面改訂

#### 追加した説明

**1. 自動化プロセスの概要**
- Semantic Releaseによる自動バージョニング
- GitHub Actionsのリリースワークフロー
- 完全自動化されていることを明記

**2. Release Workflow 詳細 (`.github/workflows/release.yml`)**
- トリガー: `production`ブランチへのpush
- 8ステップの自動処理フロー:
  1. Semantic Releaseによるバージョン決定
  2. package.json群の自動更新
  3. CHANGELOG.md自動生成
  4. リリースコミット作成
  5. GitHubリリース作成
  6. VSIX自動ビルド
  7. VSIXアップロード
  8. mainブランチへのバージョン同期

**3. Commit Message Convention (Conventional Commits)**
- `feat:` → Minor version bump (2.0.0 → 2.1.0)
- `fix:` → Patch version bump (2.1.0 → 2.1.1)
- `perf:`, `revert:` → Patch version bump
- BREAKING CHANGE → Major version bump (2.1.0 → 3.0.0)
- `docs:`, `style:`, `chore:`, `refactor:`, `test:`, `build:`, `ci:` → リリースなし

**4. Changelog Sections (`.releaserc.json`)**
- 表示セクション: Features, Bug Fixes, Performance, Reverts, Refactoring, Documentation
- 非表示セクション: Styles, Tests, Build, CI, Chores

**5. Automated File Updates**
- 自動更新されるファイルのリスト
- `[skip ci]`によるループ防止の説明

**6. Manual Version Updates (NOT RECOMMENDED)**
- 手動更新は非推奨であることを明記
- 必要な場合の手順
- 次回自動リリースで上書きされる警告

## 目的

AIエージェント（Claude）がこのプロジェクトで作業する際に、以下を認識できるようにする:

✅ **バージョン番号を手動で変更してはいけない**
✅ **CHANGELOG.mdを手動で編集してはいけない**
✅ **Conventional Commitsに従ったコミットメッセージが重要**
✅ **productionブランチへのマージでリリースが自動実行される**

## 影響範囲

- ドキュメントのみの変更
- コード変更なし
- ビルド・テストへの影響なし

## チェックリスト

- [x] CLAUDE.mdに自動化プロセスの詳細を追加
- [x] Conventional Commitsの規約を明記
- [x] 手動更新が非推奨であることを強調
- [x] .releaserc.jsonと.github/workflows/release.ymlの内容を反映