### PR TITLE
chore: add improvement commit type for patch releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,6 +8,7 @@
         "releaseRules": [
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
+          { "type": "improvement", "release": "patch" },
           { "type": "perf", "release": "patch" },
           { "type": "revert", "release": "patch" },
           { "type": "docs", "release": false },
@@ -29,6 +30,7 @@
           "types": [
             { "type": "feat", "section": "Features" },
             { "type": "fix", "section": "Bug Fixes" },
+            { "type": "improvement", "section": "Improvements" },
             { "type": "perf", "section": "Performance Improvements" },
             { "type": "revert", "section": "Reverts" },
             { "type": "docs", "section": "Documentation", "hidden": false },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ fix: add missing MCP node definition to workflow schema
 #### Types
 - `feat:` - New feature (minor version bump)
 - `fix:` - Bug fix (patch version bump)
+- `improvement:` - Minor enhancement to existing feature (patch version bump)
 - `docs:` - Documentation only
 - `refactor:` - Code refactoring
 - `chore:` - Build/tooling changes


### PR DESCRIPTION
## Summary

Add `improvement:` commit type to support patch-level releases for minor enhancements that are not bug fixes.

## Problem

Currently, minor UI/UX enhancements must use either:
- `feat:` → minor version bump (too aggressive)
- `fix:` → appears as "Bug Fixes" in CHANGELOG (misleading)

## Solution

Add `improvement:` type based on [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0-beta.2/):
- Triggers **patch** version bump
- Appears as **"Improvements"** section in CHANGELOG

## Changes

| File | Change |
|------|--------|
| `.releaserc.json` | Add `improvement` to releaseRules (patch) and types (Improvements section) |
| `CLAUDE.md` | Document new commit type in guidelines |

## Usage Example

```
improvement: hide unsupported nodes in SubAgentFlow edit mode
```

## Version Bump Summary

| Type | Version Bump | CHANGELOG Section |
|------|-------------|-------------------|
| `feat:` | minor | Features |
| `fix:` | patch | Bug Fixes |
| `improvement:` | patch | Improvements |
| `perf:` | patch | Performance Improvements |