### PR TITLE
fix: support both single and double brace placeholders in i18n

### DIFF
--- a/src/webview/src/i18n/i18n-context.tsx
+++ b/src/webview/src/i18n/i18n-context.tsx
@@ -75,10 +75,12 @@ export const I18nProvider: React.FC<I18nProviderProps> = ({ locale, children }) 
         // Replace parameters if provided
         if (params) {
           for (const paramKey of Object.keys(params)) {
+            // Support both {{paramKey}} and {paramKey} formats for backward compatibility
             text = text.replace(
               new RegExp(`\\{\\{${paramKey}\\}\\}`, 'g'),
               String(params[paramKey])
             );
+            text = text.replace(new RegExp(`\\{${paramKey}\\}`, 'g'), String(params[paramKey]));
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes character count display showing `{count}` literally instead of the actual number in AI refinement message input.

## Root Cause

After commit `7ac7de1` (which fixed wizard step display), the i18n placeholder replacement only supported double braces `{{paramKey}}`, but many translation keys still use single braces `{paramKey}`.

**Translation file inconsistency:**
- Single brace `{count}`: Used in 9 keys (`refinement.charactersRemaining`, `property.optionsCount`, etc.)
- Double brace `{{current}}`: Used in 4 keys (`mcp.dialog.wizardStep`, etc.)

## Changes

**File**: `src/webview/src/i18n/i18n-context.tsx`

- Added support for `{paramKey}` format alongside existing `{{paramKey}}` format
- Both formats are now replaced in sequence for backward compatibility
- No changes to translation files required

**Before:**
```typescript
// Only replaces {{count}}
text = text.replace(
  new RegExp(`\\{\\{${paramKey}\\}\\}`, 'g'),
  String(params[paramKey])
);
```

**After:**
```typescript
// Replaces both {{count}} and {count}
text = text.replace(
  new RegExp(`\\{\\{${paramKey}\\}\\}`, 'g'),
  String(params[paramKey])
);
text = text.replace(
  new RegExp(`\\{${paramKey}\\}`, 'g'),
  String(params[paramKey])
);
```

## Testing

- ✅ Character count display: "残り 4950 文字" (correctly showing number)
- ✅ Wizard step display: "ステップ 1 / 7" (still working)
- ✅ All other placeholder displays verified

## Impact

**Fixed displays:**
- `refinement.charactersRemaining`: "{count}" → "4950"
- `property.optionsCount`: "{count}" → "2"
- `property.detectedVariables`: "{count}" → "3"
- `refinement.iterationCounter`: "{current}" → "2"
- `refinement.chat.progressTime`: "{elapsed}/{max}" → "15/60"
- And 4 more similar cases

**Unaffected displays:**
- `mcp.dialog.wizardStep`: Already working with double braces

## Notes for Reviewers

This is a minimal change that adds backward compatibility without breaking existing functionality. The ideal long-term solution would be to standardize all translation files to use one format, but that can be done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>