### PR TITLE
feat: add AI-assisted description generation for Slack sharing

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -27,6 +27,7 @@ import { saveWorkflow } from './save-workflow';
 import { handleBrowseSkills, handleCreateSkill, handleValidateSkillFile } from './skill-operations';
 import { handleConnectSlackManual } from './slack-connect-manual';
 import { createOAuthService, handleConnectSlackOAuth } from './slack-connect-oauth';
+import { handleGenerateSlackDescription } from './slack-description-generation';
 import { handleImportWorkflowFromSlack } from './slack-import-workflow';
 import {
   handleGetSlackChannels,
@@ -504,6 +505,28 @@ export function registerOpenEditorCommand(
                   payload: {
                     code: 'VALIDATION_ERROR',
                     message: 'Share workflow payload is required',
+                  },
+                });
+              }
+              break;
+
+            case 'GENERATE_SLACK_DESCRIPTION':
+              // Generate workflow description with AI for Slack sharing
+              if (message.payload) {
+                const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+                await handleGenerateSlackDescription(
+                  message.payload,
+                  webview,
+                  message.requestId || '',
+                  workspaceRoot
+                );
+              } else {
+                webview.postMessage({
+                  type: 'ERROR',
+                  requestId: message.requestId,
+                  payload: {
+                    code: 'VALIDATION_ERROR',
+                    message: 'Generate Slack description payload is required',
                   },
                 });
               }

