### PR TITLE
feat: add Sub-Agent Flow support (Beta)

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -12,7 +12,8 @@
       "ifElse",
       "switch",
       "skill",
-      "mcp"
+      "mcp",
+      "subAgentFlow"
     ]
   },
   "nodeTypes": {
@@ -280,6 +281,40 @@
             "outputPorts": 1
           }
         }
+      }
+    },
+    "subAgentFlow": {
+      "description": "Execute a defined sub-agent flow. Use this to reference and run a sub-agent flow within the main workflow. **Important: Always has exactly 1 output port. Sub-agent flows are executed sequentially from their Start to End node.**",
+      "fields": {
+        "subAgentFlowId": {
+          "type": "string",
+          "required": true,
+          "description": "ID of the sub-agent flow to execute (must match an existing sub-agent flow in the workflow's subAgentFlows array)"
+        },
+        "label": {
+          "type": "string",
+          "required": true,
+          "maxLength": 50,
+          "description": "Display label for this node"
+        },
+        "description": {
+          "type": "string",
+          "required": false,
+          "maxLength": 200,
+          "description": "Optional description of what this sub-agent flow does"
+        },
+        "outputPorts": {
+          "type": "number",
+          "required": true,
+          "value": 1
+        }
+      },
+      "inputPorts": 1,
+      "outputPorts": 1,
+      "mvpConstraints": {
+        "noNesting": "SubAgentFlow nodes cannot be used inside sub-agent flows (no nesting allowed in Phase 1 MVP)",
+        "noSubAgentInSubAgentFlow": "SubAgent nodes cannot be used inside sub-agent flows (Claude Code constraint)",
+        "sequentialExecution": "Sub-agent flows execute sequentially from Start to End"
       }
     }
   },

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -20,6 +20,7 @@ import { RefinementChatPanel } from './components/dialogs/RefinementChatPanel';
 import { SlackConnectionRequiredDialog } from './components/dialogs/SlackConnectionRequiredDialog';
 import { SlackManualTokenDialog } from './components/dialogs/SlackManualTokenDialog';
 import { SlackShareDialog } from './components/dialogs/SlackShareDialog';
+import { SubAgentFlowDialog } from './components/dialogs/SubAgentFlowDialog';
 import { TermsOfUseDialog } from './components/dialogs/TermsOfUseDialog';
 import { ErrorNotification } from './components/ErrorNotification';
 import { NodePalette } from './components/NodePalette';
@@ -46,6 +47,8 @@ const App: React.FC = () => {
     setActiveWorkflow,
     isPropertyPanelOpen,
     selectedNodeId,
+    activeSubAgentFlowId,
+    setActiveSubAgentFlowId,
   } = useWorkflowStore();
   const { isOpen: isRefinementPanelOpen, isProcessing } = useRefinementStore();
   const [error, setError] = useState<ErrorPayload | null>(null);
@@ -201,9 +204,9 @@ const App: React.FC = () => {
         }}
       >
         {/* Left Panel: Node Palette with simple overlay (Phase 3.10 - modified) */}
-        <div style={{ position: 'relative' }}>
+        <div style={{ position: 'relative', display: 'flex', flexDirection: 'column' }}>
           <NodePalette />
-          {/* Simple overlay for Node Palette (no message) */}
+          {/* Simple overlay for Left Panel (no message) */}
           <SimpleOverlay isVisible={isProcessing} />
         </div>
 
