### PR TITLE
Release: v2.17.1

### DIFF
--- a/src/extension/commands/slack-connect-manual.ts
+++ b/src/extension/commands/slack-connect-manual.ts
@@ -183,9 +183,14 @@ export async function handleConnectSlackManual(
 
     log('ERROR', 'Manual Slack connection failed', {
       errorCode: errorInfo.code,
-      errorMessage: errorInfo.message,
+      messageKey: errorInfo.messageKey,
     });
 
-    await vscode.window.showErrorMessage(`Failed to connect to Slack: ${errorInfo.message}`, 'OK');
+    // Note: This error message is shown via VSCode native dialog, not Webview i18n
+    // The messageKey is logged for debugging, but we show a generic English message
+    await vscode.window.showErrorMessage(
+      `Failed to connect to Slack. Please check your token and try again.`,
+      'OK'
+    );
   }
 }

--- a/src/extension/types/slack-messages.ts
+++ b/src/extension/types/slack-messages.ts
@@ -166,7 +166,10 @@ export interface SlackConnectFailedEvent {
   type: 'SLACK_CONNECT_FAILED';
   payload: {
     errorCode: 'USER_CANCELLED' | 'OAUTH_FAILED' | 'NETWORK_ERROR' | 'UNKNOWN_ERROR';
-    errorMessage: string;
+    /** i18n message key for translation */
+    messageKey: string;
+    /** i18n suggested action key for translation */
+    suggestedActionKey?: string;
   };
 }
 
@@ -189,7 +192,10 @@ export interface SlackDisconnectFailedEvent {
   type: 'SLACK_DISCONNECT_FAILED';
   payload: {
     errorCode: string;
-    errorMessage: string;
+    /** i18n message key for translation */
+    messageKey: string;
+    /** i18n suggested action key for translation */
+    suggestedActionKey?: string;
   };
 }
 
@@ -214,7 +220,10 @@ export interface GetSlackChannelsFailedEvent {
   type: 'GET_SLACK_CHANNELS_FAILED';
   payload: {
     errorCode: string;
-    errorMessage: string;
+    /** i18n message key for translation */
+    messageKey: string;
+    /** i18n suggested action key for translation */
+    suggestedActionKey?: string;
   };
 }
 
@@ -265,7 +274,12 @@ export interface ShareWorkflowFailedEvent {
       | 'RATE_LIMITED'
       | 'NETWORK_ERROR'
       | 'UNKNOWN_ERROR';
-    errorMessage: string;
+    /** i18n message key for translation */
+    messageKey: string;
+    /** i18n suggested action key for translation */
+    suggestedActionKey?: string;
+    /** Parameters for message interpolation (e.g., retryAfter seconds) */
+    messageParams?: Record<string, string | number>;
   };
 }
 
