### PR TITLE
fix: add missing MCP node definition to workflow schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,46 @@ tests/
 
 ## Development Workflow & Commands
 
+### Commit Message Guidelines
+
+**IMPORTANT: Keep commit messages simple for squash merge workflow.**
+
+#### Format
+```
+<type>: <subject>
+
+<optional body with bullet points>
+```
+
+#### Example
+```
+fix: add missing MCP node definition to workflow schema
+
+- Added 'mcp' to supportedNodeTypes
+- Added complete MCP node type definition with field constraints
+- Fixes MCP_INVALID_PARAMETERS and MCP_INVALID_MODE validation errors
+```
+
+#### Rules
+- **Subject**: 50 characters max, imperative mood, no period
+- **Body**: 3-5 bullet points max, "what" changed only
+- **Details**: Put "why" and "how" in PR description, NOT commit message
+
+#### Types
+- `feat:` - New feature (minor version bump)
+- `fix:` - Bug fix (patch version bump)
+- `docs:` - Documentation only
+- `refactor:` - Code refactoring
+- `chore:` - Build/tooling changes
+
+#### What to Avoid
+❌ Long explanations (Problem/Solution/Impact sections)
+❌ Multiple paragraphs
+❌ Code blocks
+❌ Test results with checkboxes
+
+✅ Simple 3-5 line summary of changes
+
 ### Code Quality Checks (Required Before Commit/PR)
 
 **Always run these commands in the following order after code modifications:**

--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -11,7 +11,8 @@
       "askUserQuestion",
       "ifElse",
       "switch",
-      "skill"
+      "skill",
+      "mcp"
     ]
   },
   "nodeTypes": {
@@ -171,6 +172,108 @@
       },
       "inputPorts": 1,
       "outputPorts": 1
