### PR TITLE
chore: update engines.vscode to match @types/vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mcp"
   ],
   "engines": {
-    "vscode": "^1.80.0"
+    "vscode": "^1.106.0"
   },
   "categories": [
     "AI",


### PR DESCRIPTION
## Problem

The v2.17.4 release failed because `@types/vscode` was updated to 1.106.1 but `engines.vscode` remained at `^1.80.0`.

VSCE requires: `@types/vscode` version ≤ `engines.vscode` version

## Solution

Update `engines.vscode` from `^1.80.0` to `^1.106.0` to match the `@types/vscode` version.

## Impact

- VSCode 1.106.0 or later is now required
- Users on older VSCode versions will need to upgrade

## Testing

- [x] Code quality checks passed (format, lint, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)