### PR TITLE
feat: add multi-editor import support for Slack workflow sharing

### DIFF
--- a/src/extension/commands/slack-share-workflow.ts
+++ b/src/extension/commands/slack-share-workflow.ts
@@ -140,8 +140,8 @@ export async function handleShareWorkflowToSlack(
       fileId: uploadResult.fileId,
     });
 
-    // Step 6: Update message with complete deep link
-    log('INFO', 'Updating message with complete deep link', { requestId });
+    // Step 6: Update message with complete deep links
+    log('INFO', 'Updating message with complete deep links', { requestId });
 
     const updatedMessageBlock: WorkflowMessageBlock = {
       ...messageBlock,
@@ -156,7 +156,7 @@ export async function handleShareWorkflowToSlack(
       updatedMessageBlock
     );
 
-    log('INFO', 'Message updated with complete deep link', { requestId });
+    log('INFO', 'Message updated with complete deep links', { requestId });
 
     // Step 6: Send success response
     const successEvent: ShareWorkflowSuccessEvent = {


### PR DESCRIPTION
## Summary

Add support for importing workflows from Slack to multiple VSCode-derivative editors.

Supported editors:
- VS Code (existing)
- Cursor
- Windsurf  
- Kiro
- Antigravity

## Changes

**File**: `src/extension/utils/slack-message-builder.ts`

- Add `SUPPORTED_EDITORS` constant with 5 editor definitions
- Add `buildImportUri()` function to generate URIs for each editor
- Update import links section to support all 5 editors

**File**: `src/extension/commands/slack-share-workflow.ts`

- Update log message from "deep link" to "deep links"

## Slack Message Card Preview

```
📥 *Import to:*  VS Code · Cursor · Windsurf · Kiro · Antigravity
_Note: Please open your target workspace before clicking the import link_
```

## Impact

- Existing VS Code import functionality remains unchanged
- 4 new editor import links added
- Compact single-line UI display

## Testing

- [x] Code quality checks passed (format, lint, build)
- [x] Manual E2E testing with Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)