### PR TITLE
fix: require User Token for manual Slack connection

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -532,16 +532,20 @@ export function registerOpenEditorCommand(
               break;
 
             case 'CONNECT_SLACK_MANUAL':
-              // Manual Slack connection (Bot Token input)
+              // Manual Slack connection (Bot Token + User Token input)
               try {
                 if (!message.payload?.botToken) {
                   throw new Error('Bot Token is required');
+                }
+                if (!message.payload?.userToken) {
+                  throw new Error('User Token is required for secure channel listing');
                 }
 
                 const result = await handleConnectSlackManual(
                   slackTokenManager,
                   slackApiService,
-                  message.payload.botToken
+                  message.payload.botToken,
+                  message.payload.userToken
                 );
 
                 if (result) {

--- a/src/extension/commands/slack-connect-manual.ts
+++ b/src/extension/commands/slack-connect-manual.ts
@@ -19,18 +19,20 @@ import type { SlackTokenManager } from '../utils/slack-token-manager';
 /**
  * Handle manual Slack connection command
  *
- * Prompts user for workspace information and Bot Token,
- * validates the token, and stores it in VSCode Secret Storage.
+ * Prompts user for workspace information and Bot Token + User Token,
+ * validates the tokens, and stores them in VSCode Secret Storage.
  *
  * @param tokenManager - Token manager instance
  * @param slackApiService - Slack API service instance
  * @param botToken - Optional Bot Token (if provided, skip Input Box prompt)
+ * @param userToken - Optional User Token (required for secure channel listing)
  * @returns Workspace info if successful
  */
 export async function handleConnectSlackManual(
   tokenManager: SlackTokenManager,
   slackApiService: SlackApiService,
-  botToken?: string
+  botToken?: string,
+  userToken?: string
 ): Promise<{ workspaceId: string; workspaceName: string } | undefined> {
   try {
     log('INFO', 'Manual Slack connection started');
@@ -49,52 +51,101 @@ export async function handleConnectSlackManual(
             return 'Bot Token is required';
           }
           if (!value.startsWith('xoxb-')) {
-            return 'Bot Token must start with "xoxb-" (User Tokens "xoxp-" are not supported)';
+            return 'Bot Token must start with "xoxb-"';
           }
           return null;
         },
       });
 
       if (!accessToken) {
-        log('INFO', 'Manual connection cancelled: No token provided');
+        log('INFO', 'Manual connection cancelled: No Bot Token provided');
         return; // User cancelled
       }
     }
 
-    // Validate token format (for Webview path)
+    // Validate Bot token format (for Webview path)
     if (!accessToken.startsWith('xoxb-')) {
-      throw new Error('Bot Token must start with "xoxb-" (User Tokens "xoxp-" are not supported)');
+      throw new Error('Bot Token must start with "xoxb-"');
     }
 
-    // Step 2: Validate token and retrieve workspace info from Slack API (auth.test)
-    log('INFO', 'Validating token with Slack API');
+    // Step 1.5: Get User Token (from parameter or Input Box)
+    let userAccessToken = userToken;
+
+    if (!userAccessToken) {
+      // Prompt for User Token via Input Box (VSCode command path)
+      userAccessToken = await vscode.window.showInputBox({
+        prompt: 'Enter User OAuth Token (starts with "xoxp-") - Required for channel listing',
+        placeHolder: 'xoxp-...',
+        password: true, // Hide input
+        validateInput: (value) => {
+          if (!value || value.trim().length === 0) {
+            return 'User Token is required for secure channel listing';
+          }
+          if (!value.startsWith('xoxp-')) {
+            return 'User Token must start with "xoxp-"';
+          }
+          return null;
+        },
+      });
+
+      if (!userAccessToken) {
+        log('INFO', 'Manual connection cancelled: No User Token provided');
+        return; // User cancelled
+      }
+    }
+
+    // Validate User token format (for Webview path)
+    if (!userAccessToken.startsWith('xoxp-')) {
+      throw new Error('User Token must start with "xoxp-"');
+    }
+
+    // Step 2: Validate Bot token and retrieve workspace info from Slack API (auth.test)
+    log('INFO', 'Validating Bot token with Slack API');
 
     const client = new WebClient(accessToken);
     const authResponse = await client.auth.test();
 
     if (!authResponse.ok) {
-      throw new Error('Token validation failed: Invalid token');
+      throw new Error('Bot Token validation failed: Invalid token');
     }
 
     // Extract workspace information from auth.test response
     const workspaceId = authResponse.team_id as string;
     const workspaceName = authResponse.team as string;
 
-    log('INFO', 'Token validation successful', {
+    log('INFO', 'Bot Token validation successful', {
       workspaceId,
       workspaceName,
     });
 
+    // Step 2.5: Validate User token with Slack API
+    log('INFO', 'Validating User token with Slack API');
+
+    const userClient = new WebClient(userAccessToken);
+    const userAuthResponse = await userClient.auth.test();
+
+    if (!userAuthResponse.ok) {
+      throw new Error('User Token validation failed: Invalid token');
+    }
+
+    // Verify User token belongs to the same workspace
+    if (userAuthResponse.team_id !== workspaceId) {
+      throw new Error('User Token must belong to the same workspace as Bot Token');
+    }
+
+    log('INFO', 'User Token validation successful');
+
     // Step 3: Clear existing connections before storing new one (same as delete → create flow)
     await tokenManager.clearConnection();
 
-    // Step 4: Store connection in VSCode Secret Storage
+    // Step 4: Store connection in VSCode Secret Storage (with User Token)
     await tokenManager.storeManualConnection(
       workspaceId,
       workspaceName,
       workspaceId, // teamId is same as workspaceId
       accessToken,
-      '' // userId is no longer used (author name comes from git config)
+      '', // userId is no longer used (author name comes from git config)
+      userAccessToken
     );
 
     log('INFO', 'Manual Slack connection stored successfully', {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -641,6 +641,8 @@ export interface GetOAuthRedirectUriSuccessPayload {
 export interface ConnectSlackManualPayload {
   /** Slack Bot User OAuth Token (xoxb-...) */
   botToken: string;
+  /** Slack User OAuth Token (xoxp-...) - Required for secure channel listing */
+  userToken: string;
 }
 
 /**

--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -46,6 +46,7 @@ export function SlackManualTokenDialog({
 
   // Manual token state
   const [botToken, setBotToken] = useState('');
+  const [userToken, setUserToken] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -61,6 +62,7 @@ export function SlackManualTokenDialog({
   useEffect(() => {
     if (isOpen) {
       setBotToken('');
+      setUserToken('');
       setError(null);
       setOauthError(null);
       setOauthStatus('idle');
@@ -149,11 +151,21 @@ export function SlackManualTokenDialog({
       return;
     }
 
+    if (!userToken.trim()) {
+      setError(t('slack.manualToken.error.userTokenRequired'));
+      return;
+    }
+
+    if (!userToken.startsWith('xoxp-')) {
+      setError(t('slack.manualToken.error.invalidUserTokenFormat'));
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
     try {
-      await connectSlackManual(botToken);
+      await connectSlackManual(botToken, userToken);
 
       // Success - close dialog and notify parent
       if (onSuccess) {
@@ -582,6 +594,7 @@ export function SlackManualTokenDialog({
                 <div>3. {t('slack.manualToken.howToGet.step3')}</div>
                 <div>4. {t('slack.manualToken.howToGet.step4')}</div>
                 <div>5. {t('slack.manualToken.howToGet.step5')}</div>
+                <div>6. {t('slack.manualToken.howToGet.step6')}</div>
               </div>
             </div>
 
@@ -636,6 +649,40 @@ export function SlackManualTokenDialog({
                 value={botToken}
                 onChange={(e) => setBotToken(e.target.value)}
                 placeholder="xoxb-..."
+                disabled={loading}
+                style={{
+                  width: '100%',
+                  padding: '6px 8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  fontSize: '13px',
+                  fontFamily: 'monospace',
+                }}
+              />
+            </div>
+
+            {/* User Token Input */}
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="user-token"
+                style={{
+                  display: 'block',
+                  fontSize: '13px',
+                  color: 'var(--vscode-foreground)',
+                  marginBottom: '8px',
+                  fontWeight: 500,
+                }}
+              >
+                {t('slack.manualToken.userToken.label')}
+              </label>
+              <input
+                id="user-token"
+                type="password"
+                value={userToken}
+                onChange={(e) => setUserToken(e.target.value)}
+                placeholder="xoxp-..."
                 disabled={loading}
                 style={{
                   width: '100%',
@@ -719,17 +766,18 @@ export function SlackManualTokenDialog({
                 <button
                   type="button"
                   onClick={handleConnect}
-                  disabled={loading || !botToken.trim()}
+                  disabled={loading || !botToken.trim() || !userToken.trim()}
                   style={{
                     padding: '6px 16px',
                     backgroundColor: 'var(--vscode-button-background)',
                     color: 'var(--vscode-button-foreground)',
                     border: 'none',
                     borderRadius: '2px',
-                    cursor: loading || !botToken.trim() ? 'not-allowed' : 'pointer',
+                    cursor:
+                      loading || !botToken.trim() || !userToken.trim() ? 'not-allowed' : 'pointer',
                     fontSize: '13px',
                     fontWeight: 500,
-                    opacity: loading || !botToken.trim() ? 0.5 : 1,
+                    opacity: loading || !botToken.trim() || !userToken.trim() ? 0.5 : 1,
                   }}
                 >
                   {loading ? t('slack.manualToken.connecting') : t('slack.manualToken.connect')}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -583,6 +583,7 @@ export interface WebviewTranslationKeys {
   'slack.manualToken.howToGet.step3': string;
   'slack.manualToken.howToGet.step4': string;
   'slack.manualToken.howToGet.step5': string;
+  'slack.manualToken.howToGet.step6': string;
   'slack.manualToken.security.title': string;
   'slack.manualToken.security.notice': string;
   'slack.manualToken.security.storage': string;
@@ -590,9 +591,11 @@ export interface WebviewTranslationKeys {
   'slack.manualToken.security.deletion': string;
   'slack.manualToken.security.sharing': string;
   'slack.manualToken.botToken.label': string;
-  'slack.manualToken.botToken.hint': string;
+  'slack.manualToken.userToken.label': string;
   'slack.manualToken.error.tokenRequired': string;
   'slack.manualToken.error.invalidTokenFormat': string;
+  'slack.manualToken.error.userTokenRequired': string;
+  'slack.manualToken.error.invalidUserTokenFormat': string;
   'slack.manualToken.connecting': string;
   'slack.manualToken.connect': string;
   'slack.manualToken.deleteButton': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -563,16 +563,17 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Manual Token
   'slack.manualToken.title': 'Connect to Slack',
-  'slack.manualToken.description':
-    'Enter the Bot Token from your own Slack App to connect to your workspace.',
-  'slack.manualToken.howToGet.title': 'How to get Bot Token',
+  'slack.manualToken.description': 'Connect to your workspace through your own Slack App.',
+  'slack.manualToken.howToGet.title': 'How to set up Slack App',
   'slack.manualToken.howToGet.step1': 'Create Slack App (at api.slack.com/apps)',
   'slack.manualToken.howToGet.step2':
-    'Add Bot Token Scopes (OAuth & Permissions): channels:read, chat:write, files:read, files:write, groups:read',
-  'slack.manualToken.howToGet.step3': 'Install App to your workspace (OAuth & Permissions)',
-  'slack.manualToken.howToGet.step4': 'Invite App to target channel (in Slack)',
-  'slack.manualToken.howToGet.step5':
-    'Copy and paste Bot User OAuth Token to the form below (OAuth & Permissions, xoxb-...)',
+    'Add Bot Token Scopes (OAuth & Permissions): chat:write, files:read, files:write',
+  'slack.manualToken.howToGet.step3':
+    'Add User Token Scopes (OAuth & Permissions): channels:read, groups:read',
+  'slack.manualToken.howToGet.step4': 'Install App to your workspace (OAuth & Permissions)',
+  'slack.manualToken.howToGet.step5': 'Invite App to target channel (in Slack)',
+  'slack.manualToken.howToGet.step6':
+    'Copy Bot Token (xoxb-...) and User Token (xoxp-...) from OAuth & Permissions page',
   'slack.manualToken.security.title': 'Security & Privacy',
   'slack.manualToken.security.notice':
     'Note: This feature communicates with Slack servers (not local-only operation)',
@@ -583,9 +584,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.security.sharing':
     'Bot Token has channel read/write and other permissions. Only share within trusted communities.',
   'slack.manualToken.botToken.label': 'Bot User OAuth Token',
-  'slack.manualToken.botToken.hint': 'Starts with xoxb-...',
+  'slack.manualToken.userToken.label': 'User OAuth Token',
   'slack.manualToken.error.tokenRequired': 'Bot Token is required',
   'slack.manualToken.error.invalidTokenFormat': 'Bot Token must start with "xoxb-"',
+  'slack.manualToken.error.userTokenRequired': 'User Token is required for secure channel listing',
+  'slack.manualToken.error.invalidUserTokenFormat': 'User Token must start with "xoxp-"',
   'slack.manualToken.connecting': 'Connecting...',
   'slack.manualToken.connect': 'Connect',
   'slack.manualToken.deleteButton': 'Delete Saved Token',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -560,16 +560,17 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Manual Token
   'slack.manualToken.title': 'Slackに接続',
-  'slack.manualToken.description':
-    '自分で作成したSlack AppのBot Tokenを入力してワークスペースに接続します。',
-  'slack.manualToken.howToGet.title': 'Bot Tokenの取得方法',
+  'slack.manualToken.description': '自分で作成したSlack Appを通じてワークスペースに接続します。',
+  'slack.manualToken.howToGet.title': 'Slack Appの設定方法',
   'slack.manualToken.howToGet.step1': 'Slack Appを作成（api.slack.com/apps）',
   'slack.manualToken.howToGet.step2':
-    'Bot Token Scopesを追加（OAuth & Permissions）: channels:read, chat:write, files:read, files:write, groups:read',
-  'slack.manualToken.howToGet.step3': 'Appをワークスペースにインストール（OAuth & Permissions）',
-  'slack.manualToken.howToGet.step4': 'Appをワークフロー共有先のチャンネルに追加（Slack内）',
-  'slack.manualToken.howToGet.step5':
-    'Bot User OAuth Token（xoxb-...）をコピーして下部の入力欄に貼り付け（OAuth & Permissions）',
+    'Bot Token Scopesを追加（OAuth & Permissions）: chat:write, files:read, files:write',
+  'slack.manualToken.howToGet.step3':
+    'User Token Scopesを追加（OAuth & Permissions）: channels:read, groups:read',
+  'slack.manualToken.howToGet.step4': 'Appをワークスペースにインストール（OAuth & Permissions）',
+  'slack.manualToken.howToGet.step5': 'Appをワークフロー共有先のチャンネルに追加（Slack内）',
+  'slack.manualToken.howToGet.step6':
+    'Bot Token（xoxb-...）とUser Token（xoxp-...）をOAuth & Permissionsページからコピー',
   'slack.manualToken.security.title': 'セキュリティーとプライバシー',
   'slack.manualToken.security.notice':
     '注意：この機能はSlackサーバーと通信します（ローカル動作ではありません）',
@@ -580,9 +581,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.security.sharing':
     'Bot Tokenにはチャンネルの読み取り・書き込み権限等があるため、信頼できるコミュニティ内でのみ共有してください',
   'slack.manualToken.botToken.label': 'Bot User OAuth Token',
-  'slack.manualToken.botToken.hint': 'xoxb-で始まります',
+  'slack.manualToken.userToken.label': 'User OAuth Token',
   'slack.manualToken.error.tokenRequired': 'Bot Tokenは必須です',
   'slack.manualToken.error.invalidTokenFormat': 'Bot Tokenは"xoxb-"で始まる必要があります',
+  'slack.manualToken.error.userTokenRequired': 'セキュアなチャンネル一覧表示にUser Tokenが必要です',
+  'slack.manualToken.error.invalidUserTokenFormat': 'User Tokenは"xoxp-"で始まる必要があります',
   'slack.manualToken.connecting': '接続中...',
   'slack.manualToken.connect': '接続',
   'slack.manualToken.deleteButton': '保存したトークンを削除',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -559,16 +559,17 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Manual Token
   'slack.manualToken.title': 'Slack에 연결',
-  'slack.manualToken.description':
-    '직접 만든 Slack 앱의 Bot Token을 입력하여 워크스페이스에 연결합니다.',
-  'slack.manualToken.howToGet.title': 'Bot Token 받는 방법',
+  'slack.manualToken.description': '직접 만든 Slack 앱을 통해 워크스페이스에 연결합니다.',
+  'slack.manualToken.howToGet.title': 'Slack App 설정 방법',
   'slack.manualToken.howToGet.step1': 'Slack App 생성 (api.slack.com/apps)',
   'slack.manualToken.howToGet.step2':
-    'Bot Token Scopes 추가 (OAuth & Permissions): channels:read, chat:write, files:read, files:write, groups:read',
-  'slack.manualToken.howToGet.step3': '워크스페이스에 App 설치 (OAuth & Permissions)',
-  'slack.manualToken.howToGet.step4': '대상 채널에 App 추가 (Slack 내)',
-  'slack.manualToken.howToGet.step5':
-    'Bot User OAuth Token을 복사하여 아래 양식에 붙여넣기 (OAuth & Permissions, xoxb-...)',
+    'Bot Token Scopes 추가 (OAuth & Permissions): chat:write, files:read, files:write',
+  'slack.manualToken.howToGet.step3':
+    'User Token Scopes 추가 (OAuth & Permissions): channels:read, groups:read',
+  'slack.manualToken.howToGet.step4': '워크스페이스에 App 설치 (OAuth & Permissions)',
+  'slack.manualToken.howToGet.step5': '대상 채널에 App 추가 (Slack 내)',
+  'slack.manualToken.howToGet.step6':
+    'OAuth & Permissions 페이지에서 Bot Token (xoxb-...)과 User Token (xoxp-...) 복사',
   'slack.manualToken.security.title': '보안 및 개인정보',
   'slack.manualToken.security.notice':
     '참고: 이 기능은 Slack 서버와 통신합니다 (로컬 전용 작업 아님)',
@@ -579,9 +580,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.security.sharing':
     'Bot Token에는 채널 읽기/쓰기 등의 권한이 있습니다. 신뢰할 수 있는 커뮤니티 내에서만 공유하세요.',
   'slack.manualToken.botToken.label': 'Bot User OAuth Token',
-  'slack.manualToken.botToken.hint': 'xoxb-로 시작합니다',
+  'slack.manualToken.userToken.label': 'User OAuth Token',
   'slack.manualToken.error.tokenRequired': 'Bot Token은 필수입니다',
   'slack.manualToken.error.invalidTokenFormat': 'Bot Token은 "xoxb-"로 시작해야 합니다',
+  'slack.manualToken.error.userTokenRequired': '보안 채널 목록을 위해 User Token이 필요합니다',
+  'slack.manualToken.error.invalidUserTokenFormat': 'User Token은 "xoxp-"로 시작해야 합니다',
   'slack.manualToken.connecting': '연결 중...',
   'slack.manualToken.connect': '연결',
   'slack.manualToken.deleteButton': '저장된 토큰 삭제',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -539,15 +539,17 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Manual Token
   'slack.manualToken.title': '连接到 Slack',
-  'slack.manualToken.description': '输入您自己创建的 Slack 应用的 Bot Token 以连接工作区。',
-  'slack.manualToken.howToGet.title': '如何获取 Bot Token',
+  'slack.manualToken.description': '通过您自己创建的 Slack 应用连接到工作区。',
+  'slack.manualToken.howToGet.title': 'Slack App 设置方法',
   'slack.manualToken.howToGet.step1': '创建 Slack App (api.slack.com/apps)',
   'slack.manualToken.howToGet.step2':
-    '添加 Bot Token Scopes (OAuth & Permissions): channels:read, chat:write, files:read, files:write, groups:read',
-  'slack.manualToken.howToGet.step3': '将 App 安装到您的工作区 (OAuth & Permissions)',
-  'slack.manualToken.howToGet.step4': '将 App 添加到目标频道 (在 Slack 中)',
-  'slack.manualToken.howToGet.step5':
-    '复制 Bot User OAuth Token 并粘贴到下方表单 (OAuth & Permissions, xoxb-...)',
+    '添加 Bot Token Scopes (OAuth & Permissions): chat:write, files:read, files:write',
+  'slack.manualToken.howToGet.step3':
+    '添加 User Token Scopes (OAuth & Permissions): channels:read, groups:read',
+  'slack.manualToken.howToGet.step4': '将 App 安装到您的工作区 (OAuth & Permissions)',
+  'slack.manualToken.howToGet.step5': '将 App 添加到目标频道 (在 Slack 中)',
+  'slack.manualToken.howToGet.step6':
+    '复制 Bot User OAuth Token (xoxb-...) 和 User OAuth Token (xoxp-...) 并粘贴到下方表单',
   'slack.manualToken.security.title': '安全和隐私',
   'slack.manualToken.security.notice': '注意：此功能与 Slack 服务器通信（非本地操作）',
   'slack.manualToken.security.storage': '令牌安全存储在 VSCode Secret Storage (OS 密钥链)',
@@ -555,9 +557,11 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.security.deletion': '可以随时删除',
   'slack.manualToken.security.sharing': 'Bot Token 具有频道读写等权限。请仅在受信任的社区内共享。',
   'slack.manualToken.botToken.label': 'Bot User OAuth Token',
-  'slack.manualToken.botToken.hint': '以 xoxb- 开头',
+  'slack.manualToken.userToken.label': 'User OAuth Token',
   'slack.manualToken.error.tokenRequired': 'Bot Token 为必填项',
   'slack.manualToken.error.invalidTokenFormat': 'Bot Token 必须以 "xoxb-" 开头',
+  'slack.manualToken.error.userTokenRequired': 'User Token 为必填项',
+  'slack.manualToken.error.invalidUserTokenFormat': 'User Token 必须以 "xoxp-" 开头',
   'slack.manualToken.connecting': '连接中...',
   'slack.manualToken.connect': '连接',
   'slack.manualToken.deleteButton': '删除已保存的令牌',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -539,15 +539,17 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Slack Manual Token
   'slack.manualToken.title': '連接到 Slack',
-  'slack.manualToken.description': '輸入您自己建立的 Slack 應用的 Bot Token 以連接工作區。',
-  'slack.manualToken.howToGet.title': '如何取得 Bot Token',
+  'slack.manualToken.description': '透過您自己建立的 Slack 應用連接到工作區。',
+  'slack.manualToken.howToGet.title': 'Slack App 設定方法',
   'slack.manualToken.howToGet.step1': '建立 Slack App (api.slack.com/apps)',
   'slack.manualToken.howToGet.step2':
-    '新增 Bot Token Scopes (OAuth & Permissions): channels:read, chat:write, files:read, files:write, groups:read',
-  'slack.manualToken.howToGet.step3': '將 App 安裝到您的工作區 (OAuth & Permissions)',
-  'slack.manualToken.howToGet.step4': '將 App 新增至目標頻道 (在 Slack 中)',
-  'slack.manualToken.howToGet.step5':
-    '複製 Bot User OAuth Token 並貼上至下方表單 (OAuth & Permissions, xoxb-...)',
+    '新增 Bot Token Scopes (OAuth & Permissions): chat:write, files:read, files:write',
+  'slack.manualToken.howToGet.step3':
+    '新增 User Token Scopes (OAuth & Permissions): channels:read, groups:read',
+  'slack.manualToken.howToGet.step4': '將 App 安裝到您的工作區 (OAuth & Permissions)',
+  'slack.manualToken.howToGet.step5': '將 App 新增至目標頻道 (在 Slack 中)',
+  'slack.manualToken.howToGet.step6':
+    '複製 Bot User OAuth Token (xoxb-...) 和 User OAuth Token (xoxp-...) 並貼上至下方表單',
   'slack.manualToken.security.title': '安全與隱私',
   'slack.manualToken.security.notice': '注意：此功能與 Slack 伺服器通信（非本地操作）',
   'slack.manualToken.security.storage': '令牌安全儲存於 VSCode Secret Storage (OS 金鑰鏈)',
@@ -555,9 +557,11 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.security.deletion': '可隨時刪除',
   'slack.manualToken.security.sharing': 'Bot Token 具有頻道讀寫等權限。請僅在受信任的社群內分享。',
   'slack.manualToken.botToken.label': 'Bot User OAuth Token',
-  'slack.manualToken.botToken.hint': '以 xoxb- 開頭',
+  'slack.manualToken.userToken.label': 'User OAuth Token',
   'slack.manualToken.error.tokenRequired': 'Bot Token 為必填',
   'slack.manualToken.error.invalidTokenFormat': 'Bot Token 必須以 "xoxb-" 開頭',
+  'slack.manualToken.error.userTokenRequired': 'User Token 為必填',
+  'slack.manualToken.error.invalidUserTokenFormat': 'User Token 必須以 "xoxp-" 開頭',
   'slack.manualToken.connecting': '連接中...',
   'slack.manualToken.connect': '連接',
   'slack.manualToken.deleteButton': '刪除已儲存的令牌',

--- a/src/webview/src/services/slack-integration-service.ts
+++ b/src/webview/src/services/slack-integration-service.ts
@@ -224,16 +224,19 @@ export function disconnectFromSlack(): Promise<void> {
 }
 
 /**
- * Connect to Slack workspace manually with Bot Token
+ * Connect to Slack workspace manually with Bot Token and User Token
  *
- * Users only need to provide Bot Token (xoxb-...).
+ * Users need to provide both Bot Token (xoxb-...) and User Token (xoxp-...).
+ * User Token is required for secure channel listing (only shows channels user is a member of).
  * Workspace info is automatically retrieved via auth.test API.
  *
  * @param botToken - Slack Bot User OAuth Token (xoxb-...)
+ * @param userToken - Slack User OAuth Token (xoxp-...) for secure channel listing
  * @returns Promise that resolves with workspace info
  */
 export function connectSlackManual(
-  botToken: string
+  botToken: string,
+  userToken: string
 ): Promise<{ workspaceId: string; workspaceName: string }> {
   return new Promise((resolve, reject) => {
     const requestId = `req-${Date.now()}-${Math.random()}`;
@@ -262,7 +265,7 @@ export function connectSlackManual(
     vscode.postMessage({
       type: 'CONNECT_SLACK_MANUAL',
       requestId,
-      payload: { botToken },
+      payload: { botToken, userToken },
     });
 
     setTimeout(


### PR DESCRIPTION
## Problem

### Security Vulnerability
When using manual token input (Bot Token only), the channel listing could expose private channels that the user is NOT a member of.

### Current Behavior
1. User inputs only Bot Token (xoxb-...)
2. ❌ Channel list shows ALL channels the Bot is a member of, including private channels the user is not in
3. ❌ User could potentially write to channels they don't have access to

### Expected Behavior
1. User inputs both Bot Token and User Token
2. ✅ Channel list shows only channels the authenticated user is a member of
3. ✅ User can only see and write to channels they have legitimate access to

## Solution

Require both Bot Token (`xoxb-`) AND User Token (`xoxp-`) for manual Slack connection. The User Token has `channels:read` and `groups:read` scopes which return only channels the authenticated user is a member of.

### Changes

**Extension Host:**
- `src/shared/types/messages.ts` - Added `userToken` field to `ConnectSlackManualPayload`
- `src/extension/utils/slack-token-manager.ts` - Added User Token storage and validation
- `src/extension/commands/slack-connect-manual.ts` - Added User Token validation and workspace verification
- `src/extension/commands/open-editor.ts` - Updated handler to require `userToken`

**Webview:**
- `src/webview/src/services/slack-integration-service.ts` - Updated service to pass both tokens
- `src/webview/src/components/dialogs/SlackManualTokenDialog.tsx` - Added User Token input field

**Translations (5 languages):**
- Updated setup instructions (step2-6) to reflect new token requirements
- Added User Token label and error messages
- Removed unused hint translations

## Impact

- Users must now provide both Bot Token and User Token when using manual Slack connection
- Existing manual connections will need to be re-authenticated with both tokens
- OAuth flow is not affected (already requires both tokens)
- No breaking changes to workflow sharing functionality

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)