+    },
+    "mcp": {
+      "description": "Execute an MCP (Model Context Protocol) tool from an external server. MCP enables integration with external services, databases, APIs, and tools. **Important: Always use 'manualParameterConfig' mode for AI-generated workflows. Parameters must be provided as an array of parameter definitions, NOT as key-value pairs.**",
+      "fields": {
+        "serverId": {
+          "type": "string",
+          "required": true,
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "MCP server identifier (e.g., 'playwright', 'github', 'filesystem')"
+        },
+        "toolName": {
+          "type": "string",
+          "required": true,
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "Tool function name from the MCP server (e.g., 'playwright_navigate', 'get_file_contents')"
+        },
+        "toolDescription": {
+          "type": "string",
+          "required": false,
+          "maxLength": 1024,
+          "description": "Human-readable description of what the tool does"
+        },
+        "parameters": {
+          "type": "array",
+          "required": false,
+          "description": "Array of parameter schema definitions (NOT parameter values). Each parameter object must have: name (string), type (string), description (string), required (boolean). Example: [{\"name\": \"url\", \"type\": \"string\", \"description\": \"Target URL\", \"required\": true}]",
+          "items": {
+            "name": { "type": "string", "required": true },
+            "type": {
+              "type": "string",
+              "required": true,
+              "enum": ["string", "number", "boolean", "array", "object"]
+            },
+            "description": { "type": "string", "required": false },
+            "required": { "type": "boolean", "required": true }
+          }
+        },
+        "parameterValues": {
+          "type": "object",
+          "required": false,
+          "description": "Key-value pairs of parameter values. Keys must match parameter names from the 'parameters' array. Example: {\"url\": \"https://example.com\"}"
+        },
+        "mode": {
+          "type": "string",
+          "required": false,
+          "enum": ["manualParameterConfig", "aiParameterConfig", "aiToolSelection"],
+          "default": "manualParameterConfig",
+          "description": "Configuration mode - ALWAYS use 'manualParameterConfig' for AI-generated workflows"
+        },
+        "validationStatus": {
+          "type": "string",
+          "enum": ["valid", "missing", "invalid"],
+          "required": true,
+          "default": "valid"
+        },
+        "outputPorts": {
+          "type": "number",
+          "required": true,
+          "value": 1
+        }
+      },
+      "inputPorts": 1,
+      "outputPorts": 1,
+      "aiGenerationGuidance": {
+        "mode": "ALWAYS set mode to 'manualParameterConfig'",
+        "parameters": "MUST be an array of parameter schema objects with {name, type, description, required} fields",
+        "parameterValues": "Optional object with key-value pairs matching parameter names",
+        "commonTools": {
+          "playwright": [
+            "playwright_navigate",
+            "playwright_click",
+            "playwright_screenshot",
+            "playwright_evaluate"
+          ],
+          "filesystem": ["read_file", "write_file", "list_directory"],
+          "github": ["get_issue", "create_pull_request", "list_repositories"]
+        },
+        "example": {
+          "type": "mcp",
+          "data": {
+            "serverId": "playwright",
+            "toolName": "playwright_navigate",
+            "toolDescription": "Navigate browser to URL",
+            "parameters": [
+              {
+                "name": "url",
+                "type": "string",
+                "description": "Target URL to navigate to",
+                "required": true
+              }
+            ],
+            "parameterValues": {
+              "url": "https://example.com"
+            },
+            "mode": "manualParameterConfig",
+            "validationStatus": "valid",
+            "outputPorts": 1
+          }
+        }
+      }
     }
   },
   "connectionRules": {


### PR DESCRIPTION
## Problem

AI-assisted workflow generation was failing when trying to create MCP nodes with validation errors:

### Current Behavior
1. User requests AI to generate workflow with MCP nodes
2. ❌ AI generates MCP node with incorrect structure due to missing schema definition
3. ❌ Validation fails with errors:
   - `MCP_INVALID_PARAMETERS`: Parameters must be an array
   - `MCP_INVALID_MODE`: Invalid mode 'specificTool' (valid: manualParameterConfig, aiParameterConfig, aiToolSelection)

### Expected Behavior
1. User requests AI to generate workflow with MCP nodes
2. ✅ AI references MCP node schema definition
3. ✅ AI generates correct MCP node structure
4. ✅ Validation passes and workflow is created successfully

## Solution

Added complete MCP node type definition to `workflow-schema.json` to guide AI generation, and added commit message guidelines to prevent overly complex commit messages in the future.

### Changes

**File**: `resources/workflow-schema.json`

- Added `"mcp"` to `supportedNodeTypes` array
- Added comprehensive `nodeTypes.mcp` definition with:
  - **Required fields**: `serverId`, `toolName`, `validationStatus`, `outputPorts`
  - **Optional fields**: `toolDescription`, `parameters`, `parameterValues`, `mode`
  - **Field constraints**:
    - `parameters`: Must be array of parameter schema objects `[{name, type, description, required}]`
    - `mode`: Must be one of `manualParameterConfig`, `aiParameterConfig`, `aiToolSelection`
  - **AI generation guidance** section with:
    - Explicit instructions to use `manualParameterConfig` mode
    - Parameter structure examples
    - Common tool names for popular MCP servers (Playwright, GitHub, Filesystem)
    - Complete working example

**File**: `CLAUDE.md`

- Added commit message guidelines section
- Emphasizes simple commit messages for squash merge workflow
- Conventional Commits format with 3-5 bullet points max
- Clear examples of what to avoid (long explanations, code blocks, test results)

## Impact

- **UX**: AI workflow generation now correctly handles MCP nodes without validation errors
- **Breaking Change**: None - additive changes only
- **Side Effects**: None - existing workflows are unaffected
- **Schema Size**: 16KB → 21KB (~5KB increase from MCP definition)

## Testing

- [x] Manual E2E testing completed
  - Created workflow with MCP (Playwright) nodes via AI generation
  - Verified no `MCP_INVALID_PARAMETERS` or `MCP_INVALID_MODE` errors
  - Confirmed correct node structure generated with proper `parameters` array and `mode` field
- [x] Code quality checks passed
  - `npm run format && npm run lint && npm run check`
  - `npm run build` succeeded

## Notes

- **Known Limitation**: AI may generate non-existent tool names (e.g., tools not available in installed MCP servers). Tracked in #129 for future enhancement with runtime tool name validation.
- This fix unblocks AI-assisted workflow generation for MCP integration demos and README hero image creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>