### PR TITLE
feat: display Slack author as clickable mention

### DIFF
--- a/src/extension/commands/slack-share-workflow.ts
+++ b/src/extension/commands/slack-share-workflow.ts
@@ -86,6 +86,7 @@ export async function handleShareWorkflowToSlack(
     log('INFO', 'Getting Slack user information', { requestId });
     const userInfo = await slackApiService.getUserInfo(payload.workspaceId);
     const authorName = userInfo.userName;
+    const authorUserId = userInfo.userId || undefined;
 
     // Step 3: Extract workflow metadata
     const nodeCount = workflow.nodes.length;
@@ -114,6 +115,7 @@ export async function handleShareWorkflowToSlack(
       description: payload.description || workflow.description,
       version: workflow.version,
       authorName,
+      authorUserId,
       nodeCount,
       createdAt,
       fileId: '', // Will be updated after file upload

--- a/src/extension/services/slack-oauth-service.ts
+++ b/src/extension/services/slack-oauth-service.ts
@@ -28,7 +28,7 @@ const OAUTH_CONFIG = {
   /** Required Slack Bot Token scopes */
   scopes: 'chat:write,files:read,files:write',
   /** Required Slack User Token scopes (for channel listing) */
-  userScopes: 'channels:read,groups:read',
+  userScopes: 'channels:read,groups:read,users:read',
   /** Initial polling interval in milliseconds */
   pollingIntervalInitialMs: 1000,
   /** Maximum polling interval in milliseconds */

--- a/src/extension/utils/slack-message-builder.ts
+++ b/src/extension/utils/slack-message-builder.ts
@@ -60,8 +60,10 @@ export interface WorkflowMessageBlock {
   description?: string;
   /** Workflow version */
   version: string;
-  /** Author name */
+  /** Author name (fallback display) */
   authorName: string;
+  /** Author Slack user ID (for <@USER_ID> mention format) */
+  authorUserId?: string;
   /** Node count */
   nodeCount: number;
   /** Created timestamp (ISO 8601) */
@@ -121,7 +123,9 @@ export function buildWorkflowMessageBlocks(
       elements: [
         {
           type: 'mrkdwn',
-          text: `*Author:* ${block.authorName}`,
+          text: block.authorUserId
+            ? `*Author:* <@${block.authorUserId}>`
+            : `*Author:* ${block.authorName || 'Unknown'}`,
         },
         {
           type: 'mrkdwn',


### PR DESCRIPTION
## Summary

Display the Author name as a clickable Slack mention (`<@USER_ID>`) in the workflow sharing message card.

## Changes

- **OAuth scope**: Add `users:read` scope to User Token
- **getUserInfo() rewrite**: Remove Git username dependency, use Slack API instead
  - Use `auth.test` to get User ID
  - Use `users.info` to get user details
- **Message card update**: Display `<@USER_ID>` format for clickable profile links

## Before / After

| Before | After |
|--------|-------|
| `*Author:* John Doe` (Git username) | `*Author:* @username` (Clickable Slack mention) |

## Impact

- **New users**: Slack mention format after authentication
- **Existing users**: Re-authentication required (due to `users:read` scope addition)
  - Before re-auth: `Author: Unknown`

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)