### PR TITLE
chore: bump version to 2.2.0 for MCP Tool Node Integration release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
-## [2.1.1](https://github.com/breaking-brake/cc-wf-studio/compare/v2.1.0...v2.1.1) (2025-11-15)
+## [2.2.0](https://github.com/breaking-brake/cc-wf-studio/compare/v2.0.3...v2.2.0) (2025-11-15)
+
+### Features
+
+* **MCP Tool Node Integration** - Complete implementation of Model Context Protocol tool nodes
+  * MCPサーバー自動検出とツール一覧表示
+  * ツール検索・フィルタリング機能
+  * JSON Schemaベースの動的パラメータフォーム生成（5種類の型対応）
+  * リアルタイムバリデーション
+  * Slash Commandへの完全なエクスポート対応
+  * 5言語対応（en, ja, ko, zh-CN, zh-TW）
 
 ### Bug Fixes
 
 * prevent tag conflict by using @semantic-release/exec for webview sync ([bfaf0cf](https://github.com/breaking-brake/cc-wf-studio/commit/bfaf0cfa66292fbeb760d7981d421b477bcd1302))
+
+### Documentation
+
+* add Semantic Release and GitHub Actions automation guide to CLAUDE.md
 
 ## [2.1.0](https://github.com/breaking-brake/cc-wf-studio/compare/v2.0.3...v2.1.0) (2025-11-15)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code Slash Commands, Sub Agents, Agent Skills, and MCP Tools",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 目的

v2.1.1として自動リリースされた内容を、正しくv2.2.0としてリリースするためのバージョン修正です。

## 背景

PR #68がproductionにマージされた際、Semantic Releaseが`fix:`コミットのみを検出してv2.1.1としてリリースしました。しかし、実際の内容は**MCP Tool Node Integrationという大きな新機能**であり、Minor version bump（v2.2.0）が適切です。

## 変更内容

### ファイル更新
- **package.json**: 2.1.1 → 2.2.0
- **src/webview/package.json**: 2.1.1 → 2.2.0
- **src/webview/package-lock.json**: npm installで更新
- **CHANGELOG.md**: v2.1.1エントリをv2.2.0に統合、MCP機能の完全なリスト追加

### CHANGELOG.md 更新内容

**v2.2.0セクション**:
- **Features**: MCP Tool Node Integration（完全実装）
  - MCPサーバー自動検出とツール一覧表示
  - ツール検索・フィルタリング
  - 動的パラメータフォーム（5種類の型対応）
  - リアルタイムバリデーション
  - Slash Commandエクスポート対応
  - 5言語対応
- **Bug Fixes**: Semantic Releaseのタグ競合修正
- **Documentation**: リリース自動化ガイド追加

## なぜv2.2.0か？

実装内容：
- ✅ 6つのPhaseを経た完全な新機能実装
- ✅ 25個のコミット
- ✅ 新しいノードタイプの追加
- ✅ 国際化対応（5言語）
- ✅ 完全なE2Eテスト

これは明らかに**Minor version（機能追加）**に相当します。

## コミットメッセージに `[skip ci]` を含めた理由

このPRは手動でのバージョン修正のため、Semantic Releaseを実行する必要がありません。`[skip ci]`を含めることで、GitHub Actionsのリリースワークフローをスキップします。

## 次のステップ

1. ✅ このPRをmainにマージ
2. ⏳ mainブランチでv2.2.0タグを作成
3. ⏳ GitHubリリースv2.2.0を手動作成
4. ⏳ productionブランチを更新
5. ⏳ 今後はSemantic Releaseが正常に動作

## Breaking Changes

なし

## 関連PR

- #64 - feat: MCP Tool Node Integration (元の実装)
- #67 - fix: Semantic Release tag conflict fix
- #68 - release: v2.2.0 attempt (v2.1.1になった)