--- a/src/extension/commands/slack-description-generation.ts
+++ b/src/extension/commands/slack-description-generation.ts
@@ -1,0 +1,204 @@
+/**
+ * Slack Description Generation Command Handler
+ *
+ * Handles GENERATE_SLACK_DESCRIPTION messages from Webview.
+ * Uses Claude Code CLI to generate concise workflow descriptions for Slack sharing.
+ */
+
+import type * as vscode from 'vscode';
+import type {
+  GenerateSlackDescriptionPayload,
+  SlackDescriptionFailedPayload,
+  SlackDescriptionSuccessPayload,
+} from '../../shared/types/messages';
+import { log } from '../extension';
+import { executeClaudeCodeCLI } from '../services/claude-code-service';
+
+/** Default timeout for description generation (30 seconds) */
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/** Maximum description length (matches Slack share dialog limit) */
+const MAX_DESCRIPTION_LENGTH = 500;
+
+/** Language instructions for AI prompt */
+const LANGUAGE_INSTRUCTIONS: Record<string, string> = {
+  en: 'Write the description in English.',
+  ja: 'Write the description in Japanese (日本語で記述してください).',
+  ko: 'Write the description in Korean (한국어로 작성하세요).',
+  'zh-CN': 'Write the description in Simplified Chinese (用简体中文撰写).',
+  'zh-TW': 'Write the description in Traditional Chinese (用繁體中文撰寫).',
+};
+
+/**
+ * Handle Slack description generation request
+ *
+ * @param payload - Generation request payload
+ * @param webview - Webview to send response to
+ * @param requestId - Request ID for correlation
+ * @param workspaceRoot - Optional workspace root directory for CLI execution
+ */
+export async function handleGenerateSlackDescription(
+  payload: GenerateSlackDescriptionPayload,
+  webview: vscode.Webview,
+  requestId: string,
+  workspaceRoot?: string
+): Promise<void> {
+  const startTime = Date.now();
+
+  log('INFO', 'Slack description generation started', {
+    requestId,
+    targetLanguage: payload.targetLanguage,
+    workflowJsonLength: payload.workflowJson.length,
+  });
+
+  try {
+    // Construct the prompt
+    const prompt = constructDescriptionPrompt(payload.workflowJson, payload.targetLanguage);
+
+    // Execute Claude Code CLI
+    const timeoutMs = payload.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const result = await executeClaudeCodeCLI(prompt, timeoutMs, requestId, workspaceRoot);
+
+    const executionTimeMs = Date.now() - startTime;
+
+    if (!result.success || !result.output) {
+      log('ERROR', 'Slack description generation failed', {
+        requestId,
+        errorCode: result.error?.code,
+        errorMessage: result.error?.message,
+        executionTimeMs,
+      });
+
+      sendDescriptionFailed(webview, requestId, {
+        error: {
+          code: result.error?.code ?? 'UNKNOWN_ERROR',
+          message: result.error?.message ?? 'Failed to generate description',
+          details: result.error?.details,
+        },
+        executionTimeMs,
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    // Parse and clean the description
+    const description = parseDescription(result.output);
+
+    log('INFO', 'Slack description generation succeeded', {
+      requestId,
+      descriptionLength: description.length,
+      executionTimeMs,
+    });
+
+    sendDescriptionSuccess(webview, requestId, {
+      description,
+      executionTimeMs,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    const executionTimeMs = Date.now() - startTime;
+
+    log('ERROR', 'Unexpected error during Slack description generation', {
+      requestId,
+      error: error instanceof Error ? error.message : String(error),
+      executionTimeMs,
+    });
+
+    sendDescriptionFailed(webview, requestId, {
+      error: {
+        code: 'UNKNOWN_ERROR',
+        message: 'An unexpected error occurred',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      executionTimeMs,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+
+/**
+ * Construct the prompt for description generation
+ *
+ * @param workflowJson - Serialized workflow JSON
+ * @param targetLanguage - Target language for the description
+ * @returns Constructed prompt string
+ */
+function constructDescriptionPrompt(workflowJson: string, targetLanguage: string): string {
+  const languageInstruction = LANGUAGE_INSTRUCTIONS[targetLanguage] ?? LANGUAGE_INSTRUCTIONS.en;
+
+  return `You are a technical writer creating a brief workflow description for Slack sharing.
+
+**Task**: Analyze the following workflow JSON and generate a concise description.
+
+**Workflow JSON**:
+${workflowJson}
+
+**Requirements**:
+1. ${languageInstruction}
+2. Maximum 200 characters (aim for 100-150 for readability)
+3. Focus on what the workflow accomplishes, not technical implementation details
+4. Use active voice and clear language
+5. Do NOT include markdown, code blocks, or formatting
+6. Output ONLY the description text, nothing else
+
+**Output**: A single line of plain text describing the workflow purpose.`;
+}
+
+/**
+ * Parse and clean the AI output to extract the description
+ *
+ * @param output - Raw output from Claude Code CLI
+ * @returns Cleaned description string (truncated to max length)
+ */
+function parseDescription(output: string): string {
+  // Remove any markdown code blocks if present
+  let description = output.replace(/```[\s\S]*?```/g, '').trim();
+
+  // Remove any leading/trailing quotes
+  description = description.replace(/^["']|["']$/g, '').trim();
+
+  // Remove any markdown formatting
+  description = description
+    .replace(/\*\*([^*]+)\*\*/g, '$1') // Bold
+    .replace(/\*([^*]+)\*/g, '$1') // Italic
+    .replace(/_([^_]+)_/g, '$1') // Underscore italic
+    .replace(/`([^`]+)`/g, '$1') // Inline code
+    .trim();
+
+  // Truncate to max length if needed
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    description = `${description.substring(0, MAX_DESCRIPTION_LENGTH - 3)}...`;
+  }
+
+  return description;
+}
+
+/**
+ * Send success response to webview
+ */
+function sendDescriptionSuccess(
+  webview: vscode.Webview,
+  requestId: string,
+  payload: SlackDescriptionSuccessPayload
+): void {
+  webview.postMessage({
+    type: 'SLACK_DESCRIPTION_SUCCESS',
+    requestId,
+    payload,
+  });
+}
+
+/**
+ * Send failure response to webview
+ */
+function sendDescriptionFailed(
+  webview: vscode.Webview,
+  requestId: string,
+  payload: SlackDescriptionFailedPayload
+): void {
+  webview.postMessage({
+    type: 'SLACK_DESCRIPTION_FAILED',
+    requestId,
+    payload,
+  });
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -577,7 +577,50 @@ export type ExtensionMessage =
   | Message<SlackOAuthSuccessPayload, 'SLACK_OAUTH_SUCCESS'>
   | Message<SlackErrorPayload, 'SLACK_OAUTH_FAILED'>
   | Message<void, 'SLACK_OAUTH_CANCELLED'>
-  | Message<GetLastSharedChannelSuccessPayload, 'GET_LAST_SHARED_CHANNEL_SUCCESS'>;
+  | Message<GetLastSharedChannelSuccessPayload, 'GET_LAST_SHARED_CHANNEL_SUCCESS'>
+  | Message<SlackDescriptionSuccessPayload, 'SLACK_DESCRIPTION_SUCCESS'>
+  | Message<SlackDescriptionFailedPayload, 'SLACK_DESCRIPTION_FAILED'>;
+
+// ============================================================================
+// AI Slack Description Generation Payloads
+// ============================================================================
+
+/**
+ * Generate Slack description request payload
+ */
+export interface GenerateSlackDescriptionPayload {
+  /** Serialized workflow JSON for AI analysis */
+  workflowJson: string;
+  /** Current UI language (en, ja, ko, zh-CN, zh-TW) */
+  targetLanguage: string;
+  /** Optional timeout in milliseconds (default: 30000) */
+  timeoutMs?: number;
+}
+
+/**
+ * Slack description generation success payload
+ */
+export interface SlackDescriptionSuccessPayload {
+  /** Generated description (max 500 chars) */
+  description: string;
+  /** Execution time in milliseconds */
+  executionTimeMs: number;
+  /** Timestamp ISO 8601 */
+  timestamp: string;
+}
+
+/**
+ * Slack description generation failed payload
+ */
+export interface SlackDescriptionFailedPayload {
+  error: {
+    code: 'COMMAND_NOT_FOUND' | 'TIMEOUT' | 'PARSE_ERROR' | 'CANCELLED' | 'UNKNOWN_ERROR';
+    message: string;
+    details?: string;
+  };
+  executionTimeMs: number;
+  timestamp: string;
+}
 
 // ============================================================================
 // Slack Integration Payloads (001-slack-workflow-sharing)
@@ -953,7 +996,8 @@ export type WebviewMessage =
   | Message<ImportWorkflowFromSlackPayload, 'IMPORT_WORKFLOW_FROM_SLACK'>
   | Message<OpenExternalUrlPayload, 'OPEN_EXTERNAL_URL'>
   | Message<void, 'GET_LAST_SHARED_CHANNEL'>
-  | Message<SetLastSharedChannelPayload, 'SET_LAST_SHARED_CHANNEL'>;
+  | Message<SetLastSharedChannelPayload, 'SET_LAST_SHARED_CHANNEL'>
+  | Message<GenerateSlackDescriptionPayload, 'GENERATE_SLACK_DESCRIPTION'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -520,6 +520,11 @@ export interface WebviewTranslationKeys {
   'slack.share.success': string;
   'slack.share.failed': string;
 
+  // Slack Description AI Generation
+  'slack.description.generateWithAI': string;
+  'slack.description.generating': string;
+  'slack.description.generateFailed': string;
+
   // Slack Connect
   'slack.connect.button': string;
   'slack.connect.connecting': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -604,6 +604,12 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'slack.share.success': 'Workflow shared successfully',
   'slack.share.failed': 'Failed to share workflow',
 
+  // Slack Description AI Generation
+  'slack.description.generateWithAI': 'Generate with AI',
+  'slack.description.generating': 'Generating...',
+  'slack.description.generateFailed':
+    'Failed to generate description. Please try again or write manually.',
+
   // Slack Connect
   'slack.connect.button': 'Connect to Slack',
   'slack.connect.connecting': 'Connecting...',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -600,6 +600,12 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.share.failed': 'ワークフローの共有に失敗しました',
   'slack.share.descriptionPlaceholder': '説明を追加（任意）...',
 
+  // Slack Description AI Generation
+  'slack.description.generateWithAI': 'AIで生成',
+  'slack.description.generating': '生成中...',
+  'slack.description.generateFailed':
+    '説明の生成に失敗しました。再度お試しいただくか、手動で入力してください。',
+
   // Slack Connect
   'slack.connect.button': 'Slackに接続',
   'slack.connect.connecting': '接続中...',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -599,6 +599,12 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.share.failed': '워크플로우 공유에 실패했습니다',
   'slack.share.descriptionPlaceholder': '설명을 추가하세요 (선택 사항)...',
 
+  // Slack Description AI Generation
+  'slack.description.generateWithAI': 'AI로 생성',
+  'slack.description.generating': '생성 중...',
+  'slack.description.generateFailed':
+    '설명 생성에 실패했습니다. 다시 시도하거나 직접 작성해 주세요.',
+
   // Slack Connect
   'slack.connect.button': 'Slack에 연결',
   'slack.connect.connecting': '연결 중...',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -576,6 +576,11 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.share.failed': '工作流分享失败',
   'slack.share.descriptionPlaceholder': '添加描述（可选）...',
 
+  // Slack Description AI Generation
+  'slack.description.generateWithAI': 'AI生成',
+  'slack.description.generating': '生成中...',
+  'slack.description.generateFailed': '生成描述失败。请重试或手动输入。',
+
   // Slack Connect
   'slack.connect.button': '连接到 Slack',
   'slack.connect.connecting': '连接中...',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -576,6 +576,11 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.share.failed': '工作流分享失敗',
   'slack.share.descriptionPlaceholder': '新增描述（選填）...',
 
+  // Slack Description AI Generation
+  'slack.description.generateWithAI': 'AI產生',
+  'slack.description.generating': '產生中...',
+  'slack.description.generateFailed': '產生描述失敗。請重試或手動輸入。',
+
   // Slack Connect
   'slack.connect.button': '連接到 Slack',
   'slack.connect.connecting': '連接中...',


### PR DESCRIPTION
## Problem

When sharing workflows to Slack, users must manually write descriptions for each share. This is time-consuming and inconsistent, especially for complex workflows.

### Current Behavior
1. User opens Slack share dialog
2. ❌ User must manually type description or leave it empty

### Expected Behavior
1. User opens Slack share dialog
2. ✅ User can click "Generate with AI" to auto-generate a description based on workflow content

## Solution

Add an AI-assisted description generation feature that uses Claude Code CLI to analyze the workflow JSON and generate a concise description in the user's current UI language.

### Changes

**New File**: `src/extension/commands/slack-description-generation.ts`
- Main handler for AI description generation
- Uses nano-spawn to execute Claude Code CLI
- Supports 5 languages (en, ja, ko, zh-CN, zh-TW)
- Generates 100-200 char descriptions (max 500)

**File**: `src/extension/commands/open-editor.ts`
- Added routing for `GENERATE_SLACK_DESCRIPTION` message

**File**: `src/shared/types/messages.ts`
- Added payload types for request/success/failed messages

**File**: `src/webview/src/components/dialogs/SlackShareDialog.tsx`
- Added "Generate with AI" text button next to description label
- Shows IndeterminateProgressBar during generation
- Button changes to "Cancel" (red) during generation
- Supports cancellation of in-progress requests

**File**: `src/webview/src/services/slack-integration-service.ts`
- Added `generateSlackDescription()` function
- Added `AIGenerationError` class

**Files**: Translation files (5 languages)
- Added 3 new translation keys for the feature

## Impact

- **UX**: Users can quickly generate meaningful descriptions with one click
- **Breaking changes**: None
- **Side effects**: Requires Claude Code CLI installed locally

## Testing

- [x] Manual E2E testing completed
  - Generate description for simple workflow
  - Generate description for complex workflow
  - Cancel during generation
  - Error handling when CLI unavailable
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)