### PR TITLE
feat: add close button to PropertyPanel with tour highlight fix

### DIFF
--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -44,6 +44,8 @@ const App: React.FC = () => {
     setEdges,
     setWorkflowName,
     setActiveWorkflow,
+    isPropertyPanelOpen,
+    selectedNodeId,
   } = useWorkflowStore();
   const { isOpen: isRefinementPanelOpen, isProcessing } = useRefinementStore();
   const [error, setError] = useState<ErrorPayload | null>(null);
@@ -212,8 +214,12 @@ const App: React.FC = () => {
           <ProcessingOverlay isVisible={isProcessing} message={t('refinement.processingOverlay')} />
         </div>
 
-        {/* Right Panel: Property Panel or Refinement Chat Panel */}
-        {isRefinementPanelOpen ? <RefinementChatPanel /> : <PropertyPanel />}
+        {/* Right Panel: Property Panel (when node selected) > Refinement Chat Panel > none (canvas expands) */}
+        {selectedNodeId && isPropertyPanelOpen ? (
+          <PropertyPanel />
+        ) : isRefinementPanelOpen ? (
+          <RefinementChatPanel />
+        ) : null}
       </div>
 
       {/* Error Notification Overlay */}

--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -34,40 +34,12 @@ import { McpNodeEditDialog } from './dialogs/McpNodeEditDialog';
  */
 export const PropertyPanel: React.FC = () => {
   const { t } = useTranslation();
-  const { nodes, selectedNodeId, updateNodeData, setNodes } = useWorkflowStore();
+  const { nodes, selectedNodeId, updateNodeData, setNodes, closePropertyPanel } =
+    useWorkflowStore();
   const { width, handleMouseDown } = useResizablePanel();
 
   // Find the selected node
   const selectedNode = nodes.find((node) => node.id === selectedNodeId);
-
-  if (!selectedNode) {
-    return (
-      <div
-        className="property-panel"
-        style={{
-          position: 'relative',
-          width: `${width}px`,
-          height: '100%',
-          backgroundColor: 'var(--vscode-sideBar-background)',
-          borderLeft: '1px solid var(--vscode-panel-border)',
-          padding: '16px',
-          overflowY: 'auto',
-        }}
-      >
-        <ResizeHandle onMouseDown={handleMouseDown} />
-        <div
-          style={{
-            fontSize: '13px',
-            color: 'var(--vscode-descriptionForeground)',
-            textAlign: 'center',
-            marginTop: '24px',
-          }}
-        >
-          {t('property.noSelection')}
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div
@@ -83,170 +55,204 @@ export const PropertyPanel: React.FC = () => {
       }}
     >
       <ResizeHandle onMouseDown={handleMouseDown} />
-      {/* Header */}
+      {/* Header with close button */}
       <div
         style={{
-          fontSize: '13px',
-          fontWeight: 600,
-          color: 'var(--vscode-foreground)',
-          marginBottom: '16px',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-        }}
-      >
-        {t('property.title')}
-      </div>
-
-      {/* Node Type Badge */}
-      <div
-        style={{
-          fontSize: '11px',
-          color: 'var(--vscode-badge-foreground)',
-          backgroundColor: 'var(--vscode-badge-background)',
-          padding: '4px 8px',
-          borderRadius: '3px',
-          display: 'inline-block',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
           marginBottom: '16px',
         }}
       >
-        {getNodeTypeLabel(selectedNode.type)}
+        <div
+          style={{
+            fontSize: '13px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {t('property.title')}
+        </div>
+        <button
+          type="button"
+          onClick={closePropertyPanel}
+          style={{
+            padding: '4px 8px',
+            backgroundColor: 'transparent',
+            color: 'var(--vscode-foreground)',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: '16px',
+          }}
+          aria-label="Close"
+        >
+          ✕
+        </button>
       </div>
 
-      {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, and mcp types) */}
-      {(selectedNode.type === 'subAgent' ||
-        selectedNode.type === 'askUserQuestion' ||
-        selectedNode.type === 'branch' ||
-        selectedNode.type === 'ifElse' ||
-        selectedNode.type === 'switch' ||
-        selectedNode.type === 'prompt' ||
-        selectedNode.type === 'skill' ||
-        selectedNode.type === 'mcp') && (
-        <div style={{ marginBottom: '16px' }}>
-          <label
-            htmlFor="node-name-input"
-            style={{
-              display: 'block',
-              fontSize: '12px',
-              fontWeight: 600,
-              color: 'var(--vscode-foreground)',
-              marginBottom: '6px',
-            }}
-          >
-            {t('property.nodeName')}
-          </label>
-          <input
-            id="node-name-input"
-            type="text"
-            value={selectedNode.data.name ?? selectedNode.id}
-            onChange={(e) => {
-              const newName = e.target.value;
-              setNodes(
-                nodes.map((n) =>
-                  n.id === selectedNode.id ? { ...n, data: { ...n.data, name: newName } } : n
-                )
-              );
-            }}
-            onBlur={(e) => {
-              // 入力欄が空の場合は、node IDに戻す（空の名前を防ぐ）
-              const currentName = e.target.value.trim();
-              if (!currentName) {
-                setNodes(
-                  nodes.map((n) =>
-                    n.id === selectedNode.id ? { ...n, data: { ...n.data, name: undefined } } : n
-                  )
-                );
-              }
-            }}
-            className="nodrag"
-            placeholder={t('property.nodeName.placeholder')}
-            style={{
-              width: '100%',
-              padding: '6px 8px',
-              backgroundColor: 'var(--vscode-input-background)',
-              color: 'var(--vscode-input-foreground)',
-              border: '1px solid var(--vscode-input-border)',
-              borderRadius: '2px',
-              fontSize: '13px',
-            }}
-          />
+      {/* Show content only when a node is selected */}
+      {!selectedNode ? null : (
+        <>
+          {/* Node Type Badge */}
           <div
             style={{
               fontSize: '11px',
-              color: 'var(--vscode-descriptionForeground)',
-              marginTop: '4px',
+              color: 'var(--vscode-badge-foreground)',
+              backgroundColor: 'var(--vscode-badge-background)',
+              padding: '4px 8px',
+              borderRadius: '3px',
+              display: 'inline-block',
+              marginBottom: '16px',
             }}
           >
-            {t('property.nodeName.help')}
+            {getNodeTypeLabel(selectedNode.type)}
           </div>
-        </div>
-      )}
 
-      {/* Render properties based on node type */}
-      {selectedNode.type === 'subAgent' ? (
-        <SubAgentProperties
-          node={selectedNode as Node<SubAgentData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'askUserQuestion' ? (
-        <AskUserQuestionProperties
-          node={selectedNode as Node<AskUserQuestionData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'branch' ? (
-        <BranchProperties
-          node={selectedNode as Node<BranchNodeData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'ifElse' ? (
-        <IfElseProperties
-          node={selectedNode as Node<IfElseNodeData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'switch' ? (
-        <SwitchProperties
-          node={selectedNode as Node<SwitchNodeData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'prompt' ? (
-        <PromptProperties
-          node={selectedNode as Node<PromptNodeData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'skill' ? (
-        <SkillProperties
-          node={selectedNode as Node<SkillNodeData>}
-          updateNodeData={updateNodeData}
-        />
-      ) : selectedNode.type === 'mcp' ? (
-        <McpProperties node={selectedNode as Node<McpNodeData>} updateNodeData={updateNodeData} />
-      ) : selectedNode.type === 'start' || selectedNode.type === 'end' ? (
-        <div
-          style={{
-            padding: '12px',
-            backgroundColor: 'var(--vscode-textBlockQuote-background)',
-            border: '1px solid var(--vscode-textBlockQuote-border)',
-            borderRadius: '4px',
-            fontSize: '12px',
-            color: 'var(--vscode-descriptionForeground)',
-          }}
-        >
-          {selectedNode.type === 'start'
-            ? t('property.startNodeDescription')
-            : t('property.endNodeDescription')}
-        </div>
-      ) : (
-        <div
-          style={{
-            padding: '12px',
-            backgroundColor: 'var(--vscode-errorBackground)',
-            border: '1px solid var(--vscode-errorBorder)',
-            borderRadius: '4px',
-            fontSize: '12px',
-            color: 'var(--vscode-errorForeground)',
-          }}
-        >
-          {t('property.unknownNodeType')} {selectedNode.type}
-        </div>
+          {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, and mcp types) */}
+          {(selectedNode.type === 'subAgent' ||
+            selectedNode.type === 'askUserQuestion' ||
+            selectedNode.type === 'branch' ||
+            selectedNode.type === 'ifElse' ||
+            selectedNode.type === 'switch' ||
+            selectedNode.type === 'prompt' ||
+            selectedNode.type === 'skill' ||
+            selectedNode.type === 'mcp') && (
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="node-name-input"
+                style={{
+                  display: 'block',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                  marginBottom: '6px',
+                }}
+              >
+                {t('property.nodeName')}
+              </label>
+              <input
+                id="node-name-input"
+                type="text"
+                value={selectedNode.data.name ?? selectedNode.id}
+                onChange={(e) => {
+                  const newName = e.target.value;
+                  setNodes(
+                    nodes.map((n) =>
+                      n.id === selectedNode.id ? { ...n, data: { ...n.data, name: newName } } : n
+                    )
+                  );
+                }}
+                onBlur={(e) => {
+                  // 入力欄が空の場合は、node IDに戻す（空の名前を防ぐ）
+                  const currentName = e.target.value.trim();
+                  if (!currentName) {
+                    setNodes(
+                      nodes.map((n) =>
+                        n.id === selectedNode.id
+                          ? { ...n, data: { ...n.data, name: undefined } }
+                          : n
+                      )
+                    );
+                  }
+                }}
+                className="nodrag"
+                placeholder={t('property.nodeName.placeholder')}
+                style={{
+                  width: '100%',
+                  padding: '6px 8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  fontSize: '13px',
+                }}
+              />
+              <div
+                style={{
+                  fontSize: '11px',
+                  color: 'var(--vscode-descriptionForeground)',
+                  marginTop: '4px',
+                }}
+              >
+                {t('property.nodeName.help')}
+              </div>
+            </div>
+          )}
+
+          {/* Render properties based on node type */}
+          {selectedNode.type === 'subAgent' ? (
+            <SubAgentProperties
+              node={selectedNode as Node<SubAgentData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'askUserQuestion' ? (
+            <AskUserQuestionProperties
+              node={selectedNode as Node<AskUserQuestionData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'branch' ? (
+            <BranchProperties
+              node={selectedNode as Node<BranchNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'ifElse' ? (
+            <IfElseProperties
+              node={selectedNode as Node<IfElseNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'switch' ? (
+            <SwitchProperties
+              node={selectedNode as Node<SwitchNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'prompt' ? (
+            <PromptProperties
+              node={selectedNode as Node<PromptNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'skill' ? (
+            <SkillProperties
+              node={selectedNode as Node<SkillNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'mcp' ? (
+            <McpProperties
+              node={selectedNode as Node<McpNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'start' || selectedNode.type === 'end' ? (
+            <div
+              style={{
+                padding: '12px',
+                backgroundColor: 'var(--vscode-textBlockQuote-background)',
+                border: '1px solid var(--vscode-textBlockQuote-border)',
+                borderRadius: '4px',
+                fontSize: '12px',
+                color: 'var(--vscode-descriptionForeground)',
+              }}
+            >
+              {selectedNode.type === 'start'
+                ? t('property.startNodeDescription')
+                : t('property.endNodeDescription')}
+            </div>
+          ) : (
+            <div
+              style={{
+                padding: '12px',
+                backgroundColor: 'var(--vscode-errorBackground)',
+                border: '1px solid var(--vscode-errorBorder)',
+                borderRadius: '4px',
+                fontSize: '12px',
+                color: 'var(--vscode-errorForeground)',
+              }}
+            >
+              {t('property.unknownNodeType')} {selectedNode.type}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/webview/src/components/Tour.tsx
+++ b/src/webview/src/components/Tour.tsx
@@ -8,8 +8,9 @@ import { type Driver, driver } from 'driver.js';
 import type React from 'react';
 import { useEffect, useRef } from 'react';
 import 'driver.js/dist/driver.css';
-import { getDriverConfig, getTourSteps } from '../constants/tour-steps';
+import { getDriverConfig, getTourSteps, PROPERTY_PANEL_STEP_INDEX } from '../constants/tour-steps';
 import { useTranslation } from '../i18n/i18n-context';
+import { useWorkflowStore } from '../stores/workflow-store';
 
 interface TourProps {
   run: boolean;
@@ -25,11 +26,18 @@ export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
   const { t } = useTranslation();
   const driverRef = useRef<Driver | null>(null);
   const onFinishRef = useRef(onFinish);
+  const setSelectedNodeId = useWorkflowStore((state) => state.setSelectedNodeId);
+  const setSelectedNodeIdRef = useRef(setSelectedNodeId);
+  const previousStepIndexRef = useRef<number | null>(null);
 
-  // Update onFinish ref when it changes
+  // Update refs when they change
   useEffect(() => {
     onFinishRef.current = onFinish;
   }, [onFinish]);
+
+  useEffect(() => {
+    setSelectedNodeIdRef.current = setSelectedNodeId;
+  }, [setSelectedNodeId]);
 
   useEffect(() => {
     // Initialize driver instance
@@ -37,19 +45,33 @@ export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
       const config = getDriverConfig((key) => t(key as keyof typeof t));
       driverRef.current = driver({
         ...config,
+        onHighlightStarted: (_element, _step, options) => {
+          const currentIndex = options.state.activeIndex;
+          previousStepIndexRef.current = currentIndex ?? null;
+        },
         onCloseClick: () => {
           // Called when close button (X) is clicked
+          // Deselect node if we were on property panel step
+          if (previousStepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
+            setSelectedNodeIdRef.current(null);
+          }
           if (driverRef.current) {
             driverRef.current.destroy();
           }
         },
         onDestroyStarted: () => {
           // Called when tour is about to be destroyed (completed, skipped, or closed)
+          // Deselect node if we were on property panel step
+          if (previousStepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
+            setSelectedNodeIdRef.current(null);
+          }
           // Destroy the driver instance
           if (driverRef.current) {
             driverRef.current.destroy();
             driverRef.current = null;
           }
+          // Reset step tracking
+          previousStepIndexRef.current = null;
           // Call onFinish callback
           onFinishRef.current();
         },
@@ -58,7 +80,14 @@ export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
 
     // Start or stop tour based on run prop
     if (run && driverRef.current) {
-      const steps = getTourSteps((key) => t(key as keyof typeof t));
+      // Create step callbacks that reference the current driver instance
+      const driverInstance = driverRef.current;
+      const steps = getTourSteps((key) => t(key as keyof typeof t), {
+        onSelectStartNode: () => setSelectedNodeIdRef.current('start-node-default'),
+        onDeselectNode: () => setSelectedNodeIdRef.current(null),
+        moveNext: () => driverInstance.moveNext(),
+        movePrevious: () => driverInstance.movePrevious(),
+      });
       driverRef.current.setSteps(steps);
       driverRef.current.drive();
     } else if (!run && driverRef.current) {

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -91,7 +91,7 @@ export const WorkflowEditor: React.FC = () => {
     setActiveWorkflow,
     workflowName,
   } = useWorkflowStore();
-  const { closeChat, openChat, initConversation, loadConversationHistory } = useRefinementStore();
+  const { openChat, initConversation, loadConversationHistory } = useRefinementStore();
 
   /**
    * 接続制約の検証
@@ -133,10 +133,8 @@ export const WorkflowEditor: React.FC = () => {
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
       setSelectedNodeId(node.id);
-      // Close AI refinement panel to show property panel
-      closeChat();
     },
-    [setSelectedNodeId, closeChat]
+    [setSelectedNodeId]
   );
 
   // Handle pane click (deselect)

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -6,11 +6,26 @@
 
 import type { Config as DriverConfig, DriveStep } from 'driver.js';
 
+// Tour step indices (0-based)
+export const CANVAS_STEP_INDEX = 3;
+export const PROPERTY_PANEL_STEP_INDEX = 4;
+
 /**
  * Tour steps configuration
  * Each step guides users through creating their first workflow
+ *
+ * @param t - Translation function
+ * @param callbacks - Optional callbacks for step-specific actions
  */
-export const getTourSteps = (t: (key: string) => string): DriveStep[] => [
+export const getTourSteps = (
+  t: (key: string) => string,
+  callbacks?: {
+    onSelectStartNode?: () => void;
+    onDeselectNode?: () => void;
+    moveNext?: () => void;
+    movePrevious?: () => void;
+  }
+): DriveStep[] => [
   {
     popover: {
       title: '',
@@ -43,6 +58,14 @@ export const getTourSteps = (t: (key: string) => string): DriveStep[] => [
       description: t('tour.canvas'),
       side: 'over',
       align: 'center',
+      // Select Start node before moving to property panel step
+      onNextClick: () => {
+        callbacks?.onSelectStartNode?.();
+        // Small delay to allow React to render the property panel
+        setTimeout(() => {
+          callbacks?.moveNext?.();
+        }, 50);
+      },
     },
   },
   {
@@ -52,6 +75,16 @@ export const getTourSteps = (t: (key: string) => string): DriveStep[] => [
       description: t('tour.propertyPanel'),
       side: 'left',
       align: 'start',
+      // Deselect node when leaving property panel step (going back)
+      onPrevClick: () => {
+        callbacks?.onDeselectNode?.();
+        callbacks?.movePrevious?.();
+      },
+      // Deselect node when leaving property panel step (going forward)
+      onNextClick: () => {
+        callbacks?.onDeselectNode?.();
+        callbacks?.moveNext?.();
+      },
     },
   },
   {
@@ -61,6 +94,13 @@ export const getTourSteps = (t: (key: string) => string): DriveStep[] => [
       description: t('tour.addAskUserQuestion'),
       side: 'right',
       align: 'center',
+      // Select Start node when going back to property panel step
+      onPrevClick: () => {
+        callbacks?.onSelectStartNode?.();
+        setTimeout(() => {
+          callbacks?.movePrevious?.();
+        }, 50);
+      },
     },
   },
   {

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -80,7 +80,6 @@ export interface WebviewTranslationKeys {
 
   // Property Panel
   'property.title': string;
-  'property.noSelection': string;
 
   // Common property labels
   'property.nodeName': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -83,7 +83,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Property Panel
   'property.title': 'Properties',
-  'property.noSelection': 'Select a node to view its properties',
 
   // Common property labels
   'property.nodeName': 'Node Name',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -83,7 +83,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Property Panel
   'property.title': 'プロパティ',
-  'property.noSelection': 'ノードを選択してプロパティを表示',
 
   // Common property labels
   'property.nodeName': 'ノード名',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -84,7 +84,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Property Panel
   'property.title': '속성',
-  'property.noSelection': '노드를 선택하여 속성 보기',
 
   // Common property labels
   'property.nodeName': '노드 이름',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -82,7 +82,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Property Panel
   'property.title': '属性',
-  'property.noSelection': '选择节点以查看其属性',
 
   // Common property labels
   'property.nodeName': '节点名称',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -82,7 +82,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Property Panel
   'property.title': '屬性',
-  'property.noSelection': '選擇節點以檢視其屬性',
 
   // Common property labels
   'property.nodeName': '節點名稱',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -34,6 +34,7 @@ interface WorkflowStore {
   activeWorkflow: Workflow | null;
   interactionMode: InteractionMode;
   workflowName: string;
+  isPropertyPanelOpen: boolean;
 
   // React Flow Change Handlers
   onNodesChange: OnNodesChange;
@@ -47,6 +48,8 @@ interface WorkflowStore {
   setInteractionMode: (mode: InteractionMode) => void;
   toggleInteractionMode: () => void;
   setWorkflowName: (name: string) => void;
+  openPropertyPanel: () => void;
+  closePropertyPanel: () => void;
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
@@ -195,6 +198,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   activeWorkflow: null,
   interactionMode: 'pan', // Default: pan mode
   workflowName: 'my-workflow', // Default workflow name
+  isPropertyPanelOpen: true, // Property panel is open by default
 
   // React Flow Change Handlers (integrates with React Flow's onChange events)
   onNodesChange: (changes) => {
@@ -251,7 +255,14 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
 
   setEdges: (edges) => set({ edges }),
 
-  setSelectedNodeId: (selectedNodeId) => set({ selectedNodeId }),
+  setSelectedNodeId: (selectedNodeId) => {
+    // When a node is selected, auto-open the property panel
+    if (selectedNodeId !== null) {
+      set({ selectedNodeId, isPropertyPanelOpen: true });
+    } else {
+      set({ selectedNodeId });
+    }
+  },
 
   setInteractionMode: (interactionMode) => set({ interactionMode }),
 
@@ -261,6 +272,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   setWorkflowName: (workflowName) => set({ workflowName }),
+
+  openPropertyPanel: () => set({ isPropertyPanelOpen: true }),
+
+  closePropertyPanel: () => set({ isPropertyPanelOpen: false }),
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => {


### PR DESCRIPTION
## Problem

### Current Behavior
1. PropertyPanel cannot be hidden - users have no way to expand canvas area
2. ❌ Empty "プロパティ ×" header was showing when no node selected
3. ❌ When AI editing panel open → select node → deselect node, AI panel closes permanently
4. ❌ During onboarding tour, PropertyPanel step was not highlighted because panel wasn't visible

### Expected Behavior
1. ✅ Users can close PropertyPanel with × button to expand canvas area
2. ✅ PropertyPanel only shows when a node is selected
3. ✅ AI editing panel state is preserved when selecting/deselecting nodes
4. ✅ During onboarding tour, PropertyPanel is properly highlighted

## Solution

Add × button to PropertyPanel header and implement proper panel visibility logic with tour highlight fix.

### Key Changes

1. **PropertyPanel close button**: Added × button in header (same style as RefinementChatPanel)
2. **Panel visibility logic**: Only show PropertyPanel when `selectedNodeId && isPropertyPanelOpen`
3. **Panel priority**: PropertyPanel > RefinementChatPanel when node is selected
4. **Auto-reopen**: Selecting a node automatically opens PropertyPanel
5. **Tour highlight fix**: Use Driver.js step-level callbacks to select Start node before property panel step

## Changes

**`src/webview/src/stores/workflow-store.ts`**
- Added `isPropertyPanelOpen` state
- Added `openPropertyPanel()` and `closePropertyPanel()` actions
- Modified `setSelectedNodeId()` to auto-open panel when node selected

**`src/webview/src/components/PropertyPanel.tsx`**
- Added × button in header
- Removed no-selection message display

**`src/webview/src/App.tsx`**
- Changed panel display condition to `selectedNodeId && isPropertyPanelOpen`
- PropertyPanel now takes priority over RefinementChatPanel

**`src/webview/src/components/WorkflowEditor.tsx`**
- Removed `closeChat()` call from `handleNodeClick` to preserve AI panel state

**`src/webview/src/constants/tour-steps.ts`**
- Added step-level `onNextClick`/`onPrevClick` callbacks
- Exported `PROPERTY_PANEL_STEP_INDEX` constant

**`src/webview/src/components/Tour.tsx`**
- Pass callbacks to `getTourSteps()` for node selection timing
- Select Start node before property panel step (via Canvas step's `onNextClick`)

**Translation files (5 languages)**
- Removed unused `property.noSelection` key

## Impact

- UX improvement: Users can now hide PropertyPanel to get more canvas space
- Panel behavior is consistent with RefinementChatPanel
- No breaking changes - PropertyPanel auto-opens on node selection

## Testing

- [x] PropertyPanel × button closes panel
- [x] Selecting a node reopens PropertyPanel
- [x] Canvas expands when PropertyPanel is closed
- [x] AI editing panel state preserved when selecting/deselecting nodes
- [x] Onboarding tour properly highlights PropertyPanel
- [x] Going back in tour re-selects Start node for PropertyPanel step
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)