### PR TITLE
fix: remove redundant 'Node' suffix from property panel node type labels

### DIFF
--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -20,6 +20,7 @@ import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
 import type React from 'react';
 import { useState } from 'react';
 import type { Node } from 'reactflow';
+import { getNodeTypeLabel } from '../constants/node-type-labels';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
@@ -108,27 +109,7 @@ export const PropertyPanel: React.FC = () => {
           marginBottom: '16px',
         }}
       >
-        {selectedNode.type === 'subAgent'
-          ? t('property.nodeType.subAgent')
-          : selectedNode.type === 'askUserQuestion'
-            ? t('property.nodeType.askUserQuestion')
-            : selectedNode.type === 'branch'
-              ? t('property.nodeType.branch')
-              : selectedNode.type === 'ifElse'
-                ? t('property.nodeType.ifElse')
-                : selectedNode.type === 'switch'
-                  ? t('property.nodeType.switch')
-                  : selectedNode.type === 'prompt'
-                    ? t('property.nodeType.prompt')
-                    : selectedNode.type === 'start'
-                      ? t('property.nodeType.start')
-                      : selectedNode.type === 'end'
-                        ? t('property.nodeType.end')
-                        : selectedNode.type === 'skill'
-                          ? t('property.nodeType.skill')
-                          : selectedNode.type === 'mcp'
-                            ? t('property.nodeType.mcp')
-                            : t('property.nodeType.unknown')}
+        {getNodeTypeLabel(selectedNode.type)}
       </div>
 
       {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, and mcp types) */}

