### PR TITLE
feat: add default branch to Switch node

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -107,7 +107,7 @@
       "outputPorts": 2
     },
     "switch": {
-      "description": "Multi-way branching (switch/case). Use for 3+ way branching - ideal for time-based, case-based, or multi-condition routing.",
+      "description": "Multi-way branching (switch/case). Use for 3+ way branching - ideal for time-based, case-based, or multi-condition routing. **Important: Always include a default branch as the last branch with isDefault: true.**",
       "fields": {
         "evaluationTarget": { "type": "string", "required": false },
         "branches": {
@@ -118,8 +118,15 @@
           "items": {
             "id": { "type": "string", "required": false },
             "label": { "type": "string", "required": true, "maxLength": 50 },
-            "condition": { "type": "string", "required": true, "maxLength": 500 }
-          }
+            "condition": { "type": "string", "required": true, "maxLength": 500 },
+            "isDefault": {
+              "type": "boolean",
+              "required": false,
+              "default": false,
+              "description": "If true, this is the default branch (must be last, exactly one per node)"
+            }
+          },
+          "constraint": "Last branch must have isDefault: true with label 'default' and condition 'Other cases'"
         },
         "outputPorts": { "type": "number", "required": true, "min": 2, "max": 10 }
       },

--- a/src/extension/commands/load-workflow.ts
+++ b/src/extension/commands/load-workflow.ts
@@ -7,6 +7,7 @@
 import type { Webview } from 'vscode';
 import type { LoadWorkflowPayload } from '../../shared/types/messages';
 import type { FileService } from '../services/file-service';
