### PR TITLE
release: v2.2.0 - MCP Tool Node Integration (manual release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
-## [2.1.1](https://github.com/breaking-brake/cc-wf-studio/compare/v2.1.0...v2.1.1) (2025-11-15)
+## [2.2.0](https://github.com/breaking-brake/cc-wf-studio/compare/v2.0.3...v2.2.0) (2025-11-15)
+
+### Features
+
+* **MCP Tool Node Integration** - Complete implementation of Model Context Protocol tool nodes
+  * MCPサーバー自動検出とツール一覧表示
+  * ツール検索・フィルタリング機能
+  * JSON Schemaベースの動的パラメータフォーム生成（5種類の型対応）
+  * リアルタイムバリデーション
+  * Slash Commandへの完全なエクスポート対応
+  * 5言語対応（en, ja, ko, zh-CN, zh-TW）
 
 ### Bug Fixes
 
 * prevent tag conflict by using @semantic-release/exec for webview sync ([bfaf0cf](https://github.com/breaking-brake/cc-wf-studio/commit/bfaf0cfa66292fbeb760d7981d421b477bcd1302))
+
+### Documentation
+
+* add Semantic Release and GitHub Actions automation guide to CLAUDE.md
 
 ## [2.1.0](https://github.com/breaking-brake/cc-wf-studio/compare/v2.0.3...v2.1.0) (2025-11-15)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code Slash Commands, Sub Agents, Agent Skills, and MCP Tools",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## リリース内容

このPRは、v2.2.0の手動リリースです。productionブランチにマージ後、**手動で**v2.2.0タグとGitHubリリースを作成します。

## 背景

v2.1.1として自動リリースされた内容を、正しくv2.2.0としてリリースするための修正です。

## 変更内容

### v2.2.0 - MCP Tool Node Integration

**Features:**
- **MCP Tool Node Integration** - Complete implementation
  - MCPサーバー自動検出とツール一覧表示
  - ツール検索・フィルタリング機能
  - JSON Schemaベースの動的パラメータフォーム生成（5種類の型対応）
  - リアルタイムバリデーション
  - Slash Commandへの完全なエクスポート対応
  - 5言語対応（en, ja, ko, zh-CN, zh-TW）

**Bug Fixes:**
- prevent tag conflict by using @semantic-release/exec for webview sync

**Documentation:**
- add Semantic Release and GitHub Actions automation guide to CLAUDE.md

## マージ後の手順

このPRをマージ後、以下を**手動で**実行します：

1. productionブランチをチェックアウト
2. v2.2.0タグを作成: `git tag v2.2.0 && git push origin v2.2.0`
3. VSIXをビルド: `npm run build && npx vsce package`
4. GitHubリリースを作成: `gh release create v2.2.0 --title "v2.2.0 - MCP Tool Node Integration" *.vsix`

## Semantic Releaseについて

このPRのマージ時、Semantic Releaseは実行されますが：
- v2.1.1タグが既に存在
- mainブランチのコミットに`[skip ci]`が含まれている
- そのため、新しいリリースは作成されません

v2.2.0タグとリリースは手動で作成します。

## 今後のリリース

v2.2.0以降、Semantic Releaseが正常に動作し、自動リリースが継続されます。

## Breaking Changes

なし

## 関連PR

- #64 - feat: MCP Tool Node Integration
- #67 - fix: Semantic Release tag conflict fix
- #68 - release attempt (v2.1.1になった)
- #69 - chore: bump version to 2.2.0