### PR TITLE
fix: improve MCP tool dialog visibility and F5 debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "extensionHost",
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
@@ -15,9 +15,9 @@
       "request": "launch",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionTestsPath=${workspaceFolder}/out/tests/extension"
+        "--extensionTestsPath=${workspaceFolder}/dist/tests/extension"
       ],
-      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,23 @@
     {
       "type": "npm",
       "script": "watch",
-      "problemMatcher": "$tsc-watch",
+      "problemMatcher": {
+        "owner": "vite",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "build started\\.\\.\\.",
+          "endsPattern": "built in \\d+ms\\."
+        }
+      },
       "isBackground": true,
       "presentation": {
         "reveal": "never"

--- a/src/webview/src/components/dialogs/McpNodeDialog.tsx
+++ b/src/webview/src/components/dialogs/McpNodeDialog.tsx
@@ -139,7 +139,7 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
           padding: '24px',
           maxWidth: '800px',
           width: '90%',
-          maxHeight: '80vh',
+          maxHeight: '90vh',
           overflow: 'auto',
         }}
         onClick={(e) => e.stopPropagation()}
@@ -189,7 +189,7 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
             >
               {t('mcp.dialog.selectServer')}
             </h3>
-            <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+            <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
               <McpServerList
                 onServerSelect={(server) => {
                   setSelectedServer(server);
@@ -222,7 +222,7 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
                   onChange={setSearchQuery}
                   disabled={!selectedServer}
                 />
-                <div style={{ maxHeight: '250px', overflowY: 'auto' }}>
+                <div style={{ maxHeight: '350px', overflowY: 'auto' }}>
                   <McpToolList
                     serverId={selectedServer.id}
                     onToolSelect={(tool) => {


### PR DESCRIPTION
## Overview

MCPツール選択ダイアログの視認性向上と、Viteバンドリング対応後のF5デバッグ設定を修正します。

## Changes

### 1. MCPツール選択ダイアログの高さ改善

**問題:**
- ツールが多い場合や説明文が長い場合、ダイアログ内が見づらい

**修正内容:**
| 項目 | Before | After | 変更 |
|------|--------|-------|------|
| ダイアログ全体 | `maxHeight: 80vh` | `maxHeight: 90vh` | **+10vh** |
| サーバーリスト | `maxHeight: 300px` | `maxHeight: 400px` | **+100px** |
| ツールリスト | `maxHeight: 250px` | `maxHeight: 350px` | **+100px** |

**影響:**
- ✅ より多くのツールを一度に表示可能
- ✅ 長い説明文も読みやすく
- ✅ スクロール頻度が減少

### 2. F5デバッグ設定のVite対応

**問題:**
- v2.2.1でViteバンドリングを導入したが、`.vscode/launch.json`と`.vscode/tasks.json`が古い設定のまま
- F5起動時に`preLaunchTask 'watch'`で長時間待たされる

**修正内容 (`.vscode/launch.json`):**
```diff
- "outFiles": ["${workspaceFolder}/out/**/*.js"]
+ "outFiles": ["${workspaceFolder}/dist/**/*.js"]

- "extensionTestsPath": "${workspaceFolder}/out/tests/extension"
+ "extensionTestsPath": "${workspaceFolder}/dist/tests/extension"
```

**修正内容 (`.vscode/tasks.json`):**
```diff
- "problemMatcher": "$tsc-watch"
+ "problemMatcher": {
+   "owner": "vite",
+   "background": {
+     "beginsPattern": "build started\\.\\.\\.",
+     "endsPattern": "built in \\d+ms\\."
+   }
+ }
```

**影響:**
- ✅ F5デバッグが正常動作
- ✅ preLaunchTask待ち時間が大幅短縮（Viteビルド完了を正確に検知）
- ✅ ソースマップデバッグが正常動作

## Technical Background

### Vite Watch出力パターン
```
vite v7.2.2 building client environment for production...

watching for file changes...

build started...
transforming...
✓ 211 modules transformed.
rendering chunks...
computing gzip size...
dist/extension.js  603.75 kB │ gzip: 119.89 kB
built in 1337ms.
```

`problemMatcher`のbackgroundパターン：
- 開始検知: `build started...`
- 完了検知: `built in \d+ms.`

## Testing

- ✅ MCPツール選択ダイアログ: 高さ増加を確認
- ✅ F5デバッグ起動: preLaunchTask待ち時間短縮を確認
- ✅ ブレークポイント: 正常動作確認

## Related

- v2.2.1: Viteバンドリング導入 (PR #71)