@@ -268,6 +271,12 @@ const App: React.FC = () => {
       <SlackManualTokenDialog
         isOpen={isSlackManualTokenDialogOpen}
         onClose={() => setIsSlackManualTokenDialogOpen(false)}
+      />
+
+      {/* Sub-Agent Flow Edit Dialog */}
+      <SubAgentFlowDialog
+        isOpen={activeSubAgentFlowId !== null}
+        onClose={() => setActiveSubAgentFlowId(null)}
       />
 
       {/* Import Workflow Loading Overlay */}

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -78,13 +78,17 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
 
     setIsSaving(true);
     try {
-      // Phase 5 (T024): Serialize workflow with conversation history
+      // Issue #89: Get subAgentFlows from store
+      const { subAgentFlows } = useWorkflowStore.getState();
+
+      // Phase 5 (T024): Serialize workflow with conversation history and subAgentFlows
       const workflow = serializeWorkflow(
         nodes,
         edges,
         workflowName,
         'Created with Workflow Studio',
-        activeWorkflow?.conversationHistory
+        activeWorkflow?.conversationHistory,
+        subAgentFlows
       );
 
       // Validate workflow before saving
@@ -189,12 +193,17 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
 
     setIsExporting(true);
     try {
-      // Serialize workflow
+      // Issue #89: Get subAgentFlows from store for export
+      const { subAgentFlows } = useWorkflowStore.getState();
+
+      // Serialize workflow with subAgentFlows
       const workflow = serializeWorkflow(
         nodes,
         edges,
         workflowName,
-        'Created with Workflow Studio'
+        'Created with Workflow Studio',
+        undefined, // conversationHistory not needed for export
+        subAgentFlows
       );
 
       // Validate workflow before export

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -35,6 +35,7 @@ import { McpNodeComponent } from './nodes/McpNode/McpNode';
 import { PromptNode } from './nodes/PromptNode';
 import { SkillNodeComponent } from './nodes/SkillNode';
 import { StartNode } from './nodes/StartNode';
+import { SubAgentFlowNodeComponent } from './nodes/SubAgentFlowNode';
 import { SubAgentNodeComponent } from './nodes/SubAgentNode';
 import { SwitchNodeComponent } from './nodes/SwitchNode';
 
@@ -56,6 +57,7 @@ const nodeTypes: NodeTypes = {
   prompt: PromptNode,
   skill: SkillNodeComponent,
   mcp: McpNodeComponent, // Feature: 001-mcp-node
+  subAgentFlow: SubAgentFlowNodeComponent, // Feature: 089-subworkflow
 };
 
 /**
@@ -91,6 +93,7 @@ export const WorkflowEditor: React.FC = () => {
     setActiveWorkflow,
     workflowName,
   } = useWorkflowStore();
+
   const { openChat, initConversation, loadConversationHistory } = useRefinementStore();
 
   /**
@@ -219,7 +222,7 @@ export const WorkflowEditor: React.FC = () => {
   ]);
 
   return (
-    <div style={{ width: '100%', height: '100%' }}>
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -267,6 +270,8 @@ export const WorkflowEditor: React.FC = () => {
                 return 'var(--vscode-charts-purple)';
               case 'skill':
                 return 'var(--vscode-charts-cyan)';
+              case 'subAgentFlow':
+                return 'var(--vscode-charts-purple)';
               default:
                 return 'var(--vscode-foreground)';
             }

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -1,0 +1,476 @@
+/**
+ * SubAgentFlowDialog Component
+ *
+ * Fullscreen dialog for editing Sub-Agent Flows
+ * Provides a clear visual distinction from the main workflow canvas
+ */
+
+import { Check, X } from 'lucide-react';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactFlow, {
+  Background,
+  type Connection,
+  Controls,
+  type DefaultEdgeOptions,
+  type EdgeTypes,
+  MiniMap,
+  type Node,
+  type NodeTypes,
+  Panel,
+  ReactFlowProvider,
+} from 'reactflow';
+import { useIsCompactMode } from '../../hooks/useWindowWidth';
+import { useTranslation } from '../../i18n/i18n-context';
+import { useWorkflowStore } from '../../stores/workflow-store';
+import { InteractionModeToggle } from '../InteractionModeToggle';
+import { NodePalette } from '../NodePalette';
+import { AskUserQuestionNodeComponent } from '../nodes/AskUserQuestionNode';
+import { BranchNodeComponent } from '../nodes/BranchNode';
+import { EndNode } from '../nodes/EndNode';
+import { IfElseNodeComponent } from '../nodes/IfElseNode';
+import { McpNodeComponent } from '../nodes/McpNode/McpNode';
+import { PromptNode } from '../nodes/PromptNode';
+import { SkillNodeComponent } from '../nodes/SkillNode';
+import { StartNode } from '../nodes/StartNode';
+import { SubAgentFlowNodeComponent } from '../nodes/SubAgentFlowNode';
+import { SubAgentNodeComponent } from '../nodes/SubAgentNode';
+import { SwitchNodeComponent } from '../nodes/SwitchNode';
+import { PropertyPanel } from '../PropertyPanel';
+
+/**
+ * Node types registration
+ */
+const nodeTypes: NodeTypes = {
+  subAgent: SubAgentNodeComponent,
+  askUserQuestion: AskUserQuestionNodeComponent,
+  branch: BranchNodeComponent,
+  ifElse: IfElseNodeComponent,
+  switch: SwitchNodeComponent,
+  start: StartNode,
+  end: EndNode,
+  prompt: PromptNode,
+  skill: SkillNodeComponent,
+  mcp: McpNodeComponent,
+  subAgentFlow: SubAgentFlowNodeComponent,
+};
+
+/**
+ * Default edge options
+ */
+const defaultEdgeOptions: DefaultEdgeOptions = {
+  animated: false,
+  style: { stroke: 'var(--vscode-foreground)', strokeWidth: 2 },
+};
+
+/**
+ * Edge types
+ */
+const edgeTypes: EdgeTypes = {};
+
+interface SubAgentFlowDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Inner component that uses ReactFlow hooks
+ */
+const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
+  const isCompact = useIsCompactMode();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const {
+    nodes,
+    edges,
+    onNodesChange,
+    onEdgesChange,
+    onConnect,
+    setSelectedNodeId,
+    interactionMode,
+    activeSubAgentFlowId,
+    subAgentFlows,
+    updateSubAgentFlow,
+    selectedNodeId,
+    isPropertyPanelOpen,
+    cancelSubAgentFlowEditing,
+  } = useWorkflowStore();
+
+  // Get active sub-agent flow info
+  const activeSubAgentFlow = useMemo(
+    () => subAgentFlows.find((sf) => sf.id === activeSubAgentFlowId),
+    [subAgentFlows, activeSubAgentFlowId]
+  );
+
+  // Sub-Agent Flow name validation state
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  // Sub-Agent Flow name pattern validation
+  const SUBAGENTFLOW_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+  // Handle name change with validation and immediate save
+  const handleNameChange = useCallback(
+    (value: string) => {
+      if (value.length === 0) {
+        setNameError(t('error.subAgentFlow.nameRequired'));
+      } else if (value.length > 50) {
+        setNameError(t('error.subAgentFlow.nameTooLong'));
+      } else if (!SUBAGENTFLOW_NAME_PATTERN.test(value)) {
+        setNameError(t('error.subAgentFlow.invalidName'));
+      } else {
+        setNameError(null);
+        // Save immediately when valid
+        if (activeSubAgentFlowId) {
+          updateSubAgentFlow(activeSubAgentFlowId, { name: value });
+        }
+      }
+    },
+    [t, activeSubAgentFlowId, updateSubAgentFlow]
+  );
+
+  // Handle Submit: Save sub-agent flow and close dialog
+  const handleSubmit = useCallback(() => {
+    // onClose will save the sub-agent flow via setActiveSubAgentFlowId(null)
+    onClose();
+  }, [onClose]);
+
+  // Handle Cancel: Discard sub-agent flow and close dialog
+  const handleCancel = useCallback(() => {
+    cancelSubAgentFlowEditing();
+  }, [cancelSubAgentFlowEditing]);
+
+  // Connection validation
+  const isValidConnection = useCallback(
+    (connection: Connection): boolean => {
+      const sourceNode = nodes.find((n) => n.id === connection.source);
+      const targetNode = nodes.find((n) => n.id === connection.target);
+
+      if (targetNode?.type === 'start') {
+        return false;
+      }
+      if (sourceNode?.type === 'end') {
+        return false;
+      }
+      return true;
+    },
+    [nodes]
+  );
+
+  // Handle node selection
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      setSelectedNodeId(node.id);
+    },
+    [setSelectedNodeId]
+  );
+
+  // Handle pane click (deselect)
+  const handlePaneClick = useCallback(() => {
+    setSelectedNodeId(null);
+  }, [setSelectedNodeId]);
+
+  // Snap grid
+  const snapGrid = useMemo<[number, number]>(() => [15, 15], []);
+
+  // Track modifier key state
+  const [isModifierKeyPressed, setIsModifierKeyPressed] = useState(false);
+
+  // Keyboard event handlers
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Only handle Escape when not focused on input
+      if (event.key === 'Escape' && document.activeElement?.tagName !== 'INPUT') {
+        handleCancel();
+        return;
+      }
+      if (event.ctrlKey || event.metaKey) {
+        setIsModifierKeyPressed(true);
+      }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (!event.ctrlKey && !event.metaKey) {
+        setIsModifierKeyPressed(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [isOpen, handleCancel]);
+
+  // Focus dialog on open
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [isOpen]);
+
+  // Calculate effective interaction mode
+  const effectiveMode = useMemo(() => {
+    if (isModifierKeyPressed) {
+      return interactionMode === 'pan' ? 'selection' : 'pan';
+    }
+    return interactionMode;
+  }, [interactionMode, isModifierKeyPressed]);
+
+  const panOnDrag = effectiveMode === 'pan';
+  const selectionOnDrag = effectiveMode === 'selection';
+
+  if (!isOpen || !activeSubAgentFlow) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        zIndex: 2000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      role="presentation"
+      onClick={handleCancel}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        style={{
+          width: '95vw',
+          height: '95vh',
+          backgroundColor: 'var(--vscode-editor-background)',
+          border: '2px solid var(--vscode-charts-purple)',
+          borderRadius: '8px',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          outline: 'none',
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="subagentflow-dialog-title"
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '12px 16px',
+            backgroundColor: 'var(--vscode-editorWidget-background)',
+            borderBottom: '2px solid var(--vscode-charts-purple)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1 }}>
+            <span
+              id="subagentflow-dialog-title"
+              style={{
+                fontSize: '12px',
+                fontWeight: 600,
+                color: 'var(--vscode-charts-purple)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                flexShrink: 0,
+              }}
+            >
+              Sub-Agent Flow
+            </span>
+            {/* Always-visible input field (Toolbar style) */}
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, maxWidth: '300px' }}>
+              <input
+                type="text"
+                value={activeSubAgentFlow.name}
+                onChange={(e) => handleNameChange(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                style={{
+                  width: '100%',
+                  padding: '4px 8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: nameError
+                    ? '1px solid var(--vscode-inputValidation-errorBorder)'
+                    : '1px solid var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  fontSize: '13px',
+                  boxSizing: 'border-box',
+                }}
+                placeholder={t('subAgentFlow.namePlaceholder')}
+              />
+              {nameError && (
+                <span
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--vscode-inputValidation-errorForeground)',
+                    marginTop: '4px',
+                  }}
+                >
+                  {nameError}
+                </span>
+              )}
+            </div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {/* Submit button */}
+            <button
+              type="button"
+              onClick={handleSubmit}
+              title={t('subAgentFlow.dialog.submit')}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '32px',
+                height: '32px',
+                backgroundColor: 'var(--vscode-button-background)',
+                color: 'var(--vscode-button-foreground)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                transition: 'background-color 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+              }}
+            >
+              <Check size={18} />
+            </button>
+            {/* Cancel button */}
+            <button
+              type="button"
+              onClick={handleCancel}
+              title={t('subAgentFlow.dialog.cancel')}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '32px',
+                height: '32px',
+                backgroundColor: 'transparent',
+                color: 'var(--vscode-foreground)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                transition: 'background-color 0.2s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--vscode-toolbar-hoverBackground)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
+              }}
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* Main Content: 3-column layout */}
+        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          {/* Left: Node Palette */}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <NodePalette />
+          </div>
+
+          {/* Center: ReactFlow Canvas */}
+          <div style={{ flex: 1, position: 'relative' }}>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+              onNodeClick={handleNodeClick}
+              onPaneClick={handlePaneClick}
+              nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
+              defaultEdgeOptions={defaultEdgeOptions}
+              isValidConnection={isValidConnection}
+              snapToGrid={true}
+              snapGrid={snapGrid}
+              panOnDrag={panOnDrag}
+              selectionOnDrag={selectionOnDrag}
+              fitView
+              attributionPosition="bottom-left"
+            >
+              <Background color="rgba(136, 87, 229, 0.3)" gap={15} size={1} />
+              <Controls />
+              <MiniMap
+                nodeColor={(node) => {
+                  switch (node.type) {
+                    case 'subAgent':
+                      return 'var(--vscode-charts-blue)';
+                    case 'askUserQuestion':
+                      return 'var(--vscode-charts-orange)';
+                    case 'branch':
+                    case 'ifElse':
+                    case 'switch':
+                      return 'var(--vscode-charts-yellow)';
+                    case 'start':
+                      return 'var(--vscode-charts-green)';
+                    case 'end':
+                      return 'var(--vscode-charts-red)';
+                    case 'prompt':
+                    case 'subAgentFlowRef':
+                      return 'var(--vscode-charts-purple)';
+                    case 'skill':
+                      return 'var(--vscode-charts-cyan)';
+                    default:
+                      return 'var(--vscode-foreground)';
+                  }
+                }}
+                maskColor="rgba(0, 0, 0, 0.5)"
+                style={{
+                  backgroundColor: 'var(--vscode-editor-background)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  width: isCompact ? 120 : 200,
+                  height: isCompact ? 80 : 150,
+                }}
+              />
+              <Panel position="top-left">
+                <InteractionModeToggle />
+              </Panel>
+            </ReactFlow>
+          </div>
+
+          {/* Right: Property Panel (conditional) */}
+          {selectedNodeId && isPropertyPanelOpen && <PropertyPanel />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * SubAgentFlowDialog with ReactFlowProvider wrapper
+ */
+export const SubAgentFlowDialog: React.FC<SubAgentFlowDialogProps> = (props) => {
+  if (!props.isOpen) {
+    return null;
+  }
+
+  return (
+    <ReactFlowProvider>
+      <SubAgentFlowDialogContent {...props} />
+    </ReactFlowProvider>
+  );
+};
+
+export default SubAgentFlowDialog;

--- a/src/webview/src/components/nodes/SubAgentFlowNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentFlowNode.tsx
@@ -1,0 +1,185 @@
+/**
+ * Claude Code Workflow Studio - SubAgentFlow Node Component
+ *
+ * Feature: 089-subworkflow
+ * Purpose: Display and edit SubAgentFlow nodes on the React Flow canvas
+ *
+ * SubAgentFlow nodes reference and execute sub-agent flows defined in the same workflow file.
+ * At runtime, sub-agent flows are executed as Sub-Agents.
+ */
+
+import type { SubAgentFlowNodeData } from '@shared/types/workflow-definition';
+import { GitBranch } from 'lucide-react';
+import React from 'react';
+import { Handle, type NodeProps, Position } from 'reactflow';
+import { useTranslation } from '../../i18n/i18n-context';
+import { useWorkflowStore } from '../../stores/workflow-store';
+import { DeleteButton } from './DeleteButton';
+
+/**
+ * SubAgentFlowNode Component
+ *
+ * Displays a reference to a sub-agent flow that will be executed when this node is reached.
+ */
+export const SubAgentFlowNodeComponent: React.FC<NodeProps<SubAgentFlowNodeData>> = React.memo(
+  ({ id, data, selected }) => {
+    const { t } = useTranslation();
+    const { subAgentFlows } = useWorkflowStore();
+
+    // Find the referenced sub-agent flow to show its details
+    const referencedSubAgentFlow = subAgentFlows.find((sf) => sf.id === data.subAgentFlowId);
+    const isLinked = !!referencedSubAgentFlow;
+    const nodeCount = referencedSubAgentFlow?.nodes?.length ?? 0;
+
+    return (
+      <div
+        className={`subagentflow-ref-node ${selected ? 'selected' : ''}`}
+        style={{
+          position: 'relative',
+          padding: '12px',
+          borderRadius: '8px',
+          border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-charts-purple)'}`,
+          backgroundColor: 'var(--vscode-editor-background)',
+          minWidth: '180px',
+          maxWidth: '280px',
+        }}
+      >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
+
+        {/* Node Header */}
+        <div
+          style={{
+            fontSize: '11px',
+            fontWeight: 600,
+            color: 'var(--vscode-charts-purple)',
+            marginBottom: '8px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+          }}
+        >
+          <GitBranch size={12} />
+          <span>{t('node.subAgentFlow.title')}</span>
+          {/* Warning indicator for unlinked state */}
+          {!isLinked && (
+            <span
+              style={{
+                fontSize: '12px',
+                color: 'var(--vscode-editorWarning-foreground)',
+                fontWeight: 'bold',
+              }}
+              title={t('node.subAgentFlow.notLinked')}
+            >
+              ⚠
+            </span>
+          )}
+        </div>
+
+        {/* Sub-Agent Flow Name */}
+        <div
+          style={{
+            fontSize: '13px',
+            color: 'var(--vscode-foreground)',
+            marginBottom: '8px',
+            fontWeight: 500,
+          }}
+        >
+          {data.label || t('node.subAgentFlow.untitled')}
+        </div>
+
+        {/* Description */}
+        {data.description && (
+          <div
+            style={{
+              fontSize: '11px',
+              color: 'var(--vscode-descriptionForeground)',
+              marginBottom: '8px',
+              lineHeight: '1.4',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {data.description}
+          </div>
+        )}
+
+        {/* Sub-Agent Flow Info Badge */}
+        {isLinked && (
+          <div
+            style={{
+              fontSize: '10px',
+              color: 'var(--vscode-badge-foreground)',
+              backgroundColor: 'var(--vscode-badge-background)',
+              padding: '2px 6px',
+              borderRadius: '3px',
+              display: 'inline-block',
+              fontWeight: 600,
+            }}
+          >
+            {nodeCount} nodes
+          </div>
+        )}
+
+        {/* Not linked warning */}
+        {!isLinked && data.subAgentFlowId && (
+          <div
+            style={{
+              fontSize: '10px',
+              color: 'var(--vscode-editorWarning-foreground)',
+              marginTop: '4px',
+            }}
+          >
+            {t('node.subAgentFlow.subAgentFlowNotFound')}
+          </div>
+        )}
+
+        {/* Not configured message */}
+        {!data.subAgentFlowId && (
+          <div
+            style={{
+              fontSize: '10px',
+              color: 'var(--vscode-descriptionForeground)',
+              fontStyle: 'italic',
+            }}
+          >
+            {t('node.subAgentFlow.selectSubAgentFlow')}
+          </div>
+        )}
+
+        {/* Input Handle */}
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="input"
+          style={{
+            width: '12px',
+            height: '12px',
+            backgroundColor: 'var(--vscode-charts-purple)',
+            border: '2px solid var(--vscode-button-foreground)',
+          }}
+        />
+
+        {/* Output Handle */}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="output"
+          style={{
+            width: '12px',
+            height: '12px',
+            backgroundColor: 'var(--vscode-charts-purple)',
+            border: '2px solid var(--vscode-button-foreground)',
+          }}
+        />
+      </div>
+    );
+  }
+);
+
+SubAgentFlowNodeComponent.displayName = 'SubAgentFlowNode';

--- a/src/webview/src/constants/node-type-labels.ts
+++ b/src/webview/src/constants/node-type-labels.ts
@@ -7,6 +7,7 @@
 
 export const NODE_TYPE_LABELS: Record<string, string> = {
   subAgent: 'Sub-Agent',
+  subAgentFlow: 'Sub-Agent Flow',
   askUserQuestion: 'Ask User Question',
   branch: 'Branch',
   ifElse: 'If/Else',

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -7,8 +7,8 @@
 import type { Config as DriverConfig, DriveStep } from 'driver.js';
 
 // Tour step indices (0-based)
-export const CANVAS_STEP_INDEX = 3;
-export const PROPERTY_PANEL_STEP_INDEX = 4;
+export const CANVAS_STEP_INDEX = 11;
+export const PROPERTY_PANEL_STEP_INDEX = 12;
 
 /**
  * Tour steps configuration
@@ -53,6 +53,78 @@ export const getTourSteps = (
     },
   },
   {
+    element: '[data-tour="add-subagent-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addSubAgent'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-subagentflow-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addSubAgentFlow'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-skill-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addSkill'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-mcp-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addMcp'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-ifelse-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addIfElse'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-switch-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addSwitch'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-askuserquestion-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addAskUserQuestion'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="add-end-button"]',
+    popover: {
+      title: '',
+      description: t('tour.addEnd'),
+      side: 'right',
+      align: 'start',
+    },
+  },
+  {
     popover: {
       title: '',
       description: t('tour.canvas'),
@@ -84,22 +156,6 @@ export const getTourSteps = (
       onNextClick: () => {
         callbacks?.onDeselectNode?.();
         callbacks?.moveNext?.();
-      },
-    },
-  },
-  {
-    element: '[data-tour="add-askuserquestion-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addAskUserQuestion'),
-      side: 'right',
-      align: 'center',
-      // Select Start node when going back to property panel step
-      onPrevClick: () => {
-        callbacks?.onSelectStartNode?.();
-        setTimeout(() => {
-          callbacks?.movePrevious?.();
-        }, 50);
       },
     },
   },

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -72,7 +72,37 @@ export interface WebviewTranslationKeys {
   'node.skill.title': string;
   'node.skill.description': string;
 
+  // SubAgentFlow Node (Feature: 089-subworkflow)
+  'node.subAgentFlow.title': string;
+  'node.subAgentFlow.description': string;
+  'node.subAgentFlow.linked': string;
+  'node.subAgentFlow.notLinked': string;
+  'node.subAgentFlow.untitled': string;
+  'node.subAgentFlow.subAgentFlowNotFound': string;
+  'node.subAgentFlow.selectSubAgentFlow': string;
+
+  // SubAgentFlow Panel (Feature: 089-subworkflow)
+  'subAgentFlow.panel.title': string;
+  'subAgentFlow.create': string;
+  'subAgentFlow.delete': string;
+  'subAgentFlow.mainWorkflow': string;
+  'subAgentFlow.empty': string;
+  'subAgentFlow.default.name': string;
+  'subAgentFlow.editing': string;
+  'subAgentFlow.edit': string;
+  'subAgentFlow.clickToEdit': string;
+  'subAgentFlow.namePlaceholder': string;
+  'subAgentFlow.dialog.close': string;
+  'subAgentFlow.dialog.submit': string;
+  'subAgentFlow.dialog.cancel': string;
+
+  // SubAgentFlow validation errors
+  'error.subAgentFlow.nameRequired': string;
+  'error.subAgentFlow.nameTooLong': string;
+  'error.subAgentFlow.invalidName': string;
+
   // Quick start instructions
+  'palette.nestedNotAllowed': string;
   'palette.instruction.addNode': string;
   'palette.instruction.dragNode': string;
   'palette.instruction.connectNodes': string;
@@ -188,9 +218,16 @@ export interface WebviewTranslationKeys {
   'tour.welcome': string;
   'tour.nodePalette': string;
   'tour.addPrompt': string;
+  'tour.addSubAgent': string;
+  'tour.addSubAgentFlow': string;
+  'tour.addSkill': string;
+  'tour.addMcp': string;
+  'tour.addAskUserQuestion': string;
+  'tour.addEnd': string;
+  'tour.addIfElse': string;
+  'tour.addSwitch': string;
   'tour.canvas': string;
   'tour.propertyPanel': string;
-  'tour.addAskUserQuestion': string;
   'tour.connectNodes': string;
   'tour.workflowName': string;
   'tour.saveWorkflow': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -75,7 +75,38 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'node.skill.title': 'Skill',
   'node.skill.description': 'Execute a Claude Code Skill',
 
+  // SubAgentFlow Node (Feature: 089-subworkflow)
+  'node.subAgentFlow.title': 'Sub-Agent Flow',
+  'node.subAgentFlow.description': 'Execute Sub-Agent with detailed control',
+  'node.subAgentFlow.linked': 'Linked',
+  'node.subAgentFlow.notLinked': 'Not linked',
+  'node.subAgentFlow.untitled': 'Untitled Sub-Agent Flow',
+  'node.subAgentFlow.subAgentFlowNotFound': 'Sub-Agent Flow not found',
+  'node.subAgentFlow.selectSubAgentFlow': 'Select a sub-agent flow to execute',
+
+  // SubAgentFlow Panel (Feature: 089-subworkflow)
+  'subAgentFlow.panel.title': 'Sub-Agent Flows',
+  'subAgentFlow.create': 'New',
+  'subAgentFlow.delete': 'Delete',
+  'subAgentFlow.mainWorkflow': 'Main Workflow',
+  'subAgentFlow.empty': 'No sub-agent flows yet',
+  'subAgentFlow.default.name': 'subagentflow',
+  'subAgentFlow.editing': 'Editing:',
+  'subAgentFlow.edit': 'Edit Sub-Agent Flow',
+  'subAgentFlow.clickToEdit': 'Click to edit name',
+  'subAgentFlow.namePlaceholder': 'e.g., data-processing',
+  'subAgentFlow.dialog.close': 'Close and return to main workflow',
+  'subAgentFlow.dialog.submit': 'Submit and add to workflow',
+  'subAgentFlow.dialog.cancel': 'Cancel and discard changes',
+
+  // SubAgentFlow validation errors
+  'error.subAgentFlow.nameRequired': 'Name is required',
+  'error.subAgentFlow.nameTooLong': 'Name must be 50 characters or less',
+  'error.subAgentFlow.invalidName':
+    'Name must contain only letters, numbers, hyphens, and underscores',
+
   // Quick start instructions
+  'palette.nestedNotAllowed': 'Not available in Sub-Agent Flow (nesting not supported)',
   'palette.instruction.addNode': 'Click a node to add it to the canvas',
   'palette.instruction.dragNode': 'Drag nodes to reposition them',
   'palette.instruction.connectNodes': 'Connect nodes by dragging from output to input handles',
@@ -196,12 +227,26 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
     'The Node Palette contains various nodes you can use in your workflow.\n\nClick on Prompt, Sub-Agent, AskUserQuestion, If/Else, Switch, and other nodes to add them to the canvas.',
   'tour.addPrompt':
     'This "Prompt" button lets you add Prompt nodes to the canvas.\n\nA Prompt node is a template that supports variables and is the basic building block of workflows.',
+  'tour.addSubAgent':
+    'The "Sub-Agent" node is a specialized agent that executes specific tasks.\n\nConfigure prompts and tool restrictions to create agents with single responsibilities.',
+  'tour.addSubAgentFlow':
+    '"Sub-Agent Flow" allows you to visually define complex Sub-Agent processing flows.\n\nTo run MCP or Skills in parallel, wrap each process in a Sub-Agent Flow and create a flow that executes those Sub-Agent Flows in parallel.',
+  'tour.addSkill':
+    'The "Skill" node calls Claude Code skills.\n\nSelect and execute skills from personal (~/.claude/skills/) or project (.claude/skills/) directories.',
+  'tour.addMcp':
+    'The "MCP Tool" node executes MCP server tools.\n\nUse it for external service integration or custom tool invocation.',
+  'tour.addAskUserQuestion':
+    'The "AskUserQuestion" node lets you branch the workflow based on user selection.\n\nYou can add it to the canvas using this button.',
+  'tour.addEnd':
+    'The "End" node marks the endpoint of a workflow.\n\nYou can place multiple End nodes to set different endpoints based on outcomes.',
+  'tour.addIfElse':
+    'The "If/Else" node branches the workflow in two directions based on a condition.\n\nSet True or False conditions to control the flow of processing.',
+  'tour.addSwitch':
+    'The "Switch" node branches the workflow in multiple directions based on multiple conditions.\n\nSet multiple cases and a default case to implement complex branching logic.',
   'tour.canvas':
     'This is the canvas. Drag nodes to adjust their position and drag handles to connect nodes.\n\nStart and End nodes are already placed.',
   'tour.propertyPanel':
     'The Property Panel lets you configure the selected node.\n\nYou can edit node name, prompt, model selection, and more.',
-  'tour.addAskUserQuestion':
-    'The "AskUserQuestion" node lets you branch the workflow based on user selection.\n\nYou can add it to the canvas using this button.',
   'tour.connectNodes':
     'Connect nodes to create your workflow.\n\nDrag from the output handle (⚪) on the right of a node to the input handle on the left of another node.',
   'tour.workflowName':

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -75,7 +75,37 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'node.skill.title': 'Skill',
   'node.skill.description': 'Claude Code Skillを実行',
 
+  // SubAgentFlow Node (Feature: 089-subworkflow)
+  'node.subAgentFlow.title': 'Sub-Agent Flow',
+  'node.subAgentFlow.description': 'Sub-Agentを詳細に制御して実行',
+  'node.subAgentFlow.linked': 'リンク済み',
+  'node.subAgentFlow.notLinked': '未リンク',
+  'node.subAgentFlow.untitled': '無題のサブエージェントフロー',
+  'node.subAgentFlow.subAgentFlowNotFound': 'サブエージェントフローが見つかりません',
+  'node.subAgentFlow.selectSubAgentFlow': '実行するサブエージェントフローを選択',
+
+  // SubAgentFlow Panel (Feature: 089-subworkflow)
+  'subAgentFlow.panel.title': 'サブエージェントフロー',
+  'subAgentFlow.create': '新規',
+  'subAgentFlow.delete': '削除',
+  'subAgentFlow.mainWorkflow': 'メインワークフロー',
+  'subAgentFlow.empty': 'サブエージェントフローがありません',
+  'subAgentFlow.default.name': 'subagentflow',
+  'subAgentFlow.editing': '編集中:',
+  'subAgentFlow.edit': 'Sub-Agent Flowを編集',
+  'subAgentFlow.clickToEdit': 'クリックして名前を編集',
+  'subAgentFlow.namePlaceholder': '例: data-processing',
+  'subAgentFlow.dialog.close': '閉じてメインワークフローに戻る',
+  'subAgentFlow.dialog.submit': '確定してワークフローに追加',
+  'subAgentFlow.dialog.cancel': 'キャンセルして変更を破棄',
+
+  // SubAgentFlow validation errors
+  'error.subAgentFlow.nameRequired': '名前は必須です',
+  'error.subAgentFlow.nameTooLong': '名前は50文字以内で入力してください',
+  'error.subAgentFlow.invalidName': '名前は英数字、ハイフン、アンダースコアのみ使用できます',
+
   // Quick start instructions
+  'palette.nestedNotAllowed': 'サブエージェントフロー内では使用できません（ネスト非対応）',
   'palette.instruction.addNode': 'ノードをクリックしてキャンバスに追加',
   'palette.instruction.dragNode': 'ノードをドラッグして移動',
   'palette.instruction.connectNodes': '出力ハンドルから入力ハンドルへドラッグして接続',
@@ -197,12 +227,26 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
     'ノードパレットには、ワークフローで使用できる様々なノードが用意されています。\n\nPrompt、Sub-Agent、AskUserQuestion、If/Else、Switchなどのノードをクリックしてキャンバスに追加できます。',
   'tour.addPrompt':
     'この「Prompt」ボタンから、Promptノードをキャンバスに追加できます。\n\nPromptノードは変数を使用できるテンプレートで、ワークフローの基本的な構成要素です。',
+  'tour.addSubAgent':
+    '「Sub-Agent」ノードは、特定のタスクを実行する専門のエージェントです。\n\nプロンプトとツール制限を設定して、単一の責務を持つエージェントを作成できます。',
+  'tour.addSubAgentFlow':
+    '「Sub-Agent Flow」は、複雑なSub-Agentの処理フローを視覚的に定義できます。\n\nMCPやSkillを並列実行したい場合は、各処理をSub-Agent Flowに内包し、それらのSub-Agent Flowを並列実行するフローを作成することで実現できます。',
+  'tour.addSkill':
+    '「Skill」ノードは、Claude Codeのスキルを呼び出します。\n\n個人用（~/.claude/skills/）またはプロジェクト用（.claude/skills/）のスキルを選択して実行できます。',
+  'tour.addMcp':
+    '「MCP Tool」ノードは、MCPサーバーのツールを実行します。\n\n外部サービスとの連携やカスタムツールの呼び出しに使用できます。',
+  'tour.addAskUserQuestion':
+    '「AskUserQuestion」ノードは、ユーザーの選択に応じてワークフローを分岐させるために使用します。\n\nこのボタンからキャンバスに追加できます。',
+  'tour.addEnd':
+    '「End」ノードは、ワークフローの終了点を示します。\n\n複数のEndノードを配置して、異なる結果に応じた終了点を設定できます。',
+  'tour.addIfElse':
+    '「If/Else」ノードは、条件に基づいてワークフローを2方向に分岐させます。\n\n真（True）または偽（False）の条件を設定して、処理の流れを制御できます。',
+  'tour.addSwitch':
+    '「Switch」ノードは、複数の条件に基づいてワークフローを多方向に分岐させます。\n\n複数のケースとデフォルトケースを設定して、複雑な分岐ロジックを実現できます。',
   'tour.canvas':
     'ここがキャンバスです。ノードをドラッグして配置を調整し、ハンドルをドラッグしてノード間を接続できます。\n\n既にStartノードとEndノードが配置されています。',
   'tour.propertyPanel':
     'プロパティパネルでは、選択したノードの詳細設定を行います。\n\nノード名、プロンプト、モデル選択などを編集できます。',
-  'tour.addAskUserQuestion':
-    '「AskUserQuestion」ノードは、ユーザーの選択に応じてワークフローを分岐させるために使用します。\n\nこのボタンからキャンバスに追加できます。',
   'tour.connectNodes':
     'ノードを接続してワークフローを作りましょう。\n\nノードの右側の出力ハンドル(⚪)を別のノードの左側の入力ハンドルにドラッグして接続します。',
   'tour.workflowName':

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -76,7 +76,37 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'node.skill.title': 'Skill',
   'node.skill.description': 'Claude Code Skill 실행',
 
+  // SubAgentFlow Node (Feature: 089-subworkflow)
+  'node.subAgentFlow.title': 'Sub-Agent Flow',
+  'node.subAgentFlow.description': 'Sub-Agent를 세부적으로 제어하여 실행',
+  'node.subAgentFlow.linked': '연결됨',
+  'node.subAgentFlow.notLinked': '연결 안 됨',
+  'node.subAgentFlow.untitled': '제목 없는 서브 에이전트 플로우',
+  'node.subAgentFlow.subAgentFlowNotFound': '서브 에이전트 플로우를 찾을 수 없음',
+  'node.subAgentFlow.selectSubAgentFlow': '실행할 서브 에이전트 플로우 선택',
+
+  // SubAgentFlow Panel (Feature: 089-subworkflow)
+  'subAgentFlow.panel.title': '서브 에이전트 플로우',
+  'subAgentFlow.create': '새로 만들기',
+  'subAgentFlow.delete': '삭제',
+  'subAgentFlow.mainWorkflow': '메인 워크플로우',
+  'subAgentFlow.empty': '서브 에이전트 플로우가 없습니다',
+  'subAgentFlow.default.name': 'subagentflow',
+  'subAgentFlow.editing': '편집 중:',
+  'subAgentFlow.edit': 'Sub-Agent Flow 편집',
+  'subAgentFlow.clickToEdit': '클릭하여 이름 편집',
+  'subAgentFlow.namePlaceholder': '예: data-processing',
+  'subAgentFlow.dialog.close': '닫고 메인 워크플로우로 돌아가기',
+  'subAgentFlow.dialog.submit': '확정하고 워크플로우에 추가',
+  'subAgentFlow.dialog.cancel': '취소하고 변경 사항 삭제',
+
+  // SubAgentFlow validation errors
+  'error.subAgentFlow.nameRequired': '이름은 필수입니다',
+  'error.subAgentFlow.nameTooLong': '이름은 50자 이하여야 합니다',
+  'error.subAgentFlow.invalidName': '이름은 영문자, 숫자, 하이픈, 밑줄만 사용할 수 있습니다',
+
   // Quick start instructions
+  'palette.nestedNotAllowed': '서브 에이전트 플로우에서 사용할 수 없습니다 (중첩 미지원)',
   'palette.instruction.addNode': '노드를 클릭하여 캔버스에 추가',
   'palette.instruction.dragNode': '노드를 드래그하여 재배치',
   'palette.instruction.connectNodes': '출력에서 입력 핸들로 드래그하여 연결',
@@ -199,12 +229,26 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
     '노드 팔레트에는 워크플로우에서 사용할 수 있는 다양한 노드가 있습니다.\n\nPrompt, Sub-Agent, AskUserQuestion, If/Else, Switch 등의 노드를 클릭하여 캔버스에 추가할 수 있습니다.',
   'tour.addPrompt':
     '이 "Prompt" 버튼으로 캔버스에 Prompt 노드를 추가할 수 있습니다.\n\nPrompt 노드는 변수를 지원하는 템플릿으로 워크플로우의 기본 구성 요소입니다.',
+  'tour.addSubAgent':
+    '"Sub-Agent" 노드는 특정 작업을 실행하는 전문 에이전트입니다.\n\n프롬프트와 도구 제한을 설정하여 단일 책임을 가진 에이전트를 만들 수 있습니다.',
+  'tour.addSubAgentFlow':
+    '"Sub-Agent Flow"는 복잡한 Sub-Agent 처리 흐름을 시각적으로 정의할 수 있습니다.\n\nMCP나 Skill을 병렬로 실행하려면 각 처리를 Sub-Agent Flow에 포함하고 해당 Sub-Agent Flow들을 병렬로 실행하는 흐름을 만들면 됩니다.',
+  'tour.addSkill':
+    '"Skill" 노드는 Claude Code 스킬을 호출합니다.\n\n개인용(~/.claude/skills/) 또는 프로젝트용(.claude/skills/) 스킬을 선택하여 실행할 수 있습니다.',
+  'tour.addMcp':
+    '"MCP Tool" 노드는 MCP 서버 도구를 실행합니다.\n\n외부 서비스 연동이나 커스텀 도구 호출에 사용할 수 있습니다.',
+  'tour.addAskUserQuestion':
+    '"AskUserQuestion" 노드는 사용자 선택에 따라 워크플로우를 분기하는 데 사용됩니다.\n\n이 버튼으로 캔버스에 추가할 수 있습니다.',
+  'tour.addEnd':
+    '"End" 노드는 워크플로우의 종료 지점을 나타냅니다.\n\n여러 End 노드를 배치하여 결과에 따른 다른 종료 지점을 설정할 수 있습니다.',
+  'tour.addIfElse':
+    '"If/Else" 노드는 조건에 따라 워크플로우를 두 방향으로 분기합니다.\n\n참(True) 또는 거짓(False) 조건을 설정하여 처리 흐름을 제어할 수 있습니다.',
+  'tour.addSwitch':
+    '"Switch" 노드는 여러 조건에 따라 워크플로우를 다방향으로 분기합니다.\n\n여러 케이스와 기본 케이스를 설정하여 복잡한 분기 로직을 구현할 수 있습니다.',
   'tour.canvas':
     '여기가 캔버스입니다. 노드를 드래그하여 위치를 조정하고 핸들을 드래그하여 노드를 연결할 수 있습니다.\n\n시작 및 종료 노드가 이미 배치되어 있습니다.',
   'tour.propertyPanel':
     '속성 패널에서 선택한 노드를 구성할 수 있습니다.\n\n노드 이름, 프롬프트, 모델 선택 등을 편집할 수 있습니다.',
-  'tour.addAskUserQuestion':
-    '"AskUserQuestion" 노드는 사용자 선택에 따라 워크플로우를 분기하는 데 사용됩니다.\n\n이 버튼으로 캔버스에 추가할 수 있습니다.',
   'tour.connectNodes':
     '노드를 연결하여 워크플로우를 만드세요.\n\n노드 오른쪽의 출력 핸들(⚪)에서 다른 노드 왼쪽의 입력 핸들로 드래그하세요.',
   'tour.workflowName':

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -74,7 +74,37 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'node.skill.title': 'Skill',
   'node.skill.description': '执行Claude Code Skill',
 
+  // SubAgentFlow Node (Feature: 089-subworkflow)
+  'node.subAgentFlow.title': 'Sub-Agent Flow',
+  'node.subAgentFlow.description': '详细控制Sub-Agent并执行',
+  'node.subAgentFlow.linked': '已链接',
+  'node.subAgentFlow.notLinked': '未链接',
+  'node.subAgentFlow.untitled': '未命名子代理流程',
+  'node.subAgentFlow.subAgentFlowNotFound': '未找到子代理流程',
+  'node.subAgentFlow.selectSubAgentFlow': '选择要执行的子代理流程',
+
+  // SubAgentFlow Panel (Feature: 089-subworkflow)
+  'subAgentFlow.panel.title': '子代理流程',
+  'subAgentFlow.create': '新建',
+  'subAgentFlow.delete': '删除',
+  'subAgentFlow.mainWorkflow': '主工作流',
+  'subAgentFlow.empty': '暂无子代理流程',
+  'subAgentFlow.default.name': 'subagentflow',
+  'subAgentFlow.editing': '编辑中:',
+  'subAgentFlow.edit': '编辑 Sub-Agent Flow',
+  'subAgentFlow.clickToEdit': '点击编辑名称',
+  'subAgentFlow.namePlaceholder': '例如: data-processing',
+  'subAgentFlow.dialog.close': '关闭并返回主工作流',
+  'subAgentFlow.dialog.submit': '确认并添加到工作流',
+  'subAgentFlow.dialog.cancel': '取消并放弃更改',
+
+  // SubAgentFlow validation errors
+  'error.subAgentFlow.nameRequired': '名称为必填项',
+  'error.subAgentFlow.nameTooLong': '名称不能超过50个字符',
+  'error.subAgentFlow.invalidName': '名称只能包含字母、数字、连字符和下划线',
+
   // Quick start instructions
+  'palette.nestedNotAllowed': '在子代理流程中不可用（不支持嵌套）',
   'palette.instruction.addNode': '点击节点将其添加到画布',
   'palette.instruction.dragNode': '拖动节点以重新定位',
   'palette.instruction.connectNodes': '从输出拖动到输入句柄以连接节点',
@@ -193,10 +223,23 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
     '节点面板包含可在工作流中使用的各种节点。\n\n点击Prompt、Sub-Agent、AskUserQuestion、If/Else、Switch等节点将其添加到画布。',
   'tour.addPrompt':
     '这个"Prompt"按钮可以将Prompt节点添加到画布。\n\nPrompt节点是支持变量的模板，是工作流的基本构建块。',
-  'tour.canvas': '这是画布。拖动节点调整位置，拖动手柄连接节点。\n\n已经放置了开始和结束节点。',
-  'tour.propertyPanel': '属性面板可以配置所选节点。\n\n您可以编辑节点名称、提示、模型选择等。',
+  'tour.addSubAgent':
+    '"Sub-Agent"节点是执行特定任务的专业代理。\n\n配置提示和工具限制，创建具有单一职责的代理。',
+  'tour.addSubAgentFlow':
+    '「Sub-Agent Flow」可以可视化定义复杂的Sub-Agent处理流程。\n\n如果您想并行执行MCP或Skill，可以将各处理包含在Sub-Agent Flow中，然后创建并行执行这些Sub-Agent Flow的工作流来实现。',
+  'tour.addSkill':
+    '"Skill"节点调用Claude Code技能。\n\n可以选择并执行个人用（~/.claude/skills/）或项目用（.claude/skills/）的技能。',
+  'tour.addMcp': '"MCP Tool"节点执行MCP服务器工具。\n\n可用于外部服务集成或自定义工具调用。',
   'tour.addAskUserQuestion':
     '"AskUserQuestion"节点用于根据用户选择分支工作流。\n\n可以使用此按钮将其添加到画布。',
+  'tour.addEnd':
+    '"End"节点表示工作流的结束点。\n\n可以放置多个End节点，根据不同结果设置不同的结束点。',
+  'tour.addIfElse':
+    '"If/Else"节点根据条件将工作流分成两个方向。\n\n设置真（True）或假（False）条件来控制处理流程。',
+  'tour.addSwitch':
+    '"Switch"节点根据多个条件将工作流分成多个方向。\n\n设置多个案例和默认案例来实现复杂的分支逻辑。',
+  'tour.canvas': '这是画布。拖动节点调整位置，拖动手柄连接节点。\n\n已经放置了开始和结束节点。',
+  'tour.propertyPanel': '属性面板可以配置所选节点。\n\n您可以编辑节点名称、提示、模型选择等。',
   'tour.connectNodes':
     '连接节点以创建工作流。\n\n从节点右侧的输出手柄(⚪)拖动到另一个节点左侧的输入手柄。',
   'tour.workflowName': '在这里可以为工作流命名。\n\n可以使用字母、数字、连字符和下划线。',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -74,7 +74,37 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'node.skill.title': 'Skill',
   'node.skill.description': '執行Claude Code Skill',
 
+  // SubAgentFlow Node (Feature: 089-subworkflow)
+  'node.subAgentFlow.title': 'Sub-Agent Flow',
+  'node.subAgentFlow.description': '詳細控制Sub-Agent並執行',
+  'node.subAgentFlow.linked': '已連結',
+  'node.subAgentFlow.notLinked': '未連結',
+  'node.subAgentFlow.untitled': '未命名子代理流程',
+  'node.subAgentFlow.subAgentFlowNotFound': '找不到子代理流程',
+  'node.subAgentFlow.selectSubAgentFlow': '選擇要執行的子代理流程',
+
+  // SubAgentFlow Panel (Feature: 089-subworkflow)
+  'subAgentFlow.panel.title': '子代理流程',
+  'subAgentFlow.create': '新增',
+  'subAgentFlow.delete': '刪除',
+  'subAgentFlow.mainWorkflow': '主工作流程',
+  'subAgentFlow.empty': '尚無子代理流程',
+  'subAgentFlow.default.name': 'subagentflow',
+  'subAgentFlow.editing': '編輯中:',
+  'subAgentFlow.edit': '編輯 Sub-Agent Flow',
+  'subAgentFlow.clickToEdit': '點擊編輯名稱',
+  'subAgentFlow.namePlaceholder': '例如: data-processing',
+  'subAgentFlow.dialog.close': '關閉並返回主工作流程',
+  'subAgentFlow.dialog.submit': '確認並新增到工作流程',
+  'subAgentFlow.dialog.cancel': '取消並捨棄變更',
+
+  // SubAgentFlow validation errors
+  'error.subAgentFlow.nameRequired': '名稱為必填項',
+  'error.subAgentFlow.nameTooLong': '名稱不能超過50個字元',
+  'error.subAgentFlow.invalidName': '名稱只能包含字母、數字、連字符和底線',
+
   // Quick start instructions
+  'palette.nestedNotAllowed': '在子代理流程中不可用（不支援巢狀）',
   'palette.instruction.addNode': '點擊節點將其新增到畫布',
   'palette.instruction.dragNode': '拖動節點以重新定位',
   'palette.instruction.connectNodes': '從輸出拖動到輸入控點以連接節點',
@@ -193,10 +223,23 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
     '節點面板包含可在工作流程中使用的各種節點。\n\n點擊Prompt、Sub-Agent、AskUserQuestion、If/Else、Switch等節點將其新增到畫布。',
   'tour.addPrompt':
     '這個「Prompt」按鈕可以將Prompt節點新增到畫布。\n\nPrompt節點是支援變數的範本，是工作流程的基本建置區塊。',
-  'tour.canvas': '這是畫布。拖曳節點調整位置，拖曳手柄連接節點。\n\n已經放置了開始和結束節點。',
-  'tour.propertyPanel': '屬性面板可以設定所選節點。\n\n您可以編輯節點名稱、提示、模型選擇等。',
+  'tour.addSubAgent':
+    '「Sub-Agent」節點是執行特定任務的專業代理。\n\n配置提示和工具限制，建立具有單一職責的代理。',
+  'tour.addSubAgentFlow':
+    '「Sub-Agent Flow」可以視覺化定義複雜的Sub-Agent處理流程。\n\n如果您想並行執行MCP或Skill，可以將各處理包含在Sub-Agent Flow中，然後建立並行執行這些Sub-Agent Flow的工作流程來實現。',
+  'tour.addSkill':
+    '「Skill」節點呼叫Claude Code技能。\n\n可以選擇並執行個人用（~/.claude/skills/）或專案用（.claude/skills/）的技能。',
+  'tour.addMcp': '「MCP Tool」節點執行MCP伺服器工具。\n\n可用於外部服務整合或自訂工具呼叫。',
   'tour.addAskUserQuestion':
     '「AskUserQuestion」節點用於根據使用者選擇分支工作流程。\n\n可以使用此按鈕將其新增到畫布。',
+  'tour.addEnd':
+    '「End」節點表示工作流程的結束點。\n\n可以放置多個End節點，根據不同結果設定不同的結束點。',
+  'tour.addIfElse':
+    '「If/Else」節點根據條件將工作流程分成兩個方向。\n\n設定真（True）或假（False）條件來控制處理流程。',
+  'tour.addSwitch':
+    '「Switch」節點根據多個條件將工作流程分成多個方向。\n\n設定多個案例和預設案例來實現複雜的分支邏輯。',
+  'tour.canvas': '這是畫布。拖曳節點調整位置，拖曳手柄連接節點。\n\n已經放置了開始和結束節點。',
+  'tour.propertyPanel': '屬性面板可以設定所選節點。\n\n您可以編輯節點名稱、提示、模型選擇等。',
   'tour.connectNodes':
     '連接節點以建立工作流程。\n\n從節點右側的輸出手柄(⚪)拖曳到另一個節點左側的輸入手柄。',
   'tour.workflowName': '在這裡可以為工作流程命名。\n\n可以使用字母、數字、連字號和底線。',

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -8,6 +8,7 @@
 import type {
   Connection,
   ConversationHistory,
+  SubAgentFlow,
   Workflow,
   WorkflowNode,
 } from '@shared/types/workflow-definition';
@@ -21,6 +22,7 @@ import type { Edge, Node } from 'reactflow';
  * @param workflowName - Workflow name
  * @param workflowDescription - Workflow description
  * @param conversationHistory - Optional conversation history to preserve
+ * @param subAgentFlows - Optional sub-agent flows to include
  * @returns Workflow definition
  */
 export function serializeWorkflow(
@@ -28,7 +30,8 @@ export function serializeWorkflow(
   edges: Edge[],
   workflowName: string,
   workflowDescription?: string,
-  conversationHistory?: ConversationHistory
+  conversationHistory?: ConversationHistory,
+  subAgentFlows?: SubAgentFlow[]
 ): Workflow {
   // Convert React Flow nodes to WorkflowNodes
   const workflowNodes: WorkflowNode[] = nodes.map((node) => ({
@@ -61,6 +64,8 @@ export function serializeWorkflow(
     updatedAt: new Date(),
     // Phase 5 (T024): Include conversation history if provided
     conversationHistory,
+    // Issue #89: Include subAgentFlows if provided
+    subAgentFlows,
   };
 
   return workflow;


### PR DESCRIPTION
## Summary

Adds Sub-Agent Flow (SubWorkflow) support to Claude Code Workflow Studio as a Beta feature, allowing users to create reusable workflow components that can be referenced from the main workflow.

- Introduced new Sub-Agent Flow node type with visual editor
- Added Sub-Agent Flow panel for managing multiple flows
- Canvas context switching between main workflow and sub-agent flows
- Export integration for Sub-Agent Flows as individual files
- Full i18n support (5 languages: en, ja, ko, zh-CN, zh-TW)
- Comprehensive onboarding tour updates

## Changes

### New Components
- `SubAgentFlowNode.tsx`: Canvas node displaying linked sub-agent flow status
- `SubAgentFlowDialog.tsx`: Dialog for creating/renaming sub-agent flows

### Core Features
- **Sub-Agent Flow Management**: Create, rename, delete sub-agent flows via panel
- **Canvas Switching**: Edit main workflow or any sub-agent flow
- **Node Linking**: SubAgentFlow nodes reference defined sub-agent flows
- **Export**: Sub-agent flows exported as separate `.md` files

### Modified Files
- `workflow-store.ts`: State management for sub-agent flows and canvas switching
- `PropertyPanel.tsx`: Sub-Agent Flow node properties
- `NodePalette.tsx`: Sub-Agent Flow button with nesting prevention
- `export-service.ts`: Multi-file export for sub-agent flows
- `validate-workflow.ts`: Sub-Agent Flow node validation
- `workflow-schema.json`: Schema documentation for AI generation
- `tour-steps.ts`: Added tour steps for all node types (If/Else, Switch included)

## Impact

- New Beta feature (non-breaking change)
- "β" label displayed in node palette to indicate beta status
- No changes to existing workflow functionality

## Testing

- [x] Manual E2E testing completed
  - Create/rename/delete sub-agent flows
  - Canvas switching between main and sub-agent flows
  - Node linking and unlinking
  - Export with sub-agent flows
  - Nesting prevention (cannot add SubAgentFlow inside SubAgentFlow)
- [x] Code quality checks passed (`npm run format && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)