### PR TITLE
fix: add responsive layout for toolbar and canvas elements

### DIFF
--- a/src/webview/src/hooks/useWindowWidth.ts
+++ b/src/webview/src/hooks/useWindowWidth.ts
@@ -1,0 +1,33 @@
+/**
+ * Claude Code Workflow Studio - Window Width Hook
+ *
+ * Custom hook for detecting window width changes
+ * Used for responsive toolbar buttons
+ */
+
+import { useEffect, useState } from 'react';
+
+const RESPONSIVE_BREAKPOINT = 900;
+
+/**
+ * Hook to get current window width with resize listener
+ */
+export function useWindowWidth(): number {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return width;
+}
+
+/**
+ * Hook to check if window is in compact mode (width <= 900px)
+ */
+export function useIsCompactMode(): boolean {
+  const width = useWindowWidth();
+  return width <= RESPONSIVE_BREAKPOINT;
+}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -41,6 +41,12 @@ export interface WebviewTranslationKeys {
   'toolbar.generateNameWithAI': string;
   'toolbar.error.nameGenerationFailed': string;
 
+  // Toolbar responsive tooltips
+  'toolbar.save.tooltip': string;
+  'toolbar.convert.iconTooltip': string;
+  'toolbar.load.tooltip': string;
+  'slack.share.tooltip': string;
+
   // Node Palette
   'palette.title': string;
   'palette.basicNodes': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -44,6 +44,12 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.nameGenerationFailed':
     'Failed to generate workflow name. Please try again or enter manually.',
 
+  // Toolbar responsive tooltips
+  'toolbar.save.tooltip': 'Save workflow',
+  'toolbar.convert.iconTooltip': 'Convert to Slash Command',
+  'toolbar.load.tooltip': 'Load selected workflow',
+  'slack.share.tooltip': 'Share to Slack',
+
   // Node Palette
   'palette.title': 'Node Palette',
   'palette.basicNodes': 'Basic Nodes',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -44,6 +44,12 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.nameGenerationFailed':
     'ワークフロー名の生成に失敗しました。再度お試しいただくか、手動で入力してください。',
 
+  // Toolbar responsive tooltips
+  'toolbar.save.tooltip': 'ワークフローを保存',
+  'toolbar.convert.iconTooltip': 'Slash Commandに変換',
+  'toolbar.load.tooltip': '選択したワークフローを読み込み',
+  'slack.share.tooltip': 'Slackに共有',
+
   // Node Palette
   'palette.title': 'ノードパレット',
   'palette.basicNodes': '基本ノード',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -44,6 +44,12 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.nameGenerationFailed':
     '워크플로 이름 생성에 실패했습니다. 다시 시도하거나 수동으로 입력하세요.',
 
+  // Toolbar responsive tooltips
+  'toolbar.save.tooltip': '워크플로 저장',
+  'toolbar.convert.iconTooltip': 'Slash Command로 변환',
+  'toolbar.load.tooltip': '선택한 워크플로 불러오기',
+  'slack.share.tooltip': 'Slack에 공유',
+
   // Node Palette
   'palette.title': '노드 팔레트',
   'palette.basicNodes': '기본 노드',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -43,6 +43,12 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.generateNameWithAI': '使用AI生成名称',
   'toolbar.error.nameGenerationFailed': '生成工作流名称失败。请重试或手动输入。',
 
+  // Toolbar responsive tooltips
+  'toolbar.save.tooltip': '保存工作流',
+  'toolbar.convert.iconTooltip': '转换为Slash Command',
+  'toolbar.load.tooltip': '加载选定的工作流',
+  'slack.share.tooltip': '分享到Slack',
+
   // Node Palette
   'palette.title': '节点面板',
   'palette.basicNodes': '基本节点',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -43,6 +43,12 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.generateNameWithAI': '使用AI生成名稱',
   'toolbar.error.nameGenerationFailed': '生成工作流名稱失敗。請重試或手動輸入。',
 
+  // Toolbar responsive tooltips
+  'toolbar.save.tooltip': '儲存工作流程',
+  'toolbar.convert.iconTooltip': '轉換為Slash Command',
+  'toolbar.load.tooltip': '載入選取的工作流程',
+  'slack.share.tooltip': '分享到Slack',
+
   // Node Palette
   'palette.title': '節點面板',
   'palette.basicNodes': '基本節點',


### PR DESCRIPTION
## Problem

When the display area is narrow, the toolbar buttons overflow and UI elements become cramped, affecting usability.

### Current Behavior
1. Toolbar buttons always show full text labels regardless of window width
2. AI refine button is in the toolbar, taking up space
3. MiniMap has fixed size that takes too much space on narrow screens

### Expected Behavior
1. ✅ Toolbar buttons show icons only when width ≤ 900px
2. ✅ AI refine button moves to canvas top-right corner
3. ✅ MiniMap shrinks on narrow screens

## Solution

Implement responsive layout using a custom `useWindowWidth` hook with 900px breakpoint.

### Changes

**New file**: `src/webview/src/hooks/useWindowWidth.ts`
- `useWindowWidth()`: Returns current window width
- `useIsCompactMode()`: Returns true when width ≤ 900px

**File**: `src/webview/src/components/Toolbar.tsx`
- Wrap toolbar in `StyledTooltipProvider`
- Make 4 buttons responsive with icons:
  - Save: `Save` icon
  - Convert: `SquareSlash` icon
  - Load: `FileDown` icon
  - Slack: `Share2` icon
- Remove AI refine button (moved to WorkflowEditor)

**File**: `src/webview/src/components/WorkflowEditor.tsx`
- Add AI refine button in `Panel position="top-right"`
- Make AI button icon-only when compact
- Add responsive MiniMap sizing (200×150 → 120×80)

**i18n files**: Added tooltip translations for 5 languages
- `toolbar.save.tooltip`
- `toolbar.convert.iconTooltip`
- `toolbar.load.tooltip`
- `slack.share.tooltip`

## Impact

- Improved UX on narrow screens
- No breaking changes
- All existing functionality preserved

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)