### PR TITLE
fix: enable keyboard copy-paste in flow name editing fields

### DIFF
--- a/src/webview/src/components/common/EditableNameField.tsx
+++ b/src/webview/src/components/common/EditableNameField.tsx
@@ -58,8 +58,10 @@ export const EditableNameField: React.FC<EditableNameFieldProps> = ({
   }, []);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    e.stopPropagation();
+    // Only stop propagation for Enter/Escape to prevent parent handlers
+    // Allow other keys (like Ctrl+C/V) to work normally
     if (e.key === 'Enter' || e.key === 'Escape') {
+      e.stopPropagation();
       setIsEditing(false);
     }
   }, []);

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -425,7 +425,13 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
           outline: 'none',
         }}
         onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          // Only stop propagation for Escape to prevent closing parent dialogs
+          // Allow other keys (like Ctrl+C/V) to work normally
+          if (e.key === 'Escape') {
+            e.stopPropagation();
+          }
+        }}
         role="dialog"
         aria-modal="true"
         aria-labelledby="subagentflow-dialog-title"


### PR DESCRIPTION
## Problem

### Current Behavior
1. Click on workflow name in Toolbar to edit
2. ❌ Ctrl+C/V (or Cmd+C/V on Mac) does not work - cannot copy or paste text
3. Same issue occurs in SubAgentFlow dialog name input

### Expected Behavior
1. Click on workflow name to edit
2. ✅ Standard keyboard shortcuts (Ctrl/Cmd+C, Ctrl/Cmd+V, Ctrl/Cmd+X) work normally

## Solution

The root cause was `e.stopPropagation()` being called unconditionally on all keyboard events, which prevented clipboard shortcuts from working.

### Changes

**File**: `src/webview/src/components/common/EditableNameField.tsx`
- Made `stopPropagation()` conditional - only called for Enter/Escape keys
- Other keys (including Ctrl+C/V) now propagate normally

**File**: `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`
- Made dialog container's `onKeyDown` handler conditional
- Only stops propagation for Escape key to prevent closing parent dialogs

## Impact

- Keyboard copy/paste now works in Toolbar workflow name editing
- Keyboard copy/paste now works in SubAgentFlow dialog name input
- Enter and Escape keys continue to work as expected (finish editing, cancel)
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)