### PR TITLE
fix: preserve SubAgentFlow references when opening AI edit dialog

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -92,6 +92,7 @@ export const WorkflowEditor: React.FC = () => {
     activeWorkflow,
     setActiveWorkflow,
     workflowName,
+    subAgentFlows,
   } = useWorkflowStore();
 
   const { openChat, initConversation, loadConversationHistory } = useRefinementStore();
@@ -190,12 +191,14 @@ export const WorkflowEditor: React.FC = () => {
   // Handle opening AI refinement chat
   const handleOpenRefinementChat = useCallback(() => {
     // Serialize current workflow state to set as active workflow
+    // Include subAgentFlows to preserve SubAgentFlow references
     const currentWorkflow = serializeWorkflow(
       nodes,
       edges,
       workflowName || 'Untitled',
       'Created with Workflow Studio',
-      activeWorkflow?.conversationHistory
+      activeWorkflow?.conversationHistory,
+      subAgentFlows
     );
     setActiveWorkflow(currentWorkflow);
 
@@ -214,6 +217,7 @@ export const WorkflowEditor: React.FC = () => {
     edges,
     workflowName,
     activeWorkflow?.conversationHistory,
+    subAgentFlows,
     setActiveWorkflow,
     loadConversationHistory,
     initConversation,


### PR DESCRIPTION
## Problem

When opening the AI edit dialog on a workflow containing SubAgentFlow nodes, the SubAgentFlow node links become broken.

### Current Behavior
1. Create a SubAgentFlow and add it to the main workflow
2. Open the AI edit dialog (Refinement panel)
3. ❌ SubAgentFlow node references are lost - links appear broken

### Expected Behavior
1. Create a SubAgentFlow and add it to the main workflow
2. Open the AI edit dialog
3. ✅ SubAgentFlow node references are preserved

## Root Cause

In `WorkflowEditor.tsx`, the `handleOpenRefinementChat` function calls `serializeWorkflow()` without passing the `subAgentFlows` parameter. This causes `activeWorkflow` to be set without `subAgentFlows`, breaking the references.

## Solution

Pass `subAgentFlows` from Zustand store to `serializeWorkflow()` when opening the AI edit dialog.

### Changes

**File**: `src/webview/src/components/WorkflowEditor.tsx`

- Added `subAgentFlows` to destructured values from `useWorkflowStore()`
- Pass `subAgentFlows` as the 6th argument to `serializeWorkflow()`

## Impact

- SubAgentFlow node links are now preserved when opening the AI edit dialog
- No breaking changes
- Minimal code change (1 file, +5/-1 lines)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)