### PR TITLE
feat: add Terms of Service link to Slack connection dialog

### DIFF
--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -352,71 +352,86 @@ export function SlackManualTokenDialog({
               {t('slack.oauth.description')}
             </div>
 
-            {/* Privacy Policy Link */}
-            <div
+            {/* Links */}
+            <ul
               style={{
+                listStyle: 'disc',
+                paddingLeft: '20px',
                 marginBottom: '16px',
+                fontSize: '12px',
               }}
             >
-              <button
-                type="button"
-                onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--vscode-textLink-foreground)',
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  cursor: 'pointer',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.textDecoration = 'underline';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.textDecoration = 'none';
-                }}
-              >
-                {t('slack.oauth.privacyPolicy')}
-              </button>
-            </div>
-
-            {/* Support Page Link */}
-            <div
-              style={{
-                marginBottom: '16px',
-              }}
-            >
-              <button
-                type="button"
-                onClick={() =>
-                  openExternalUrl(
-                    'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
-                  )
-                }
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--vscode-textLink-foreground)',
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  cursor: 'pointer',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.textDecoration = 'underline';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.textDecoration = 'none';
-                }}
-              >
-                {t('slack.oauth.supportPage')}
-              </button>
-            </div>
+              <li>
+                <button
+                  type="button"
+                  onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-textLink-foreground)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = 'underline';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = 'none';
+                  }}
+                >
+                  {t('slack.oauth.termsOfService')}
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-textLink-foreground)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = 'underline';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = 'none';
+                  }}
+                >
+                  {t('slack.oauth.privacyPolicy')}
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  onClick={() =>
+                    openExternalUrl(
+                      'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
+                    )
+                  }
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-textLink-foreground)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = 'underline';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = 'none';
+                  }}
+                >
+                  {t('slack.oauth.supportPage')}
+                </button>
+              </li>
+            </ul>
 
             {/* OAuth Status Display */}
             {isOAuthLoading && (
@@ -633,36 +648,86 @@ export function SlackManualTokenDialog({
               </div>
             </div>
 
-            {/* Privacy Policy Link */}
-            <div
+            {/* Links */}
+            <ul
               style={{
+                listStyle: 'disc',
+                paddingLeft: '20px',
                 marginBottom: '16px',
+                fontSize: '12px',
               }}
             >
-              <button
-                type="button"
-                onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--vscode-textLink-foreground)',
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  cursor: 'pointer',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.textDecoration = 'underline';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.textDecoration = 'none';
-                }}
-              >
-                {t('slack.oauth.privacyPolicy')}
-              </button>
-            </div>
+              <li>
+                <button
+                  type="button"
+                  onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-textLink-foreground)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = 'underline';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = 'none';
+                  }}
+                >
+                  {t('slack.oauth.termsOfService')}
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-textLink-foreground)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = 'underline';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = 'none';
+                  }}
+                >
+                  {t('slack.oauth.privacyPolicy')}
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  onClick={() =>
+                    openExternalUrl(
+                      'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
+                    )
+                  }
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-textLink-foreground)',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = 'underline';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = 'none';
+                  }}
+                >
+                  {t('slack.oauth.supportPage')}
+                </button>
+              </li>
+            </ul>
 
             {/* Bot Token Input */}
             <div style={{ marginBottom: '16px' }}>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -566,6 +566,7 @@ export interface WebviewTranslationKeys {
 
   // Slack OAuth
   'slack.oauth.description': string;
+  'slack.oauth.termsOfService': string;
   'slack.oauth.privacyPolicy': string;
   'slack.oauth.supportPage': string;
   'slack.oauth.connectButton': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -626,6 +626,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Slack OAuth
   'slack.oauth.description':
     'Click the Connect to Workspace button to display a confirmation screen for granting "Claude Code Workflow Studio" access to Slack.\nOnce you grant permission, the Slack App for integration will be installed to your workspace.',
+  'slack.oauth.termsOfService': 'Terms of Service',
   'slack.oauth.privacyPolicy': 'Privacy Policy',
   'slack.oauth.supportPage': 'Support Page',
   'slack.oauth.connectButton': 'Connect to Workspace',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -623,6 +623,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Slack OAuth
   'slack.oauth.description':
     'ワークスペースに接続ボタンをクリックすると、「Claude Code Workflow Studio」にSlackへのアクセスを許可する確認画面が表示されます。\n許可を行うとワークスペースに連携用のSlack Appがインストールされます。',
+  'slack.oauth.termsOfService': '利用規約',
   'slack.oauth.privacyPolicy': 'プライバシーポリシー',
   'slack.oauth.supportPage': 'サポートページ',
   'slack.oauth.connectButton': 'ワークスペースに接続',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -621,6 +621,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Slack OAuth
   'slack.oauth.description':
     '워크스페이스에 연결 버튼을 클릭하면 "Claude Code Workflow Studio"가 Slack에 액세스할 수 있도록 허용하는 확인 화면이 표시됩니다.\n허용하면 워크스페이스에 연동용 Slack App이 설치됩니다.',
+  'slack.oauth.termsOfService': '이용약관',
   'slack.oauth.privacyPolicy': '개인정보처리방침',
   'slack.oauth.supportPage': '지원 페이지',
   'slack.oauth.connectButton': '워크스페이스에 연결',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -597,6 +597,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Slack OAuth
   'slack.oauth.description':
     '点击连接到工作区按钮将显示允许"Claude Code Workflow Studio"访问 Slack 的确认画面。\n授权后，连接用的 Slack App 将安装到您的工作区。',
+  'slack.oauth.termsOfService': '服务条款',
   'slack.oauth.privacyPolicy': '隐私政策',
   'slack.oauth.supportPage': '支持页面',
   'slack.oauth.connectButton': '连接到工作区',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -597,6 +597,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Slack OAuth
   'slack.oauth.description':
     '點擊連接到工作區按鈕將顯示允許「Claude Code Workflow Studio」訪問 Slack 的確認畫面。\n授權後，連接用的 Slack App 將安裝到您的工作區。',
+  'slack.oauth.termsOfService': '服務條款',
   'slack.oauth.privacyPolicy': '隱私政策',
   'slack.oauth.supportPage': '支援頁面',
   'slack.oauth.connectButton': '連接到工作區',


### PR DESCRIPTION
## Summary

Added Terms of Service link to Slack connection dialog and improved link section layout using list format.

## Changes

### Added
- `slack.oauth.termsOfService` translation key with translations for 5 languages (en, ja, ko, zh-CN, zh-TW)
- Terms of Service link (https://cc-wf-studio.com/terms) to both OAuth and Manual Token tabs

### Improved
- Refactored link section to use `<ul>`/`<li>` list format for consistent spacing
- Added Support Page link to Manual Token tab for parity with OAuth tab

### Links displayed (both tabs)
- Terms of Service
- Privacy Policy
- Support Page

## Files Changed

- `src/webview/src/i18n/translation-keys.ts` - Added translation key
- `src/webview/src/i18n/translations/*.ts` - Added translations for 5 languages
- `src/webview/src/components/dialogs/SlackManualTokenDialog.tsx` - UI implementation

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)