### PR TITLE
fix: display User Token Scopes as list with permission reasons

### DIFF
--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -629,7 +629,16 @@ export function SlackManualTokenDialog({
                 }}
               >
                 <div>1. {t('slack.manualToken.howToGet.step1')}</div>
-                <div>2. {t('slack.manualToken.howToGet.step2')}</div>
+                <div>
+                  2. {t('slack.manualToken.howToGet.step2')}
+                  <ul style={{ margin: '4px 0 4px 20px', paddingLeft: '0', listStyle: 'disc' }}>
+                    <li>chat:write ({t('slack.scopes.chatWrite.reason')})</li>
+                    <li>files:read ({t('slack.scopes.filesRead.reason')})</li>
+                    <li>files:write ({t('slack.scopes.filesWrite.reason')})</li>
+                    <li>channels:read ({t('slack.scopes.channelsRead.reason')})</li>
+                    <li>groups:read ({t('slack.scopes.groupsRead.reason')})</li>
+                  </ul>
+                </div>
                 <div>3. {t('slack.manualToken.howToGet.step3')}</div>
                 <div>4. {t('slack.manualToken.howToGet.step4')}</div>
               </div>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -547,6 +547,13 @@ export interface WebviewTranslationKeys {
   'slack.search.searching': string;
   'slack.search.noResults': string;
 
+  // Slack Scopes - reasons why each scope is required
+  'slack.scopes.chatWrite.reason': string;
+  'slack.scopes.filesRead.reason': string;
+  'slack.scopes.filesWrite.reason': string;
+  'slack.scopes.channelsRead.reason': string;
+  'slack.scopes.groupsRead.reason': string;
+
   // Slack Errors
   'slack.error.channelNotFound': string;
   'slack.error.noChannels': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -566,8 +566,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.description': 'Connect to your workspace through your own Slack App.',
   'slack.manualToken.howToGet.title': 'How to set up Slack App',
   'slack.manualToken.howToGet.step1': 'Create Slack App (at api.slack.com/apps)',
-  'slack.manualToken.howToGet.step2':
-    'Add User Token Scopes (OAuth & Permissions): chat:write, files:read, files:write, channels:read, groups:read',
+  'slack.manualToken.howToGet.step2': 'Add User Token Scopes (OAuth & Permissions):',
   'slack.manualToken.howToGet.step3': 'Install App to your workspace (OAuth & Permissions)',
   'slack.manualToken.howToGet.step4': 'Copy User Token (xoxp-...) from OAuth & Permissions page',
   'slack.manualToken.security.title': 'Security & Privacy',
@@ -650,6 +649,13 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.placeholder': 'Search by name, author, or channel...',
   'slack.search.searching': 'Searching...',
   'slack.search.noResults': 'No workflows found',
+
+  // Slack Scopes - reasons why each scope is required
+  'slack.scopes.chatWrite.reason': 'to share workflows',
+  'slack.scopes.filesRead.reason': 'to import workflows',
+  'slack.scopes.filesWrite.reason': 'to attach workflow files',
+  'slack.scopes.channelsRead.reason': 'to select destination channel',
+  'slack.scopes.groupsRead.reason': 'to select private channels',
 
   // Slack Errors
   'slack.error.channelNotFound': 'Channel not found',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -563,8 +563,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.description': '自分で作成したSlack Appを通じてワークスペースに接続します。',
   'slack.manualToken.howToGet.title': 'Slack Appの設定方法',
   'slack.manualToken.howToGet.step1': 'Slack Appを作成（api.slack.com/apps）',
-  'slack.manualToken.howToGet.step2':
-    'User Token Scopesを追加（OAuth & Permissions）: chat:write, files:read, files:write, channels:read, groups:read',
+  'slack.manualToken.howToGet.step2': 'User Token Scopesを追加（OAuth & Permissions）:',
   'slack.manualToken.howToGet.step3': 'Appをワークスペースにインストール（OAuth & Permissions）',
   'slack.manualToken.howToGet.step4': 'User Token（xoxp-...）をOAuth & Permissionsページからコピー',
   'slack.manualToken.security.title': 'セキュリティーとプライバシー',
@@ -645,6 +644,13 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.placeholder': '名前、作成者、チャンネルで検索...',
   'slack.search.searching': '検索中...',
   'slack.search.noResults': 'ワークフローが見つかりませんでした',
+
+  // Slack Scopes - reasons why each scope is required
+  'slack.scopes.chatWrite.reason': 'ワークフロー共有用',
+  'slack.scopes.filesRead.reason': 'ワークフロー取り込み用',
+  'slack.scopes.filesWrite.reason': 'ワークフローファイル添付用',
+  'slack.scopes.channelsRead.reason': '共有先チャンネル選択用',
+  'slack.scopes.groupsRead.reason': 'プライベートチャンネル選択用',
 
   // Slack Errors
   'slack.error.channelNotFound': 'チャンネルが見つかりません',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -562,8 +562,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.description': '직접 만든 Slack 앱을 통해 워크스페이스에 연결합니다.',
   'slack.manualToken.howToGet.title': 'Slack App 설정 방법',
   'slack.manualToken.howToGet.step1': 'Slack App 생성 (api.slack.com/apps)',
-  'slack.manualToken.howToGet.step2':
-    'User Token Scopes 추가 (OAuth & Permissions): chat:write, files:read, files:write, channels:read, groups:read',
+  'slack.manualToken.howToGet.step2': 'User Token Scopes 추가 (OAuth & Permissions):',
   'slack.manualToken.howToGet.step3': '워크스페이스에 App 설치 (OAuth & Permissions)',
   'slack.manualToken.howToGet.step4': 'OAuth & Permissions 페이지에서 User Token (xoxp-...) 복사',
   'slack.manualToken.security.title': '보안 및 개인정보',
@@ -644,6 +643,13 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.placeholder': '이름, 작성자 또는 채널로 검색...',
   'slack.search.searching': '검색 중...',
   'slack.search.noResults': '워크플로우를 찾을 수 없습니다',
+
+  // Slack Scopes - reasons why each scope is required
+  'slack.scopes.chatWrite.reason': '워크플로우 공유용',
+  'slack.scopes.filesRead.reason': '워크플로우 가져오기용',
+  'slack.scopes.filesWrite.reason': '워크플로우 파일 첨부용',
+  'slack.scopes.channelsRead.reason': '공유 대상 채널 선택용',
+  'slack.scopes.groupsRead.reason': '비공개 채널 선택용',
 
   // Slack Errors
   'slack.error.channelNotFound': '채널을 찾을 수 없습니다',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -542,8 +542,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.description': '通过您自己创建的 Slack 应用连接到工作区。',
   'slack.manualToken.howToGet.title': 'Slack App 设置方法',
   'slack.manualToken.howToGet.step1': '创建 Slack App (api.slack.com/apps)',
-  'slack.manualToken.howToGet.step2':
-    '添加 User Token Scopes (OAuth & Permissions): chat:write, files:read, files:write, channels:read, groups:read',
+  'slack.manualToken.howToGet.step2': '添加 User Token Scopes (OAuth & Permissions):',
   'slack.manualToken.howToGet.step3': '将 App 安装到您的工作区 (OAuth & Permissions)',
   'slack.manualToken.howToGet.step4': '从 OAuth & Permissions 页面复制 User Token (xoxp-...)',
   'slack.manualToken.security.title': '安全和隐私',
@@ -621,6 +620,13 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.placeholder': '按名称、作者或频道搜索...',
   'slack.search.searching': '搜索中...',
   'slack.search.noResults': '未找到工作流',
+
+  // Slack Scopes - reasons why each scope is required
+  'slack.scopes.chatWrite.reason': '用于共享工作流',
+  'slack.scopes.filesRead.reason': '用于导入工作流',
+  'slack.scopes.filesWrite.reason': '用于附加工作流文件',
+  'slack.scopes.channelsRead.reason': '用于选择目标频道',
+  'slack.scopes.groupsRead.reason': '用于选择私有频道',
 
   // Slack Errors
   'slack.error.channelNotFound': '未找到频道',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -542,8 +542,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.manualToken.description': '透過您自己建立的 Slack 應用連接到工作區。',
   'slack.manualToken.howToGet.title': 'Slack App 設定方法',
   'slack.manualToken.howToGet.step1': '建立 Slack App (api.slack.com/apps)',
-  'slack.manualToken.howToGet.step2':
-    '新增 User Token Scopes (OAuth & Permissions): chat:write, files:read, files:write, channels:read, groups:read',
+  'slack.manualToken.howToGet.step2': '新增 User Token Scopes (OAuth & Permissions):',
   'slack.manualToken.howToGet.step3': '將 App 安裝到您的工作區 (OAuth & Permissions)',
   'slack.manualToken.howToGet.step4': '從 OAuth & Permissions 頁面複製 User Token (xoxp-...)',
   'slack.manualToken.security.title': '安全與隱私',
@@ -621,6 +620,13 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.search.placeholder': '按名稱、作者或頻道搜尋...',
   'slack.search.searching': '搜尋中...',
   'slack.search.noResults': '未找到工作流',
+
+  // Slack Scopes - reasons why each scope is required
+  'slack.scopes.chatWrite.reason': '用於共享工作流',
+  'slack.scopes.filesRead.reason': '用於匯入工作流',
+  'slack.scopes.filesWrite.reason': '用於附加工作流檔案',
+  'slack.scopes.channelsRead.reason': '用於選擇目標頻道',
+  'slack.scopes.groupsRead.reason': '用於選擇私有頻道',
 
   // Slack Errors
   'slack.error.channelNotFound': '未找到頻道',


### PR DESCRIPTION
## Problem

In the Slack App manual setup dialog, the User Token Scopes are listed inline which makes it difficult to read and doesn't explain why each permission is needed.

### Current Behavior
- Scopes displayed as inline text
- ❌ Users don't understand why each permission is required

### Expected Behavior
- Scopes displayed as a nested list
- ✅ Each scope includes a reason explaining its purpose

## Solution

Changed the scope display format from inline text to a structured nested list, with each scope accompanied by a translated reason explaining why the app needs that permission.

### Changes

**File**: `src/webview/src/components/dialogs/SlackManualTokenDialog.tsx`

- Replaced inline scope text with `<ul>` nested list
- Added translated reason text for each scope

```tsx
<ul style={{ margin: '4px 0 4px 20px', paddingLeft: '0', listStyle: 'disc' }}>
  <li>chat:write ({t('slack.scopes.chatWrite.reason')})</li>
  <li>files:read ({t('slack.scopes.filesRead.reason')})</li>
  <li>files:write ({t('slack.scopes.filesWrite.reason')})</li>
  <li>channels:read ({t('slack.scopes.channelsRead.reason')})</li>
  <li>groups:read ({t('slack.scopes.groupsRead.reason')})</li>
</ul>
```

**Files**: Translation files (en, ja, ko, zh-CN, zh-TW)

- Added semantic translation keys with `.reason` suffix
- Reasons explain app purpose (e.g., "to share workflows", "to import workflows")

| Scope | English Reason |
|-------|---------------|
| chat:write | to share workflows |
| files:read | to import workflows |
| files:write | to attach workflow files |
| channels:read | to select destination channel |
| groups:read | to select private channels |

## Impact

- Improved UX: Users can now understand why each Slack permission is required
- Better trust: Transparent permission explanations help users feel confident granting access
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)