### PR TITLE
fix: allow empty parameters for MCP tools without parameters

### DIFF
--- a/src/extension/utils/validate-workflow.ts
+++ b/src/extension/utils/validate-workflow.ts
@@ -424,19 +424,23 @@ function validateMcpNode(node: WorkflowNode): ValidationError[] {
           field: `nodes[${node.id}].data.toolDescription`,
         });
       }
-      if (!mcpData.parameters || mcpData.parameters.length === 0) {
+      // parameters配列が定義されていない場合のみエラー（空配列はOK - パラメータなしツール用）
+      if (!mcpData.parameters) {
         errors.push({
           code: 'MCP_MODE_CONFIG_MISMATCH',
           message: 'Manual parameter config mode requires parameters array to be set',
           field: `nodes[${node.id}].data.parameters`,
         });
       }
-      if (!mcpData.parameterValues || Object.keys(mcpData.parameterValues).length === 0) {
-        errors.push({
-          code: 'MCP_MODE_CONFIG_MISMATCH',
-          message: 'Manual parameter config mode requires parameterValues to be configured',
-          field: `nodes[${node.id}].data.parameterValues`,
-        });
+      // parametersが空でない場合のみ、parameterValuesの存在をチェック
+      if (mcpData.parameters && mcpData.parameters.length > 0) {
+        if (!mcpData.parameterValues || Object.keys(mcpData.parameterValues).length === 0) {
+          errors.push({
+            code: 'MCP_MODE_CONFIG_MISMATCH',
+            message: 'Manual parameter config mode requires parameterValues to be configured',
+            field: `nodes[${node.id}].data.parameterValues`,
+          });
+        }
       }
       break;
 


### PR DESCRIPTION
## Problem

MCP tools that have no parameters (e.g., `browser_snapshot`) were failing export validation with errors:
- "Manual parameter config mode requires parameters array to be set"
- "Manual parameter config mode requires parameterValues to be configured"

### Current Behavior
1. User creates workflow with parameter-less MCP tool (e.g., `browser_snapshot`)
2. Node has `parameters: []` and `parameterValues: {}` (valid empty state)
3. ❌ Export validation fails
4. ❌ User cannot export workflow to slash commands

### Expected Behavior
1. User creates workflow with parameter-less MCP tool
2. Node has `parameters: []` and `parameterValues: {}` (valid empty state)
3. ✅ Export validation passes
4. ✅ Workflow exports successfully

## Solution

Modified validation logic in `validate-workflow.ts` to allow empty arrays/objects for parameter-less tools.

### Changes

**File**: `src/extension/utils/validate-workflow.ts` (Lines 427-444)

**Before**:
```typescript
if (!mcpData.parameters || mcpData.parameters.length === 0) {
  errors.push({ ... }); // Rejects empty array
}
if (!mcpData.parameterValues || Object.keys(mcpData.parameterValues).length === 0) {
  errors.push({ ... }); // Rejects empty object
}
```

**After**:
```typescript
// Allow empty array for parameter-less tools
if (!mcpData.parameters) {
  errors.push({ ... });
}
// Only check parameterValues if parameters exist
if (mcpData.parameters && mcpData.parameters.length > 0) {
  if (!mcpData.parameterValues || Object.keys(mcpData.parameterValues).length === 0) {
    errors.push({ ... });
  }
}
```

**Logic**:
- `parameters: []` is now valid (parameter-less tools)
- `parameterValues: {}` is valid when `parameters` is empty
- `parameterValues` existence is only checked when `parameters` has items

## Impact

- **UX**: Users can now export workflows with parameter-less MCP tools
- **Breaking Change**: None - validation is more permissive
- **Side Effects**: None - tools with parameters still require values

## Testing

- [x] Manual E2E testing completed
  - Created workflow with `browser_snapshot` (no parameters)
  - Verified export succeeds with `parameters: []` and `parameterValues: {}`
  - Verified tools with parameters still require values
- [x] Code quality checks passed
  - `npm run format && npm run lint && npm run check`
  - `npm run build` succeeded

## Notes

- This fix enables creation of README hero image workflow using `browser_snapshot`
- Export service already handles empty parameters correctly (lines 418-445)
- Validation was the only blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>