### PR TITLE
improvement: add ellipsis truncation for workflow name fields

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -20,7 +20,7 @@ import {
 } from '../services/workflow-service';
 import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
-import { AiGenerateButton } from './common/AiGenerateButton';
+import { EditableNameField } from './common/EditableNameField';
 import { ProcessingOverlay } from './common/ProcessingOverlay';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
 import { ConfirmDialog } from './dialogs/ConfirmDialog';
@@ -283,46 +283,21 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
           backgroundColor: 'var(--vscode-editor-background)',
         }}
       >
-        {/* Workflow Name Input with AI Generate Button (inside input) */}
-        <div style={{ position: 'relative', flex: 1 }}>
-          <input
-            type="text"
-            value={workflowName}
-            onChange={(e) => setWorkflowName(e.target.value)}
-            placeholder={t('toolbar.workflowNamePlaceholder')}
-            disabled={isGeneratingName}
-            className="nodrag"
-            data-tour="workflow-name-input"
-            style={{
-              width: '100%',
-              padding: '4px 44px 4px 8px',
-              backgroundColor: 'var(--vscode-input-background)',
-              color: 'var(--vscode-input-foreground)',
-              border: '1px solid var(--vscode-input-border)',
-              borderRadius: '2px',
-              fontSize: '13px',
-              opacity: isGeneratingName ? 0.7 : 1,
-              boxSizing: 'border-box',
-            }}
-          />
-          {/* AI Generate / Cancel Button (positioned inside input) */}
-          <div
-            style={{
-              position: 'absolute',
-              right: '4px',
-              top: '50%',
-              transform: 'translateY(-50%)',
-            }}
-          >
-            <AiGenerateButton
-              isGenerating={isGeneratingName}
-              onGenerate={handleGenerateWorkflowName}
-              onCancel={handleCancelNameGeneration}
-              generateTooltip={t('toolbar.generateNameWithAI')}
-              cancelTooltip={t('cancel')}
-            />
-          </div>
-        </div>
+        {/* Workflow Name Display/Input with AI Generate Button */}
+        <EditableNameField
+          value={workflowName}
+          onChange={setWorkflowName}
+          placeholder={t('toolbar.workflowNamePlaceholder')}
+          disabled={isGeneratingName}
+          dataTour="workflow-name-input"
+          aiGeneration={{
+            isGenerating: isGeneratingName,
+            onGenerate: handleGenerateWorkflowName,
+            onCancel: handleCancelNameGeneration,
+            generateTooltip: t('toolbar.generateNameWithAI'),
+            cancelTooltip: t('cancel'),
+          }}
+        />
 
         {/* Save Button */}
         <StyledTooltipItem content={t('toolbar.save.tooltip')}>

