### PR TITLE
fix: support MCP server config in .claude.json.projects scope

### DIFF
--- a/src/extension/services/mcp-config-reader.ts
+++ b/src/extension/services/mcp-config-reader.ts
@@ -178,11 +178,12 @@ export function getMcpServerConfig(
       }
     }
 
-    // Priority 2: Local scope - .claude.json[<workspace>].mcpServers
+    // Priority 2: Local scope - .claude.json.projects[<workspace>].mcpServers
     if (legacyConfig && workspacePath) {
-      const localConfig = legacyConfig[workspacePath] as
-        | { mcpServers?: Record<string, McpServerConfig> }
+      const projectsConfig = legacyConfig.projects as
+        | Record<string, { mcpServers?: Record<string, McpServerConfig> }>
         | undefined;
+      const localConfig = projectsConfig?.[workspacePath];
       if (localConfig?.mcpServers?.[serverId]) {
         const rawConfig = localConfig.mcpServers[serverId];
         const serverConfig = normalizeServerConfig(rawConfig);
@@ -278,9 +279,10 @@ export function getAllMcpServerIds(workspacePath?: string): string[] {
     if (legacyConfig) {
       // Local scope (project-specific)
       if (workspacePath) {
-        const localConfig = legacyConfig[workspacePath] as
-          | { mcpServers?: Record<string, McpServerConfig> }
+        const projectsConfig = legacyConfig.projects as
+          | Record<string, { mcpServers?: Record<string, McpServerConfig> }>
           | undefined;
+        const localConfig = projectsConfig?.[workspacePath];
         if (localConfig?.mcpServers) {
           for (const id of Object.keys(localConfig.mcpServers)) {
             serverIds.add(id);


### PR DESCRIPTION
## Problem

MCP Node feature was unable to correctly read project-scoped MCP configurations.

### Current Behavior
1. Define project-specific MCP configuration in `.claude.json`
2. ❌ Accessed directly as `legacyConfig[workspacePath]`, causing configuration to not be loaded

### Expected Behavior
1. Define project-specific MCP configuration in `.claude.json`
2. ✅ Correctly access as `legacyConfig.projects[workspacePath]` to load configuration

## Solution

Fixed to read project-scoped configuration from under the `projects` object to match the correct structure of `.claude.json`.

### Changes

**File**: `src/extension/services/mcp-config-reader.ts`

- Fixed `getMcpServerConfig()` function
- Fixed `getAllMcpServerIds()` function
- Updated comments to reflect accurate configuration path

**Before**:
```typescript
// Priority 2: Local scope - .claude.json[<workspace>].mcpServers
const localConfig = legacyConfig[workspacePath] as
  | { mcpServers?: Record<string, McpServerConfig> }
  | undefined;
```

**After**:
```typescript
// Priority 2: Local scope - .claude.json.projects[<workspace>].mcpServers
const projectsConfig = legacyConfig.projects as
  | Record<string, { mcpServers?: Record<string, McpServerConfig> }>
  | undefined;
const localConfig = projectsConfig?.[workspacePath];
```

## Impact

- Project-scoped MCP configurations are now correctly recognized
- No impact on existing user-scoped configurations
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed

## Notes

Correct `.claude.json` structure:
```json
{
  "mcpServers": { /* Global configuration */ },
  "projects": {
    "/path/to/workspace": {
      "mcpServers": { /* Project-specific configuration */ }
    }
  }
}
```