### PR TITLE
Release: v2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.22.0",
         "nano-spawn": "^2.0.0"

--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -100,16 +100,7 @@ export function McpServerList({
             color: 'var(--vscode-descriptionForeground)',
           }}
         >
-          <div>{t('mcp.empty.servers.hint')}</div>
-          <div
-            style={{
-              marginTop: '4px',
-              fontFamily: 'monospace',
-              fontSize: '11px',
-            }}
-          >
-            {t('mcp.empty.servers.docUrl')}
-          </div>
+          {t('mcp.empty.servers.hint')}
         </div>
       </div>
     );

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -328,7 +328,6 @@ export interface WebviewTranslationKeys {
   'mcp.error.serverLoadFailed': string;
   'mcp.empty.servers': string;
   'mcp.empty.servers.hint': string;
-  'mcp.empty.servers.docUrl': string;
 
   // MCP Tool List
   'mcp.loading.tools': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -366,7 +366,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.serverLoadFailed': 'Failed to load MCP servers',
   'mcp.empty.servers': 'No available MCP servers in this project.',
   'mcp.empty.servers.hint': 'Please configure MCP servers for Claude Code.',
-  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/en/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': 'Loading tools...',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -364,7 +364,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.serverLoadFailed': 'MCPサーバーの読み込みに失敗しました',
   'mcp.empty.servers': 'このプロジェクトで利用可能なMCPサーバーがありません。',
   'mcp.empty.servers.hint': 'Claude Codeで利用できるMCPサーバーを設定してください。',
-  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/ja/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': 'ツールを読み込み中...',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -363,7 +363,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.serverLoadFailed': 'MCP 서버 로드 실패',
   'mcp.empty.servers': '이 프로젝트에서 사용 가능한 MCP 서버가 없습니다.',
   'mcp.empty.servers.hint': 'Claude Code용 MCP 서버를 설정하세요.',
-  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/ko/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': '도구 로드 중...',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -347,7 +347,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.serverLoadFailed': '加载MCP服务器失败',
   'mcp.empty.servers': '此项目中没有可用的MCP服务器。',
   'mcp.empty.servers.hint': '请为Claude Code配置MCP服务器。',
-  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/zh-CN/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': '正在加载工具...',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -347,7 +347,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.serverLoadFailed': '載入MCP伺服器失敗',
   'mcp.empty.servers': '此專案中沒有可用的MCP伺服器。',
   'mcp.empty.servers.hint': '請為Claude Code設定MCP伺服器。',
-  'mcp.empty.servers.docUrl': 'https://code.claude.com/docs/zh-TW/mcp',
 
   // MCP Tool List
   'mcp.loading.tools': '正在載入工具...',


### PR DESCRIPTION
## Release Summary

This patch release removes the MCP documentation URL from the empty state display to maintain the extension's "fully local operation" characteristic and improve user trust.

## What's Changed

### Bug Fixes
- **Remove MCP documentation URL from empty state display** (#101)
  - Removed `https://code.claude.com/docs/*/mcp` URL display when no MCP servers are found
  - Simplified empty state message to avoid concerns about external communication
  - Maintains "fully local operation" principle for security-conscious users

## Version

This PR will trigger an automatic release:
- Current version: **v2.7.0**
- Expected version: **v2.7.1** (patch version bump due to `fix:` commit)

## Context

The extension advertises "fully local operation" as a key feature. However, having external URLs in the source code could raise concerns among security-conscious users who audit the codebase by searching for `https://`. This change removes the documentation URL to prevent misunderstandings about external communication, even though the URL was only displayed as text and not used for any network requests.

## Automated Release Process

Upon merging to `production`:
1. Semantic Release will analyze commits and determine version (v2.7.1)
2. Version will be updated in `package.json` and related files
3. `CHANGELOG.md` will be automatically generated
4. GitHub release will be created with release notes
5. VSIX package will be built and attached to the release
6. Changes will be synced back to `main` branch

## Merge Strategy

- Use **Merge commit** (not squash) to preserve commit history for Semantic Release

## Related Issues

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)