### PR TITLE
fix: add refresh button to Skill Browser dialog

### DIFF
--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -25,6 +25,7 @@ type TabType = 'personal' | 'project';
 export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [personalSkills, setPersonalSkills] = useState<SkillReference[]>([]);
   const [projectSkills, setProjectSkills] = useState<SkillReference[]>([]);
@@ -100,6 +101,27 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
 
     loadSkills();
   }, [isOpen, t]);
+
+  /**
+   * Handle refresh button click
+   */
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setError(null);
+
+    try {
+      const skills = await browseSkills();
+      const personal = skills.filter((s) => s.scope === 'personal');
+      const project = skills.filter((s) => s.scope === 'project');
+
+      setPersonalSkills(personal);
+      setProjectSkills(project);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('skill.error.refreshFailed'));
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   if (!isOpen) {
     return null;
@@ -270,6 +292,30 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
             {t('skill.browser.projectTab')} ({projectSkills.length})
           </button>
         </div>
+
+        {/* Refresh Button */}
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={refreshing || loading}
+          style={{
+            width: '100%',
+            padding: '8px 12px',
+            marginBottom: '16px',
+            fontSize: '13px',
+            backgroundColor: 'var(--vscode-button-secondaryBackground)',
+            color: 'var(--vscode-button-secondaryForeground)',
+            border: '1px solid var(--vscode-panel-border)',
+            borderRadius: '4px',
+            cursor: refreshing || loading ? 'wait' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '6px',
+          }}
+        >
+          <span>{refreshing ? t('skill.refreshing') : t('skill.action.refresh')}</span>
+        </button>
 
         {/* Loading State */}
         {loading && (

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -245,10 +245,15 @@ export interface WebviewTranslationKeys {
   'skill.browser.skillPath': string;
   'skill.browser.validationStatus': string;
 
+  // Skill Browser Actions
+  'skill.action.refresh': string;
+  'skill.refreshing': string;
+
   // Skill Browser Errors
   'skill.error.loadFailed': string;
   'skill.error.noSelection': string;
   'skill.error.unknown': string;
+  'skill.error.refreshFailed': string;
 
   // Skill Creation Dialog
   'skill.creation.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -264,10 +264,15 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': 'Path',
   'skill.browser.validationStatus': 'Status',
 
+  // Skill Browser Actions
+  'skill.action.refresh': 'Refresh',
+  'skill.refreshing': 'Refreshing...',
+
   // Skill Browser Errors
   'skill.error.loadFailed': 'Failed to load Skills. Please check your Skill directories.',
   'skill.error.noSelection': 'Please select a Skill',
   'skill.error.unknown': 'An unexpected error occurred',
+  'skill.error.refreshFailed': 'Failed to refresh Skills',
 
   // Skill Creation Dialog
   'skill.creation.title': 'Create New Skill',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -265,10 +265,15 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': 'パス',
   'skill.browser.validationStatus': 'ステータス',
 
+  // Skill Browser Actions
+  'skill.action.refresh': '再読み込み',
+  'skill.refreshing': '再読み込み中...',
+
   // Skill Browser Errors
   'skill.error.loadFailed': 'Skillの読み込みに失敗しました。Skillディレクトリを確認してください。',
   'skill.error.noSelection': 'Skillを選択してください',
   'skill.error.unknown': '予期しないエラーが発生しました',
+  'skill.error.refreshFailed': 'Skillの再読み込みに失敗しました',
 
   // Skill Creation Dialog
   'skill.creation.title': '新しいSkillを作成',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -267,10 +267,15 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': '경로',
   'skill.browser.validationStatus': '상태',
 
+  // Skill Browser Actions
+  'skill.action.refresh': '새로고침',
+  'skill.refreshing': '새로고침 중...',
+
   // Skill Browser Errors
   'skill.error.loadFailed': 'Skill을 로드하지 못했습니다. Skill 디렉터리를 확인하세요.',
   'skill.error.noSelection': 'Skill을 선택하세요',
   'skill.error.unknown': '예기치 않은 오류가 발생했습니다',
+  'skill.error.refreshFailed': 'Skill 새로고침에 실패했습니다',
 
   // Skill Creation Dialog
   'skill.creation.title': '새 스킬 만들기',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -257,10 +257,15 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': '路径',
   'skill.browser.validationStatus': '状态',
 
+  // Skill Browser Actions
+  'skill.action.refresh': '刷新',
+  'skill.refreshing': '刷新中...',
+
   // Skill Browser Errors
   'skill.error.loadFailed': '加载Skill失败。请检查Skill目录。',
   'skill.error.noSelection': '请选择一个Skill',
   'skill.error.unknown': '发生意外错误',
+  'skill.error.refreshFailed': '刷新Skill失败',
 
   // Skill Creation Dialog
   'skill.creation.title': '创建新技能',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -257,10 +257,15 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': '路徑',
   'skill.browser.validationStatus': '狀態',
 
+  // Skill Browser Actions
+  'skill.action.refresh': '重新整理',
+  'skill.refreshing': '重新整理中...',
+
   // Skill Browser Errors
   'skill.error.loadFailed': '載入Skill失敗。請檢查Skill目錄。',
   'skill.error.noSelection': '請選擇一個Skill',
   'skill.error.unknown': '發生意外錯誤',
+  'skill.error.refreshFailed': '重新整理Skill失敗',
 
   // Skill Creation Dialog
   'skill.creation.title': '建立新技能',


### PR DESCRIPTION
## Problem

### Current Behavior
1. User opens Skill Browser dialog
2. ❌ Adding a new skill while dialog is open does not update the list
3. User must close and reopen the dialog to refresh the skill list

### Expected Behavior
1. User opens Skill Browser dialog
2. ✅ Clicking the "Refresh" button updates the skill list to the latest state

## Solution

Add a refresh button similar to MCP server selection, allowing users to update the skill list without closing the dialog.

### Changes

**File**: `src/webview/src/components/dialogs/SkillBrowserDialog.tsx`

- Added `refreshing` state
- Added `handleRefresh()` function
- Placed refresh button UI below tabs

**Files**: Translation files (6 files)

- Added `skill.action.refresh` key
- Added `skill.refreshing` key
- Added `skill.error.refreshFailed` key

## Impact

- Improved UX for adding Skill nodes
- No impact on existing functionality (new feature only)
- Supported languages: en, ja, ko, zh-CN, zh-TW

## Testing

- [x] Manual E2E testing: Open dialog → Refresh button is displayed
- [x] Manual E2E testing: Click refresh button → Loading state is shown
- [x] Manual E2E testing: Add skill then refresh → New skill appears in list
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)