### PR TITLE
feat: add indeterminate progress bar for MCP server loading

### DIFF
--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -62,11 +62,55 @@ export function McpServerList({
       <div
         style={{
           padding: '16px',
-          textAlign: 'center',
-          color: 'var(--vscode-descriptionForeground)',
         }}
       >
-        {t('mcp.loading.servers')}
+        {/* Loading label */}
+        <div
+          style={{
+            marginBottom: '6px',
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+            fontStyle: 'italic',
+          }}
+        >
+          {t('mcp.loading.servers')}
+        </div>
+
+        {/* Indeterminate progress bar */}
+        <div
+          style={{
+            width: '100%',
+            height: '4px',
+            backgroundColor: 'var(--vscode-editor-background)',
+            borderRadius: '2px',
+            overflow: 'hidden',
+            border: '1px solid var(--vscode-panel-border)',
+            position: 'relative',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              height: '100%',
+              width: '30%',
+              backgroundColor: 'var(--vscode-progressBar-background)',
+              animation: 'slide 1.5s ease-in-out infinite',
+            }}
+          />
+        </div>
+
+        <style>
+          {`
+            @keyframes slide {
+              0% {
+                left: -30%;
+              }
+              100% {
+                left: 100%;
+              }
+            }
+          `}
+        </style>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Add visual progress bar during MCP server list loading
- Replace text-based loading indicator with sliding progress bar animation
- Maintain consistent styling with existing ProgressBar component

## Changes
- **McpServerList.tsx**: Implement indeterminate progress bar with sliding animation
  - 4px height bar matching ProgressBar component design
  - 30% width sliding from left to right (1.5s cycle)
  - VSCode theme-aware colors (`--vscode-progressBar-background`)
  - Remove unused frame-based character animation code

## Test Plan
- [x] Open MCP node dialog
- [x] Verify progress bar displays during server loading
- [x] Confirm smooth sliding animation
- [x] Check visual consistency with MessageBubble ProgressBar

## Screenshots
Progress bar displays with label "MCPサーバーを読み込み中..." and sliding animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)