### PR TITLE
fix: clear all Slack client cache on token update and disconnect

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -540,6 +540,7 @@ export function registerOpenEditorCommand(
               // Disconnect from Slack workspace
               try {
                 await slackTokenManager.clearConnection();
+                slackApiService.invalidateClient();
                 vscode.window.showInformationMessage('Slack Bot Token deleted successfully');
                 webview.postMessage({
                   type: 'SLACK_DISCONNECT_SUCCESS',

--- a/src/extension/commands/slack-connect-manual.ts
+++ b/src/extension/commands/slack-connect-manual.ts
@@ -85,7 +85,10 @@ export async function handleConnectSlackManual(
       workspaceName,
     });
 
-    // Step 3: Store connection in VSCode Secret Storage
+    // Step 3: Clear existing connections before storing new one (same as delete → create flow)
+    await tokenManager.clearConnection();
+
+    // Step 4: Store connection in VSCode Secret Storage
     await tokenManager.storeManualConnection(
       workspaceId,
       workspaceName,
@@ -115,7 +118,7 @@ export async function handleConnectSlackManual(
     }
 
     // Invalidate SlackApiService client cache to force re-initialization
-    slackApiService.invalidateClient(workspaceId);
+    slackApiService.invalidateClient();
 
     log('INFO', 'Manual Slack connection completed successfully');
 


### PR DESCRIPTION
## Problem

When updating Slack workspace token directly (without deleting the old token first), the workspace did not switch properly.

### Current Behavior
1. Connect with Workspace A token
2. Update directly to Workspace B token (without deletion)
3. ❌ Stays on Workspace A (does not switch)

### Expected Behavior
1. Connect with Workspace A token
2. Update directly to Workspace B token (without deletion)
3. ✅ Switches to Workspace B

### Workaround (Before Fix)
1. Connect with Workspace A token
2. **Delete token**
3. Connect with Workspace B token
4. ✅ Switches to Workspace B (works correctly)

## Solution

Since the delete → create flow was working correctly, we made token update flow **use exactly the same implementation** as the delete → create flow.

### Root Cause

`SlackTokenManager.storeManualConnection()` only **adds** a new token without deleting old ones. This caused:

- Both Workspace A and Workspace B tokens remain in Secret Storage
- Workspace A's WebClient remains cached in `SlackApiService`
- Result: System continues to use Workspace A

## Changes

### File 1: `src/extension/commands/slack-connect-manual.ts`

**Changes:**
- Call `tokenManager.clearConnection()` before storing new token to delete all existing tokens
- Changed `invalidateClient(workspaceId)` to `invalidateClient()` to clear all WebClient cache

```typescript
// Step 3: Clear existing connections before storing new one (same as delete → create flow)
await tokenManager.clearConnection();

// Step 4: Store connection in VSCode Secret Storage
await tokenManager.storeManualConnection(
  workspaceId,
  workspaceName,
  workspaceId,
  accessToken,
  ''
);

// Invalidate SlackApiService client cache to force re-initialization
slackApiService.invalidateClient();  // Changed from invalidateClient(workspaceId)
```

### File 2: `src/extension/commands/open-editor.ts`

**Changes:**
- Added `slackApiService.invalidateClient()` call in `SLACK_DISCONNECT` message handler

```typescript
case 'SLACK_DISCONNECT':
  try {
    await slackTokenManager.clearConnection();
    slackApiService.invalidateClient();  // ← Added
    vscode.window.showInformationMessage('Slack Bot Token deleted successfully');
    // ...
  }
```

## Impact

- ✅ Direct token update (Workspace A → B) now works correctly
- ✅ Delete → create flow behavior unchanged (maintains existing behavior)
- ✅ Multiple workspace management not supported (single workspace only)
- ✅ Secret Storage and cache are reliably synchronized

## Testing

- [x] Manual E2E testing completed
  - [x] Connect with Workspace A token
  - [x] Update directly to Workspace B token (no deletion)
  - [x] Workspace B is displayed correctly
  - [x] Sharing to Workspace B succeeds
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

## Notes

This fix makes the token update flow **use the exact same implementation** as the delete → create flow. This prevents future bugs and ensures consistent behavior.