### PR TITLE
chore: revert to v2.17.3 and downgrade @types/vscode for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [2.17.4](https://github.com/breaking-brake/cc-wf-studio/compare/v2.17.3...v2.17.4) (2025-12-02)
-
-### Bug Fixes
-
-* display User Token Scopes as list with permission reasons ([#202](https://github.com/breaking-brake/cc-wf-studio/issues/202)) ([90284d1](https://github.com/breaking-brake/cc-wf-studio/commit/90284d1c65e199b10ade7516ac7f6507aa333d0d))
-
 ## [2.17.3](https://github.com/breaking-brake/cc-wf-studio/compare/v2.17.2...v2.17.3) (2025-12-01)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio",
-  "version": "2.17.4",
+  "version": "2.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio",
-      "version": "2.17.4",
+      "version": "2.17.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@slack/web-api": "^7.12.0",
@@ -18,7 +18,7 @@
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
         "@types/node": "^24.10.1",
-        "@types/vscode": "^1.106.1",
+        "@types/vscode": "^1.80.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.3.8",
         "conventional-changelog-conventionalcommits": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
   "description": "Visual workflow editor for Claude Code Slash Commands, Sub Agents, Agent Skills, and MCP Tools",
-  "version": "2.17.4",
+  "version": "2.17.3",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
   "repository": {
@@ -23,7 +23,7 @@
     "mcp"
   ],
   "engines": {
-    "vscode": "^1.106.0"
+    "vscode": "^1.80.0"
   },
   "categories": [
     "AI",
@@ -90,7 +90,7 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^24.10.1",
-    "@types/vscode": "^1.106.1",
+    "@types/vscode": "^1.80.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.3.8",
     "conventional-changelog-conventionalcommits": "^9.1.0",

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.17.4",
+  "version": "2.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-wf-studio-webview",
-      "version": "2.17.4",
+      "version": "2.17.3",
       "dependencies": {
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-switch": "^1.2.6",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-wf-studio-webview",
-  "version": "2.17.4",
+  "version": "2.17.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Problem

The v2.17.4 release updated `engines.vscode` to `^1.106.0`, which is not compatible with many user environments.

## Solution

Revert all v2.17.4 release changes and downgrade `@types/vscode` to match the original `engines.vscode` version.

### Changes

1. **package.json**:
   - `version`: `2.17.4` → `2.17.3`
   - `engines.vscode`: `^1.106.0` → `^1.80.0`
   - `@types/vscode`: `^1.106.1` → `^1.80.0`

2. **src/webview/package.json**: `version`: `2.17.4` → `2.17.3`

3. **src/webview/package-lock.json**: `version`: `2.17.4` → `2.17.3`

4. **CHANGELOG.md**: Removed 2.17.4 section

## Impact

- Maintains compatibility with VSCode 1.80.0+
- Semantic Release will re-create v2.17.4 with the fix from #202

## Testing

- [x] Code quality checks passed (format, lint, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)