### PR TITLE
fix: remove Bot Token required check from manual connection

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -532,19 +532,16 @@ export function registerOpenEditorCommand(
               break;
 
             case 'CONNECT_SLACK_MANUAL':
-              // Manual Slack connection (Bot Token + User Token input)
+              // Manual Slack connection (User Token only)
               try {
-                if (!message.payload?.botToken) {
-                  throw new Error('Bot Token is required');
-                }
                 if (!message.payload?.userToken) {
-                  throw new Error('User Token is required for secure channel listing');
+                  throw new Error('User Token is required');
                 }
 
                 const result = await handleConnectSlackManual(
                   slackTokenManager,
                   slackApiService,
-                  message.payload.botToken,
+                  '', // Bot Token is no longer used
                   message.payload.userToken
                 );
 


### PR DESCRIPTION
## Problem

The manual token connection flow still required Bot Token validation even though the implementation was migrated to use User Token only (#185, #187, #188).

### Current Behavior
1. User enters User Token in the manual connection dialog
2. ❌ Extension throws "Bot Token is required" error
3. ❌ `storeManualConnection` validates Bot Token format (fails with empty string)

### Expected Behavior
1. User enters User Token in the manual connection dialog
2. ✅ Extension validates only User Token
3. ✅ Connection succeeds with User Token only

## Solution

Remove Bot Token validation from the Extension side to match the UI changes.

### Changes

**`src/extension/commands/open-editor.ts`**:
- Removed `botToken` required check
- Updated comment to "User Token only"
- Pass empty string for deprecated botToken parameter

**`src/extension/utils/slack-token-manager.ts`**:
- Changed `storeManualConnection` to require User Token instead of Bot Token
- Marked `accessToken` parameter as `@deprecated`
- Store empty Bot token for backward compatibility
- Updated JSDoc comments

## Impact

- Fixes manual token connection flow
- No breaking changes (backward compatible)
- Consistent with UI and previous migrations

## Testing

- [x] Code quality checks passed (format, lint, check)
- [x] Build successful
- [x] Manual E2E testing - connection successful with User Token only

🤖 Generated with [Claude Code](https://claude.com/claude-code)