### PR TITLE
fix: close AI refinement panel when node is clicked to show property panel

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -17,6 +17,7 @@ import ReactFlow, {
   type Node,
   type NodeTypes,
 } from 'reactflow';
+import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from './nodes/BranchNode';
@@ -70,6 +71,7 @@ export const WorkflowEditor: React.FC = () => {
   // Get state and handlers from Zustand store
   const { nodes, edges, onNodesChange, onEdgesChange, onConnect, setSelectedNodeId } =
     useWorkflowStore();
+  const { closeChat } = useRefinementStore();
 
   /**
    * 接続制約の検証
@@ -111,8 +113,10 @@ export const WorkflowEditor: React.FC = () => {
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
       setSelectedNodeId(node.id);
+      // Close AI refinement panel to show property panel
+      closeChat();
     },
-    [setSelectedNodeId]
+    [setSelectedNodeId, closeChat]
   );
 
   // Handle pane click (deselect)


### PR DESCRIPTION
## Problem

When the AI refinement panel is open and a user clicks on a node, the property panel cannot be viewed because the AI panel remains open and covers it.

### Current Behavior

1. User opens AI refinement panel
2. User clicks on a node to view its properties
3. ❌ AI panel remains open
4. ❌ Property panel is hidden behind AI panel

### Expected Behavior

1. User opens AI refinement panel
2. User clicks on a node to view its properties
3. ✅ AI panel automatically closes
4. ✅ Property panel is visible

## Solution

Modified `WorkflowEditor.tsx` to call `closeChat()` when a node is clicked.

### Changes

**File**: `src/webview/src/components/WorkflowEditor.tsx`

1. Imported `useRefinementStore` to access `closeChat()` function
2. Added `closeChat()` call in `handleNodeClick` callback
3. Updated `useCallback` dependencies

```typescript
const handleNodeClick = useCallback(
  (_event: React.MouseEvent, node: Node) => {
    setSelectedNodeId(node.id);
    // Close AI refinement panel to show property panel
    closeChat();
  },
  [setSelectedNodeId, closeChat]
);
```

## Impact

- Improves UX by automatically showing the property panel when nodes are clicked
- Users can still reopen the AI panel via the toolbar button if needed
- No breaking changes

## Testing

✅ Manual E2E testing completed successfully

## Notes

- Code quality checks passed: ✓