### PR TITLE
style: improve Slack OAuth dialog UI

### DIFF
--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -322,6 +322,7 @@ export function SlackManualTokenDialog({
                 fontSize: '11px',
                 color: 'var(--vscode-descriptionForeground)',
                 lineHeight: '1.6',
+                whiteSpace: 'pre-line',
               }}
             >
               {t('slack.oauth.reviewNotice.message')}
@@ -379,28 +380,54 @@ export function SlackManualTokenDialog({
                   border: '1px solid var(--vscode-panel-border)',
                   borderRadius: '4px',
                   marginBottom: '16px',
-                  textAlign: 'center',
                 }}
               >
                 <div
                   style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '8px',
                     fontSize: '14px',
                     color: 'var(--vscode-foreground)',
                     marginBottom: '8px',
                   }}
                 >
-                  {oauthStatus === 'initiated'
-                    ? t('slack.oauth.status.initiated')
-                    : t('slack.oauth.status.polling')}
+                  {/* Spinner */}
+                  <div
+                    style={{
+                      width: '16px',
+                      height: '16px',
+                      border: '2px solid var(--vscode-progressBar-background)',
+                      borderTopColor: 'transparent',
+                      borderRadius: '50%',
+                      animation: 'oauth-spinner 1s linear infinite',
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span>
+                    {oauthStatus === 'initiated'
+                      ? t('slack.oauth.status.initiated')
+                      : t('slack.oauth.status.polling')}
+                  </span>
                 </div>
                 <div
                   style={{
                     fontSize: '12px',
                     color: 'var(--vscode-descriptionForeground)',
+                    textAlign: 'center',
                   }}
                 >
                   {t('slack.oauth.status.waitingHint')}
                 </div>
+                <style>
+                  {`
+                    @keyframes oauth-spinner {
+                      0% { transform: rotate(0deg); }
+                      100% { transform: rotate(360deg); }
+                    }
+                  `}
+                </style>
               </div>
             )}
 
@@ -558,41 +585,35 @@ export function SlackManualTokenDialog({
               </div>
             </div>
 
-            {/* Security & Privacy Box */}
+            {/* Privacy Policy Link */}
             <div
               style={{
                 marginBottom: '16px',
-                padding: '12px',
-                backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-                border: '1px solid var(--vscode-panel-border)',
-                borderRadius: '4px',
               }}
             >
-              <div
+              <button
+                type="button"
+                onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
                 style={{
                   fontSize: '12px',
-                  fontWeight: 600,
-                  color: 'var(--vscode-foreground)',
-                  marginBottom: '8px',
+                  color: 'var(--vscode-textLink-foreground)',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.textDecoration = 'underline';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.textDecoration = 'none';
                 }}
               >
-                {t('slack.manualToken.security.title')}
-              </div>
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--vscode-descriptionForeground)',
-                  lineHeight: '1.6',
-                }}
-              >
-                <div style={{ marginBottom: '8px', fontStyle: 'italic' }}>
-                  {t('slack.manualToken.security.notice')}
-                </div>
-                <div>• {t('slack.manualToken.security.storage')}</div>
-                <div>• {t('slack.manualToken.security.transmission')}</div>
-                <div>• {t('slack.manualToken.security.deletion')}</div>
-                <div>• {t('slack.manualToken.security.sharing')}</div>
-              </div>
+                {t('slack.oauth.privacyPolicy')}
+              </button>
             </div>
 
             {/* Bot Token Input */}

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -597,7 +597,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Share
   'slack.share.button': 'Share',
-  'slack.share.title': 'Share to Slack β',
+  'slack.share.title': 'Share to Slack',
   'slack.share.selectWorkspace': 'Select workspace',
   'slack.share.selectWorkspacePlaceholder': 'Choose a workspace...',
   'slack.share.selectChannel': 'Select channel',
@@ -628,7 +628,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
     'Complete the authentication in your browser, then return here.',
   'slack.oauth.cancelled': 'Authentication was cancelled',
   'slack.oauth.reviewNotice.message':
