### PR TITLE
fix: include SubAgentFlows in Slack workflow export

### DIFF
--- a/src/webview/src/components/dialogs/SlackShareDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackShareDialog.tsx
@@ -65,7 +65,7 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
   };
 
   // Get current canvas state for workflow generation
-  const { nodes, edges, activeWorkflow, workflowName } = useWorkflowStore();
+  const { nodes, edges, activeWorkflow, workflowName, subAgentFlows } = useWorkflowStore();
 
   // State management
   const [loading, setLoading] = useState(false);
@@ -206,7 +206,8 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
         edges,
         workflowName || 'Untitled Workflow',
         'Created with Workflow Studio',
-        activeWorkflow?.conversationHistory
+        activeWorkflow?.conversationHistory,
+        subAgentFlows
       );
       const workflowJson = JSON.stringify(workflow, null, 2);
 
@@ -239,7 +240,7 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
         generationRequestIdRef.current = null;
       }
     }
-  }, [nodes, edges, workflowName, activeWorkflow?.conversationHistory, locale, t]);
+  }, [nodes, edges, workflowName, activeWorkflow?.conversationHistory, locale, t, subAgentFlows]);
 
   // Handle cancel AI description generation
   const handleCancelGeneration = useCallback(() => {
@@ -270,7 +271,8 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
         edges,
         workflowName,
         'Created with Workflow Studio',
-        activeWorkflow?.conversationHistory
+        activeWorkflow?.conversationHistory,
+        subAgentFlows
       );
 
       const result = await shareWorkflowToSlack({
@@ -315,7 +317,8 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
         edges,
         workflowName,
         'Created with Workflow Studio',
-        activeWorkflow?.conversationHistory
+        activeWorkflow?.conversationHistory,
+        subAgentFlows
       );
 
       const result = await shareWorkflowToSlack({


### PR DESCRIPTION
## Problem

When sharing workflows to Slack, SubAgentFlow information was not included in the exported workflow JSON.

### Current Behavior
1. Create a workflow with SubAgentFlow nodes
2. Share to Slack
3. ❌ Exported JSON does not contain `subAgentFlows` array

### Expected Behavior
1. Create a workflow with SubAgentFlow nodes
2. Share to Slack
3. ✅ Exported JSON contains complete `subAgentFlows` array with all SubAgentFlow definitions

## Solution

The `serializeWorkflow()` function already accepts `subAgentFlows` as a parameter, but `SlackShareDialog` was not passing it.

### Changes

**File**: `src/webview/src/components/dialogs/SlackShareDialog.tsx`

- Added `subAgentFlows` to `useWorkflowStore()` destructuring
- Passed `subAgentFlows` to all three `serializeWorkflow()` calls:
  1. AI description generation
  2. Initial share
  3. Share with sensitive data warning override
- Added `subAgentFlows` to `useCallback` dependency array

## Impact

- Slack-shared workflows now include complete SubAgentFlow definitions
- No breaking changes
- No changes required on Extension side (already serializes the entire workflow object)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build verification passed (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)