### PR TITLE
fix: add MCP server refresh button to resolve cache issue

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -16,7 +16,12 @@ import { handleGenerateWorkflow } from './ai-generation';
 import { handleExportWorkflow } from './export-workflow';
 import { loadWorkflow } from './load-workflow';
 import { loadWorkflowList } from './load-workflow-list';
-import { handleGetMcpToolSchema, handleGetMcpTools, handleListMcpServers } from './mcp-handlers';
+import {
+  handleGetMcpToolSchema,
+  handleGetMcpTools,
+  handleListMcpServers,
+  handleRefreshMcpCache,
+} from './mcp-handlers';
 import { saveWorkflow } from './save-workflow';
 import { handleBrowseSkills, handleCreateSkill, handleValidateSkillFile } from './skill-operations';
 import { handleConnectSlackManual } from './slack-connect-manual';
@@ -440,6 +445,11 @@ export function registerOpenEditorCommand(
                   },
                 });
               }
+              break;
+
+            case 'REFRESH_MCP_CACHE':
+              // Refresh MCP cache (invalidate all cached data)
+              await handleRefreshMcpCache(message.payload || {}, webview, message.requestId || '');
               break;
 
             case 'LIST_SLACK_WORKSPACES':

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -503,6 +503,24 @@ export interface McpErrorPayload {
   timestamp: string; // ISO 8601
 }
 
+/**
+ * Refresh MCP cache request payload
+ *
+ * Invalidates all in-memory MCP cache (server list, tools, schemas).
+ * Useful when MCP servers are added/removed after initial load.
+ */
+export type RefreshMcpCachePayload = Record<string, never>;
+
+/**
+ * MCP cache refreshed result payload
+ */
+export interface McpCacheRefreshedPayload {
+  /** Whether the cache refresh succeeded */
+  success: boolean;
+  /** Request timestamp */
+  timestamp: string; // ISO 8601
+}
+
 // ============================================================================
 // Extension → Webview Messages
 // ============================================================================
@@ -534,6 +552,7 @@ export type ExtensionMessage =
   | Message<McpToolSchemaResultPayload, 'MCP_TOOL_SCHEMA_RESULT'>
   | Message<McpNodeValidationResultPayload, 'MCP_NODE_VALIDATION_RESULT'>
   | Message<McpErrorPayload, 'MCP_ERROR'>
+  | Message<McpCacheRefreshedPayload, 'MCP_CACHE_REFRESHED'>
   | Message<ShareWorkflowSuccessPayload, 'SHARE_WORKFLOW_SUCCESS'>
   | Message<SensitiveDataWarningPayload, 'SENSITIVE_DATA_WARNING'>
   | Message<ShareWorkflowFailedPayload, 'SHARE_WORKFLOW_FAILED'>
@@ -842,6 +861,7 @@ export type WebviewMessage =
   | Message<GetMcpToolSchemaPayload, 'GET_MCP_TOOL_SCHEMA'>
   | Message<ValidateMcpNodePayload, 'VALIDATE_MCP_NODE'>
   | Message<UpdateMcpNodePayload, 'UPDATE_MCP_NODE'>
