### PR TITLE
chore: remove unused slack.error.noChannelsHelp translation key

### DIFF
--- a/slack-scopes-description.md
+++ b/slack-scopes-description.md
@@ -1,0 +1,27 @@
+# Slack OAuth Scopes
+
+## User Token Scopes
+
+### chat:write
+
+Used to post Claude Code Workflow cards to Slack channels. When users share a Claude Code Workflow, a rich message card containing workflow name, description, author information, and import links is posted.
+
+### files:read
+
+Used to download Claude Code Workflow JSON files from Slack messages. When users click an import link in a Claude Code Workflow card, the attached JSON file is fetched and opened in the editor for editing.
+
+### files:write
+
+Used to upload Claude Code Workflow JSON files to Slack. When users share a Claude Code Workflow, the JSON file is uploaded as a thread reply attachment, allowing team members to import it into their editors.
+
+### channels:read
+
+Used to display public Slack channels in the share dialog dropdown. Only channels the authenticated user is a member of are shown, ensuring users can only share Claude Code Workflows to channels they have access to.
+
+### groups:read
+
+Used to display private Slack channels in the share dialog dropdown. Only private channels the authenticated user is a member of are shown, ensuring users can only share Claude Code Workflows to channels they have access to.
+
+### users:read
+
+Used to display the Claude Code Workflow author as a clickable @mention in the shared message card. When sharing a Claude Code Workflow, the author's Slack username is fetched to create a profile link in the card.

--- a/src/webview/src/components/dialogs/SlackShareDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackShareDialog.tsx
@@ -626,23 +626,6 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
               ))
             )}
           </select>
-
-          {/* Help message when no channels available */}
-          {!loadingChannels && channels.length === 0 && workspace && (
-            <div
-              style={{
-                marginTop: '8px',
-                padding: '8px 12px',
-                backgroundColor: 'var(--vscode-textBlockQuote-background)',
-                border: '1px solid var(--vscode-textBlockQuote-border)',
-                borderRadius: '2px',
-                fontSize: '12px',
-                color: 'var(--vscode-descriptionForeground)',
-              }}
-            >
-              💡 {t('slack.error.noChannelsHelp')}
-            </div>
-          )}
         </div>
 
         {/* Description Input */}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -550,7 +550,6 @@ export interface WebviewTranslationKeys {
   // Slack Errors
   'slack.error.channelNotFound': string;
   'slack.error.noChannels': string;
-  'slack.error.noChannelsHelp': string;
   'slack.error.noWorkspaces': string;
   'slack.error.notInChannel': string;
   'slack.error.networkError': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -655,8 +655,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.error.channelNotFound': 'Channel not found',
   'slack.error.noWorkspaces': 'No workspaces connected',
   'slack.error.noChannels': 'No channels available',
-  'slack.error.noChannelsHelp':
-    'The Slack App is not a member of any channels. Invite the Slack App to channels using /invite @Claude Code Workflow Studio in Slack.',
   'slack.error.notInChannel': 'Slack App has not been added to the destination channel.',
   'slack.error.networkError': 'Network error. Please check your connection.',
   'slack.error.rateLimited': 'Rate limit exceeded. Please try again in {seconds} seconds.',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -653,8 +653,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.error.rateLimited': 'レート制限を超過しました。{seconds}秒後に再試行してください。',
   'slack.error.noWorkspaces': '接続されているワークスペースがありません',
   'slack.error.noChannels': '利用可能なチャンネルがありません',
-  'slack.error.noChannelsHelp':
-    'Slack Appがどのチャンネルにも参加していません。Slackで /invite @Claude Code Workflow Studio を実行してSlack Appをチャンネルに招待してください。',
   'slack.error.invalidAuth': 'Slackトークンが無効です。',
   'slack.error.missingScope': '必要な権限がありません。',
   'slack.error.fileTooLarge': 'ファイルサイズが大きすぎます。',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -652,8 +652,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.error.rateLimited': '요청 한도를 초과했습니다. {seconds}초 후에 다시 시도하세요.',
   'slack.error.noWorkspaces': '연결된 워크스페이스가 없습니다',
   'slack.error.noChannels': '사용 가능한 채널이 없습니다',
-  'slack.error.noChannelsHelp':
-    'Slack 앱이 어떤 채널에도 참여하지 않았습니다. Slack에서 /invite @Claude Code Workflow Studio를 실행하여 Slack 앱을 채널에 초대하세요.',
   'slack.error.invalidAuth': 'Slack 토큰이 유효하지 않습니다.',
   'slack.error.missingScope': '필요한 권한이 없습니다.',
   'slack.error.fileTooLarge': '파일 크기가 너무 큽니다.',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -629,8 +629,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.error.rateLimited': '超出速率限制。请在 {seconds} 秒后重试。',
   'slack.error.noWorkspaces': '没有连接的工作区',
   'slack.error.noChannels': '没有可用的频道',
-  'slack.error.noChannelsHelp':
-    'Slack 应用未加入任何频道。在 Slack 中使用 /invite @Claude Code Workflow Studio 邀请 Slack 应用加入频道。',
   'slack.error.invalidAuth': 'Slack 令牌无效。',
   'slack.error.missingScope': '缺少必要权限。',
   'slack.error.fileTooLarge': '文件大小过大。',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -629,8 +629,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.error.rateLimited': '超出速率限制。請在 {seconds} 秒後重試。',
   'slack.error.noWorkspaces': '沒有連接的工作區',
   'slack.error.noChannels': '沒有可用的頻道',
-  'slack.error.noChannelsHelp':
-    'Slack 應用未加入任何頻道。在 Slack 中使用 /invite @Claude Code Workflow Studio 邀請 Slack 應用加入頻道。',
   'slack.error.invalidAuth': 'Slack 令牌無效。',
   'slack.error.missingScope': '缺少必要權限。',
   'slack.error.fileTooLarge': '檔案大小過大。',


### PR DESCRIPTION
## Summary

Remove the obsolete `slack.error.noChannelsHelp` translation key that was used during the Bot Token era.

## Problem

With the migration from Bot Token to User Token for Slack sharing, the help message instructing users to invite the Slack App to channels (`/invite @Claude Code Workflow Studio`) is no longer applicable.

- **Bot Token**: Required the app to be invited to channels
- **User Token**: Uses the user's own permissions, no app invitation needed

The outdated message could cause confusion for users.

## Changes

- Removed help message display from `SlackShareDialog.tsx`
- Removed type definition from `translation-keys.ts`
- Removed translation entries from all 5 language files (en, ja, ko, zh-CN, zh-TW)

## Impact

- No breaking changes
- No user-facing functionality removed (the message was misleading with User Token)
- 28 lines of dead code removed

## Testing

- [x] `npm run format` passed
- [x] `npm run lint` passed
- [x] `npm run check` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)