### PR TITLE
improvement: add AI name generation to SubAgentFlow dialog

### DIFF
--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -95,6 +95,7 @@ export interface WebviewTranslationKeys {
   'subAgentFlow.dialog.close': string;
   'subAgentFlow.dialog.submit': string;
   'subAgentFlow.dialog.cancel': string;
+  'subAgentFlow.generateNameWithAI': string;
 
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -98,6 +98,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': 'Close and return to main workflow',
   'subAgentFlow.dialog.submit': 'Submit and add to workflow',
   'subAgentFlow.dialog.cancel': 'Cancel and discard changes',
+  'subAgentFlow.generateNameWithAI': 'Generate name with AI',
 
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': 'Name is required',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -98,6 +98,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '閉じてメインワークフローに戻る',
   'subAgentFlow.dialog.submit': '確定してワークフローに追加',
   'subAgentFlow.dialog.cancel': 'キャンセルして変更を破棄',
+  'subAgentFlow.generateNameWithAI': 'AIで名前を生成',
 
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '名前は必須です',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -99,6 +99,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '닫고 메인 워크플로우로 돌아가기',
   'subAgentFlow.dialog.submit': '확정하고 워크플로우에 추가',
   'subAgentFlow.dialog.cancel': '취소하고 변경 사항 삭제',
+  'subAgentFlow.generateNameWithAI': 'AI로 이름 생성',
 
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '이름은 필수입니다',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -97,6 +97,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '关闭并返回主工作流',
   'subAgentFlow.dialog.submit': '确认并添加到工作流',
   'subAgentFlow.dialog.cancel': '取消并放弃更改',
+  'subAgentFlow.generateNameWithAI': '使用 AI 生成名称',
 
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '名称为必填项',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -97,6 +97,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '關閉並返回主工作流程',
   'subAgentFlow.dialog.submit': '確認並新增到工作流程',
   'subAgentFlow.dialog.cancel': '取消並捨棄變更',
+  'subAgentFlow.generateNameWithAI': '使用 AI 生成名稱',
 
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '名稱為必填項',


### PR DESCRIPTION
## Summary

- Add AI-powered name generation feature to SubAgentFlow edit dialog
- Reuse existing `generateWorkflowName` service from main workflow (no Extension Host changes required)
- Add translations for all 5 supported languages

## Changes

### SubAgentFlowDialog.tsx
- Import `AiGenerateButton` component and `generateWorkflowName` service
- Add state management for AI generation (`isGeneratingName`, `generationNameRequestIdRef`)
- Add `handleGenerateSubAgentFlowName` and `handleCancelNameGeneration` handlers
- Position AI button inside input field (consistent with main workflow toolbar)

### Translations (5 languages)
- `subAgentFlow.generateNameWithAI` key added to:
  - `en.ts`: "Generate name with AI"
  - `ja.ts`: "AIで名前を生成"
  - `ko.ts`: "AI로 이름 생성"
  - `zh-CN.ts`: "使用 AI 生成名称"
  - `zh-TW.ts`: "使用 AI 生成名稱"

## Implementation Details

- Serializes SubAgentFlow structure (nodes, edges, name, description) as JSON for AI analysis
- Validates generated name (removes invalid characters, enforces 50 char limit)
- Supports cancellation during generation
- Disables input field during generation with visual feedback (opacity)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)