### PR TITLE
fix: improve error message when no workspace is open

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -7,6 +7,7 @@
 
 import * as vscode from 'vscode';
 import type { WebviewMessage } from '../../shared/types/messages';
+import { translate } from '../i18n/i18n-service';
 import { cancelGeneration } from '../services/claude-code-service';
 import { FileService } from '../services/file-service';
 import { SlackApiService } from '../services/slack-api-service';
@@ -82,9 +83,13 @@ export function registerOpenEditorCommand(
       try {
         fileService = new FileService();
       } catch (error) {
-        vscode.window.showErrorMessage(
-          `Failed to initialize File Service: ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
+        // Check if this is a "no workspace" error
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        if (errorMessage === 'No workspace folder is open') {
+          vscode.window.showErrorMessage(translate('error.noWorkspaceOpen'));
+        } else {
+          vscode.window.showErrorMessage(`Failed to initialize File Service: ${errorMessage}`);
+        }
         return;
       }
 

--- a/src/extension/i18n/translation-keys.ts
+++ b/src/extension/i18n/translation-keys.ts
@@ -64,4 +64,7 @@ export interface TranslationKeys {
   'mcpNode.optional': string;
   'mcpNode.noDescription': string;
   'mcpNode.executionMethod': string;
+
+  // Error messages
+  'error.noWorkspaceOpen': string;
 }

--- a/src/extension/i18n/translations/en.ts
+++ b/src/extension/i18n/translations/en.ts
@@ -72,4 +72,7 @@ export const enTranslations: TranslationKeys = {
   'mcpNode.noDescription': 'No description available',
   'mcpNode.executionMethod':
     'This node invokes an MCP (Model Context Protocol) tool. When executing this workflow, use the configured parameters to call the tool via the MCP server.',
+
+  // Error messages
+  'error.noWorkspaceOpen': 'Please open a folder or workspace first.',
 };

--- a/src/extension/i18n/translations/ja.ts
+++ b/src/extension/i18n/translations/ja.ts
@@ -71,4 +71,7 @@ export const jaTranslations: TranslationKeys = {
   'mcpNode.noDescription': '説明なし',
   'mcpNode.executionMethod':
     'このノードはMCP(Model Context Protocol)ツールを呼び出します。ワークフロー実行時は、設定されたパラメータを使用してMCPサーバー経由でツールを呼び出してください。',
+
+  // Error messages
+  'error.noWorkspaceOpen': 'フォルダまたはワークスペースを開いてから実行してください。',
 };

--- a/src/extension/i18n/translations/ko.ts
+++ b/src/extension/i18n/translations/ko.ts
@@ -71,4 +71,7 @@ export const koTranslations: TranslationKeys = {
   'mcpNode.noDescription': '설명 없음',
   'mcpNode.executionMethod':
     '이 노드는 MCP(Model Context Protocol) 도구를 호출합니다. 워크플로를 실행할 때 구성된 매개변수를 사용하여 MCP 서버를 통해 도구를 호출하세요.',
+
+  // Error messages
+  'error.noWorkspaceOpen': '폴더 또는 워크스페이스를 먼저 열어주세요.',
 };

--- a/src/extension/i18n/translations/zh-CN.ts
+++ b/src/extension/i18n/translations/zh-CN.ts
@@ -68,4 +68,7 @@ export const zhCNTranslations: TranslationKeys = {
   'mcpNode.noDescription': '无描述',
   'mcpNode.executionMethod':
     '此节点调用MCP（Model Context Protocol）工具。执行此工作流时，请使用已配置的参数通过MCP服务器调用该工具。',
+
+  // Error messages
+  'error.noWorkspaceOpen': '请先打开文件夹或工作区。',
 };

--- a/src/extension/i18n/translations/zh-TW.ts
+++ b/src/extension/i18n/translations/zh-TW.ts
@@ -68,4 +68,7 @@ export const zhTWTranslations: TranslationKeys = {
   'mcpNode.noDescription': '無描述',
   'mcpNode.executionMethod':
     '此節點調用MCP（Model Context Protocol）工具。執行此工作流時，請使用已配置的參數通過MCP伺服器調用該工具。',
+
+  // Error messages
+  'error.noWorkspaceOpen': '請先開啟資料夾或工作區。',
 };


### PR DESCRIPTION
## Problem

### Current Behavior
1. User opens VSCode without a workspace/folder
2. User tries to launch Claude Code Workflow Studio
3. ❌ Technical error message displayed: `Failed to initialize File Service: No workspace folder is open`

### Expected Behavior
1. User opens VSCode without a workspace/folder
2. User tries to launch Claude Code Workflow Studio
3. ✅ User-friendly message displayed: `フォルダまたはワークスペースを開いてから実行してください。`

## Solution

Add i18n support for the workspace error message to display a clear, actionable message to users.

### Changes

**File**: `src/extension/commands/open-editor.ts`
- Import translate function from i18n-service
- Check if error is "No workspace folder is open" and display localized message

**File**: `src/extension/i18n/translation-keys.ts`
- Add `error.noWorkspaceOpen` key

**Files**: `src/extension/i18n/translations/*.ts`
- Add translations for 5 languages:
  - English: "Please open a folder or workspace first."
  - Japanese: "フォルダまたはワークスペースを開いてから実行してください。"
  - Korean: "폴더 또는 워크스페이스를 먼저 열어주세요."
  - Simplified Chinese: "请先打开文件夹或工作区。"
  - Traditional Chinese: "請先開啟資料夾或工作區。"

## Impact

- Improved UX for users who launch the extension without a workspace
- No breaking changes
- Consistent with existing i18n patterns

## Testing

- [x] Manual E2E testing completed (launch extension without workspace)
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)