@@ -308,7 +322,12 @@ export interface ImportWorkflowFailedEvent {
   payload: {
     workflowId: string;
     errorCode: string;
-    errorMessage: string;
+    /** i18n message key for translation */
+    messageKey: string;
+    /** i18n suggested action key for translation */
+    suggestedActionKey?: string;
+    /** Parameters for message interpolation (e.g., retryAfter seconds) */
+    messageParams?: Record<string, string | number>;
     /** Source workspace ID (for WORKSPACE_NOT_CONNECTED errors) */
     workspaceId?: string;
     /** Workspace name for display in error dialogs */
@@ -338,7 +357,10 @@ export interface SearchSlackWorkflowsFailedEvent {
   type: 'SEARCH_SLACK_WORKFLOWS_FAILED';
   payload: {
     errorCode: string;
-    errorMessage: string;
+    /** i18n message key for translation */
+    messageKey: string;
+    /** i18n suggested action key for translation */
+    suggestedActionKey?: string;
   };
 }
 

--- a/src/extension/utils/slack-error-handler.ts
+++ b/src/extension/utils/slack-error-handler.ts
@@ -2,23 +2,23 @@
  * Slack Error Handler Utility
  *
  * Provides unified error handling for Slack API operations.
- * Maps Slack API errors to user-friendly messages.
+ * Maps Slack API errors to i18n translation keys.
  *
  * Based on specs/001-slack-workflow-sharing/contracts/slack-api-contracts.md
  */
 
 /**
- * Slack error information
+ * Slack error information with i18n keys
  */
 export interface SlackErrorInfo {
   /** Error code (for programmatic handling) */
   code: string;
-  /** User-friendly error message */
-  message: string;
+  /** i18n message key for translation */
+  messageKey: string;
   /** Whether error is recoverable */
   recoverable: boolean;
-  /** Suggested action for user */
-  suggestedAction?: string;
+  /** i18n suggested action key for translation */
+  suggestedActionKey?: string;
   /** Retry after seconds (for rate limiting) */
   retryAfter?: number;
   /** Workspace ID (for WORKSPACE_NOT_CONNECTED errors) */
@@ -26,84 +26,83 @@ export interface SlackErrorInfo {
 }
 
 /**
- * Error code mappings
+ * Error code mappings with i18n keys
  */
 const ERROR_MAPPINGS: Record<string, Omit<SlackErrorInfo, 'code' | 'retryAfter'>> = {
   invalid_auth: {
-    message: 'Slackトークンが無効です',
+    messageKey: 'slack.error.invalidAuth',
     recoverable: true,
-    suggestedAction: '再度Slackに接続してください',
+    suggestedActionKey: 'slack.error.action.reconnect',
   },
   missing_scope: {
-    message: '必要な権限がありません',
+    messageKey: 'slack.error.missingScope',
     recoverable: true,
-    suggestedAction: 'Slackアプリに必要な権限を追加し、再度接続してください',
+    suggestedActionKey: 'slack.error.action.addPermission',
   },
   rate_limited: {
-    message: 'Slack APIのレート制限に達しました',
+    messageKey: 'slack.error.rateLimited',
     recoverable: true,
-    suggestedAction: 'しばらく待ってから再試行してください',
+    suggestedActionKey: 'slack.error.action.waitAndRetry',
   },
   channel_not_found: {
-    message: 'チャンネルが見つかりません',
+    messageKey: 'slack.error.channelNotFound',
     recoverable: false,
-    suggestedAction: 'チャンネルIDを確認してください',
+    suggestedActionKey: 'slack.error.action.checkChannelId',
   },
   not_in_channel: {
-    message: 'Slack Appがチャンネルに招待されていません',
+    messageKey: 'slack.error.notInChannel',
     recoverable: true,
-    suggestedAction:
-      '共有先のチャンネルで /invite @Claude Code Workflow Studio を実行してSlack Appを招待してから、再度お試しください',
+    suggestedActionKey: 'slack.error.action.inviteBot',
   },
   file_too_large: {
-    message: 'ファイルサイズが大きすぎます',
+    messageKey: 'slack.error.fileTooLarge',
     recoverable: false,
-    suggestedAction: 'ワークフローファイルのサイズを1MB未満に削減してください',
+    suggestedActionKey: 'slack.error.action.reduceFileSize',
   },
   invalid_file_type: {
-    message: 'サポートされていないファイルタイプです',
+    messageKey: 'slack.error.invalidFileType',
     recoverable: false,
-    suggestedAction: 'JSON形式のワークフローファイルのみサポートされています',
+    suggestedActionKey: 'slack.error.action.useJsonFormat',
   },
   internal_error: {
-    message: 'Slack内部エラーが発生しました',
+    messageKey: 'slack.error.internalError',
     recoverable: true,
-    suggestedAction: 'しばらく待ってから再試行してください',
+    suggestedActionKey: 'slack.error.action.waitAndRetry',
   },
   not_authed: {
-    message: '認証情報が提供されていません',
+    messageKey: 'slack.error.notAuthed',
     recoverable: true,
-    suggestedAction: 'Slackに接続してください',
+    suggestedActionKey: 'slack.error.action.connect',
   },
   invalid_code: {
-    message: '認証コードが無効または期限切れです',
+    messageKey: 'slack.error.invalidCode',
     recoverable: true,
-    suggestedAction: '再度認証を開始してください',
+    suggestedActionKey: 'slack.error.action.restartAuth',
   },
   bad_client_secret: {
-    message: 'クライアントシークレットが無効です',
+    messageKey: 'slack.error.badClientSecret',
     recoverable: false,
-    suggestedAction: 'Slackアプリの設定を確認してください',
+    suggestedActionKey: 'slack.error.action.checkAppSettings',
   },
   invalid_grant_type: {
-    message: '無効な認証タイプです',
+    messageKey: 'slack.error.invalidGrantType',
     recoverable: false,
-    suggestedAction: 'Slackアプリの設定を確認してください',
+    suggestedActionKey: 'slack.error.action.checkAppSettings',
   },
   account_inactive: {
-    message: 'アカウントが無効化されています',
+    messageKey: 'slack.error.accountInactive',
     recoverable: false,
-    suggestedAction: 'Slackアカウントの状態を確認してください',
+    suggestedActionKey: 'slack.error.action.checkAccountStatus',
   },
   invalid_query: {
-    message: '無効な検索クエリです',
+    messageKey: 'slack.error.invalidQuery',
     recoverable: false,
-    suggestedAction: '検索キーワードを確認してください',
+    suggestedActionKey: 'slack.error.action.checkSearchKeyword',
   },
   msg_too_long: {
-    message: 'メッセージが長すぎます',
+    messageKey: 'slack.error.msgTooLong',
     recoverable: false,
-    suggestedAction: 'ワークフローの説明を短くするか、ファイルサイズを削減してください',
+    suggestedActionKey: 'slack.error.action.reduceDescription',
   },
 };
 
@@ -111,7 +110,7 @@ const ERROR_MAPPINGS: Record<string, Omit<SlackErrorInfo, 'code' | 'retryAfter'>
  * Handles Slack API errors
  *
  * @param error - Error from Slack API call
- * @returns Structured error information
+ * @returns Structured error information with i18n keys
  */
 export function handleSlackError(error: unknown): SlackErrorInfo {
   // Check for WORKSPACE_NOT_CONNECTED custom error
@@ -124,9 +123,9 @@ export function handleSlackError(error: unknown): SlackErrorInfo {
     const workspaceError = error as { code: string; workspaceId?: string; message?: string };
     return {
       code: 'WORKSPACE_NOT_CONNECTED',
-      message: 'インポート元のSlackワークスペースに接続されていません',
+      messageKey: 'slack.error.workspaceNotConnected',
       recoverable: true,
-      suggestedAction: 'Slackに接続してからワークフローをインポートしてください',
+      suggestedActionKey: 'slack.error.action.connectAndImport',
       workspaceId: workspaceError.workspaceId,
     };
   }
@@ -146,9 +145,9 @@ export function handleSlackError(error: unknown): SlackErrorInfo {
 
     // Get error mapping
     const mapping = ERROR_MAPPINGS[errorCode] || {
-      message: `Slack APIエラー: ${errorCode}`,
+      messageKey: 'slack.error.unknownApiError',
       recoverable: false,
-      suggestedAction: 'エラーが継続する場合は、サポートにお問い合わせください',
+      suggestedActionKey: 'slack.error.action.contactSupport',
     };
 
     // Extract retry-after for rate limiting
@@ -165,36 +164,38 @@ export function handleSlackError(error: unknown): SlackErrorInfo {
   if (error instanceof Error) {
     return {
       code: 'NETWORK_ERROR',
-      message: 'ネットワークエラーが発生しました',
+      messageKey: 'slack.error.networkError',
       recoverable: true,
-      suggestedAction: 'インターネット接続を確認してください',
+      suggestedActionKey: 'slack.error.action.checkConnection',
     };
   }
 
   // Unknown error
   return {
     code: 'UNKNOWN_ERROR',
-    message: '不明なエラーが発生しました',
+    messageKey: 'slack.error.unknownError',
     recoverable: false,
-    suggestedAction: 'エラーが継続する場合は、サポートにお問い合わせください',
+    suggestedActionKey: 'slack.error.action.contactSupport',
   };
 }
 
 /**
- * Formats error for user display
+ * Formats error for user display (deprecated - use i18n on Webview side)
  *
  * @param errorInfo - Error information
- * @returns Formatted error message
+ * @returns Formatted error message key (for debugging purposes)
+ * @deprecated Use messageKey and suggestedActionKey for i18n translation on Webview side
  */
 export function formatErrorMessage(errorInfo: SlackErrorInfo): string {
-  let message = errorInfo.message;
+  // Return messageKey for debugging - actual translation happens on Webview side
+  let message = errorInfo.messageKey;
 
-  if (errorInfo.suggestedAction) {
-    message += `\n\n${errorInfo.suggestedAction}`;
+  if (errorInfo.suggestedActionKey) {
+    message += ` | ${errorInfo.suggestedActionKey}`;
   }
 
   if (errorInfo.retryAfter) {
-    message += `\n\n${errorInfo.retryAfter}秒後に再試行してください。`;
+    message += ` | retryAfter: ${errorInfo.retryAfter}`;
   }
 
   return message;

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -786,8 +786,14 @@ export interface ImportWorkflowFailedPayload {
     | 'NETWORK_ERROR'
     | 'WORKSPACE_NOT_CONNECTED'
     | 'UNKNOWN_ERROR';
-  /** Error message */
-  errorMessage: string;
+  /** @deprecated Use messageKey for i18n */
+  errorMessage?: string;
+  /** i18n message key for translation */
+  messageKey: string;
+  /** i18n suggested action key for translation */
+  suggestedActionKey?: string;
+  /** Parameters for message interpolation (e.g., retryAfter seconds) */
+  messageParams?: Record<string, string | number>;
   /** Workspace ID that is not connected (for WORKSPACE_NOT_CONNECTED error) */
   workspaceId?: string;
   /** Workspace name for display in error dialogs (decoded from Base64) */
@@ -872,7 +878,14 @@ export interface ShareWorkflowFailedPayload {
     | 'MESSAGE_POST_FAILED'
     | 'NETWORK_ERROR'
     | 'UNKNOWN_ERROR';
-  errorMessage: string;
+  /** @deprecated Use messageKey for i18n */
+  errorMessage?: string;
+  /** i18n message key for translation */
+  messageKey: string;
+  /** i18n suggested action key for translation */
+  suggestedActionKey?: string;
+  /** Parameters for message interpolation (e.g., retryAfter seconds) */
+  messageParams?: Record<string, string | number>;
 }
 
 // ============================================================================

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -550,7 +550,6 @@ export interface WebviewTranslationKeys {
   'slack.search.noResults': string;
 
   // Slack Errors
-  'slack.error.notAuthenticated': string;
   'slack.error.channelNotFound': string;
   'slack.error.noChannels': string;
   'slack.error.noChannelsHelp': string;
@@ -558,6 +557,21 @@ export interface WebviewTranslationKeys {
   'slack.error.notInChannel': string;
   'slack.error.networkError': string;
   'slack.error.rateLimited': string;
+  'slack.error.invalidAuth': string;
+  'slack.error.missingScope': string;
+  'slack.error.fileTooLarge': string;
+  'slack.error.invalidFileType': string;
+  'slack.error.internalError': string;
+  'slack.error.notAuthed': string;
+  'slack.error.invalidCode': string;
+  'slack.error.badClientSecret': string;
+  'slack.error.invalidGrantType': string;
+  'slack.error.accountInactive': string;
+  'slack.error.invalidQuery': string;
+  'slack.error.msgTooLong': string;
+  'slack.error.workspaceNotConnected': string;
+  'slack.error.unknownError': string;
+  'slack.error.unknownApiError': string;
 
   // Slack Connection Dialog
   'slack.connect.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -660,16 +660,29 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.noResults': 'No workflows found',
 
   // Slack Errors
-  'slack.error.notAuthenticated': 'Please connect to Slack first',
   'slack.error.channelNotFound': 'Channel not found',
   'slack.error.noWorkspaces': 'No workspaces connected',
   'slack.error.noChannels': 'No channels available',
   'slack.error.noChannelsHelp':
     'The Slack App is not a member of any channels. Invite the Slack App to channels using /invite @Claude Code Workflow Studio in Slack.',
-  'slack.error.notInChannel':
-    'Slack App is not a member of this channel. Please invite the Slack App first.',
+  'slack.error.notInChannel': 'Slack App has not been added to the destination channel.',
   'slack.error.networkError': 'Network error. Please check your connection.',
   'slack.error.rateLimited': 'Rate limit exceeded. Please try again in {seconds} seconds.',
+  'slack.error.invalidAuth': 'Slack token is invalid.',
+  'slack.error.missingScope': 'Required permissions are missing.',
+  'slack.error.fileTooLarge': 'File size is too large.',
+  'slack.error.invalidFileType': 'Unsupported file type.',
+  'slack.error.internalError': 'Slack internal error occurred.',
+  'slack.error.notAuthed': 'Authentication credentials not provided.',
+  'slack.error.invalidCode': 'Authentication code is invalid or expired.',
+  'slack.error.badClientSecret': 'Client secret is invalid.',
+  'slack.error.invalidGrantType': 'Invalid authentication type.',
+  'slack.error.accountInactive': 'Account has been deactivated.',
+  'slack.error.invalidQuery': 'Invalid search query.',
+  'slack.error.msgTooLong': 'Message is too long.',
+  'slack.error.workspaceNotConnected': 'Not connected to the source Slack workspace.',
+  'slack.error.unknownError': 'An unknown error occurred.',
+  'slack.error.unknownApiError': 'Slack API error occurred.',
 
   // Sensitive Data Warning
   'slack.sensitiveData.warning.title': 'Sensitive Data Detected',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -655,16 +655,29 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.noResults': 'ワークフローが見つかりませんでした',
 
   // Slack Errors
-  'slack.error.notAuthenticated': '先にSlackに接続してください',
   'slack.error.channelNotFound': 'チャンネルが見つかりません',
-  'slack.error.notInChannel':
-    'Slack Appがこのチャンネルのメンバーではありません。先にSlack Appを招待してください。',
+  'slack.error.notInChannel': '共有先のチャンネルにSlack Appが追加されていません。',
   'slack.error.networkError': 'ネットワークエラー。接続を確認してください。',
   'slack.error.rateLimited': 'レート制限を超過しました。{seconds}秒後に再試行してください。',
   'slack.error.noWorkspaces': '接続されているワークスペースがありません',
   'slack.error.noChannels': '利用可能なチャンネルがありません',
   'slack.error.noChannelsHelp':
     'Slack Appがどのチャンネルにも参加していません。Slackで /invite @Claude Code Workflow Studio を実行してSlack Appをチャンネルに招待してください。',
+  'slack.error.invalidAuth': 'Slackトークンが無効です。',
+  'slack.error.missingScope': '必要な権限がありません。',
+  'slack.error.fileTooLarge': 'ファイルサイズが大きすぎます。',
+  'slack.error.invalidFileType': 'サポートされていないファイルタイプです。',
+  'slack.error.internalError': 'Slack内部エラーが発生しました。',
+  'slack.error.notAuthed': '認証情報が提供されていません。',
+  'slack.error.invalidCode': '認証コードが無効または期限切れです。',
+  'slack.error.badClientSecret': 'クライアントシークレットが無効です。',
+  'slack.error.invalidGrantType': '無効な認証タイプです。',
+  'slack.error.accountInactive': 'アカウントが無効化されています。',
+  'slack.error.invalidQuery': '無効な検索クエリです。',
+  'slack.error.msgTooLong': 'メッセージが長すぎます。',
+  'slack.error.workspaceNotConnected': 'インポート元のSlackワークスペースに接続されていません。',
+  'slack.error.unknownError': '不明なエラーが発生しました。',
+  'slack.error.unknownApiError': 'Slack APIエラーが発生しました。',
 
   // Sensitive Data Warning
   'slack.sensitiveData.warning.title': '機密情報が検出されました',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -654,15 +654,29 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.noResults': '워크플로우를 찾을 수 없습니다',
 
   // Slack Errors
-  'slack.error.notAuthenticated': '먼저 Slack에 연결하세요',
   'slack.error.channelNotFound': '채널을 찾을 수 없습니다',
-  'slack.error.notInChannel': 'Slack 앱이 이 채널의 멤버가 아닙니다. 먼저 Slack 앱을 초대하세요.',
+  'slack.error.notInChannel': '공유 대상 채널에 Slack 앱이 추가되지 않았습니다.',
   'slack.error.networkError': '네트워크 오류가 발생했습니다. 연결을 확인하세요.',
   'slack.error.rateLimited': '요청 한도를 초과했습니다. {seconds}초 후에 다시 시도하세요.',
   'slack.error.noWorkspaces': '연결된 워크스페이스가 없습니다',
   'slack.error.noChannels': '사용 가능한 채널이 없습니다',
   'slack.error.noChannelsHelp':
     'Slack 앱이 어떤 채널에도 참여하지 않았습니다. Slack에서 /invite @Claude Code Workflow Studio를 실행하여 Slack 앱을 채널에 초대하세요.',
+  'slack.error.invalidAuth': 'Slack 토큰이 유효하지 않습니다.',
+  'slack.error.missingScope': '필요한 권한이 없습니다.',
+  'slack.error.fileTooLarge': '파일 크기가 너무 큽니다.',
+  'slack.error.invalidFileType': '지원되지 않는 파일 형식입니다.',
+  'slack.error.internalError': 'Slack 내부 오류가 발생했습니다.',
+  'slack.error.notAuthed': '인증 정보가 제공되지 않았습니다.',
+  'slack.error.invalidCode': '인증 코드가 유효하지 않거나 만료되었습니다.',
+  'slack.error.badClientSecret': '클라이언트 시크릿이 유효하지 않습니다.',
+  'slack.error.invalidGrantType': '유효하지 않은 인증 유형입니다.',
+  'slack.error.accountInactive': '계정이 비활성화되었습니다.',
+  'slack.error.invalidQuery': '유효하지 않은 검색 쿼리입니다.',
+  'slack.error.msgTooLong': '메시지가 너무 깁니다.',
+  'slack.error.workspaceNotConnected': '원본 Slack 워크스페이스에 연결되어 있지 않습니다.',
+  'slack.error.unknownError': '알 수 없는 오류가 발생했습니다.',
+  'slack.error.unknownApiError': 'Slack API 오류가 발생했습니다.',
 
   // Sensitive Data Warning
   'slack.sensitiveData.warning.title': '민감한 데이터 감지됨',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -630,15 +630,29 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.noResults': '未找到工作流',
 
   // Slack Errors
-  'slack.error.notAuthenticated': '请先连接到 Slack',
   'slack.error.channelNotFound': '未找到频道',
-  'slack.error.notInChannel': 'Slack 应用不是此频道的成员。请先邀请 Slack 应用。',
+  'slack.error.notInChannel': '共享目标频道未添加 Slack 应用。',
   'slack.error.networkError': '网络错误。请检查您的连接。',
   'slack.error.rateLimited': '超出速率限制。请在 {seconds} 秒后重试。',
   'slack.error.noWorkspaces': '没有连接的工作区',
   'slack.error.noChannels': '没有可用的频道',
   'slack.error.noChannelsHelp':
     'Slack 应用未加入任何频道。在 Slack 中使用 /invite @Claude Code Workflow Studio 邀请 Slack 应用加入频道。',
+  'slack.error.invalidAuth': 'Slack 令牌无效。',
+  'slack.error.missingScope': '缺少必要权限。',
+  'slack.error.fileTooLarge': '文件大小过大。',
+  'slack.error.invalidFileType': '不支持的文件类型。',
+  'slack.error.internalError': '发生 Slack 内部错误。',
+  'slack.error.notAuthed': '未提供认证信息。',
+  'slack.error.invalidCode': '认证码无效或已过期。',
+  'slack.error.badClientSecret': '客户端密钥无效。',
+  'slack.error.invalidGrantType': '无效的认证类型。',
+  'slack.error.accountInactive': '账户已停用。',
+  'slack.error.invalidQuery': '无效的搜索查询。',
+  'slack.error.msgTooLong': '消息过长。',
+  'slack.error.workspaceNotConnected': '未连接到源 Slack 工作区。',
+  'slack.error.unknownError': '发生未知错误。',
+  'slack.error.unknownApiError': '发生 Slack API 错误。',
 
   // Sensitive Data Warning
   'slack.sensitiveData.warning.title': '检测到敏感数据',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -630,15 +630,29 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.noResults': '未找到工作流',
 
   // Slack Errors
-  'slack.error.notAuthenticated': '請先連接到 Slack',
   'slack.error.channelNotFound': '未找到頻道',
-  'slack.error.notInChannel': 'Slack 應用不是此頻道的成員。請先邀請 Slack 應用。',
+  'slack.error.notInChannel': '共享目標頻道未添加 Slack 應用。',
   'slack.error.networkError': '網路錯誤。請檢查您的連接。',
   'slack.error.rateLimited': '超出速率限制。請在 {seconds} 秒後重試。',
   'slack.error.noWorkspaces': '沒有連接的工作區',
   'slack.error.noChannels': '沒有可用的頻道',
   'slack.error.noChannelsHelp':
     'Slack 應用未加入任何頻道。在 Slack 中使用 /invite @Claude Code Workflow Studio 邀請 Slack 應用加入頻道。',
+  'slack.error.invalidAuth': 'Slack 令牌無效。',
+  'slack.error.missingScope': '缺少必要權限。',
+  'slack.error.fileTooLarge': '檔案大小過大。',
+  'slack.error.invalidFileType': '不支援的檔案類型。',
+  'slack.error.internalError': '發生 Slack 內部錯誤。',
+  'slack.error.notAuthed': '未提供認證資訊。',
+  'slack.error.invalidCode': '認證碼無效或已過期。',
+  'slack.error.badClientSecret': '用戶端密鑰無效。',
+  'slack.error.invalidGrantType': '無效的認證類型。',
+  'slack.error.accountInactive': '帳戶已停用。',
+  'slack.error.invalidQuery': '無效的搜尋查詢。',
+  'slack.error.msgTooLong': '訊息過長。',
+  'slack.error.workspaceNotConnected': '未連接到來源 Slack 工作區。',
+  'slack.error.unknownError': '發生未知錯誤。',
+  'slack.error.unknownApiError': '發生 Slack API 錯誤。',
 
   // Sensitive Data Warning
   'slack.sensitiveData.warning.title': '檢測到敏感資料',


### PR DESCRIPTION
## Summary

Merge latest changes from `main` to `production` for automated release v2.17.1.

## Included Changes

### Bug Fixes
- fix: add i18n support for Slack error messages (#183)
  - Changed Slack error handling from hardcoded Japanese messages to i18n-supported translation keys
  - Extension Host now sends `messageKey` instead of hardcoded error messages
  - Webview translates errors using its i18n system based on user's locale
  - Added `SlackError` class for Webview-side i18n error handling
  - Supports 5 languages: English, Japanese, Korean, Simplified Chinese, Traditional Chinese

## Release Version Calculation

**v2.17.1** (patch bump)

Semantic Release will analyze commits since the last release (v2.17.0) and will bump the version based on:
- ✅ `fix: add i18n support for Slack error messages` (#183) → **patch bump**

Result: **2.17.0 + patch = 2.17.1**

## CHANGELOG.md Contents

The following bug fixes will be included:
- add i18n support for Slack error messages (#183)

## Release Automation

This merge will trigger the automated release workflow which will:
1. Analyze commit messages to determine version bump (2.17.0 → 2.17.1)
2. Update version in package.json files
3. Generate CHANGELOG.md with bug fixes
4. Create GitHub release with release notes
5. Build and upload VSIX package
6. Sync version changes back to main branch

## Merge Strategy

**Use merge commit** (not squash) to preserve all individual commits and their history for proper Semantic Release analysis.