--- a/src/webview/src/components/common/EditableNameField.tsx
+++ b/src/webview/src/components/common/EditableNameField.tsx
@@ -1,0 +1,173 @@
+/**
+ * EditableNameField Component
+ *
+ * A reusable component for displaying and editing names with ellipsis truncation.
+ * Click to edit, with optional AI generation button.
+ */
+
+import type React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AiGenerateButton } from './AiGenerateButton';
+
+interface EditableNameFieldProps {
+  /** Current value of the name */
+  value: string;
+  /** Callback when value changes */
+  onChange: (value: string) => void;
+  /** Placeholder text when value is empty */
+  placeholder: string;
+  /** Whether the field is disabled (e.g., during AI generation) */
+  disabled?: boolean;
+  /** Validation error message (if any) */
+  error?: string | null;
+  /** AI generation props (optional) */
+  aiGeneration?: {
+    isGenerating: boolean;
+    onGenerate: () => void;
+    onCancel: () => void;
+    generateTooltip: string;
+    cancelTooltip: string;
+  };
+  /** Minimum width for the field */
+  minWidth?: string;
+  /** data-tour attribute for guided tours */
+  dataTour?: string;
+}
+
+export const EditableNameField: React.FC<EditableNameFieldProps> = ({
+  value,
+  onChange,
+  placeholder,
+  disabled = false,
+  error = null,
+  aiGeneration,
+  minWidth = '120px',
+  dataTour,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleStartEditing = useCallback(() => {
+    if (!disabled) {
+      setIsEditing(true);
+    }
+  }, [disabled]);
+
+  const handleFinishEditing = useCallback(() => {
+    setIsEditing(false);
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+    if (e.key === 'Enter' || e.key === 'Escape') {
+      setIsEditing(false);
+    }
+  }, []);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const borderColor = error
+    ? '1px solid var(--vscode-inputValidation-errorBorder)'
+    : '1px solid var(--vscode-input-border)';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth }}>
+      <div style={{ position: 'relative' }}>
+        {isEditing ? (
+          // Edit mode: Show input field
+          <input
+            ref={inputRef}
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onBlur={handleFinishEditing}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            disabled={disabled}
+            className="nodrag"
+            data-tour={dataTour}
+            style={{
+              width: '100%',
+              padding: '4px 44px 4px 8px',
+              backgroundColor: 'var(--vscode-input-background)',
+              color: 'var(--vscode-input-foreground)',
+              border: borderColor,
+              borderRadius: '2px',
+              fontSize: '13px',
+              opacity: disabled ? 0.7 : 1,
+              boxSizing: 'border-box',
+            }}
+          />
+        ) : (
+          // Display mode: Show text with ellipsis
+          <div
+            onClick={handleStartEditing}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleStartEditing();
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            data-tour={dataTour}
+            style={{
+              width: '100%',
+              padding: '4px 44px 4px 8px',
+              backgroundColor: 'var(--vscode-input-background)',
+              color: value
+                ? 'var(--vscode-input-foreground)'
+                : 'var(--vscode-input-placeholderForeground)',
+              border: borderColor,
+              borderRadius: '2px',
+              fontSize: '13px',
+              opacity: disabled ? 0.7 : 1,
+              boxSizing: 'border-box',
+              cursor: disabled ? 'not-allowed' : 'text',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {value || placeholder}
+          </div>
+        )}
+        {/* AI Generate / Cancel Button (positioned inside input/display) */}
+        {aiGeneration && (
+          <div
+            style={{
+              position: 'absolute',
+              right: '4px',
+              top: '50%',
+              transform: 'translateY(-50%)',
+            }}
+          >
+            <AiGenerateButton
+              isGenerating={aiGeneration.isGenerating}
+              onGenerate={aiGeneration.onGenerate}
+              onCancel={aiGeneration.onCancel}
+              generateTooltip={aiGeneration.generateTooltip}
+              cancelTooltip={aiGeneration.cancelTooltip}
+            />
+          </div>
+        )}
+      </div>
+      {error && (
+        <span
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-inputValidation-errorForeground)',
+            marginTop: '4px',
+          }}
+        >
+          {error}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -26,7 +26,7 @@ import { generateWorkflowName } from '../../services/ai-generation-service';
 import { serializeWorkflow } from '../../services/workflow-service';
 import { useRefinementStore } from '../../stores/refinement-store';
 import { useWorkflowStore } from '../../stores/workflow-store';
-import { AiGenerateButton } from '../common/AiGenerateButton';
+import { EditableNameField } from '../common/EditableNameField';
 import { StyledTooltip } from '../common/StyledTooltip';
 import { InteractionModeToggle } from '../InteractionModeToggle';
 import { NodePalette } from '../NodePalette';
@@ -469,59 +469,22 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
             >
               Sub-Agent Flow
             </span>
-            {/* Always-visible input field (Toolbar style) with AI Generate button inside */}
-            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, maxWidth: '300px' }}>
-              <div style={{ position: 'relative' }}>
-                <input
-                  type="text"
-                  value={localName}
-                  onChange={(e) => handleNameChange(e.target.value)}
-                  onKeyDown={(e) => e.stopPropagation()}
-                  disabled={isGeneratingName}
-                  style={{
-                    width: '100%',
-                    padding: '4px 44px 4px 8px',
-                    backgroundColor: 'var(--vscode-input-background)',
-                    color: 'var(--vscode-input-foreground)',
-                    border: nameError
-                      ? '1px solid var(--vscode-inputValidation-errorBorder)'
-                      : '1px solid var(--vscode-input-border)',
-                    borderRadius: '2px',
-                    fontSize: '13px',
-                    boxSizing: 'border-box',
-                    opacity: isGeneratingName ? 0.7 : 1,
-                  }}
-                  placeholder={t('subAgentFlow.namePlaceholder')}
-                />
-                {/* AI Generate / Cancel Button (positioned inside input) */}
-                <div
-                  style={{
-                    position: 'absolute',
-                    right: '4px',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                  }}
-                >
-                  <AiGenerateButton
-                    isGenerating={isGeneratingName}
-                    onGenerate={handleGenerateSubAgentFlowName}
-                    onCancel={handleCancelNameGeneration}
-                    generateTooltip={t('subAgentFlow.generateNameWithAI')}
-                    cancelTooltip={t('cancel')}
-                  />
-                </div>
-              </div>
-              {nameError && (
-                <span
-                  style={{
-                    fontSize: '11px',
-                    color: 'var(--vscode-inputValidation-errorForeground)',
-                    marginTop: '4px',
-                  }}
-                >
-                  {nameError}
-                </span>
-              )}
+            {/* Flow name display/input with AI Generate button inside */}
+            <div style={{ flex: 1, maxWidth: '300px' }}>
+              <EditableNameField
+                value={localName}
+                onChange={handleNameChange}
+                placeholder={t('subAgentFlow.namePlaceholder')}
+                disabled={isGeneratingName}
+                error={nameError}
+                aiGeneration={{
+                  isGenerating: isGeneratingName,
+                  onGenerate: handleGenerateSubAgentFlowName,
+                  onCancel: handleCancelNameGeneration,
+                  generateTooltip: t('subAgentFlow.generateNameWithAI'),
+                  cancelTooltip: t('cancel'),
+                }}
+              />
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>


### PR DESCRIPTION
## Summary

- Add text-overflow ellipsis for long workflow names in Toolbar and Sub-Agent Flow dialog
- Create reusable `EditableNameField` component with click-to-edit behavior
- Reduce code duplication by extracting common name field logic

## Changes

### New Component
**`src/webview/src/components/common/EditableNameField.tsx`**
- Reusable component for displaying and editing names
- Display mode: shows text with ellipsis truncation
- Edit mode: click to switch to input field
- Optional AI generation button support
- Validation error display support

### Refactored Files
- **`Toolbar.tsx`**: Use `EditableNameField` for workflow name
- **`SubAgentFlowDialog.tsx`**: Use `EditableNameField` with maxWidth constraint (300px)

## Impact

- Better UX when workflow names are long (shows "..." instead of overflowing)
- Click-to-edit pattern for cleaner interface
- Reduced code duplication (~90 lines removed)

## Testing

- [x] Toolbar workflow name truncates with ellipsis
- [x] Click to edit works correctly
- [x] Enter/Escape/blur exits edit mode
- [x] Sub-Agent Flow dialog name field has same behavior
- [x] AI generation button still works
- [x] Code quality checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)