### PR TITLE
fix: skip Snyk scan for Dependabot PRs to prevent authentication errors

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,6 +18,8 @@ jobs:
   snyk-security-scan:
     name: Snyk Security Scan
     runs-on: ubuntu-latest
+    # DependabotのPRではSNYK_TOKENシークレットにアクセスできないためスキップ
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 概要
DependabotのPRでSnyk Security Scanが認証エラーで失敗する問題を修正

## 問題
- DependabotのPRではGitHub Actionsのシークレット(`SNYK_TOKEN`)へのアクセスが制限される
- Snyk認証エラー(SNYK-0005)が発生し、ワークフローが失敗
- `snyk.sarif`ファイルが生成されず、SARIFアップロードステップも失敗

## 解決策
`.github/workflows/security-scan.yml`に条件を追加し、Dependabotが作成したPRではSnykスキャンジョブ全体をスキップ

\`\`\`yaml
if: github.actor != 'dependabot[bot]'
\`\`\`

## 変更内容
- `.github/workflows/security-scan.yml`に`if: github.actor != 'dependabot[bot]'`を追加
- Dependabot PRでの認証エラーとSARIFアップロードエラーを解消
- 通常のPRとスケジュール実行には影響なし

## 影響範囲
- ✅ Dependabot PRでの認証エラーとSARIFアップロードエラーを解消
- ✅ 通常のPR(開発者によるPR)では引き続きSnykスキャンが実行される
- ✅ スケジュール実行(毎週月曜)も通常通り実行される

## テスト
次回のDependabot PRでエラーが発生しないことを確認予定

## マージ方法
このPRはスカッシュマージを想定しています。