+import { migrateWorkflow } from '../utils/migrate-workflow';
 
 /**
  * Load a specific workflow and send to webview
@@ -42,7 +43,10 @@ export async function loadWorkflow(
 
     // Read and parse workflow file
     const content = await fileService.readFile(filePath);
-    const workflow = JSON.parse(content);
+    const parsedWorkflow = JSON.parse(content);
+
+    // Apply migrations for backward compatibility
+    const workflow = migrateWorkflow(parsedWorkflow);
 
     // Send success response
     const payload: LoadWorkflowPayload = { workflow };

--- a/src/extension/commands/slack-import-workflow.ts
+++ b/src/extension/commands/slack-import-workflow.ts
@@ -17,6 +17,7 @@ import type {
   ImportWorkflowFailedEvent,
   ImportWorkflowSuccessEvent,
 } from '../types/slack-messages';
+import { migrateWorkflow } from '../utils/migrate-workflow';
 import { handleSlackError } from '../utils/slack-error-handler';
 import { validateWorkflowFile } from '../utils/workflow-validator';
 
@@ -75,10 +76,13 @@ export async function handleImportWorkflowFromSlack(
       return;
     }
 
-    const workflow = validationResult.workflow;
-    if (!workflow) {
+    const parsedWorkflow = validationResult.workflow;
+    if (!parsedWorkflow) {
       throw new Error('Workflow validation succeeded but workflow object is missing');
     }
+
+    // Apply migrations for backward compatibility
+    const workflow = migrateWorkflow(parsedWorkflow);
 
     log('INFO', 'Workflow validation passed', {
       requestId,

--- a/src/extension/utils/migrate-workflow.ts
+++ b/src/extension/utils/migrate-workflow.ts
@@ -1,0 +1,117 @@
+/**
+ * Workflow Migration Utility
+ *
+ * Migrates older workflow formats to current version.
+ * Handles backward compatibility for workflow structure changes.
+ */
+
+import type {
+  SwitchCondition,
+  SwitchNodeData,
+  Workflow,
+  WorkflowNode,
+} from '../../shared/types/workflow-definition';
+
+/**
+ * Generate a unique branch ID
+ */
+function generateBranchId(): string {
+  return `branch_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Migrate Switch nodes to include default branch
+ *
+ * For existing workflows without default branch:
+ * - Adds a default branch at the end
+ * - Updates outputPorts count
+ *
+ * For existing workflows with default branch:
+ * - Ensures default branch is last
+ * - Ensures only one default branch exists
+ *
+ * @param workflow - The workflow to migrate
+ * @returns Migrated workflow with updated Switch nodes
+ */
+export function migrateSwitchNodes(workflow: Workflow): Workflow {
+  const migratedNodes = workflow.nodes.map((node) => {
+    if (node.type !== 'switch') return node;
+
+    const switchData = node.data as SwitchNodeData;
+    const branches = switchData.branches || [];
+
+    // Check if any branch has isDefault
+    const hasDefault = branches.some((b: SwitchCondition) => b.isDefault);
+
+    if (hasDefault) {
+      // Ensure default branch is last
+      const defaultIndex = branches.findIndex((b: SwitchCondition) => b.isDefault);
+      if (defaultIndex !== branches.length - 1) {
+        const defaultBranch = branches[defaultIndex];
+        const newBranches = [
+          ...branches.slice(0, defaultIndex),
+          ...branches.slice(defaultIndex + 1),
+          defaultBranch,
+        ];
+        return {
+          ...node,
+          data: {
+            ...switchData,
+            branches: newBranches,
+            outputPorts: newBranches.length,
+          },
+        } as WorkflowNode;
+      }
+      return node;
+    }
+
+    // Add default branch for legacy workflows
+    const newBranches: SwitchCondition[] = [
+      ...branches.map((b: SwitchCondition) => ({
+        ...b,
+        isDefault: false,
+      })),
+      {
+        id: generateBranchId(),
+        label: 'default',
+        condition: 'Other cases',
+        isDefault: true,
+      },
+    ];
+
+    return {
+      ...node,
+      data: {
+        ...switchData,
+        branches: newBranches,
+        outputPorts: newBranches.length,
+      },
+    } as WorkflowNode;
+  });
+
+  return {
+    ...workflow,
+    nodes: migratedNodes,
+  };
+}
+
+/**
+ * Apply all workflow migrations
+ *
+ * Runs all migration functions in sequence.
+ * Add new migration functions here as the schema evolves.
+ *
+ * @param workflow - The workflow to migrate
+ * @returns Fully migrated workflow
+ */
+export function migrateWorkflow(workflow: Workflow): Workflow {
+  // Apply migrations in order
+  let migrated = workflow;
+
+  // Migration 1: Add default branch to Switch nodes
+  migrated = migrateSwitchNodes(migrated);
+
+  // Add future migrations here...
+
+  return migrated;
+}

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -101,9 +101,14 @@ export interface BranchNodeData {
   outputPorts: number; // Number of output ports (2 for conditional, 2-N for switch)
 }
 
-// Condition type aliases for IfElse and Switch (same structure as BranchCondition)
+// Condition type alias for IfElse (same structure as BranchCondition)
 export type IfElseCondition = BranchCondition;
-export type SwitchCondition = BranchCondition;
+
+// Switch condition extends BranchCondition with isDefault flag
+export interface SwitchCondition extends BranchCondition {
+  /** If true, this is the default branch (must be last, cannot be deleted or edited) */
+  isDefault?: boolean;
+}
 
 export interface IfElseNodeData {
   evaluationTarget?: string; // Natural language description of what to evaluate (e.g., "前のステップの実行結果")

--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -167,9 +167,13 @@ export const NodePalette: React.FC = () => {
       data: {
         evaluationTarget: '',
         branches: [
-          { label: t('default.case1'), condition: t('default.case1Condition') },
-          { label: t('default.case2'), condition: t('default.case2Condition') },
-          { label: t('default.case3'), condition: t('default.case3Condition') },
+          { label: t('default.case1'), condition: t('default.case1Condition'), isDefault: false },
+          { label: t('default.case2'), condition: t('default.case2Condition'), isDefault: false },
+          {
+            label: t('default.defaultBranch'),
+            condition: t('default.defaultBranchCondition'),
+            isDefault: true,
+          },
         ],
         outputPorts: 3,
       },

--- a/src/webview/src/components/nodes/SwitchNode.tsx
+++ b/src/webview/src/components/nodes/SwitchNode.tsx
@@ -77,7 +77,11 @@ export const SwitchNodeComponent: React.FC<NodeProps<SwitchNodeData>> = React.me
                   marginBottom: '8px',
                   padding: '6px 8px',
                   backgroundColor: 'var(--vscode-textBlockQuote-background)',
-                  borderLeft: '3px solid var(--vscode-textLink-foreground)',
+                  borderLeft: `3px solid ${
+                    branch.isDefault
+                      ? 'var(--vscode-editorWarning-foreground)'
+                      : 'var(--vscode-textLink-foreground)'
+                  }`,
                   borderRadius: '3px',
                 }}
               >

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -184,8 +184,8 @@ export interface WebviewTranslationKeys {
   'default.case1Condition': string;
   'default.case2': string;
   'default.case2Condition': string;
-  'default.case3': string;
-  'default.case3Condition': string;
+  'default.defaultBranch': string;
+  'default.defaultBranchCondition': string;
   'default.conditionPrefix': string;
   'default.conditionSuffix': string;
 

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -188,8 +188,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'default.case1Condition': 'When condition 1 is met',
   'default.case2': 'Case 2',
   'default.case2Condition': 'When condition 2 is met',
-  'default.case3': 'Case 3',
-  'default.case3Condition': 'When condition 3 is met',
+  'default.defaultBranch': 'default',
+  'default.defaultBranchCondition': 'Other cases',
   'default.conditionPrefix': 'When condition ',
   'default.conditionSuffix': ' is met',
 

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -189,8 +189,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'default.case1Condition': '条件1の場合',
   'default.case2': 'Case 2',
   'default.case2Condition': '条件2の場合',
-  'default.case3': 'Case 3',
-  'default.case3Condition': '条件3の場合',
+  'default.defaultBranch': 'default',
+  'default.defaultBranchCondition': '上記以外',
   'default.conditionPrefix': '条件',
   'default.conditionSuffix': 'の場合',
 

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -191,8 +191,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'default.case1Condition': '조건 1이 충족될 때',
   'default.case2': 'Case 2',
   'default.case2Condition': '조건 2가 충족될 때',
-  'default.case3': 'Case 3',
-  'default.case3Condition': '조건 3이 충족될 때',
+  'default.defaultBranch': 'default',
+  'default.defaultBranchCondition': '기타',
   'default.conditionPrefix': '조건 ',
   'default.conditionSuffix': '이 충족될 때',
 

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -186,8 +186,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'default.case1Condition': '满足条件 1 时',
   'default.case2': 'Case 2',
   'default.case2Condition': '满足条件 2 时',
-  'default.case3': 'Case 3',
-  'default.case3Condition': '满足条件 3 时',
+  'default.defaultBranch': 'default',
+  'default.defaultBranchCondition': '其他情况',
   'default.conditionPrefix': '满足条件 ',
   'default.conditionSuffix': ' 时',
 

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -186,8 +186,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'default.case1Condition': '滿足條件 1 時',
   'default.case2': 'Case 2',
   'default.case2Condition': '滿足條件 2 時',
-  'default.case3': 'Case 3',
-  'default.case3Condition': '滿足條件 3 時',
+  'default.defaultBranch': 'default',
+  'default.defaultBranchCondition': '其他情況',
   'default.conditionPrefix': '滿足條件 ',
   'default.conditionSuffix': ' 時',
 


### PR DESCRIPTION
## Summary

Adds a mandatory default branch to Switch nodes that cannot be deleted or edited, ensuring all switch cases have a fallback path.

## Problem

### Current Behavior
1. Create a Switch node
2. ❌ No default/fallback branch exists
3. ❌ Users must manually handle "other cases" logic

### Expected Behavior
1. Create a Switch node
2. ✅ Default branch is automatically included as the last branch
3. ✅ Default branch cannot be deleted or have its label/condition modified

## Solution

Add `isDefault` flag to `SwitchCondition` type and implement protection logic throughout the application.

### Changes

**Type Definition** (`src/shared/types/workflow-definition.ts`)
- Added `isDefault?: boolean` flag to `SwitchCondition` interface

**Node Initialization** (`src/webview/src/components/NodePalette.tsx`)
- New Switch nodes initialize with: Case 1, Case 2, default

**Property Panel** (`src/webview/src/components/PropertyPanel.tsx`)
- Default branch inputs are disabled (opacity: 0.6, cursor: not-allowed)
- Delete button hidden for default branch
- New branches insert before default (maintaining default as last)
- Minimum 1 regular case required for removal

**Canvas Display** (`src/webview/src/components/nodes/SwitchNode.tsx`)
- Default branch distinguished by warning color left border

**Validation** (`src/extension/utils/validate-workflow.ts`)
- Validates only one default branch exists
- Validates default branch is last in array

**Migration** (`src/extension/utils/migrate-workflow.ts`) - NEW FILE
- Auto-migrates existing workflows without default branch
- Ensures default branch is always last
- Applied on workflow load and Slack import

**Schema** (`resources/workflow-schema.json`)
- Updated AI generation instructions for isDefault field

**Translations** (5 languages: en, ja, ko, zh-CN, zh-TW)
- Added `default.defaultBranch`: "default"
- Added `default.defaultBranchCondition`: "Other cases" / "上記以外" etc.

## Impact

- **Backward Compatible**: Existing workflows auto-migrate on load
- **No Breaking Changes**: Old workflows work without modification
- **UX Improvement**: Users always have a fallback path in Switch logic

## Testing

- [x] Manual E2E testing completed
- [x] New Switch node creates with 3 branches (Case 1, Case 2, default)
- [x] Default branch cannot be deleted
- [x] Default branch label/condition cannot be edited
- [x] New cases insert before default
- [x] Existing workflows without default auto-migrate on load
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)