### PR TITLE
fix: remove Author display and users:read scope from Slack sharing

### DIFF
--- a/src/extension/commands/slack-share-workflow.ts
+++ b/src/extension/commands/slack-share-workflow.ts
@@ -82,20 +82,10 @@ export async function handleShareWorkflowToSlack(
 
     log('INFO', 'No sensitive data detected or warning overridden', { requestId });
 
-    // Step 2: Get Slack user information for author
-    log('INFO', 'Getting Slack user information', { requestId });
-    const userInfo = await slackApiService.getUserInfo(payload.workspaceId);
-    const authorName = userInfo.userName;
-    const authorUserId = userInfo.userId || undefined;
-
-    // Step 3: Extract workflow metadata
+    // Step 2: Extract workflow metadata
     const nodeCount = workflow.nodes.length;
-    const createdAt =
-      typeof workflow.createdAt === 'string'
-        ? workflow.createdAt
-        : new Date(workflow.createdAt).toISOString();
 
-    // Step 4: Get workspace name for deep link
+    // Step 3: Get workspace name for deep link
     log('INFO', 'Getting workspace name for deep link', { requestId });
     let workspaceName: string | undefined;
     try {
@@ -106,7 +96,7 @@ export async function handleShareWorkflowToSlack(
       log('WARN', 'Failed to get workspace name, continuing without it', { requestId });
     }
 
-    // Step 5: Post rich message card to channel (main message)
+    // Step 4: Post rich message card to channel (main message)
     log('INFO', 'Posting workflow message card to Slack', { requestId });
 
     const messageBlock: WorkflowMessageBlock = {
@@ -114,10 +104,7 @@ export async function handleShareWorkflowToSlack(
       name: workflow.name,
       description: payload.description || workflow.description,
       version: workflow.version,
-      authorName,
-      authorUserId,
       nodeCount,
-      createdAt,
       fileId: '', // Will be updated after file upload
       workspaceId: payload.workspaceId,
       workspaceName,
@@ -136,7 +123,7 @@ export async function handleShareWorkflowToSlack(
       permalink: messageResult.permalink,
     });
 
-    // Step 6: Upload workflow file to thread as reply
+    // Step 5: Upload workflow file to thread as reply
     log('INFO', 'Uploading workflow file to thread', { requestId });
 
     const filename = `${payload.workflowName.replace(/[^a-zA-Z0-9-_]/g, '_')}.json`;
@@ -154,7 +141,7 @@ export async function handleShareWorkflowToSlack(
       fileId: uploadResult.fileId,
     });
 
-    // Step 7: Update message with complete deep links
+    // Step 6: Update message with complete deep links
     log('INFO', 'Updating message with complete deep links', { requestId });
 
     const updatedMessageBlock: WorkflowMessageBlock = {
@@ -172,7 +159,7 @@ export async function handleShareWorkflowToSlack(
 
     log('INFO', 'Message updated with complete deep links', { requestId });
 
-    // Step 8: Send success response
+    // Step 7: Send success response
     const successEvent: ShareWorkflowSuccessEvent = {
       type: 'SHARE_WORKFLOW_SUCCESS',
       payload: {

--- a/src/extension/services/slack-api-service.ts
+++ b/src/extension/services/slack-api-service.ts
@@ -416,48 +416,6 @@ export class SlackApiService {
   }
 
   /**
-   * Gets current Slack user information
-   *
-   * Uses auth.test to get user ID, then users.info to get user details.
-   * Requires 'users:read' scope for users.info API.
-   *
-   * @param workspaceId - Target workspace ID
-   * @returns User information (Slack user ID and username)
-   */
-  async getUserInfo(workspaceId: string): Promise<{
-    userId: string;
-    userName: string;
-  }> {
-    try {
-      const client = await this.ensureUserClient(workspaceId);
-
-      const authResponse = await client.auth.test();
-      const userId = (authResponse.user_id as string) || '';
-
-      if (!userId) {
-        return { userId: '', userName: '' };
-      }
-
-      // users.infoでユーザー情報を取得（users:readスコープ必要）
-      const userResponse = await client.users.info({ user: userId });
-
-      if (userResponse.ok && userResponse.user) {
-        return {
-          userId,
-          userName: userResponse.user.name || '',
-        };
-      }
-
-      // ユーザー名は取得できなくてもUser IDは返す
-      return { userId, userName: '' };
-    } catch (error) {
-      // スコープ不足またはAPIエラーの場合
-      console.error('[SlackApiService] getUserInfo failed:', error);
-      return { userId: '', userName: '' };
-    }
-  }
-
-  /**
    * Updates existing workflow message with new content
    *
    * Uses User Token to update messages posted by the authenticated user.

--- a/src/extension/services/slack-oauth-service.ts
+++ b/src/extension/services/slack-oauth-service.ts
@@ -28,7 +28,7 @@ const OAUTH_CONFIG = {
   /** Bot Token scopes (empty - all operations use User Token) */
   scopes: '',
   /** User Token scopes (all functionality including message posting and file operations) */
-  userScopes: 'channels:read,groups:read,users:read,chat:write,files:read,files:write',
+  userScopes: 'channels:read,groups:read,chat:write,files:read,files:write',
   /** Initial polling interval in milliseconds */
   pollingIntervalInitialMs: 1000,
   /** Maximum polling interval in milliseconds */

--- a/src/extension/utils/slack-message-builder.ts
+++ b/src/extension/utils/slack-message-builder.ts
@@ -60,14 +60,8 @@ export interface WorkflowMessageBlock {
   description?: string;
   /** Workflow version */
   version: string;
-  /** Author name (fallback display) */
-  authorName: string;
-  /** Author Slack user ID (for <@USER_ID> mention format) */
-  authorUserId?: string;
   /** Node count */
   nodeCount: number;
-  /** Created timestamp (ISO 8601) */
-  createdAt: string;
   /** File ID (after upload) */
   fileId: string;
   /** Workspace ID (for deep link) */
@@ -86,7 +80,7 @@ export interface WorkflowMessageBlock {
  * Creates a rich message card with:
  * - Header with workflow name
  * - Description section (if provided)
- * - Metadata fields (Author, Date)
+ * - Metadata fields (Date)
  * - Import link with deep link to VS Code
  *
  * @param block - Workflow message block
@@ -117,22 +111,6 @@ export function buildWorkflowMessageBlocks(
           { type: 'divider' },
         ]
       : [{ type: 'divider' }]),
-    // Metadata fields
-    {
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          text: block.authorUserId
-            ? `*Author:* <@${block.authorUserId}>`
-            : `*Author:* ${block.authorName || 'Unknown'}`,
-        },
-        {
-          type: 'mrkdwn',
-          text: `*Date:* ${new Date(block.createdAt).toLocaleDateString()}`,
-        },
-      ],
-    },
     // Import links section
     ...(block.workspaceId && block.channelId && block.messageTs && block.fileId
       ? [
@@ -144,15 +122,6 @@ export function buildWorkflowMessageBlocks(
                 text: `📥 *Import to:*  ${SUPPORTED_EDITORS.map(
                   (editor) => `<${buildImportUri(editor.scheme, block)}|${editor.name}>`
                 ).join(' · ')}`,
-              },
-            ],
-          },
-          {
-            type: 'context',
-            elements: [
-              {
-                type: 'mrkdwn',
-                text: '_Note: Please open your target workspace before clicking the import link_',
               },
             ],
           },


### PR DESCRIPTION
## Problem

After migrating to User Token, the Slack message poster is automatically the logged-in user, making the explicit Author display redundant.

### Current Behavior
1. Share workflow to Slack
2. ❌ Message displays `Author: @username` and `Date: 2025/12/1`
3. ❌ OAuth requests unnecessary `users:read` scope

### Expected Behavior
1. Share workflow to Slack
2. ✅ Poster is automatically shown in Slack's native poster field (due to User Token posting)
3. ✅ Only minimal required scopes are requested

## Solution

Remove features that became unnecessary after User Token migration:

- Remove `users:read` scope from OAuth
- Remove `getUserInfo()` method from SlackApiService
- Remove Author/Date display blocks from Slack messages
- Remove Note message from import links

### Changes

**File**: `src/extension/services/slack-oauth-service.ts`
- Remove `users:read` from userScopes

**File**: `src/extension/services/slack-api-service.ts`
- Remove `getUserInfo()` method entirely

**File**: `src/extension/commands/slack-share-workflow.ts`
- Remove Author-related variables and code
- Remove `createdAt` related code

**File**: `src/extension/utils/slack-message-builder.ts`
- Remove `authorName`, `authorUserId`, `createdAt` fields from interface
- Remove Author/Date block from message builder
- Remove Note message from import links section

## Impact

- Slack messages become simpler and cleaner
- OAuth requested scopes are reduced (privacy improvement)
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)