### PR TITLE
improvement: replace workflow dropdown with OS file picker

### DIFF
--- a/src/extension/i18n/translation-keys.ts
+++ b/src/extension/i18n/translation-keys.ts
@@ -67,4 +67,9 @@ export interface TranslationKeys {
 
   // Error messages
   'error.noWorkspaceOpen': string;
+
+  // File picker
+  'filePicker.title': string;
+  'filePicker.error.invalidWorkflow': string;
+  'filePicker.error.loadFailed': string;
 }

--- a/src/extension/i18n/translations/en.ts
+++ b/src/extension/i18n/translations/en.ts
@@ -75,4 +75,10 @@ export const enTranslations: TranslationKeys = {
 
   // Error messages
   'error.noWorkspaceOpen': 'Please open a folder or workspace first.',
+
+  // File picker
+  'filePicker.title': 'Select Workflow File',
+  'filePicker.error.invalidWorkflow':
+    'Invalid workflow file. Please select a valid JSON workflow file.',
+  'filePicker.error.loadFailed': 'Failed to load workflow file.',
 };

--- a/src/extension/i18n/translations/ja.ts
+++ b/src/extension/i18n/translations/ja.ts
@@ -74,4 +74,10 @@ export const jaTranslations: TranslationKeys = {
 
   // Error messages
   'error.noWorkspaceOpen': 'フォルダまたはワークスペースを開いてから実行してください。',
+
+  // File picker
+  'filePicker.title': 'ワークフローファイルを選択',
+  'filePicker.error.invalidWorkflow':
+    '無効なワークフローファイルです。有効なJSONワークフローファイルを選択してください。',
+  'filePicker.error.loadFailed': 'ワークフローファイルの読み込みに失敗しました。',
 };

--- a/src/extension/i18n/translations/ko.ts
+++ b/src/extension/i18n/translations/ko.ts
@@ -74,4 +74,10 @@ export const koTranslations: TranslationKeys = {
 
   // Error messages
   'error.noWorkspaceOpen': '폴더 또는 워크스페이스를 먼저 열어주세요.',
+
+  // File picker
+  'filePicker.title': '워크플로 파일 선택',
+  'filePicker.error.invalidWorkflow':
+    '잘못된 워크플로 파일입니다. 유효한 JSON 워크플로 파일을 선택해주세요.',
+  'filePicker.error.loadFailed': '워크플로 파일을 불러오는데 실패했습니다.',
 };

--- a/src/extension/i18n/translations/zh-CN.ts
+++ b/src/extension/i18n/translations/zh-CN.ts
@@ -71,4 +71,9 @@ export const zhCNTranslations: TranslationKeys = {
 
   // Error messages
   'error.noWorkspaceOpen': '请先打开文件夹或工作区。',
+
+  // File picker
+  'filePicker.title': '选择工作流文件',
+  'filePicker.error.invalidWorkflow': '无效的工作流文件。请选择有效的JSON工作流文件。',
+  'filePicker.error.loadFailed': '加载工作流文件失败。',
 };

--- a/src/extension/i18n/translations/zh-TW.ts
+++ b/src/extension/i18n/translations/zh-TW.ts
@@ -71,4 +71,9 @@ export const zhTWTranslations: TranslationKeys = {
 
   // Error messages
   'error.noWorkspaceOpen': '請先開啟資料夾或工作區。',
+
+  // File picker
+  'filePicker.title': '選擇工作流程檔案',
+  'filePicker.error.invalidWorkflow': '無效的工作流程檔案。請選擇有效的JSON工作流程檔案。',
+  'filePicker.error.loadFailed': '載入工作流程檔案失敗。',
 };

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -609,7 +609,8 @@ export type ExtensionMessage =
   | Message<SlackDescriptionSuccessPayload, 'SLACK_DESCRIPTION_SUCCESS'>
   | Message<SlackDescriptionFailedPayload, 'SLACK_DESCRIPTION_FAILED'>
   | Message<WorkflowNameSuccessPayload, 'WORKFLOW_NAME_SUCCESS'>
-  | Message<WorkflowNameFailedPayload, 'WORKFLOW_NAME_FAILED'>;
+  | Message<WorkflowNameFailedPayload, 'WORKFLOW_NAME_FAILED'>
+  | Message<void, 'FILE_PICKER_CANCELLED'>;
 
 // ============================================================================
 // AI Slack Description Generation Payloads
