### PR TITLE
fix: reset export button state when user cancels overwrite dialog

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -110,6 +110,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour }) => {
         }
       } else if (message.type === 'EXPORT_SUCCESS') {
         setIsExporting(false);
+      } else if (message.type === 'EXPORT_CANCELLED') {
+        // User cancelled export - reset exporting state
+        setIsExporting(false);
       } else if (message.type === 'ERROR') {
         // Reset exporting state on any error
         setIsExporting(false);


### PR DESCRIPTION
## Summary

Fixed an issue where the export button remained in "Exporting..." state when the user cancelled the overwrite confirmation dialog.

## Changes

- Added handling for `EXPORT_CANCELLED` message in `Toolbar.tsx` message listener
- Now properly resets `isExporting` state by calling `setIsExporting(false)` when export is cancelled

## Root Cause

The `Toolbar.tsx` component's message handler was missing a case for `EXPORT_CANCELLED`. It only handled:
- `EXPORT_SUCCESS` → reset state ✓
- `ERROR` → reset state ✓
- `EXPORT_CANCELLED` → **missing** ✗

When users clicked "Cancel" in the overwrite confirmation dialog:
1. Extension sent `EXPORT_CANCELLED` message
2. `vscode-bridge.ts` resolved the promise successfully
3. But `Toolbar.tsx` never reset the button state

## Modified Files

- `src/webview/src/components/Toolbar.tsx` (lines 113-115)

## Notes

- This PR is intended for **squash merge**
- Code quality checks passed: `npm run format && npm run lint && npm run check` ✓