--- a/src/webview/src/constants/node-type-labels.ts
+++ b/src/webview/src/constants/node-type-labels.ts
@@ -1,0 +1,31 @@
+/**
+ * Node type labels for PropertyPanel
+ *
+ * These are technical terms that don't need translation.
+ * They are consistent across all languages.
+ */
+
+export const NODE_TYPE_LABELS: Record<string, string> = {
+  subAgent: 'Sub-Agent',
+  askUserQuestion: 'Ask User Question',
+  branch: 'Branch',
+  ifElse: 'If/Else',
+  switch: 'Switch',
+  prompt: 'Prompt',
+  start: 'Start',
+  end: 'End',
+  skill: 'Skill',
+  mcp: 'MCP Tool',
+} as const;
+
+export const NODE_TYPE_UNKNOWN = 'Unknown';
+
+/**
+ * Get the label for a node type
+ * @param nodeType - The node type string (can be undefined)
+ * @returns The label for the node type, or 'Unknown' if not found
+ */
+export const getNodeTypeLabel = (nodeType: string | undefined): string => {
+  if (!nodeType) return NODE_TYPE_UNKNOWN;
+  return NODE_TYPE_LABELS[nodeType] ?? NODE_TYPE_UNKNOWN;
+};

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -76,18 +76,6 @@ export interface WebviewTranslationKeys {
   'property.title': string;
   'property.noSelection': string;
 
-  // Node type badges
-  'property.nodeType.subAgent': string;
-  'property.nodeType.askUserQuestion': string;
-  'property.nodeType.branch': string;
-  'property.nodeType.ifElse': string;
-  'property.nodeType.switch': string;
-  'property.nodeType.prompt': string;
-  'property.nodeType.start': string;
-  'property.nodeType.end': string;
-  'property.nodeType.skill': string;
-  'property.nodeType.unknown': string;
-
   // Common property labels
   'property.nodeName': string;
   'property.nodeName.placeholder': string;
@@ -401,7 +389,6 @@ export interface WebviewTranslationKeys {
   'mcp.dialog.error.invalidMode': string;
 
   // MCP Property Panel
-  'property.nodeType.mcp': string;
   'property.mcp.serverId': string;
   'property.mcp.toolName': string;
   'property.mcp.toolDescription': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -79,18 +79,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.title': 'Properties',
   'property.noSelection': 'Select a node to view its properties',
 
-  // Node type badges
-  'property.nodeType.subAgent': 'Sub-Agent',
-  'property.nodeType.askUserQuestion': 'Ask User Question',
-  'property.nodeType.branch': 'Branch Node',
-  'property.nodeType.ifElse': 'If/Else Node',
-  'property.nodeType.switch': 'Switch Node',
-  'property.nodeType.prompt': 'Prompt Node',
-  'property.nodeType.start': 'Start Node',
-  'property.nodeType.end': 'End Node',
-  'property.nodeType.skill': 'Skill Node',
-  'property.nodeType.unknown': 'Unknown',
-
   // Common property labels
   'property.nodeName': 'Node Name',
   'property.nodeName.placeholder': 'Enter node name',
@@ -440,7 +428,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'mcp.dialog.error.invalidMode': 'Invalid mode selected',
 
   // MCP Property Panel
-  'property.nodeType.mcp': 'MCP Tool',
   'property.mcp.serverId': 'Server',
   'property.mcp.toolName': 'Tool Name',
   'property.mcp.toolDescription': 'Description',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -79,18 +79,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.title': 'プロパティ',
   'property.noSelection': 'ノードを選択してプロパティを表示',
 
-  // Node type badges
-  'property.nodeType.subAgent': 'Sub-Agent',
-  'property.nodeType.askUserQuestion': 'Ask User Question',
-  'property.nodeType.branch': 'Branch Node',
-  'property.nodeType.ifElse': 'If/Else Node',
-  'property.nodeType.switch': 'Switch Node',
-  'property.nodeType.prompt': 'Prompt Node',
-  'property.nodeType.start': 'Start Node',
-  'property.nodeType.end': 'End Node',
-  'property.nodeType.skill': 'Skillノード',
-  'property.nodeType.unknown': '不明',
-
   // Common property labels
   'property.nodeName': 'ノード名',
   'property.nodeName.placeholder': 'ノード名を入力',
@@ -439,7 +427,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'mcp.dialog.error.invalidMode': '無効なモードが選択されました',
 
   // MCP Property Panel
-  'property.nodeType.mcp': 'MCP Tool',
   'property.mcp.serverId': 'サーバー',
   'property.mcp.toolName': 'ツール名',
   'property.mcp.toolDescription': '説明',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -80,18 +80,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.title': '속성',
   'property.noSelection': '노드를 선택하여 속성 보기',
 
-  // Node type badges
-  'property.nodeType.subAgent': 'Sub-Agent',
-  'property.nodeType.askUserQuestion': 'Ask User Question',
-  'property.nodeType.branch': 'Branch Node',
-  'property.nodeType.ifElse': 'If/Else Node',
-  'property.nodeType.switch': 'Switch Node',
-  'property.nodeType.prompt': 'Prompt Node',
-  'property.nodeType.start': 'Start Node',
-  'property.nodeType.end': 'End Node',
-  'property.nodeType.skill': 'Skill 노드',
-  'property.nodeType.unknown': '알 수 없음',
-
   // Common property labels
   'property.nodeName': '노드 이름',
   'property.nodeName.placeholder': '노드 이름 입력',
@@ -438,7 +426,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'mcp.dialog.error.invalidMode': '잘못된 모드가 선택되었습니다',
 
   // MCP Property Panel
-  'property.nodeType.mcp': 'MCP Tool',
   'property.mcp.serverId': '서버',
   'property.mcp.toolName': '도구 이름',
   'property.mcp.toolDescription': '설명',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -78,18 +78,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.title': '属性',
   'property.noSelection': '选择节点以查看其属性',
 
-  // Node type badges
-  'property.nodeType.subAgent': 'Sub-Agent',
-  'property.nodeType.askUserQuestion': 'Ask User Question',
-  'property.nodeType.branch': 'Branch Node',
-  'property.nodeType.ifElse': 'If/Else Node',
-  'property.nodeType.switch': 'Switch Node',
-  'property.nodeType.prompt': 'Prompt Node',
-  'property.nodeType.start': 'Start Node',
-  'property.nodeType.end': 'End Node',
-  'property.nodeType.skill': 'Skill节点',
-  'property.nodeType.unknown': '未知',
-
   // Common property labels
   'property.nodeName': '节点名称',
   'property.nodeName.placeholder': '输入节点名称',
@@ -421,7 +409,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'mcp.dialog.error.invalidMode': '选择了无效的模式',
 
   // MCP Property Panel
-  'property.nodeType.mcp': 'MCP Tool',
   'property.mcp.serverId': '服务器',
   'property.mcp.toolName': '工具名称',
   'property.mcp.toolDescription': '描述',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -78,18 +78,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.title': '屬性',
   'property.noSelection': '選擇節點以檢視其屬性',
 
-  // Node type badges
-  'property.nodeType.subAgent': 'Sub-Agent',
-  'property.nodeType.askUserQuestion': 'Ask User Question',
-  'property.nodeType.branch': 'Branch Node',
-  'property.nodeType.ifElse': 'If/Else Node',
-  'property.nodeType.switch': 'Switch Node',
-  'property.nodeType.prompt': 'Prompt Node',
-  'property.nodeType.start': 'Start Node',
-  'property.nodeType.end': 'End Node',
-  'property.nodeType.skill': 'Skill節點',
-  'property.nodeType.unknown': '未知',
-
   // Common property labels
   'property.nodeName': '節點名稱',
   'property.nodeName.placeholder': '輸入節點名稱',
@@ -421,7 +409,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'mcp.dialog.error.invalidMode': '選擇了無效的模式',
 
   // MCP Property Panel
-  'property.nodeType.mcp': 'MCP Tool',
   'property.mcp.serverId': '伺服器',
   'property.mcp.toolName': '工具名稱',
   'property.mcp.toolDescription': '描述',


### PR DESCRIPTION
## Problem

### Current Behavior
Property panel node type badges had inconsistent naming:
- Some had "Node" suffix: "Prompt Node", "Start Node", "End Node", etc.
- Some didn't: "Sub-Agent", "Ask User Question", "MCP Tool"

### Expected Behavior
All node type labels should be consistent without the "Node" suffix.

## Solution

Extract node type labels to a shared constant file since they are technical terms that don't require translation.

### Changes

**New File**: `src/webview/src/constants/node-type-labels.ts`
- Centralized node type label definitions
- `getNodeTypeLabel()` helper function

**Modified**: `src/webview/src/components/PropertyPanel.tsx`
- Replaced 20-line nested ternary with single function call

**Removed from i18n** (5 languages × 11 keys = 55 entries):
- `property.nodeType.subAgent`
- `property.nodeType.askUserQuestion`
- `property.nodeType.branch`
- `property.nodeType.ifElse`
- `property.nodeType.switch`
- `property.nodeType.prompt`
- `property.nodeType.start`
- `property.nodeType.end`
- `property.nodeType.skill`
- `property.nodeType.mcp`
- `property.nodeType.unknown`

## Impact

- Consistent UI labels across all node types
- Reduced i18n file size (-99 lines total)
- Simplified PropertyPanel component code
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)