### PR TITLE
fix: update token deletion wording to use auth token

### DIFF
--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -591,10 +591,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.error.invalidUserTokenFormat': 'User Token must start with "xoxp-"',
   'slack.manualToken.connecting': 'Connecting...',
   'slack.manualToken.connect': 'Connect',
-  'slack.manualToken.deleteButton': 'Delete Saved Token',
+  'slack.manualToken.deleteButton': 'Delete Saved Auth Token',
   'slack.manualToken.deleteConfirm.title': 'Delete Token',
   'slack.manualToken.deleteConfirm.message':
-    'Are you sure you want to delete the saved Slack Bot Token?',
+    'Are you sure you want to delete the saved auth token?',
   'slack.manualToken.deleteConfirm.confirm': 'Delete',
   'slack.manualToken.deleteConfirm.cancel': 'Cancel',
 

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -588,9 +588,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.error.invalidUserTokenFormat': 'User Tokenは"xoxp-"で始まる必要があります',
   'slack.manualToken.connecting': '接続中...',
   'slack.manualToken.connect': '接続',
-  'slack.manualToken.deleteButton': '保存したトークンを削除',
+  'slack.manualToken.deleteButton': '保存した認証トークンを削除',
   'slack.manualToken.deleteConfirm.title': 'トークンの削除',
-  'slack.manualToken.deleteConfirm.message': '保存されているSlack Bot Tokenを削除しますか？',
+  'slack.manualToken.deleteConfirm.message': '保存した認証トークンを削除しますか？',
   'slack.manualToken.deleteConfirm.confirm': '削除',
   'slack.manualToken.deleteConfirm.cancel': 'キャンセル',
 

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -587,9 +587,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.error.invalidUserTokenFormat': 'User Token은 "xoxp-"로 시작해야 합니다',
   'slack.manualToken.connecting': '연결 중...',
   'slack.manualToken.connect': '연결',
-  'slack.manualToken.deleteButton': '저장된 토큰 삭제',
+  'slack.manualToken.deleteButton': '저장된 인증 토큰 삭제',
   'slack.manualToken.deleteConfirm.title': '토큰 삭제',
-  'slack.manualToken.deleteConfirm.message': '저장된 Slack Bot Token을 삭제하시겠습니까?',
+  'slack.manualToken.deleteConfirm.message': '저장된 인증 토큰을 삭제하시겠습니까?',
   'slack.manualToken.deleteConfirm.confirm': '삭제',
   'slack.manualToken.deleteConfirm.cancel': '취소',
 

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -564,9 +564,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.error.invalidUserTokenFormat': 'User Token 必须以 "xoxp-" 开头',
   'slack.manualToken.connecting': '连接中...',
   'slack.manualToken.connect': '连接',
-  'slack.manualToken.deleteButton': '删除已保存的令牌',
+  'slack.manualToken.deleteButton': '删除已保存的认证令牌',
   'slack.manualToken.deleteConfirm.title': '删除令牌',
-  'slack.manualToken.deleteConfirm.message': '确定要删除已保存的 Slack Bot Token 吗？',
+  'slack.manualToken.deleteConfirm.message': '确定要删除已保存的认证令牌吗？',
   'slack.manualToken.deleteConfirm.confirm': '删除',
   'slack.manualToken.deleteConfirm.cancel': '取消',
 

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -564,9 +564,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.error.invalidUserTokenFormat': 'User Token 必須以 "xoxp-" 開頭',
   'slack.manualToken.connecting': '連接中...',
   'slack.manualToken.connect': '連接',
-  'slack.manualToken.deleteButton': '刪除已儲存的令牌',
+  'slack.manualToken.deleteButton': '刪除已儲存的認證令牌',
   'slack.manualToken.deleteConfirm.title': '刪除令牌',
-  'slack.manualToken.deleteConfirm.message': '確定要刪除已儲存的 Slack Bot Token 嗎？',
+  'slack.manualToken.deleteConfirm.message': '確定要刪除已儲存的認證令牌嗎？',
   'slack.manualToken.deleteConfirm.confirm': '刪除',
   'slack.manualToken.deleteConfirm.cancel': '取消',
 


### PR DESCRIPTION
## Problem

The Slack token deletion wording still referenced "Slack Bot Token" instead of "auth token".

### Current Behavior
- Button: "Delete Saved Token"
- Confirm message: "Are you sure you want to delete the saved Slack Bot Token?"

### Expected Behavior
- Button: "Delete Saved Auth Token"
- Confirm message: "Are you sure you want to delete the saved auth token?"

## Solution

Updated the following i18n keys in all 5 language files (en, ja, ko, zh-CN, zh-TW):
- `slack.manualToken.deleteButton`
- `slack.manualToken.deleteConfirm.message`

## Changes

| Language | deleteButton | deleteConfirm.message |
|----------|--------------|----------------------|
| en | Delete Saved Auth Token | Are you sure you want to delete the saved auth token? |
| ja | 保存した認証トークンを削除 | 保存した認証トークンを削除しますか？ |
| ko | 저장된 인증 토큰 삭제 | 저장된 인증 토큰을 삭제하시겠습니까? |
| zh-CN | 删除已保存的认证令牌 | 确定要删除已保存的认证令牌吗？ |
| zh-TW | 刪除已儲存的認證令牌 | 確定要刪除已儲存的認證令牌嗎？ |

## Impact

- UI wording change only
- No functional changes

## Testing

- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)