-    'The Slack App used for sharing is pending Slack review. A warning will be displayed on the permission screen until the review is approved.',
+    'The Slack App used for sharing is pending Slack review.\nA warning will be displayed on the permission screen until the review is approved.',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -593,7 +593,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Share
   'slack.share.button': '共有',
-  'slack.share.title': 'Slack共有 β版',
+  'slack.share.title': 'Slack共有',
   'slack.share.selectWorkspace': 'ワークスペース選択',
   'slack.share.selectWorkspacePlaceholder': 'ワークスペースを選択...',
   'slack.share.selectChannel': 'チャンネル選択',
@@ -624,7 +624,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': 'ブラウザで認証を完了し、こちらに戻ってください。',
   'slack.oauth.cancelled': '認証がキャンセルされました',
   'slack.oauth.reviewNotice.message':
-    '共有に使用するSlack AppはSlackへの審査を予定しています。審査の承認が下りるまで、許可画面で警告が表示されます。',
+    '共有に使用するSlack AppはSlackへの審査を予定しています。\n審査の承認が下りるまで、許可画面で警告が表示されます。',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Slackに再接続',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -592,7 +592,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Share
   'slack.share.button': '공유',
-  'slack.share.title': 'Slack에 공유 β 버전',
+  'slack.share.title': 'Slack에 공유',
   'slack.share.selectWorkspace': '워크스페이스 선택',
   'slack.share.selectWorkspacePlaceholder': '워크스페이스를 선택하세요...',
   'slack.share.selectChannel': '채널 선택',
@@ -622,7 +622,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': '브라우저에서 인증을 완료한 후 여기로 돌아오세요.',
   'slack.oauth.cancelled': '인증이 취소되었습니다',
   'slack.oauth.reviewNotice.message':
-    '공유에 사용되는 Slack 앱은 Slack 심사 예정입니다. 심사 승인이 완료될 때까지 권한 화면에 경고가 표시됩니다.',
+    '공유에 사용되는 Slack 앱은 Slack 심사 예정입니다.\n심사 승인이 완료될 때까지 권한 화면에 경고가 표시됩니다.',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -568,7 +568,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Share
   'slack.share.button': '分享',
-  'slack.share.title': '分享到 Slack β版',
+  'slack.share.title': '分享到 Slack',
   'slack.share.selectWorkspace': '选择工作区',
   'slack.share.selectWorkspacePlaceholder': '选择一个工作区...',
   'slack.share.selectChannel': '选择频道',
@@ -598,7 +598,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': '在浏览器中完成身份验证后返回此处。',
   'slack.oauth.cancelled': '身份验证已取消',
   'slack.oauth.reviewNotice.message':
-    '用于共享的 Slack 应用计划进行 Slack 审核。在审核通过之前，权限画面会显示警告。',
+    '用于共享的 Slack 应用计划进行 Slack 审核。\n在审核通过之前，权限画面会显示警告。',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -568,7 +568,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Share
   'slack.share.button': '分享',
-  'slack.share.title': '分享到 Slack β版',
+  'slack.share.title': '分享到 Slack',
   'slack.share.selectWorkspace': '選擇工作區',
   'slack.share.selectWorkspacePlaceholder': '選擇一個工作區...',
   'slack.share.selectChannel': '選擇頻道',
@@ -598,7 +598,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': '在瀏覽器中完成身份驗證後返回此處。',
   'slack.oauth.cancelled': '身份驗證已取消',
   'slack.oauth.reviewNotice.message':
-    '用於共享的 Slack 應用計劃進行 Slack 審核。在審核通過之前，權限畫面會顯示警告。',
+    '用於共享的 Slack 應用計劃進行 Slack 審核。\n在審核通過之前，權限畫面會顯示警告。',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',


### PR DESCRIPTION
## Summary

UI improvements for Slack app review submission.

## Changes

### Add loading spinner during OAuth connection
- Display circle spinner while waiting for connection
- Consistent design with existing App.tsx import loading

### Remove beta label from dialog title
- Remove "β" suffix from share dialog title (all 5 languages)
- Prevents Slack review from treating it as a test feature

### Simplify security section in Manual tab
- Remove "Security & Privacy" box
- Replace with privacy policy link

### Add line break to review notice message
- Split long text into 2 lines for better readability (all 5 languages)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)