### PR TITLE
fix: use User Token for bot membership check

### DIFF
--- a/src/extension/commands/slack-connect-oauth.ts
+++ b/src/extension/commands/slack-connect-oauth.ts
@@ -89,6 +89,7 @@ export async function handleConnectSlackOAuth(
         userAccessToken: tokenResponse.authed_user?.access_token,
         tokenScope: tokenResponse.scope?.split(','),
         userId: tokenResponse.authed_user?.id || '',
+        botUserId: tokenResponse.bot_user_id,
         authorizedAt: new Date(),
       };
 

--- a/src/extension/services/slack-oauth-service.ts
+++ b/src/extension/services/slack-oauth-service.ts
@@ -53,6 +53,7 @@ export interface OAuthInitiation {
 export interface SlackOAuthTokenResponse {
   ok: boolean;
   access_token?: string;
+  bot_user_id?: string; // Bot User ID (for membership check)
   team?: {
     id: string;
     name: string;

--- a/src/extension/types/slack-integration-types.ts
+++ b/src/extension/types/slack-integration-types.ts
@@ -37,6 +37,9 @@ export interface SlackWorkspaceConnection {
   /** Authenticated user's Slack User ID (e.g., U01234EFGH) */
   userId: string;
 
+  /** Bot User ID for membership check (e.g., U01234ABCD) */
+  botUserId?: string;
+
   /** Authorization timestamp (ISO 8601) */
   authorizedAt: Date;
 

--- a/src/extension/utils/slack-token-manager.ts
+++ b/src/extension/utils/slack-token-manager.ts
@@ -69,6 +69,7 @@ export class SlackTokenManager {
       teamId: connection.teamId,
       tokenScope: connection.tokenScope,
       userId: connection.userId,
+      botUserId: connection.botUserId,
       authorizedAt: connection.authorizedAt.toISOString(),
       lastValidatedAt: connection.lastValidatedAt?.toISOString(),
     };
@@ -244,6 +245,7 @@ export class SlackTokenManager {
         userAccessToken: userAccessToken || undefined,
         tokenScope: workspaceData.tokenScope,
         userId: workspaceData.userId,
+        botUserId: workspaceData.botUserId,
         authorizedAt: new Date(workspaceData.authorizedAt),
         lastValidatedAt: workspaceData.lastValidatedAt
           ? new Date(workspaceData.lastValidatedAt)
@@ -290,6 +292,19 @@ export class SlackTokenManager {
   async getUserAccessTokenByWorkspaceId(workspaceId: string): Promise<string | null> {
     const userTokenKey = getWorkspaceSecretKey(workspaceId, 'user-token');
     return (await this.context.secrets.get(userTokenKey)) || null;
+  }
+
+  /**
+   * Gets Bot User ID for specific workspace
+   *
+   * Bot User ID is used for membership check with conversations.members API.
+   *
+   * @param workspaceId - Workspace ID
+   * @returns Bot User ID if exists, null otherwise
+   */
+  async getBotUserId(workspaceId: string): Promise<string | null> {
+    const connection = await this.getConnectionByWorkspaceId(workspaceId);
+    return connection?.botUserId || null;
   }
 
   /**


### PR DESCRIPTION
## Problem

`checkBotMembership` was always returning `false` and showing "Bot not in channel" warning because:

### Current Behavior
1. User selects a channel to share workflow
2. ❌ `checkBotMembership` calls `conversations.info` with Bot Token
3. ❌ Bot Token lacks `channels:read` scope, API returns `missing_scope` error
4. ❌ Warning always displayed: "Bot is not a member of this channel"

### Expected Behavior
1. User selects a channel to share workflow
2. ✅ Correctly detect if Bot is a member of the channel
3. ✅ Only show warning when Bot is actually not a member

## Solution

Use User Token (which has `channels:read`/`groups:read` scopes) to call `conversations.members` API, then check if Bot User ID is in the member list.

### Changes

**File**: `src/extension/services/slack-oauth-service.ts`
- Added `bot_user_id` field to `SlackOAuthTokenResponse`

**File**: `src/extension/types/slack-integration-types.ts`
- Added `botUserId` field to `SlackWorkspaceConnection`

**File**: `src/extension/commands/slack-connect-oauth.ts`
- Store `bot_user_id` from OAuth response

**File**: `src/extension/utils/slack-token-manager.ts`
- Store and retrieve `botUserId` in workspace data
- Added `getBotUserId(workspaceId)` method

**File**: `src/extension/services/slack-api-service.ts`
- Rewrote `checkBotMembership` to use User Token with `conversations.members` API
- Added fallback to `auth.test` for existing users without stored `bot_user_id`

## Impact

- No additional Bot Token scopes required
- Existing users work without re-authentication (fallback to `auth.test`)
- Pagination support for large channels (200+ members)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, build)

## Notes

- Credit to user for proposing this solution approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)