### PR TITLE
fix: update SubAgentFlow name on canvas after editing

### DIFF
--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -658,9 +658,27 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
             mainWorkflowSnapshot: null,
           });
         } else {
-          // No need to add ref node, just restore
+          // Update existing SubAgentFlowNode with latest name and description
+          const updatedNodes = snapshot.nodes.map((node) => {
+            if (
+              node.type === 'subAgentFlow' &&
+              node.data?.subAgentFlowId === currentActiveId &&
+              subAgentFlow
+            ) {
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  label: subAgentFlow.name,
+                  description: subAgentFlow.description || '',
+                },
+              };
+            }
+            return node;
+          });
+
           set({
-            nodes: snapshot.nodes,
+            nodes: updatedNodes,
             edges: snapshot.edges,
             selectedNodeId: snapshot.selectedNodeId,
             activeSubAgentFlowId: null,
@@ -752,7 +770,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       });
 
       // Only remove the sub-agent flow if it was newly created (not editing existing)
-      // For existing sub-agent flows, cancel just discards changes
+      // For existing sub-agent flows, cancel just discards canvas changes (name is managed locally in dialog)
       if (snapshot.isNewSubAgentFlow) {
         set({
           subAgentFlows: get().subAgentFlows.filter((sf) => sf.id !== currentActiveId),


### PR DESCRIPTION
## Problem

### Current Behavior
1. Add a SubAgentFlow from the node palette and submit
2. Open the edit dialog from the property panel
3. Change the flow name and submit
4. ❌ The canvas displays the old name instead of the updated name
5. ❌ When canceling after changing the name, the change is still saved

### Expected Behavior
1. Add a SubAgentFlow from the node palette and submit
2. Open the edit dialog from the property panel
3. Change the flow name and submit
4. ✅ The canvas displays the updated name
5. ✅ When canceling, the name change is discarded

## Solution

Changed the name editing approach from "immediate save" to "save on submit":

- **Before**: Name was saved to store immediately on every keystroke via `updateSubAgentFlow`
- **After**: Name is kept in local state (`localName`) and only saved on submit

### Changes

**SubAgentFlowDialog.tsx**
- Added `localName` state to manage name locally
- Modified `handleNameChange` to update local state only (removed `updateSubAgentFlow` call)
- Modified `handleSubmit` to save name via `updateSubAgentFlow` before closing
- AI-generated names are also set to local state instead of store

**workflow-store.ts**
- Added logic to update existing SubAgentFlowNode's `data.label` when dialog closes
- This ensures the canvas node displays the latest name from SubAgentFlow

## Impact

- SubAgentFlow name editing behavior is now consistent with standard form patterns
- Name changes are properly reflected on canvas after submit
- Cancel properly discards unsaved changes

## Testing

- [x] Manual E2E testing completed
  - Submit updates canvas node name ✓
  - Cancel discards name changes ✓
  - AI-generated name follows same submit/cancel behavior ✓
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)