@@ -1069,7 +1070,8 @@ export type WebviewMessage =
   | Message<void, 'GET_LAST_SHARED_CHANNEL'>
   | Message<SetLastSharedChannelPayload, 'SET_LAST_SHARED_CHANNEL'>
   | Message<GenerateSlackDescriptionPayload, 'GENERATE_SLACK_DESCRIPTION'>
-  | Message<GenerateWorkflowNamePayload, 'GENERATE_WORKFLOW_NAME'>;
+  | Message<GenerateWorkflowNamePayload, 'GENERATE_WORKFLOW_NAME'>
+  | Message<void, 'OPEN_FILE_PICKER'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -23,6 +23,7 @@ export interface WebviewTranslationKeys {
   'toolbar.refineWithAI': string;
   'toolbar.selectWorkflow': string;
   'toolbar.load': string;
+  'toolbar.loading': string;
   'toolbar.refreshList': string;
 
   // Toolbar interaction mode
@@ -38,6 +39,7 @@ export interface WebviewTranslationKeys {
   'toolbar.error.validationFailed': string;
   'toolbar.error.missingEndNode': string;
   'toolbar.error.noActiveWorkflow': string;
+  'toolbar.error.invalidWorkflowFile': string;
   'toolbar.generateNameWithAI': string;
   'toolbar.error.nameGenerationFailed': string;
 

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -25,6 +25,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.refineWithAI': 'Edit with AI',
   'toolbar.selectWorkflow': 'Select workflow...',
   'toolbar.load': 'Load',
+  'toolbar.loading': 'Loading...',
   'toolbar.refreshList': 'Refresh workflow list',
 
   // Toolbar interaction mode
@@ -40,6 +41,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.validationFailed': 'Workflow validation failed',
   'toolbar.error.missingEndNode': 'Workflow must have at least one End node',
   'toolbar.error.noActiveWorkflow': 'Please load a workflow first',
+  'toolbar.error.invalidWorkflowFile':
+    'Invalid workflow file. Please select a valid JSON workflow file.',
   'toolbar.generateNameWithAI': 'Generate name with AI',
   'toolbar.error.nameGenerationFailed':
     'Failed to generate workflow name. Please try again or enter manually.',
@@ -47,7 +50,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar responsive tooltips
   'toolbar.save.tooltip': 'Save workflow',
   'toolbar.convert.iconTooltip': 'Convert to Slash Command',
-  'toolbar.load.tooltip': 'Load selected workflow',
+  'toolbar.load.tooltip': 'Load saved workflow',
   'slack.share.tooltip': 'Share to Slack',
 
   // Node Palette

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -25,6 +25,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.refineWithAI': 'AI編集',
   'toolbar.selectWorkflow': 'ワークフローを選択...',
   'toolbar.load': '読み込み',
+  'toolbar.loading': '読み込み中...',
   'toolbar.refreshList': 'ワークフローリストを更新',
 
   // Toolbar interaction mode
@@ -40,6 +41,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.validationFailed': 'ワークフローの検証に失敗しました',
   'toolbar.error.missingEndNode': 'ワークフローには最低1つのEndノードが必要です',
   'toolbar.error.noActiveWorkflow': 'ワークフローを読み込んでください',
+  'toolbar.error.invalidWorkflowFile':
+    '無効なワークフローファイルです。有効なJSONワークフローファイルを選択してください。',
   'toolbar.generateNameWithAI': 'AIで名前を生成',
   'toolbar.error.nameGenerationFailed':
     'ワークフロー名の生成に失敗しました。再度お試しいただくか、手動で入力してください。',
@@ -47,7 +50,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar responsive tooltips
   'toolbar.save.tooltip': 'ワークフローを保存',
   'toolbar.convert.iconTooltip': 'Slash Commandに変換',
-  'toolbar.load.tooltip': '選択したワークフローを読み込み',
+  'toolbar.load.tooltip': '保存したワークフローを読み込む',
   'slack.share.tooltip': 'Slackに共有',
 
   // Node Palette

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -25,6 +25,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.refineWithAI': 'AI로 편집',
   'toolbar.selectWorkflow': '워크플로 선택...',
   'toolbar.load': '불러오기',
+  'toolbar.loading': '불러오는 중...',
   'toolbar.refreshList': '워크플로 목록 새로고침',
 
   // Toolbar interaction mode
@@ -40,6 +41,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.validationFailed': '워크플로 검증에 실패했습니다',
   'toolbar.error.missingEndNode': '워크플로에는 최소 1개의 End 노드가 필요합니다',
   'toolbar.error.noActiveWorkflow': '먼저 워크플로를 불러오세요',
+  'toolbar.error.invalidWorkflowFile':
+    '잘못된 워크플로 파일입니다. 유효한 JSON 워크플로 파일을 선택해주세요.',
   'toolbar.generateNameWithAI': 'AI로 이름 생성',
   'toolbar.error.nameGenerationFailed':
     '워크플로 이름 생성에 실패했습니다. 다시 시도하거나 수동으로 입력하세요.',
@@ -47,7 +50,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar responsive tooltips
   'toolbar.save.tooltip': '워크플로 저장',
   'toolbar.convert.iconTooltip': 'Slash Command로 변환',
-  'toolbar.load.tooltip': '선택한 워크플로 불러오기',
+  'toolbar.load.tooltip': '저장된 워크플로 불러오기',
   'slack.share.tooltip': 'Slack에 공유',
 
   // Node Palette

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -25,6 +25,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.refineWithAI': 'AI编辑',
   'toolbar.selectWorkflow': '选择工作流...',
   'toolbar.load': '加载',
+  'toolbar.loading': '加载中...',
   'toolbar.refreshList': '刷新工作流列表',
 
   // Toolbar interaction mode
@@ -40,13 +41,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.validationFailed': '工作流验证失败',
   'toolbar.error.missingEndNode': '工作流必须至少包含一个End节点',
   'toolbar.error.noActiveWorkflow': '请先加载工作流',
+  'toolbar.error.invalidWorkflowFile': '无效的工作流文件。请选择有效的JSON工作流文件。',
   'toolbar.generateNameWithAI': '使用AI生成名称',
   'toolbar.error.nameGenerationFailed': '生成工作流名称失败。请重试或手动输入。',
 
   // Toolbar responsive tooltips
   'toolbar.save.tooltip': '保存工作流',
   'toolbar.convert.iconTooltip': '转换为Slash Command',
-  'toolbar.load.tooltip': '加载选定的工作流',
+  'toolbar.load.tooltip': '加载已保存的工作流',
   'slack.share.tooltip': '分享到Slack',
 
   // Node Palette

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -25,6 +25,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.refineWithAI': 'AI編輯',
   'toolbar.selectWorkflow': '選擇工作流...',
   'toolbar.load': '載入',
+  'toolbar.loading': '載入中...',
   'toolbar.refreshList': '重新整理工作流清單',
 
   // Toolbar interaction mode
@@ -40,13 +41,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.validationFailed': '工作流驗證失敗',
   'toolbar.error.missingEndNode': '工作流必須至少包含一個End節點',
   'toolbar.error.noActiveWorkflow': '請先載入工作流',
+  'toolbar.error.invalidWorkflowFile': '無效的工作流程檔案。請選擇有效的JSON工作流程檔案。',
   'toolbar.generateNameWithAI': '使用AI生成名稱',
   'toolbar.error.nameGenerationFailed': '生成工作流名稱失敗。請重試或手動輸入。',
 
   // Toolbar responsive tooltips
   'toolbar.save.tooltip': '儲存工作流程',
   'toolbar.convert.iconTooltip': '轉換為Slash Command',
-  'toolbar.load.tooltip': '載入選取的工作流程',
+  'toolbar.load.tooltip': '載入已儲存的工作流程',
   'slack.share.tooltip': '分享到Slack',
 
   // Node Palette


### PR DESCRIPTION
## Summary

Improves the toolbar file loading UI by replacing the dropdown selector with an OS file picker dialog, saving toolbar space and providing a more intuitive user experience.

## Changes

### UI Changes
- Removed workflow selector dropdown from toolbar
- Load button now opens OS file picker directly
- Swapped Load and Convert button positions for better UX
- Changed Convert button to primary color style (matches Save button)

### Technical Implementation
- Added `OPEN_FILE_PICKER` message type (Webview → Extension)
- Added `FILE_PICKER_CANCELLED` message type (Extension → Webview)
- Implemented `vscode.window.showOpenDialog()` with JSON file filter
- Default directory: `.vscode/workflows/`
- File validation using `validateWorkflowFile()` before loading

### i18n Updates (5 languages)
- Added file picker translations (en, ja, ko, zh-CN, zh-TW)
- Updated tooltip text to reflect new behavior

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)