### PR TITLE
chore: add support page link and GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly and concisely
+      placeholder: When I tried to..., the extension...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Open VSCode
+        2. Click on...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Extension version
+      description: Check in VSCode Extensions panel
+      placeholder: e.g., 2.16.0
+    validations:
+      required: true
+
+  - type: input
+    id: vscode-version
+    attributes:
+      label: VSCode version
+      description: Help > About
+      placeholder: e.g., 1.85.0
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Copy from Output panel > "Claude Code Workflow Studio"
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the issue

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/breaking-brake/cc-wf-studio/discussions
+    about: For general discussions and community support

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? Why do you need it?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe how you'd like this feature to work
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or examples

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,35 @@
+name: Question
+description: Ask a question about usage or behavior
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? We're happy to help!
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any background information that helps us understand your question
+      placeholder: I'm trying to...
+
+  - type: input
+    id: version
+    attributes:
+      label: Extension version (if relevant)
+      placeholder: e.g., 2.16.0
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your question

--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -383,6 +383,41 @@ export function SlackManualTokenDialog({
               </button>
             </div>
 
+            {/* Support Page Link */}
+            <div
+              style={{
+                marginBottom: '16px',
+              }}
+            >
+              <button
+                type="button"
+                onClick={() =>
+                  openExternalUrl(
+                    'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
+                  )
+                }
+                style={{
+                  fontSize: '12px',
+                  color: 'var(--vscode-textLink-foreground)',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.textDecoration = 'underline';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.textDecoration = 'none';
+                }}
+              >
+                {t('slack.oauth.supportPage')}
+              </button>
+            </div>
+
             {/* OAuth Status Display */}
             {isOAuthLoading && (
               <div

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -567,6 +567,7 @@ export interface WebviewTranslationKeys {
   // Slack OAuth
   'slack.oauth.description': string;
   'slack.oauth.privacyPolicy': string;
+  'slack.oauth.supportPage': string;
   'slack.oauth.connectButton': string;
   'slack.oauth.status.initiated': string;
   'slack.oauth.status.polling': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -627,6 +627,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.description':
     'Click the Connect to Workspace button to display a confirmation screen for granting "Claude Code Workflow Studio" access to Slack.\nOnce you grant permission, the Slack App for integration will be installed to your workspace.',
   'slack.oauth.privacyPolicy': 'Privacy Policy',
+  'slack.oauth.supportPage': 'Support Page',
   'slack.oauth.connectButton': 'Connect to Workspace',
   'slack.oauth.status.initiated': 'Opening browser for authentication...',
   'slack.oauth.status.polling': 'Waiting for authentication...',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -624,6 +624,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.description':
     'ワークスペースに接続ボタンをクリックすると、「Claude Code Workflow Studio」にSlackへのアクセスを許可する確認画面が表示されます。\n許可を行うとワークスペースに連携用のSlack Appがインストールされます。',
   'slack.oauth.privacyPolicy': 'プライバシーポリシー',
+  'slack.oauth.supportPage': 'サポートページ',
   'slack.oauth.connectButton': 'ワークスペースに接続',
   'slack.oauth.status.initiated': 'ブラウザを開いて認証中...',
   'slack.oauth.status.polling': '認証を待っています...',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -622,6 +622,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.description':
     '워크스페이스에 연결 버튼을 클릭하면 "Claude Code Workflow Studio"가 Slack에 액세스할 수 있도록 허용하는 확인 화면이 표시됩니다.\n허용하면 워크스페이스에 연동용 Slack App이 설치됩니다.',
   'slack.oauth.privacyPolicy': '개인정보처리방침',
+  'slack.oauth.supportPage': '지원 페이지',
   'slack.oauth.connectButton': '워크스페이스에 연결',
   'slack.oauth.status.initiated': '브라우저를 열어 인증 중...',
   'slack.oauth.status.polling': '인증 대기 중...',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -598,6 +598,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.description':
     '点击连接到工作区按钮将显示允许"Claude Code Workflow Studio"访问 Slack 的确认画面。\n授权后，连接用的 Slack App 将安装到您的工作区。',
   'slack.oauth.privacyPolicy': '隐私政策',
+  'slack.oauth.supportPage': '支持页面',
   'slack.oauth.connectButton': '连接到工作区',
   'slack.oauth.status.initiated': '正在打开浏览器进行身份验证...',
   'slack.oauth.status.polling': '等待身份验证...',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -598,6 +598,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.description':
     '點擊連接到工作區按鈕將顯示允許「Claude Code Workflow Studio」訪問 Slack 的確認畫面。\n授權後，連接用的 Slack App 將安裝到您的工作區。',
   'slack.oauth.privacyPolicy': '隱私政策',
+  'slack.oauth.supportPage': '支援頁面',
   'slack.oauth.connectButton': '連接到工作區',
   'slack.oauth.status.initiated': '正在開啟瀏覽器進行身份驗證...',
   'slack.oauth.status.polling': '等待身份驗證...',


### PR DESCRIPTION
## Summary

Add a support page link to the Slack OAuth connection tab and introduce GitHub issue templates for structured issue reporting.

## Changes

### Support Page Link
- Added "Support Page" link below Privacy Policy in Slack OAuth tab
- Links to GitHub issue template chooser (`/issues/new/choose`)
- Translated to 5 languages (EN, JA, KO, ZH-CN, ZH-TW)

### GitHub Issue Templates
| Template | Label | Purpose |
|----------|-------|---------|
| `bug_report.yml` | `bug` | Bug reports with reproduction steps, version info, logs |
| `feature_request.yml` | `enhancement` | Feature requests with problem/solution format |
| `question.yml` | `question` | General questions about usage |
| `config.yml` | - | Disables blank issues, adds Discussions link |

## Files Changed

- `src/webview/src/components/dialogs/SlackManualTokenDialog.tsx`
- `src/webview/src/i18n/translation-keys.ts`
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts`
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,question,config}.yml`

## Testing

- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)
- [x] Manual E2E: Verify support page link in Slack OAuth tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)