### PR TITLE
feat: add workflow reset button to toolbar

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { Workflow } from '@shared/types/messages';
-import { FileDown, Save, Share2, SquareSlash } from 'lucide-react';
+import { FileDown, Save, Share2, SquareSlash, Trash2 } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
@@ -23,6 +23,7 @@ import { useWorkflowStore } from '../stores/workflow-store';
 import { AiGenerateButton } from './common/AiGenerateButton';
 import { ProcessingOverlay } from './common/ProcessingOverlay';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
+import { ConfirmDialog } from './dialogs/ConfirmDialog';
 
 interface ToolbarProps {
   onError: (error: { code: string; message: string; details?: unknown }) => void;
@@ -49,6 +50,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
     setActiveWorkflow,
     workflowName,
     setWorkflowName,
+    clearWorkflow,
   } = useWorkflowStore();
   const { isProcessing } = useRefinementStore();
   const [isSaving, setIsSaving] = useState(false);
@@ -56,7 +58,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
   const [workflows, setWorkflows] = useState<WorkflowListItem[]>([]);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>('');
   const [isGeneratingName, setIsGeneratingName] = useState(false);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
   const generationNameRequestIdRef = useRef<string | null>(null);
+
+  // Handle reset workflow
+  const handleResetWorkflow = useCallback(() => {
+    clearWorkflow();
+    setShowResetConfirm(false);
+  }, [clearWorkflow]);
 
   const handleSave = async () => {
     if (!workflowName.trim()) {
@@ -485,14 +494,27 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
           </button>
         </StyledTooltipItem>
 
-        {/* Divider */}
-        <div
-          style={{
-            width: '1px',
-            height: '20px',
-            backgroundColor: 'var(--vscode-panel-border)',
-          }}
-        />
+        {/* Reset Workflow Button */}
+        <StyledTooltipItem content={t('toolbar.resetWorkflow')}>
+          <button
+            type="button"
+            onClick={() => setShowResetConfirm(true)}
+            style={{
+              padding: '4px 8px',
+              backgroundColor: 'var(--vscode-button-secondaryBackground)',
+              color: 'var(--vscode-button-secondaryForeground)',
+              border: 'none',
+              borderRadius: '2px',
+              cursor: 'pointer',
+              fontSize: '13px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
+            }}
+          >
+            <Trash2 size={16} />
+          </button>
+        </StyledTooltipItem>
 
         {/* Help Button */}
         <button
@@ -515,6 +537,17 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
 
         {/* Processing Overlay (Phase 3.10) */}
         <ProcessingOverlay isVisible={isProcessing} />
+
+        {/* Reset Workflow Confirmation Dialog */}
+        <ConfirmDialog
+          isOpen={showResetConfirm}
+          title={t('dialog.resetWorkflow.title')}
+          message={t('dialog.resetWorkflow.message')}
+          confirmLabel={t('dialog.resetWorkflow.confirm')}
+          cancelLabel={t('common.cancel')}
+          onConfirm={handleResetWorkflow}
+          onCancel={() => setShowResetConfirm(false)}
+        />
       </div>
     </StyledTooltipProvider>
   );

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -227,6 +227,12 @@ export interface WebviewTranslationKeys {
   'dialog.deleteNode.confirm': string;
   'dialog.deleteNode.cancel': string;
 
+  // Reset Workflow Confirmation Dialog
+  'toolbar.resetWorkflow': string;
+  'dialog.resetWorkflow.title': string;
+  'dialog.resetWorkflow.message': string;
+  'dialog.resetWorkflow.confirm': string;
+
   // Skill Browser Dialog
   'skill.browser.title': string;
   'skill.browser.description': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -246,6 +246,13 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': 'Delete',
   'dialog.deleteNode.cancel': 'Cancel',
 
+  // Reset Workflow Confirmation Dialog
+  'toolbar.resetWorkflow': 'Reset Workflow',
+  'dialog.resetWorkflow.title': 'Reset Workflow',
+  'dialog.resetWorkflow.message':
+    'Are you sure you want to reset the workflow? All nodes except Start and End will be removed.',
+  'dialog.resetWorkflow.confirm': 'Reset',
+
   // Skill Browser Dialog
   'skill.browser.title': 'Browse Skills',
   'skill.browser.description':

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -247,6 +247,13 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '削除',
   'dialog.deleteNode.cancel': 'キャンセル',
 
+  // Reset Workflow Confirmation Dialog
+  'toolbar.resetWorkflow': 'ワークフローをリセット',
+  'dialog.resetWorkflow.title': 'ワークフローをリセット',
+  'dialog.resetWorkflow.message':
+    'ワークフローをリセットしてもよろしいですか？Start と End 以外のすべてのノードが削除されます。',
+  'dialog.resetWorkflow.confirm': 'リセット',
+
   // Skill Browser Dialog
   'skill.browser.title': 'Skillを参照',
   'skill.browser.description':

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -249,6 +249,13 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '삭제',
   'dialog.deleteNode.cancel': '취소',
 
+  // Reset Workflow Confirmation Dialog
+  'toolbar.resetWorkflow': '워크플로우 초기화',
+  'dialog.resetWorkflow.title': '워크플로우 초기화',
+  'dialog.resetWorkflow.message':
+    '워크플로우를 초기화하시겠습니까? Start와 End를 제외한 모든 노드가 삭제됩니다.',
+  'dialog.resetWorkflow.confirm': '초기화',
+
   // Skill Browser Dialog
   'skill.browser.title': 'Skill 탐색',
   'skill.browser.description':

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -238,6 +238,12 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '删除',
   'dialog.deleteNode.cancel': '取消',
 
+  // Reset Workflow Confirmation Dialog
+  'toolbar.resetWorkflow': '重置工作流',
+  'dialog.resetWorkflow.title': '重置工作流',
+  'dialog.resetWorkflow.message': '确定要重置工作流吗？除 Start 和 End 外的所有节点都将被删除。',
+  'dialog.resetWorkflow.confirm': '重置',
+
   // Skill Browser Dialog
   'skill.browser.title': '浏览Skill',
   'skill.browser.description':

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -238,6 +238,12 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '刪除',
   'dialog.deleteNode.cancel': '取消',
 
+  // Reset Workflow Confirmation Dialog
+  'toolbar.resetWorkflow': '重設工作流程',
+  'dialog.resetWorkflow.title': '重設工作流程',
+  'dialog.resetWorkflow.message': '確定要重設工作流程嗎？除 Start 和 End 外的所有節點都將被刪除。',
+  'dialog.resetWorkflow.confirm': '重設',
+
   // Skill Browser Dialog
   'skill.browser.title': '瀏覽Skill',
   'skill.browser.description':


### PR DESCRIPTION
## Summary

Add a reset button to the toolbar that clears all workflow nodes except Start and End.

- Button placed between Slack share and help buttons in the "other actions" group
- Confirmation dialog shown before clearing to prevent accidental data loss
- Full i18n support for 5 languages (English, Japanese, Korean, Simplified Chinese, Traditional Chinese)

## Changes

**Files Modified:**
- `src/webview/src/components/Toolbar.tsx` - Added reset button and confirmation dialog
- `src/webview/src/i18n/translation-keys.ts` - Added new translation keys
- `src/webview/src/i18n/translations/*.ts` - Added translations for all 5 languages

## Impact

- New UI element in toolbar
- No breaking changes
- Calls existing `clearWorkflow()` function from workflow-store

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)