### PR TITLE
ci: upgrade Node.js to v22 in release workflow for Semantic Release v25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install root dependencies


### PR DESCRIPTION
## Summary

Upgraded Node.js version from v20 to v22 in the release workflow to fix Semantic Release v25 compatibility issue.

## Problem

The release workflow failed with the following error:
```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.5.
```

This occurred because:
- Semantic Release was upgraded to v25.0.2 via Dependabot (#90)
- Semantic Release v25 requires Node.js v22.14.0 or higher
- Our release workflow was using Node.js v20.19.5

## Solution

Changed `.github/workflows/release.yml`:
```diff
- node-version: '20'
+ node-version: '22'
```

## Impact on Versioning

**This commit will NOT trigger a version bump** because it uses the `ci:` prefix, which Semantic Release ignores for version calculation.

When merged to production via the next release PR, Semantic Release will:
- Analyze commits from the previous failed release (591cb34)
- Only count `fix:` commits for version bump
- Release as v2.7.2 (not v2.7.3)

## Modified Files

- `.github/workflows/release.yml`

## Notes

- Node.js 22 is stable and will become LTS in October 2025
- Code quality checks passed: ✓