### PR TITLE
fix: revert @types/vscode to ~1.80.0 to match engines.vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.22.0",
         "nano-spawn": "^2.0.0"
@@ -17,7 +17,7 @@
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
         "@types/node": "^24.10.1",
-        "@types/vscode": "^1.106.1",
+        "@types/vscode": "~1.80.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.3.8",
         "conventional-changelog-conventionalcommits": "^9.1.0",
@@ -2125,9 +2125,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.106.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.106.1.tgz",
-      "integrity": "sha512-R/HV8u2h8CAddSbX8cjpdd7B8/GnE4UjgjpuGuHcbp1xV6yh4OeqU4L1pKjlwujCrSFS0MOpwJAIs/NexMB1fQ==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.80.0.tgz",
+      "integrity": "sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^24.10.1",
-    "@types/vscode": "^1.106.1",
+    "@types/vscode": "~1.80.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.3.8",
     "conventional-changelog-conventionalcommits": "^9.1.0",


### PR DESCRIPTION
## Problem

The @types/vscode update in #92 (^1.106.1) caused vsce packaging error during release workflow due to version mismatch with engines.vscode (^1.80.0).

### Error Message
```
@types/vscode ^1.106.1 greater than engines.vscode ^1.80.0. 
Either upgrade engines.vscode or use an older @types/vscode version
```

## Solution

Revert @types/vscode to ~1.80.0 to match engines.vscode ^1.80.0.

## Changes

**Files**: `package.json`, `package-lock.json`

- Downgrade @types/vscode: ^1.106.1 → ~1.80.0
- Keep engines.vscode: ^1.80.0 (unchanged)

## Impact

- Fixes VSIX packaging during release workflow
- No breaking changes (only development dependency)
- Extension continues to support VSCode 1.80.0+

## Testing

- [x] Code quality checks passed
  - `npm run format` ✓
  - `npm run lint` ✓
  - `npm run check` ✓
  - `npm run build` ✓

## Related

- Reverts: #92
- Fixes: Release workflow failure for v2.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)