### PR TITLE
fix: improve badge and description text visibility across UI

### DIFF
--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -585,7 +585,7 @@ export const NodePalette: React.FC = () => {
         <div
           style={{
             fontSize: '11px',
-            color: 'var(--vscode-button-foreground)',
+            color: 'var(--vscode-button-secondaryForeground)',
             opacity: 0.8,
           }}
         >

--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -100,7 +100,7 @@ export const PropertyPanel: React.FC = () => {
       <div
         style={{
           fontSize: '11px',
-          color: 'var(--vscode-descriptionForeground)',
+          color: 'var(--vscode-badge-foreground)',
           backgroundColor: 'var(--vscode-badge-background)',
           padding: '4px 8px',
           borderRadius: '3px',

--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -243,7 +243,7 @@ export function McpServerList({
                   padding: '2px 6px',
                   borderRadius: '3px',
                   backgroundColor: getScopeColor(server.scope),
-                  color: 'var(--vscode-badge-foreground)',
+                  color: getScopeForegroundColor(server.scope),
                 }}
               >
                 {server.scope}
@@ -255,7 +255,7 @@ export function McpServerList({
                     padding: '2px 6px',
                     borderRadius: '3px',
                     backgroundColor: getStatusColor(server.status),
-                    color: 'var(--vscode-badge-foreground)',
+                    color: getStatusForegroundColor(server.status),
                   }}
                 >
                   {server.status}
@@ -286,6 +286,22 @@ function getScopeColor(scope: 'user' | 'project' | 'enterprise'): string {
 }
 
 /**
+ * Get foreground color for scope badge
+ */
+function getScopeForegroundColor(scope: 'user' | 'project' | 'enterprise'): string {
+  switch (scope) {
+    case 'user':
+      return 'var(--vscode-button-foreground)';
+    case 'project':
+      return 'var(--vscode-button-secondaryForeground)';
+    case 'enterprise':
+      return 'var(--vscode-badge-foreground)';
+    default:
+      return 'var(--vscode-badge-foreground)';
+  }
+}
+
+/**
  * Get background color for status badge
  */
 function getStatusColor(status: 'connected' | 'disconnected' | 'error'): string {
@@ -298,5 +314,19 @@ function getStatusColor(status: 'connected' | 'disconnected' | 'error'): string 
       return 'var(--vscode-errorForeground)';
     default:
       return 'var(--vscode-badge-background)';
+  }
+}
+
+/**
+ * Get foreground color for status badge
+ */
+function getStatusForegroundColor(status: 'connected' | 'disconnected' | 'error'): string {
+  switch (status) {
+    case 'connected':
+    case 'disconnected':
+    case 'error':
+      return '#ffffff'; // White text for colored backgrounds
+    default:
+      return 'var(--vscode-badge-foreground)';
   }
 }

--- a/src/webview/src/components/nodes/AskUserQuestionNode.tsx
+++ b/src/webview/src/components/nodes/AskUserQuestionNode.tsx
@@ -109,7 +109,7 @@ export const AskUserQuestionNodeComponent: React.FC<NodeProps<AskUserQuestionDat
                 key={option.label}
                 style={{
                   fontSize: '11px',
-                  color: 'var(--vscode-descriptionForeground)',
+                  color: 'var(--vscode-badge-foreground)',
                   backgroundColor: 'var(--vscode-badge-background)',
                   padding: '4px 8px',
                   borderRadius: '3px',

--- a/src/webview/src/components/nodes/PromptNode.tsx
+++ b/src/webview/src/components/nodes/PromptNode.tsx
@@ -99,7 +99,7 @@ export const PromptNode: React.FC<NodeProps<PromptNodeData>> = React.memo(
           <div
             style={{
               fontSize: '10px',
-              color: 'var(--vscode-descriptionForeground)',
+              color: 'var(--vscode-badge-foreground)',
               backgroundColor: 'var(--vscode-badge-background)',
               padding: '2px 6px',
               borderRadius: '3px',

--- a/src/webview/src/components/nodes/SkillNode.tsx
+++ b/src/webview/src/components/nodes/SkillNode.tsx
@@ -139,7 +139,7 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
         <div
           style={{
             fontSize: '10px',
-            color: 'var(--vscode-descriptionForeground)',
+            color: 'var(--vscode-badge-foreground)',
             backgroundColor:
               data.scope === 'personal'
                 ? 'var(--vscode-badge-background)'

--- a/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -83,7 +83,7 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
             <div
               style={{
                 fontSize: '10px',
-                color: 'var(--vscode-descriptionForeground)',
+                color: 'var(--vscode-badge-foreground)',
                 backgroundColor: 'var(--vscode-badge-background)',
                 padding: '2px 6px',
                 borderRadius: '3px',


### PR DESCRIPTION
## Problem

### Current Behavior
Multiple UI components have badge/description text with poor contrast against their background colors:
1. ❌ Canvas node badges use `descriptionForeground` on `badge-background`
2. ❌ PropertyPanel Node Type badge has same issue
3. ❌ MCP server selector badges use `badge-foreground` on non-badge backgrounds
4. ❌ NodePalette Branch(Legacy) uses `button-foreground` on `button-secondaryBackground`

### Expected Behavior
✅ All badges and descriptions should use appropriate foreground colors matching their background

## Solution

Fixed text colors to properly match their respective background colors.

### Changes

**Canvas Nodes** (`PromptNode.tsx`, `SubAgentNode.tsx`, `SkillNode.tsx`, `AskUserQuestionNode.tsx`):
- Changed badge text from `descriptionForeground` to `badge-foreground`

**PropertyPanel.tsx**:
- Changed Node Type badge text from `descriptionForeground` to `badge-foreground`

**McpServerList.tsx**:
- Added `getScopeForegroundColor()` function for scope badges
- Added `getStatusForegroundColor()` function for status badges
- Scope badges now use matching foreground colors (`button-foreground`, `button-secondaryForeground`, `badge-foreground`)
- Status badges use white text (`#ffffff`) for colored backgrounds

**NodePalette.tsx**:
- Changed Branch(Legacy) description from `button-foreground` to `button-secondaryForeground`

## Impact

- Improved readability of all badges and descriptions
- Better accessibility with proper color contrast
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

## Related

Follow-up to #154 (node palette description text visibility)