### PR TITLE
fix: unify prompt terminology and rename translation keys

### DIFF
--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -102,7 +102,7 @@ export const NodePalette: React.FC = () => {
       position,
       data: {
         label: t('default.newPrompt'),
-        prompt: t('default.promptTemplate'),
+        prompt: t('default.prompt'),
         variables: {},
       },
     };

--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -779,7 +779,7 @@ const PromptProperties: React.FC<{
         />
       </div>
 
-      {/* Prompt Template */}
+      {/* Prompt */}
       <div>
         <label
           htmlFor="prompt-textarea"
@@ -791,7 +791,7 @@ const PromptProperties: React.FC<{
             marginBottom: '6px',
           }}
         >
-          {t('property.promptTemplate')}
+          {t('property.prompt.label')}
         </label>
         <textarea
           id="prompt-textarea"
@@ -799,7 +799,7 @@ const PromptProperties: React.FC<{
           onChange={(e) => updateNodeData(node.id, { prompt: e.target.value })}
           className="nodrag"
           rows={8}
-          placeholder={t('property.promptTemplate.placeholder')}
+          placeholder={t('property.prompt.placeholder')}
           style={{
             width: '100%',
             padding: '6px 8px',
@@ -819,7 +819,7 @@ const PromptProperties: React.FC<{
             marginTop: '4px',
           }}
         >
-          {t('property.promptTemplate.help')}
+          {t('property.prompt.help')}
         </div>
       </div>
 

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -130,9 +130,9 @@ export interface WebviewTranslationKeys {
   'property.optionDescription.placeholder': string;
 
   // Prompt properties
-  'property.promptTemplate': string;
-  'property.promptTemplate.placeholder': string;
-  'property.promptTemplate.help': string;
+  'property.prompt.label': string;
+  'property.prompt.placeholder': string;
+  'property.prompt.help': string;
   'property.detectedVariables': string;
   'property.variablesSubstituted': string;
 
@@ -161,7 +161,7 @@ export interface WebviewTranslationKeys {
   'default.secondOption': string;
   'default.newOption': string;
   'default.newPrompt': string;
-  'default.promptTemplate': string;
+  'default.prompt': string;
   'default.branchTrue': string;
   'default.branchTrueCondition': string;
   'default.branchFalse': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -134,9 +134,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.optionDescription.placeholder': 'Description',
 
   // Prompt properties
-  'property.promptTemplate': 'Prompt Template',
-  'property.promptTemplate.placeholder': 'Enter prompt template with {{variables}}',
-  'property.promptTemplate.help': 'Use {{variableName}} syntax for dynamic values',
+  'property.prompt.label': 'Prompt',
+  'property.prompt.placeholder': 'Enter prompt with {{variables}}',
+  'property.prompt.help': 'Use {{variableName}} syntax for dynamic values',
   'property.detectedVariables': 'Detected Variables ({count})',
   'property.variablesSubstituted': 'Variables will be substituted at runtime',
 
@@ -165,8 +165,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'default.secondOption': 'Second option',
   'default.newOption': 'New option',
   'default.newPrompt': 'New Prompt',
-  'default.promptTemplate':
-    'Enter your prompt template here.\n\nYou can use variables like {{variableName}}.',
+  'default.prompt': 'Enter your prompt here.\n\nYou can use variables like {{variableName}}.',
   'default.branchTrue': 'True',
   'default.branchTrueCondition': 'When condition is true',
   'default.branchFalse': 'False',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -134,9 +134,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.optionDescription.placeholder': '説明',
 
   // Prompt properties
-  'property.promptTemplate': 'プロンプトテンプレート',
-  'property.promptTemplate.placeholder': '{{variables}}を含むプロンプトテンプレートを入力',
-  'property.promptTemplate.help': '動的な値には{{variableName}}構文を使用',
+  'property.prompt.label': 'プロンプト',
+  'property.prompt.placeholder': '{{variables}}を含むプロンプトを入力',
+  'property.prompt.help': '動的な値には{{variableName}}構文を使用',
   'property.detectedVariables': '検出された変数（{count}）',
   'property.variablesSubstituted': '変数は実行時に置換されます',
 
@@ -165,8 +165,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'default.secondOption': '2番目の選択肢',
   'default.newOption': '新しい選択肢',
   'default.newPrompt': '新しいPrompt',
-  'default.promptTemplate':
-    'ここにプロンプトテンプレートを入力してください。\n\n{{variableName}}のように変数を使用できます。',
+  'default.prompt':
+    'ここにプロンプトを入力してください。\n\n{{variableName}}のように変数を使用できます。',
   'default.branchTrue': 'True',
   'default.branchTrueCondition': '条件が真の場合',
   'default.branchFalse': 'False',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -136,9 +136,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.optionDescription.placeholder': '설명',
 
   // Prompt properties
-  'property.promptTemplate': '프롬프트 템플릿',
-  'property.promptTemplate.placeholder': '{{variables}}를 포함하는 프롬프트 템플릿 입력',
-  'property.promptTemplate.help': '동적 값에는 {{variableName}} 구문 사용',
+  'property.prompt.label': '프롬프트',
+  'property.prompt.placeholder': '{{variables}}를 포함하는 프롬프트 입력',
+  'property.prompt.help': '동적 값에는 {{variableName}} 구문 사용',
   'property.detectedVariables': '감지된 변수 ({count})',
   'property.variablesSubstituted': '변수는 런타임에 대체됩니다',
 
@@ -167,8 +167,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'default.secondOption': '두 번째 옵션',
   'default.newOption': '새 옵션',
   'default.newPrompt': '새 Prompt',
-  'default.promptTemplate':
-    '여기에 프롬프트 템플릿을 입력하세요.\n\n{{variableName}}과 같이 변수를 사용할 수 있습니다.',
+  'default.prompt':
+    '여기에 프롬프트를 입력하세요.\n\n{{variableName}}과 같이 변수를 사용할 수 있습니다.',
   'default.branchTrue': 'True',
   'default.branchTrueCondition': '조건이 참일 때',
   'default.branchFalse': 'False',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -132,9 +132,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.optionDescription.placeholder': '描述',
 
   // Prompt properties
-  'property.promptTemplate': '提示模板',
-  'property.promptTemplate.placeholder': '输入包含{{variables}}的提示模板',
-  'property.promptTemplate.help': '对动态值使用{{variableName}}语法',
+  'property.prompt.label': '提示词',
+  'property.prompt.placeholder': '输入包含{{variables}}的提示词',
+  'property.prompt.help': '对动态值使用{{variableName}}语法',
   'property.detectedVariables': '检测到的变量（{count}）',
   'property.variablesSubstituted': '变量将在运行时替换',
 
@@ -163,7 +163,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'default.secondOption': '第二个选项',
   'default.newOption': '新选项',
   'default.newPrompt': '新Prompt',
-  'default.promptTemplate': '在此输入您的提示模板。\n\n您可以使用{{variableName}}这样的变量。',
+  'default.prompt': '在此输入您的提示词。\n\n您可以使用{{variableName}}这样的变量。',
   'default.branchTrue': 'True',
   'default.branchTrueCondition': '条件为真时',
   'default.branchFalse': 'False',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -132,9 +132,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.optionDescription.placeholder': '描述',
 
   // Prompt properties
-  'property.promptTemplate': '提示範本',
-  'property.promptTemplate.placeholder': '輸入包含{{variables}}的提示範本',
-  'property.promptTemplate.help': '對動態值使用{{variableName}}語法',
+  'property.prompt.label': '提示詞',
+  'property.prompt.placeholder': '輸入包含{{variables}}的提示詞',
+  'property.prompt.help': '對動態值使用{{variableName}}語法',
   'property.detectedVariables': '偵測到的變數（{count}）',
   'property.variablesSubstituted': '變數將在執行時替換',
 
@@ -163,7 +163,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'default.secondOption': '第二個選項',
   'default.newOption': '新選項',
   'default.newPrompt': '新Prompt',
-  'default.promptTemplate': '在此輸入您的提示範本。\n\n您可以使用{{variableName}}這樣的變數。',
+  'default.prompt': '在此輸入您的提示詞。\n\n您可以使用{{variableName}}這樣的變數。',
   'default.branchTrue': 'True',
   'default.branchTrueCondition': '條件為真時',
   'default.branchFalse': 'False',


### PR DESCRIPTION
## Problem

The Prompt node used inconsistent terminology across the codebase:
- Translation keys were named `promptTemplate` 
- Some UI text displayed "プロンプトテンプレート" (Prompt Template) instead of "プロンプト" (Prompt)
- Translation key structure was flat, lacking hierarchical organization

### Current Behavior
- ❌ Mixed terminology: "Prompt Template" vs "Prompt"
- ❌ Flat key structure: `property.promptTemplate`, `property.promptTemplate.placeholder`
- ❌ Inconsistent with other property keys

### Expected Behavior
- ✅ Unified terminology: "Prompt" everywhere
- ✅ Hierarchical key structure: `property.prompt.label`, `property.prompt.placeholder`
- ✅ Consistent with other property naming patterns

## Solution

Renamed all translation keys from `promptTemplate` to `prompt` and updated display text for consistency across all supported languages.

### Changes

**Translation Keys**: `src/webview/src/i18n/translation-keys.ts`
- `property.promptTemplate` → `property.prompt.label`
- `property.promptTemplate.placeholder` → `property.prompt.placeholder`
- `property.promptTemplate.help` → `property.prompt.help`
- `default.promptTemplate` → `default.prompt`

**Translation Files**: All 5 language files updated
- **Japanese**: "プロンプトテンプレート" → "プロンプト"
- **Simplified Chinese**: "提示模板" → "提示词"
- **Traditional Chinese**: "提示範本" → "提示詞"
- **English/Korean**: Key names updated (text already consistent)

**Component Updates**:
- `PropertyPanel.tsx`: Updated to use new translation keys (`property.prompt.label`, etc.)
- `NodePalette.tsx`: Updated default prompt value to use `default.prompt`
- Comment updated from "Prompt Template" to "Prompt"

## Impact

- **UX**: More consistent and clearer terminology across all languages
- **i18n**: Better organized translation key structure with hierarchical naming
- **Breaking Changes**: None - internal key refactoring only

## Testing

- [x] Manual E2E testing completed - verified prompt input displays correctly
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful (extension + webview)
- [x] Verified all translation files load correctly

## Notes

This change affects UI text only. No functional behavior changes.