### PR TITLE
Release: v2.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,49 @@ src/
 tests/
 ```
 
-## Commands
+## Development Workflow & Commands
 
-npm test && npm run lint
+### Code Quality Checks (Required Before Commit/PR)
+
+**Always run these commands in the following order after code modifications:**
+
+```bash
+npm run format  # Auto-format code with Biome
+npm run lint    # Check for linting issues
+npm run check   # Run all Biome checks (lint + format verification)
+npm run build   # Build extension and webview (verify compilation)
+```
+
+### Command Execution Timing
+
+#### During Development
+1. **After code modification**:
+   ```bash
+   npm run format && npm run lint && npm run check
+   ```
+   - Fixes formatting issues automatically
+   - Identifies linting problems
+   - Verifies code quality standards
+
+2. **Before manual E2E testing**:
+   ```bash
+   npm run build
+   ```
+   - Compiles TypeScript and builds extension
+   - Required for testing changes in VSCode
+
+3. **Before git commit**:
+   ```bash
+   npm run format && npm run lint && npm run check
+   ```
+   - Ensures all code quality standards are met
+   - Prevents committing code with linting/formatting issues
+
+#### Testing
+- **Unit/Integration tests**: Not required (manual E2E testing only)
+- **Manual E2E testing**: Required for all feature changes and bug fixes
+  - Run `npm run build` first
+  - Test in VSCode Extension Development Host
 
 ## Version Update Procedure
 

--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -2126,20 +2126,118 @@ const McpProperties: React.FC<{
           </button>
         </div>
 
-        {/* Info Note */}
-        <div
-          style={{
-            padding: '12px',
-            backgroundColor: 'var(--vscode-textBlockQuote-background)',
-            border: '1px solid var(--vscode-textBlockQuote-border)',
-            borderRadius: '4px',
-            fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
-            lineHeight: '1.5',
-          }}
-        >
-          💡 {t('property.mcp.infoNote')}
-        </div>
+        {/* Configuration Values Display - Mode-specific */}
+        {currentMode === 'aiToolSelection' && data.aiToolSelectionConfig?.taskDescription && (
+          <div>
+            <label
+              htmlFor="mcp-task-description"
+              style={{
+                display: 'block',
+                fontSize: '12px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '6px',
+              }}
+            >
+              {t('property.mcp.taskDescription')}
+            </label>
+            <div
+              id="mcp-task-description"
+              style={{
+                width: '100%',
+                padding: '8px',
+                backgroundColor: 'var(--vscode-input-background)',
+                color: 'var(--vscode-descriptionForeground)',
+                border: '1px solid var(--vscode-input-border)',
+                borderRadius: '2px',
+                fontSize: '12px',
+                lineHeight: '1.5',
+                maxHeight: '200px',
+                overflowY: 'auto',
+              }}
+            >
+              {data.aiToolSelectionConfig.taskDescription}
+            </div>
+          </div>
+        )}
+
+        {currentMode === 'aiParameterConfig' && data.aiParameterConfig?.description && (
+          <div>
+            <label
+              htmlFor="mcp-parameter-description"
+              style={{
+                display: 'block',
+                fontSize: '12px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '6px',
+              }}
+            >
+              {t('property.mcp.parameterDescription')}
+            </label>
+            <div
+              id="mcp-parameter-description"
+              style={{
+                width: '100%',
+                padding: '8px',
+                backgroundColor: 'var(--vscode-input-background)',
+                color: 'var(--vscode-descriptionForeground)',
+                border: '1px solid var(--vscode-input-border)',
+                borderRadius: '2px',
+                fontSize: '12px',
+                lineHeight: '1.5',
+                maxHeight: '200px',
+                overflowY: 'auto',
+              }}
+            >
+              {data.aiParameterConfig.description}
+            </div>
+          </div>
+        )}
+
+        {currentMode === 'manualParameterConfig' &&
+          data.parameterValues &&
+          Object.keys(data.parameterValues).length > 0 && (
+            <div>
+              <label
+                htmlFor="mcp-configured-values"
+                style={{
+                  display: 'block',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                  marginBottom: '6px',
+                }}
+              >
+                {t('property.mcp.configuredValues')}
+              </label>
+              <div
+                id="mcp-configured-values"
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-descriptionForeground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  fontSize: '11px',
+                  fontFamily: 'monospace',
+                  lineHeight: '1.6',
+                  maxHeight: '200px',
+                  overflowY: 'auto',
+                }}
+              >
+                {Object.entries(data.parameterValues).map(([key, value]) => (
+                  <div key={key} style={{ marginBottom: '4px' }}>
+                    <span style={{ fontWeight: 600, color: 'var(--vscode-foreground)' }}>
+                      {key}:
+                    </span>{' '}
+                    <span>{typeof value === 'object' ? JSON.stringify(value) : String(value)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
       </div>
 
       {/* MCP Node Edit Dialog */}

--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -84,10 +84,33 @@ export function McpServerList({
         style={{
           padding: '16px',
           textAlign: 'center',
-          color: 'var(--vscode-descriptionForeground)',
         }}
       >
-        {t('mcp.empty.servers')}
+        <div
+          style={{
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: '8px',
+          }}
+        >
+          {t('mcp.empty.servers')}
+        </div>
+        <div
+          style={{
+            fontSize: '12px',
+            color: 'var(--vscode-descriptionForeground)',
+          }}
+        >
+          <div>{t('mcp.empty.servers.hint')}</div>
+          <div
+            style={{
+              marginTop: '4px',
+              fontFamily: 'monospace',
+              fontSize: '11px',
+            }}
+          >
+            {t('mcp.empty.servers.docUrl')}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/webview/src/components/nodes/McpNode/McpNode.tsx
+++ b/src/webview/src/components/nodes/McpNode/McpNode.tsx
@@ -44,6 +44,29 @@ function getValidationColor(status: 'valid' | 'missing' | 'invalid'): string {
 }
 
 /**
+ * Truncate text with ellipsis
+ */
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.substring(0, maxLength)}...`;
+}
+
+/**
+ * Get main parameter values for display (up to 2 parameters)
+ */
+function getMainParameterPreview(parameterValues: Record<string, unknown>): string {
+  const entries = Object.entries(parameterValues).slice(0, 2);
+  if (entries.length === 0) return 'No parameters configured';
+
+  return entries
+    .map(([key, value]) => {
+      const valueStr = typeof value === 'object' ? JSON.stringify(value) : String(value);
+      return `${key}: ${truncateText(valueStr, 30)}`;
+    })
+    .join(', ');
+}
+
+/**
  * McpNode Component
  */
 export const McpNodeComponent: React.FC<NodeProps<McpNodeData>> = React.memo(
@@ -143,8 +166,8 @@ export const McpNodeComponent: React.FC<NodeProps<McpNodeData>> = React.memo(
           <ModeIndicatorBadge mode={currentMode} />
         </div>
 
-        {/* Description */}
-        {data.toolDescription && (
+        {/* Mode-specific content display */}
+        {currentMode === 'aiToolSelection' && data.aiToolSelectionConfig?.taskDescription && (
           <div
             style={{
               fontSize: '11px',
@@ -158,23 +181,45 @@ export const McpNodeComponent: React.FC<NodeProps<McpNodeData>> = React.memo(
               WebkitBoxOrient: 'vertical',
             }}
           >
-            {data.toolDescription}
+            <strong>Task:</strong> {data.aiToolSelectionConfig.taskDescription}
           </div>
         )}
 
-        {/* Parameter Count */}
-        {data.parameters && data.parameters.length > 0 && (
+        {currentMode === 'aiParameterConfig' && data.aiParameterConfig?.description && (
           <div
             style={{
-              fontSize: '10px',
+              fontSize: '11px',
               color: 'var(--vscode-descriptionForeground)',
               marginTop: '8px',
-              fontStyle: 'italic',
+              lineHeight: '1.4',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
             }}
           >
-            {data.parameters.length} parameter{data.parameters.length !== 1 ? 's' : ''}
+            <strong>Params:</strong> {data.aiParameterConfig.description}
           </div>
         )}
+
+        {currentMode === 'manualParameterConfig' &&
+          data.parameterValues &&
+          Object.keys(data.parameterValues).length > 0 && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-descriptionForeground)',
+                marginTop: '8px',
+                lineHeight: '1.4',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {getMainParameterPreview(data.parameterValues)}
+            </div>
+          )}
 
         {/* Output Handle */}
         <Handle

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -327,6 +327,8 @@ export interface WebviewTranslationKeys {
   'mcp.loading.servers': string;
   'mcp.error.serverLoadFailed': string;
   'mcp.empty.servers': string;
+  'mcp.empty.servers.hint': string;
+  'mcp.empty.servers.docUrl': string;
 
   // MCP Tool List
   'mcp.loading.tools': string;
@@ -365,6 +367,9 @@ export interface WebviewTranslationKeys {
   'property.mcp.edit.manualParameterConfig': string;
   'property.mcp.edit.aiParameterConfig': string;
   'property.mcp.edit.aiToolSelection': string;
+  'property.mcp.taskDescription': string;
+  'property.mcp.parameterDescription': string;
+  'property.mcp.configuredValues': string;
   'property.mcp.infoNote': string;
 
   // MCP Parameter Form

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -362,9 +362,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'node.mcp.description': 'Execute MCP tool',
 
   // MCP Server List
-  'mcp.loading.servers': 'Loading MCP servers...',
+  'mcp.loading.servers': 'Loading available MCP servers in this project...',
   'mcp.error.serverLoadFailed': 'Failed to load MCP servers',
-  'mcp.empty.servers': 'No MCP servers configured',
+  'mcp.empty.servers': 'No available MCP servers in this project.',
+  'mcp.empty.servers.hint': 'Please configure MCP servers for Claude Code.',
+  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/en/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': 'Loading tools...',
@@ -401,8 +403,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.mcp.parameterCount': 'Parameter Count',
   'property.mcp.editParameters': 'Edit Parameters',
   'property.mcp.edit.manualParameterConfig': 'Edit Parameters',
-  'property.mcp.edit.aiParameterConfig': 'Edit Parameter Config Description',
-  'property.mcp.edit.aiToolSelection': 'Edit Task',
+  'property.mcp.edit.aiParameterConfig': 'Edit Parameter Content',
+  'property.mcp.edit.aiToolSelection': 'Edit Task Content',
+  'property.mcp.taskDescription': 'Task Content',
+  'property.mcp.parameterDescription': 'Parameter Content',
+  'property.mcp.configuredValues': 'Configured Values',
   'property.mcp.infoNote':
     'MCP tool properties are loaded from the server. Click "Edit Parameters" to configure parameter values.',
 
@@ -428,7 +433,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameter.validationErrors': 'Please fix the following validation errors:',
 
   // MCP Edit Dialog
-  'mcp.editDialog.title': 'Configure MCP Tool Parameters',
+  'mcp.editDialog.title': 'Configure MCP Tool',
   'mcp.editDialog.saveButton': 'Save',
   'mcp.editDialog.cancelButton': 'Cancel',
   'mcp.editDialog.loading': 'Loading tool schema...',
@@ -474,10 +479,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameterDetailedConfig.title': 'Configure Tool Parameters',
 
   // Natural Language Input
-  'mcp.naturalLanguage.paramDescription.label': 'Parameter Configuration Description',
+  'mcp.naturalLanguage.paramDescription.label': 'Parameter Content',
   'mcp.naturalLanguage.paramDescription.placeholder':
     'Describe what you want to do with this tool (e.g., "Check if Lambda is available in us-east-1")...',
-  'mcp.naturalLanguage.taskDescription.label': 'Task Description',
+  'mcp.naturalLanguage.taskDescription.label': 'Task Content',
   'mcp.naturalLanguage.taskDescription.placeholder':
     'Describe the task you want to accomplish (e.g., "Find documentation about S3 bucket policies")...',
 

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -360,9 +360,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'node.mcp.description': 'MCPツールを実行',
 
   // MCP Server List
-  'mcp.loading.servers': 'MCPサーバーを読み込み中...',
+  'mcp.loading.servers': 'このプロジェクトで利用可能なMCPサーバーを読み込み中...',
   'mcp.error.serverLoadFailed': 'MCPサーバーの読み込みに失敗しました',
-  'mcp.empty.servers': '設定されたMCPサーバーがありません',
+  'mcp.empty.servers': 'このプロジェクトで利用可能なMCPサーバーがありません。',
+  'mcp.empty.servers.hint': 'Claude Codeで利用できるMCPサーバーを設定してください。',
+  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/ja/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': 'ツールを読み込み中...',
@@ -399,8 +401,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.mcp.parameterCount': 'パラメータ数',
   'property.mcp.editParameters': 'パラメータを編集',
   'property.mcp.edit.manualParameterConfig': 'パラメータを編集',
-  'property.mcp.edit.aiParameterConfig': 'パラメータ設定の説明を編集',
-  'property.mcp.edit.aiToolSelection': 'タスクを編集',
+  'property.mcp.edit.aiParameterConfig': 'パラメータ内容を編集',
+  'property.mcp.edit.aiToolSelection': 'タスク内容を編集',
+  'property.mcp.taskDescription': 'タスク内容',
+  'property.mcp.parameterDescription': 'パラメータ内容',
+  'property.mcp.configuredValues': '設定値',
   'property.mcp.infoNote':
     'MCPツールのプロパティはサーバーから読み込まれます。「パラメータを編集」をクリックしてパラメータ値を設定してください。',
 
@@ -426,7 +431,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameter.validationErrors': '以下の検証エラーを修正してください:',
 
   // MCP Edit Dialog
-  'mcp.editDialog.title': 'MCPツールパラメータの設定',
+  'mcp.editDialog.title': 'MCPツールの設定',
   'mcp.editDialog.saveButton': '保存',
   'mcp.editDialog.cancelButton': 'キャンセル',
   'mcp.editDialog.loading': 'ツールスキーマを読み込み中...',
@@ -471,10 +476,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameterDetailedConfig.title': 'ツールパラメータの設定',
 
   // Natural Language Input
-  'mcp.naturalLanguage.paramDescription.label': 'パラメータ設定の説明',
+  'mcp.naturalLanguage.paramDescription.label': 'パラメータ内容',
   'mcp.naturalLanguage.paramDescription.placeholder':
     'このツールで何をしたいか説明してください（例:「us-east-1でLambdaが利用可能か確認する」）...',
-  'mcp.naturalLanguage.taskDescription.label': 'タスクの説明',
+  'mcp.naturalLanguage.taskDescription.label': 'タスク内容',
   'mcp.naturalLanguage.taskDescription.placeholder':
     '実現したいタスクを説明してください（例:「S3バケットポリシーに関するドキュメントを検索する」）...',
 

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -359,9 +359,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'node.mcp.description': 'MCP 도구 실행',
 
   // MCP Server List
-  'mcp.loading.servers': 'MCP 서버 로드 중...',
+  'mcp.loading.servers': '이 프로젝트에서 사용 가능한 MCP 서버 로드 중...',
   'mcp.error.serverLoadFailed': 'MCP 서버 로드 실패',
-  'mcp.empty.servers': '구성된 MCP 서버가 없습니다',
+  'mcp.empty.servers': '이 프로젝트에서 사용 가능한 MCP 서버가 없습니다.',
+  'mcp.empty.servers.hint': 'Claude Code용 MCP 서버를 설정하세요.',
+  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/ko/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': '도구 로드 중...',
@@ -398,8 +400,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.mcp.parameterCount': '매개변수 개수',
   'property.mcp.editParameters': '매개변수 편집',
   'property.mcp.edit.manualParameterConfig': '매개변수 편집',
-  'property.mcp.edit.aiParameterConfig': '매개변수 설정 설명 편집',
-  'property.mcp.edit.aiToolSelection': '작업 편집',
+  'property.mcp.edit.aiParameterConfig': '매개변수 내용 편집',
+  'property.mcp.edit.aiToolSelection': '작업 내용 편집',
+  'property.mcp.taskDescription': '작업 내용',
+  'property.mcp.parameterDescription': '매개변수 내용',
+  'property.mcp.configuredValues': '구성된 값',
   'property.mcp.infoNote':
     'MCP 도구 속성은 서버에서 로드됩니다. "매개변수 편집"을 클릭하여 매개변수 값을 구성하세요.',
 
@@ -425,7 +430,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameter.validationErrors': '다음 검증 오류를 수정하세요:',
 
   // MCP Edit Dialog
-  'mcp.editDialog.title': 'MCP 도구 매개변수 구성',
+  'mcp.editDialog.title': 'MCP 도구 구성',
   'mcp.editDialog.saveButton': '저장',
   'mcp.editDialog.cancelButton': '취소',
   'mcp.editDialog.loading': '도구 스키마 로드 중...',
@@ -470,10 +475,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameterDetailedConfig.title': '도구 매개변수 구성',
 
   // Natural Language Input
-  'mcp.naturalLanguage.paramDescription.label': '매개변수 설정 설명',
+  'mcp.naturalLanguage.paramDescription.label': '매개변수 내용',
   'mcp.naturalLanguage.paramDescription.placeholder':
     '이 도구로 수행하려는 작업을 설명하세요(예: "us-east-1에서 Lambda를 사용할 수 있는지 확인")...',
-  'mcp.naturalLanguage.taskDescription.label': '작업 설명',
+  'mcp.naturalLanguage.taskDescription.label': '작업 내용',
   'mcp.naturalLanguage.taskDescription.placeholder':
     '수행하려는 작업을 설명하세요(예: "S3 버킷 정책에 대한 문서 찾기")...',
 

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -343,9 +343,11 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'node.mcp.description': '执行MCP工具',
 
   // MCP Server List
-  'mcp.loading.servers': '正在加载MCP服务器...',
+  'mcp.loading.servers': '正在加载此项目中可用的MCP服务器...',
   'mcp.error.serverLoadFailed': '加载MCP服务器失败',
-  'mcp.empty.servers': '未配置MCP服务器',
+  'mcp.empty.servers': '此项目中没有可用的MCP服务器。',
+  'mcp.empty.servers.hint': '请为Claude Code配置MCP服务器。',
+  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/zh-CN/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': '正在加载工具...',
@@ -382,8 +384,11 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.mcp.parameterCount': '参数数量',
   'property.mcp.editParameters': '编辑参数',
   'property.mcp.edit.manualParameterConfig': '编辑参数',
-  'property.mcp.edit.aiParameterConfig': '编辑参数配置说明',
-  'property.mcp.edit.aiToolSelection': '编辑任务',
+  'property.mcp.edit.aiParameterConfig': '编辑参数内容',
+  'property.mcp.edit.aiToolSelection': '编辑任务内容',
+  'property.mcp.taskDescription': '任务内容',
+  'property.mcp.parameterDescription': '参数内容',
+  'property.mcp.configuredValues': '配置值',
   'property.mcp.infoNote': 'MCP工具属性从服务器加载。点击"编辑参数"以配置参数值。',
 
   // MCP Parameter Form
@@ -408,7 +413,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameter.validationErrors': '请修复以下验证错误:',
 
   // MCP Edit Dialog
-  'mcp.editDialog.title': '配置MCP工具参数',
+  'mcp.editDialog.title': '配置MCP工具',
   'mcp.editDialog.saveButton': '保存',
   'mcp.editDialog.cancelButton': '取消',
   'mcp.editDialog.loading': '正在加载工具架构...',
@@ -452,10 +457,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameterDetailedConfig.title': '配置工具参数',
 
   // Natural Language Input
-  'mcp.naturalLanguage.paramDescription.label': '参数配置说明',
+  'mcp.naturalLanguage.paramDescription.label': '参数内容',
   'mcp.naturalLanguage.paramDescription.placeholder':
     '描述您想用此工具做什么（例如："检查Lambda在us-east-1中是否可用"）...',
-  'mcp.naturalLanguage.taskDescription.label': '任务描述',
+  'mcp.naturalLanguage.taskDescription.label': '任务内容',
   'mcp.naturalLanguage.taskDescription.placeholder':
     '描述您想完成的任务（例如："查找有关S3存储桶策略的文档"）...',
 

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -343,9 +343,11 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'node.mcp.description': '執行MCP工具',
 
   // MCP Server List
-  'mcp.loading.servers': '正在載入MCP伺服器...',
+  'mcp.loading.servers': '正在載入此專案中可用的MCP伺服器...',
   'mcp.error.serverLoadFailed': '載入MCP伺服器失敗',
-  'mcp.empty.servers': '未設定MCP伺服器',
+  'mcp.empty.servers': '此專案中沒有可用的MCP伺服器。',
+  'mcp.empty.servers.hint': '請為Claude Code設定MCP伺服器。',
+  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/zh-TW/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': '正在載入工具...',
@@ -382,8 +384,11 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.mcp.parameterCount': '參數數量',
   'property.mcp.editParameters': '編輯參數',
   'property.mcp.edit.manualParameterConfig': '編輯參數',
-  'property.mcp.edit.aiParameterConfig': '編輯參數配置說明',
-  'property.mcp.edit.aiToolSelection': '編輯任務',
+  'property.mcp.edit.aiParameterConfig': '編輯參數內容',
+  'property.mcp.edit.aiToolSelection': '編輯任務內容',
+  'property.mcp.taskDescription': '任務內容',
+  'property.mcp.parameterDescription': '參數內容',
+  'property.mcp.configuredValues': '配置值',
   'property.mcp.infoNote': 'MCP工具屬性從伺服器載入。點擊「編輯參數」以設定參數值。',
 
   // MCP Parameter Form
@@ -408,7 +413,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameter.validationErrors': '請修正以下驗證錯誤:',
 
   // MCP Edit Dialog
-  'mcp.editDialog.title': '配置MCP工具參數',
+  'mcp.editDialog.title': '配置MCP工具',
   'mcp.editDialog.saveButton': '儲存',
   'mcp.editDialog.cancelButton': '取消',
   'mcp.editDialog.loading': '正在載入工具架構...',
@@ -452,10 +457,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'mcp.parameterDetailedConfig.title': '設定工具參數',
 
   // Natural Language Input
-  'mcp.naturalLanguage.paramDescription.label': '參數配置說明',
+  'mcp.naturalLanguage.paramDescription.label': '參數內容',
   'mcp.naturalLanguage.paramDescription.placeholder':
     '描述您想用此工具做什麼（例如：「檢查Lambda在us-east-1中是否可用」）...',
-  'mcp.naturalLanguage.taskDescription.label': '任務描述',
+  'mcp.naturalLanguage.taskDescription.label': '任務內容',
   'mcp.naturalLanguage.taskDescription.placeholder':
     '描述您想完成的任務（例如：「查找有關S3儲存貯體原則的文件」）...',
 


### PR DESCRIPTION
## Release Summary

This release includes improvements to MCP Tool node UI text clarity and user guidance.

## What's Changed

### Features
- **Improve MCP Tool node UI text clarity and add documentation hint** (#97)
  - Changed task/parameter labels from "説明" (description) to "内容" (content) for better clarity
  - Updated button and property panel labels for consistency
  - Clarified MCP server scope in loading and empty state messages
  - Added documentation URL hint when no MCP servers are found (with language-specific URLs)

## Version

This PR will trigger an automatic release:
- Current version: **v2.6.0**
- Expected version: **v2.7.0** (minor version bump due to `feat:` commit)

## Automated Release Process

Upon merging to `production`:
1. Semantic Release will analyze commits and determine version
2. Version will be updated in `package.json` and related files
3. `CHANGELOG.md` will be automatically generated
4. GitHub release will be created with release notes
5. VSIX package will be built and attached to the release
6. Changes will be synced back to `main` branch

## Merge Strategy

- Use **Merge commit** (not squash) to preserve commit history for Semantic Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)