### PR TITLE
chore(deps): bump @modelcontextprotocol/sdk from 1.23.0 to 1.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.23.0",
+        "@modelcontextprotocol/sdk": "^1.24.1",
         "@slack/web-api": "^7.13.0",
         "nano-spawn": "^2.0.0"
       },
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
-      "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.1.tgz",
+      "integrity": "sha512-YTg4v6bKSst8EJM8NXHC3nGm8kgHD08IbIBbognUeLAgGLVgLpYrgQswzLQd4OyTL4l614ejhqsDrV1//t02Qw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -815,6 +815,7 @@
         "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
@@ -4886,6 +4887,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "vite": "^7.2.6"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.23.0",
+    "@modelcontextprotocol/sdk": "^1.24.1",
     "@slack/web-api": "^7.13.0",
     "nano-spawn": "^2.0.0"
   }


### PR DESCRIPTION
## Summary

Update `@modelcontextprotocol/sdk` to fix a high severity security vulnerability.

## Security Advisory

| Item | Details |
|------|---------|
| CVE | CVE-2025-66414 |
| Severity | **High** |
| Issue | DNS rebinding protection not enabled by default |
| Fixed in | 1.24.0 |
| Dependabot Alert | #8 |

## Changes

- Updated `@modelcontextprotocol/sdk` from `^1.23.0` to `^1.24.1`

## Testing

- [x] `npm run format` - passed
- [x] `npm run lint` - passed
- [x] `npm run check` - passed
- [x] `npm run build` - passed
- [x] `npm audit` - 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)