### PR TITLE
fix: auto-generate SubAgentFlow definitions for AI-created nodes

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -315,6 +315,65 @@
         "noNesting": "SubAgentFlow nodes cannot be used inside sub-agent flows (no nesting allowed in Phase 1 MVP)",
         "noSubAgentInSubAgentFlow": "SubAgent nodes cannot be used inside sub-agent flows (Claude Code constraint)",
         "sequentialExecution": "Sub-agent flows execute sequentially from Start to End"
+      },
+      "aiGenerationGuidance": {
+        "requirement": "When generating a subAgentFlow node, you MUST also create a corresponding SubAgentFlow definition in the 'subAgentFlows' array at the workflow root level",
+        "subAgentFlowDefinition": {
+          "id": "MUST match the subAgentFlowId in the reference node",
+          "name": "Same as the label of the reference node",
+          "description": "Optional description",
+          "nodes": "MUST include at least Start and End nodes",
+          "connections": "Connect Start to End (minimum structure)"
+        },
+        "constraints": [
+          "SubAgentFlow nodes array can only contain: start, end, prompt, ifElse, switch, skill, mcp",
+          "SubAgentFlow nodes array CANNOT contain: subAgent, subAgentFlow, askUserQuestion",
+          "Maximum 30 nodes per SubAgentFlow"
+        ],
+        "example": {
+          "nodeInWorkflow": {
+            "id": "subflow-ref-1",
+            "type": "subAgentFlow",
+            "name": "validation-ref",
+            "position": { "x": 400, "y": 200 },
+            "data": {
+              "subAgentFlowId": "validation-subflow-1",
+              "label": "Input Validation",
+              "description": "Validates user input",
+              "outputPorts": 1
+            }
+          },
+          "subAgentFlowDefinition": {
+            "id": "validation-subflow-1",
+            "name": "Input Validation",
+            "description": "Validates user input",
+            "nodes": [
+              {
+                "id": "sf-start",
+                "type": "start",
+                "name": "Start",
+                "position": { "x": 100, "y": 200 },
+                "data": { "label": "Start" }
+              },
+              {
+                "id": "sf-end",
+                "type": "end",
+                "name": "End",
+                "position": { "x": 400, "y": 200 },
+                "data": { "label": "End" }
+              }
+            ],
+            "connections": [
+              {
+                "id": "sf-conn-1",
+                "from": "sf-start",
+                "to": "sf-end",
+                "fromPort": "output",
+                "toPort": "input"
+              }
+            ]
+          }
+        }
       }
     }
   },
@@ -349,6 +408,43 @@
       "Sub-Agent Flows must have exactly one Start node and at least one End node",
       "Maximum 30 nodes per Sub-Agent Flow"
     ]
+  },
+  "workflowStructure": {
+    "description": "Top-level workflow structure fields",
+    "fields": {
+      "id": { "type": "string", "required": true },
+      "name": { "type": "string", "required": true, "maxLength": 100 },
+      "description": { "type": "string", "required": false },
+      "version": { "type": "string", "required": true, "pattern": "semver" },
+      "nodes": { "type": "array", "required": true },
+      "connections": { "type": "array", "required": true },
+      "subAgentFlows": {
+        "type": "array",
+        "required": false,
+        "description": "Array of SubAgentFlow definitions. Each subAgentFlow node in 'nodes' MUST have a corresponding entry here with matching id.",
+        "item": {
+          "id": {
+            "type": "string",
+            "required": true,
+            "description": "Unique ID matching subAgentFlowId in the reference node"
+          },
+          "name": { "type": "string", "required": true, "maxLength": 50 },
+          "description": { "type": "string", "required": false, "maxLength": 200 },
+          "nodes": {
+            "type": "array",
+            "required": true,
+            "description": "Workflow nodes (must include Start and End)"
+          },
+          "connections": {
+            "type": "array",
+            "required": true,
+            "description": "Connections between nodes"
+          }
+        }
+      },
+      "createdAt": { "type": "string", "required": true, "format": "ISO8601" },
+      "updatedAt": { "type": "string", "required": true, "format": "ISO8601" }
+    }
   },
   "examples": [
     {

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -405,11 +405,13 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     );
 
     // Completely replace existing workflow with generated workflow
+    // Also include subAgentFlows from the generated workflow
     set({
       nodes: newNodes,
       edges: newEdges,
       selectedNodeId: firstSelectableNode?.id || null,
       activeWorkflow: workflow,
+      subAgentFlows: workflow.subAgentFlows || [],
     });
   },
 
@@ -436,10 +438,12 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     }));
 
     // Update workflow while preserving selection
+    // Also include subAgentFlows from the refined workflow
     set({
       nodes: newNodes,
       edges: newEdges,
       activeWorkflow: workflow,
+      subAgentFlows: workflow.subAgentFlows || [],
     });
   },
 


### PR DESCRIPTION
## Problem

### Current Behavior
1. User creates a workflow using main workflow AI edit
2. AI generates a SubAgentFlow node (reference)
3. ❌ The corresponding SubAgentFlow definition (internal nodes/connections) is not created
4. ❌ SubAgentFlow dialog cannot be opened ("Not linked" warning)

### Expected Behavior
1. User creates a workflow using main workflow AI edit
2. AI generates a SubAgentFlow node (reference)
3. ✅ The corresponding SubAgentFlow definition with internal structure is also created
4. ✅ SubAgentFlow dialog opens normally

## Solution

Implemented a hybrid approach to ensure SubAgentFlow definitions are always created:

1. **Primary**: Extended workflow-schema.json with AI generation guidance to instruct AI to generate complete SubAgentFlow definitions
2. **Fallback**: Added `resolveSubAgentFlows` post-processing to create minimal structures (Start → End) for any missing definitions

### Changes

**resources/workflow-schema.json**
- Added `aiGenerationGuidance` section to subAgentFlow node type
- Added `workflowStructure` section documenting the `subAgentFlows` array field

**src/extension/commands/ai-generation.ts**
- Added SubAgentFlow requirements to AI prompt
- Added `createMinimalSubAgentFlow()` function
- Added `resolveSubAgentFlows()` function for fallback processing

**src/extension/utils/validate-workflow.ts**
- Added `validateSubAgentFlowReferences()` function for reference integrity checks

**src/extension/services/refinement-service.ts**
- Added same `resolveSubAgentFlows` processing for AI refinement flow

**src/webview/src/stores/workflow-store.ts**
- Updated `addGeneratedWorkflow` and `updateWorkflow` to handle `subAgentFlows`

## Impact

- SubAgentFlow nodes created via AI edit now have proper internal definitions
- SubAgentFlow dialog opens correctly after AI generation
- No breaking changes to existing workflows

## Testing

- [x] Manual E2E testing completed
- [x] AI generates complete SubAgentFlow internal structure (not just Start→End)
- [x] SubAgentFlow dialog opens correctly
- [x] Code quality checks passed (format, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)