### PR TITLE
fix: improve node palette description text visibility

### DIFF
--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -250,7 +250,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.prompt.description')}
@@ -289,7 +290,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.subAgent.description')}
@@ -328,7 +330,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.skill.description')}
@@ -367,7 +370,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.mcp.description')}
@@ -420,7 +424,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.ifElse.description')}
@@ -458,7 +463,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.switch.description')}
@@ -497,7 +503,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.askUserQuestion.description')}
@@ -536,7 +543,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.end.description')}
@@ -577,7 +585,8 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-button-foreground)',
+            opacity: 0.8,
           }}
         >
           {t('node.branch.description')}


### PR DESCRIPTION
## Problem

### Current Behavior
1. Node palette buttons have description text
2. ❌ Description text uses `var(--vscode-descriptionForeground)` which has poor contrast against button background

### Expected Behavior
1. Node palette buttons have description text
2. ✅ Description text is clearly visible against button background

## Solution

Changed the description text color from `var(--vscode-descriptionForeground)` to `var(--vscode-button-foreground)` with `opacity: 0.8` for visual hierarchy.

### Changes

**File**: `src/webview/src/components/NodePalette.tsx`

- Changed `color` from `var(--vscode-descriptionForeground)` to `var(--vscode-button-foreground)`
- Added `opacity: 0.8` to maintain visual hierarchy between title and description

```tsx
// Before
fontSize: '11px',
color: 'var(--vscode-descriptionForeground)',

// After
fontSize: '11px',
color: 'var(--vscode-button-foreground)',
opacity: 0.8,
```

## Impact

- Improved readability of node descriptions in the palette
- Maintains visual hierarchy (title is more prominent than description)
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)