### PR TITLE
fix: update biome schema and package-lock version to match package.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
   "files": {
     "includes": ["**", "!**/out", "!**/dist", "!**/node_modules", "!**/.vscode"]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.22.0",
         "nano-spawn": "^2.0.0"


### PR DESCRIPTION
## Summary

Complete the updates that were missed in PR #93 (semantic-release update).

## Changes

- Update `biome.json` schema version from 2.3.4 to 2.3.6
- Update `package-lock.json` version from 2.7.0 to 2.7.1

These changes ensure consistency across configuration files after the semantic-release version bump in PR #93.

## Related

- Related: #93 (semantic-release update PR)

## Testing

- [x] Build successful: `npm run build`
- [x] Code quality checks passed: `npm run format && npm run lint && npm run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)