### PR TITLE
fix: prevent SubAgentFlow canvas overwrite when opening AI edit dialog

### DIFF
--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -23,7 +23,6 @@ import ReactFlow, {
 import { useIsCompactMode } from '../../hooks/useWindowWidth';
 import { useTranslation } from '../../i18n/i18n-context';
 import { generateWorkflowName } from '../../services/ai-generation-service';
-import { serializeWorkflow } from '../../services/workflow-service';
 import { useRefinementStore } from '../../stores/refinement-store';
 import { useWorkflowStore } from '../../stores/workflow-store';
 import { EditableNameField } from '../common/EditableNameField';
@@ -102,9 +101,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
     isPropertyPanelOpen,
     cancelSubAgentFlowEditing,
     mainWorkflowSnapshot,
-    workflowName,
-    activeWorkflow,
-    setActiveWorkflow,
+    updateActiveWorkflowMetadata,
   } = useWorkflowStore();
 
   const { loadConversationHistory, initConversation } = useRefinementStore();
@@ -163,18 +160,9 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
             : sf
         );
 
-        // Reconstruct the main workflow from snapshot
-        const mainWorkflow = serializeWorkflow(
-          mainWorkflowSnapshot.nodes,
-          mainWorkflowSnapshot.edges,
-          workflowName || 'Untitled',
-          activeWorkflow?.description || 'Created with Workflow Studio',
-          activeWorkflow?.conversationHistory,
-          updatedSubAgentFlows
-        );
-
-        // Set the main workflow as active
-        setActiveWorkflow(mainWorkflow);
+        // Update only the subAgentFlows in activeWorkflow without changing the canvas
+        // Using updateActiveWorkflowMetadata to avoid overwriting SubAgentFlow canvas with main workflow
+        updateActiveWorkflowMetadata({ subAgentFlows: updatedSubAgentFlows });
 
         // Initialize conversation history for the SubAgentFlow
         const subAgentFlow = updatedSubAgentFlows.find((sf) => sf.id === activeSubAgentFlowId);
@@ -193,9 +181,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
     nodes,
     edges,
     subAgentFlows,
-    workflowName,
-    activeWorkflow,
-    setActiveWorkflow,
+    updateActiveWorkflowMetadata,
     loadConversationHistory,
     initConversation,
   ]);

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -78,6 +78,7 @@ interface WorkflowStore {
   addGeneratedWorkflow: (workflow: Workflow) => void;
   updateWorkflow: (workflow: Workflow) => void;
   setActiveWorkflow: (workflow: Workflow) => void; // Phase 3.12
+  updateActiveWorkflowMetadata: (updates: Partial<Workflow>) => void; // Update activeWorkflow without changing canvas
 
   // Sub-Agent Flow Actions (Feature: 089-subworkflow)
   addSubAgentFlow: (subAgentFlow: SubAgentFlow) => void;
@@ -471,6 +472,25 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       edges: newEdges,
       activeWorkflow: workflow,
       subAgentFlows: workflow.subAgentFlows || [],
+    });
+  },
+
+  updateActiveWorkflowMetadata: (updates: Partial<Workflow>) => {
+    const { activeWorkflow } = get();
+    if (!activeWorkflow) return;
+
+    // Update only activeWorkflow without changing canvas (nodes/edges)
+    // This is used when editing SubAgentFlow to update parent workflow metadata
+    // without overwriting the SubAgentFlow canvas
+    set({
+      activeWorkflow: {
+        ...activeWorkflow,
+        ...updates,
+      },
+      // Also sync subAgentFlows if it's being updated
+      ...(updates.subAgentFlows !== undefined && {
+        subAgentFlows: updates.subAgentFlows,
+      }),
     });
   },
 


### PR DESCRIPTION
## Problem

When opening the AI edit dialog in SubAgentFlow editing mode, the SubAgentFlow canvas was being overwritten with the main workflow content.

### Current Behavior
1. Open a workflow with SubAgentFlow node
2. Double-click SubAgentFlow node to edit
3. Click AI edit button
4. ❌ SubAgentFlow canvas is replaced with main workflow content

### Expected Behavior
1. Open a workflow with SubAgentFlow node
2. Double-click SubAgentFlow node to edit
3. Click AI edit button
4. ✅ SubAgentFlow canvas remains intact

## Solution

The root cause was `setActiveWorkflow()` being called in `handleToggleAiEditMode()`. This function updates not only `activeWorkflow` but also `nodes` and `edges`, which overwrote the SubAgentFlow canvas.

### Changes

**File**: `src/webview/src/stores/workflow-store.ts`

Added new function `updateActiveWorkflowMetadata()`:
- Updates only `activeWorkflow` metadata without changing canvas (`nodes`/`edges`)
- Syncs `subAgentFlows` if included in updates

**File**: `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`

- Replaced `setActiveWorkflow(mainWorkflow)` with `updateActiveWorkflowMetadata({ subAgentFlows: updatedSubAgentFlows })`
- Removed unused imports (`serializeWorkflow`) and variables (`workflowName`, `activeWorkflow`)

## Impact

- SubAgentFlow AI edit dialog now works correctly
- No impact on main workflow AI edit functionality
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)