### PR TITLE
chore: remove unused translation keys

### DIFF
--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -224,8 +224,6 @@ export interface WebviewTranslationKeys {
   'terms.agree': string;
   'terms.agreeButton': string;
   'terms.cancelButton': string;
-  'terms.warning.aiGeneration': string;
-  'terms.warning.workflow': string;
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -242,8 +242,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'terms.agree': 'I agree to the above',
   'terms.agreeButton': 'Agree and Start',
   'terms.cancelButton': 'Cancel',
-  'terms.warning.aiGeneration': '⚠️ Misuse of this feature is prohibited',
-  'terms.warning.workflow': '⚠️ This workflow should only be used for legitimate purposes',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': 'Delete Node',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -243,8 +243,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'terms.agree': '上記に同意します',
   'terms.agreeButton': '同意して開始',
   'terms.cancelButton': 'キャンセル',
-  'terms.warning.aiGeneration': '⚠️ 本機能の悪用は禁止されています',
-  'terms.warning.workflow': '⚠️ このワークフローは正当な目的でのみ使用してください',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': 'ノードを削除',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -245,8 +245,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'terms.agree': '위 내용에 동의합니다',
   'terms.agreeButton': '동의하고 시작',
   'terms.cancelButton': '취소',
-  'terms.warning.aiGeneration': '⚠️ 이 기능의 악용은 금지됩니다',
-  'terms.warning.workflow': '⚠️ 이 워크플로우는 정당한 목적으로만 사용해야 합니다',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '노드 삭제',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -235,8 +235,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'terms.agree': '我同意以上内容',
   'terms.agreeButton': '同意并开始',
   'terms.cancelButton': '取消',
-  'terms.warning.aiGeneration': '⚠️ 禁止滥用此功能',
-  'terms.warning.workflow': '⚠️ 此工作流仅应用于合法目的',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '删除节点',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -235,8 +235,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'terms.agree': '我同意以上內容',
   'terms.agreeButton': '同意並開始',
   'terms.cancelButton': '取消',
-  'terms.warning.aiGeneration': '⚠️ 禁止濫用此功能',
-  'terms.warning.workflow': '⚠️ 此工作流僅應用於合法目的',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '刪除節點',


### PR DESCRIPTION
## Problem

During the Terms of Use feature implementation (#148), two translation keys were added but are not actually used in the TermsOfUseDialog component:

- `terms.warning.aiGeneration`
- `terms.warning.workflow`

## Solution

Removed the unused translation keys from all translation files.

### Changes

**Files modified:**
- `src/webview/src/i18n/translation-keys.ts` - Removed type definitions
- `src/webview/src/i18n/translations/en.ts` - Removed English translations
- `src/webview/src/i18n/translations/ja.ts` - Removed Japanese translations
- `src/webview/src/i18n/translations/ko.ts` - Removed Korean translations
- `src/webview/src/i18n/translations/zh-CN.ts` - Removed Simplified Chinese translations
- `src/webview/src/i18n/translations/zh-TW.ts` - Removed Traditional Chinese translations

## Impact

- No functional impact (unused keys removal)
- Minimal bundle size reduction (~100-200 bytes per language)

## Testing

- [x] Code quality checks passed (format, lint, check)
- [x] Build succeeded without errors

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)