### PR TITLE
docs: clarify MCP network connectivity requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Designed workflows automatically export to `.claude/agents/` and `.claude/comman
 ### 🔄 Easy Iteration
 Save and load workflows as JSON. Experiment and refine your flows through trial and error.
 
-### 🔒 Fully Offline & Secure
-All operations run locally within VSCode. No network communication means zero risk of data leaks or privacy concerns.
+### 🔒 Fully Local & Secure
+All operations run locally within VSCode. **Note:** MCP Tool nodes may require network connectivity depending on the specific MCP server configuration (e.g., remote API servers). Non-MCP features operate entirely offline.
 
 ## Key Features
 
@@ -343,7 +343,11 @@ MCP (Model Context Protocol) is Claude Code's extensibility system that allows i
 **Prerequisites:**
 - Claude Code CLI must be installed and configured with MCP servers
 - MCP servers must be properly configured in Claude Code settings (user/project/enterprise scope)
-- Network connectivity may be required depending on the MCP server
+
+**Network Connectivity:**
+- **Local MCP servers** (e.g., file system tools): No external network required
+- **Remote MCP servers** (e.g., cloud APIs): External network connectivity required
+- The extension itself does not communicate externally - network usage depends entirely on your configured MCP servers
 
 ### Conditional Branching Nodes
 Implement conditional logic with specialized nodes:


### PR DESCRIPTION
## Overview

README.mdに「No network communication」という記載がありましたが、MCPツールノード機能では一部のMCPサーバー設定により外部ネットワーク通信が発生する可能性があるため、正確な説明に修正します。

## Changes

### 1. 「Fully Offline & Secure」セクションを修正
**Before:**
> ### 🔒 Fully Offline & Secure
> All operations run locally within VSCode. No network communication means zero risk of data leaks or privacy concerns.

**After:**
> ### 🔒 Fully Local & Secure
> All operations run locally within VSCode. **Note:** MCP Tool nodes may require network connectivity depending on the specific MCP server configuration (e.g., remote API servers). Non-MCP features operate entirely offline.

### 2. MCP Tool Nodesセクションに詳細な説明を追加

**Network Connectivity:**
- **Local MCP servers** (e.g., file system tools): No external network required
- **Remote MCP servers** (e.g., cloud APIs): External network connectivity required
- The extension itself does not communicate externally - network usage depends entirely on your configured MCP servers

## Technical Background

MCPツールスキャンの仕組み：
- Extension → MCPサーバープロセスを起動（stdio通信）
- MCPサーバー → `listTools()`でツール一覧を取得
- **ネットワーク通信の有無はMCPサーバーの実装に依存**

### 例：ローカルMCPサーバー
```json
{
  "command": "node",
  "args": ["./local-tools.js"]
}
```
→ ❌ 外部通信なし

### 例：リモートMCPサーバー
```json
{
  "command": "npx",
  "args": ["mcp-remote", "https://api.example.com/mcp"]
}
```
→ ✅ 外部通信あり

## Impact

- ✅ ユーザーに正確な情報を提供
- ✅ プライバシー/セキュリティの懸念に対する透明性向上
- ✅ MCP機能の正しい理解を促進
- ❌ 既存機能への影響なし（ドキュメントのみの変更）