+  | Message<RefreshMcpCachePayload, 'REFRESH_MCP_CACHE'>
   | Message<SlackConnectPayload, 'SLACK_CONNECT'>
   | Message<void, 'SLACK_DISCONNECT'>
   | Message<void, 'GET_OAUTH_REDIRECT_URI'> // @deprecated Will be removed in favor of CONNECT_SLACK_MANUAL

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -370,6 +370,11 @@ export interface WebviewTranslationKeys {
   'mcp.error.toolLoadFailed': string;
   'mcp.empty.tools': string;
 
+  // MCP Cache Actions
+  'mcp.action.refresh': string;
+  'mcp.refreshing': string;
+  'mcp.error.refreshFailed': string;
+
   // MCP Tool Search
   'mcp.search.placeholder': string;
   'mcp.search.noResults': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -408,6 +408,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.toolLoadFailed': 'Failed to load tools from server',
   'mcp.empty.tools': 'No tools available for this server',
 
+  // MCP Cache Actions
+  'mcp.action.refresh': 'Refresh',
+  'mcp.refreshing': 'Refreshing...',
+  'mcp.error.refreshFailed': 'Failed to refresh MCP cache',
+
   // MCP Tool Search
   'mcp.search.placeholder': 'Search tools by name or description...',
   'mcp.search.noResults': 'No tools found matching "{query}"',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -407,6 +407,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.toolLoadFailed': 'サーバーからツールの読み込みに失敗しました',
   'mcp.empty.tools': 'このサーバーで利用可能なツールがありません',
 
+  // MCP Cache Actions
+  'mcp.action.refresh': '再読み込み',
+  'mcp.refreshing': '再読み込み中...',
+  'mcp.error.refreshFailed': 'MCPキャッシュの再読み込みに失敗しました',
+
   // MCP Tool Search
   'mcp.search.placeholder': 'ツール名または説明で検索...',
   'mcp.search.noResults': '"{query}" に一致するツールが見つかりません',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -406,6 +406,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.toolLoadFailed': '서버에서 도구 로드 실패',
   'mcp.empty.tools': '이 서버에서 사용할 수 있는 도구가 없습니다',
 
+  // MCP Cache Actions
+  'mcp.action.refresh': '새로 고침',
+  'mcp.refreshing': '새로 고침 중...',
+  'mcp.error.refreshFailed': 'MCP 캐시 새로 고침에 실패했습니다',
+
   // MCP Tool Search
   'mcp.search.placeholder': '이름이나 설명으로 도구 검색...',
   'mcp.search.noResults': '"{query}"와 일치하는 도구를 찾을 수 없습니다',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -390,6 +390,11 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.toolLoadFailed': '从服务器加载工具失败',
   'mcp.empty.tools': '此服务器没有可用工具',
 
+  // MCP Cache Actions
+  'mcp.action.refresh': '刷新',
+  'mcp.refreshing': '正在刷新...',
+  'mcp.error.refreshFailed': 'MCP 缓存刷新失败',
+
   // MCP Tool Search
   'mcp.search.placeholder': '按名称或描述搜索工具...',
   'mcp.search.noResults': '未找到与"{query}"匹配的工具',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -390,6 +390,11 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'mcp.error.toolLoadFailed': '從伺服器載入工具失敗',
   'mcp.empty.tools': '此伺服器沒有可用工具',
 
+  // MCP Cache Actions
+  'mcp.action.refresh': '重新整理',
+  'mcp.refreshing': '正在重新整理...',
+  'mcp.error.refreshFailed': 'MCP 快取重新整理失敗',
+
   // MCP Tool Search
   'mcp.search.placeholder': '按名稱或描述搜尋工具...',
   'mcp.search.noResults': '未找到與"{query}"匹配的工具',


### PR DESCRIPTION
## Problem

After loading MCP servers once, the cache persists and newly added MCP servers don't appear in the UI.

### Current Behavior
1. Load MCP server list in MCP Tool node settings
2. Add a new MCP server configuration
3. ❌ Newly added MCP server doesn't appear in the list (cache remains)

### Expected Behavior
1. Load MCP server list in MCP Tool node settings
2. Add a new MCP server configuration
3. Click refresh button
4. ✅ Newly added MCP server appears in the list

## Solution

Added manual cache invalidation mechanism with refresh buttons in MCP Tool node settings.

### Changes

**Extension Host**:
- `src/shared/types/messages.ts`: Added REFRESH_MCP_CACHE / MCP_CACHE_REFRESHED message types
- `src/extension/commands/mcp-handlers.ts`: Added handleRefreshMcpCache handler function
- `src/extension/commands/open-editor.ts`: Added REFRESH_MCP_CACHE routing

**Webview**:
- `src/webview/src/services/mcp-service.ts`: Added refreshMcpCache service function
- `src/webview/src/components/mcp/McpServerList.tsx`: Added refresh button and handler
- `src/webview/src/components/dialogs/McpNodeEditDialog.tsx`: Added refresh button to tool info section

**i18n**:
- `src/webview/src/i18n/translation-keys.ts`: Added translation keys
- Added translations for 5 languages (en, ja, ko, zh-CN, zh-TW)

```typescript
// handleRefreshMcpCache implementation
export async function handleRefreshMcpCache(
  _payload: RefreshMcpCachePayload,
  webview: vscode.Webview,
  requestId: string
): Promise<void> {
  try {
    invalidateAllCache(); // Clear all MCP cache
    
    const successPayload: McpCacheRefreshedPayload = {
      success: true,
      timestamp: new Date().toISOString(),
    };
    
    webview.postMessage({
      type: 'MCP_CACHE_REFRESHED',
      requestId,
      payload: successPayload,
    });
  } catch (error) {
    // Error handling...
  }
}
```

## Impact

- ✅ UX improvement: Users can manually refresh MCP server list
- ✅ Resolves cache issue: Newly added MCP servers appear immediately after refresh
- ✅ No breaking changes: Existing functionality remains intact

## Testing

- [x] Manual E2E testing completed
  - Verified refresh button in McpServerList component
  - Verified refresh button in McpNodeEditDialog component
  - Verified loading states display correctly
  - Verified error handling works properly
- [x] Code quality checks passed
  - `npm run format` ✅
  - `npm run lint` ✅
  - `npm run check` ✅
  - `npm run build` ✅

## Notes

- Refresh buttons are placed in 2 locations:
  1. **McpServerList**: Refreshes entire server list
  2. **McpNodeEditDialog**: Refreshes tool schema (except aiToolSelection mode)
- Uses existing `invalidateAllCache()` function for cache invalidation