### PR TITLE
improvement: add minimap visibility toggle with container UI

### DIFF
--- a/src/webview/src/components/MinimapContainer.tsx
+++ b/src/webview/src/components/MinimapContainer.tsx
@@ -1,0 +1,117 @@
+/**
+ * Claude Code Workflow Studio - Minimap Container Component
+ *
+ * Container component that wraps the MiniMap with a border frame
+ * and provides minimize/expand toggle button
+ */
+
+import { Map as MapIcon, Minus } from 'lucide-react';
+import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
+import { useWorkflowStore } from '../stores/workflow-store';
+import { StyledTooltip } from './common/StyledTooltip';
+
+interface MinimapContainerProps {
+  children: React.ReactNode;
+}
+
+/**
+ * MinimapContainer Component
+ *
+ * Wraps MiniMap with a bordered container and minimize button (top-right)
+ * When minimized, shows only a Map icon button to expand
+ */
+export const MinimapContainer: React.FC<MinimapContainerProps> = ({ children }) => {
+  const { t } = useTranslation();
+  const { isMinimapVisible, toggleMinimapVisibility } = useWorkflowStore();
+
+  // Common button styles (highly transparent to not obstruct canvas)
+  const buttonBaseStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'color-mix(in srgb, var(--vscode-editor-background) 30%, transparent)',
+    border: '1px solid color-mix(in srgb, var(--vscode-panel-border) 30%, transparent)',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    color: 'var(--vscode-foreground)',
+  };
+
+  // When minimized: show expand button only
+  if (!isMinimapVisible) {
+    return (
+      <StyledTooltip content={t('toolbar.minimapToggle.show')} side="left">
+        <button
+          type="button"
+          onClick={toggleMinimapVisibility}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              toggleMinimapVisibility();
+            }
+          }}
+          aria-label={t('toolbar.minimapToggle.show')}
+          style={{
+            ...buttonBaseStyle,
+            width: '28px',
+            height: '28px',
+          }}
+        >
+          <MapIcon size={14} />
+        </button>
+      </StyledTooltip>
+    );
+  }
+
+  // When visible: show bordered container with minimize button (highly transparent frame)
+  return (
+    <div
+      style={{
+        position: 'relative',
+        border: '1px solid color-mix(in srgb, var(--vscode-panel-border) 30%, transparent)',
+        borderRadius: '6px',
+        backgroundColor: 'color-mix(in srgb, var(--vscode-editor-background) 20%, transparent)',
+        padding: '2px 8px 2px 0px',
+      }}
+    >
+      {/* Minimize button (top-right corner) */}
+      <StyledTooltip content={t('toolbar.minimapToggle.hide')} side="left">
+        <button
+          type="button"
+          onClick={toggleMinimapVisibility}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              toggleMinimapVisibility();
+            }
+          }}
+          aria-label={t('toolbar.minimapToggle.hide')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'color-mix(in srgb, var(--vscode-editor-background) 70%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--vscode-panel-border) 30%, transparent)',
+            borderTop: 'none',
+            borderRight: 'none',
+            borderRadius: '0px 0px 0px 4px',
+            cursor: 'pointer',
+            color: 'var(--vscode-foreground)',
+            backdropFilter: 'blur(4px)',
+            position: 'absolute',
+            top: '0px',
+            right: '0px',
+            zIndex: 10,
+            width: '20px',
+            height: '20px',
+          }}
+        >
+          <Minus size={12} />
+        </button>
+      </StyledTooltip>
+
+      {/* MiniMap content */}
+      {children}
+    </div>
+  );
+};

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -26,6 +26,7 @@ import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { StyledTooltip } from './common/StyledTooltip';
 import { InteractionModeToggle } from './InteractionModeToggle';
+import { MinimapContainer } from './MinimapContainer';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from './nodes/BranchNode';
 import { EndNode } from './nodes/EndNode';
@@ -252,42 +253,46 @@ export const WorkflowEditor: React.FC = () => {
         {/* Controls (zoom, fit view, etc.) */}
         <Controls />
 
-        {/* Mini map */}
-        <MiniMap
-          nodeColor={(node) => {
-            switch (node.type) {
-              case 'subAgent':
-                return 'var(--vscode-charts-blue)';
-              case 'askUserQuestion':
-                return 'var(--vscode-charts-orange)';
-              case 'branch': // Legacy
-                return 'var(--vscode-charts-yellow)';
-              case 'ifElse':
-                return 'var(--vscode-charts-yellow)';
-              case 'switch':
-                return 'var(--vscode-charts-yellow)';
-              case 'start':
-                return 'var(--vscode-charts-green)';
-              case 'end':
-                return 'var(--vscode-charts-red)';
-              case 'prompt':
-                return 'var(--vscode-charts-purple)';
-              case 'skill':
-                return 'var(--vscode-charts-cyan)';
-              case 'subAgentFlow':
-                return 'var(--vscode-charts-purple)';
-              default:
-                return 'var(--vscode-foreground)';
-            }
-          }}
-          maskColor="rgba(0, 0, 0, 0.5)"
-          style={{
-            backgroundColor: 'var(--vscode-editor-background)',
-            border: '1px solid var(--vscode-panel-border)',
-            width: isCompact ? 120 : 200,
-            height: isCompact ? 80 : 150,
-          }}
-        />
+        {/* Mini map with container */}
+        <Panel position="bottom-right">
+          <MinimapContainer>
+            <MiniMap
+              nodeColor={(node) => {
+                switch (node.type) {
+                  case 'subAgent':
+                    return 'var(--vscode-charts-blue)';
+                  case 'askUserQuestion':
+                    return 'var(--vscode-charts-orange)';
+                  case 'branch': // Legacy
+                    return 'var(--vscode-charts-yellow)';
+                  case 'ifElse':
+                    return 'var(--vscode-charts-yellow)';
+                  case 'switch':
+                    return 'var(--vscode-charts-yellow)';
+                  case 'start':
+                    return 'var(--vscode-charts-green)';
+                  case 'end':
+                    return 'var(--vscode-charts-red)';
+                  case 'prompt':
+                    return 'var(--vscode-charts-purple)';
+                  case 'skill':
+                    return 'var(--vscode-charts-cyan)';
+                  case 'subAgentFlow':
+                    return 'var(--vscode-charts-purple)';
+                  default:
+                    return 'var(--vscode-foreground)';
+                }
+              }}
+              maskColor="rgba(0, 0, 0, 0.5)"
+              style={{
+                position: 'relative',
+                backgroundColor: 'var(--vscode-editor-background)',
+                width: isCompact ? 120 : 200,
+                height: isCompact ? 80 : 150,
+              }}
+            />
+          </MinimapContainer>
+        </Panel>
 
         {/* Interaction Mode Toggle */}
         <Panel position="top-left">

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -28,6 +28,7 @@ import { useWorkflowStore } from '../../stores/workflow-store';
 import { EditableNameField } from '../common/EditableNameField';
 import { StyledTooltip } from '../common/StyledTooltip';
 import { InteractionModeToggle } from '../InteractionModeToggle';
+import { MinimapContainer } from '../MinimapContainer';
 import { NodePalette } from '../NodePalette';
 import { AskUserQuestionNodeComponent } from '../nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from '../nodes/BranchNode';
@@ -567,38 +568,46 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
             >
               <Background color="rgba(136, 87, 229, 0.3)" gap={15} size={1} />
               <Controls />
-              <MiniMap
-                nodeColor={(node) => {
-                  switch (node.type) {
-                    case 'subAgent':
-                      return 'var(--vscode-charts-blue)';
-                    case 'askUserQuestion':
-                      return 'var(--vscode-charts-orange)';
-                    case 'branch':
-                    case 'ifElse':
-                    case 'switch':
-                      return 'var(--vscode-charts-yellow)';
-                    case 'start':
-                      return 'var(--vscode-charts-green)';
-                    case 'end':
-                      return 'var(--vscode-charts-red)';
-                    case 'prompt':
-                    case 'subAgentFlowRef':
-                      return 'var(--vscode-charts-purple)';
-                    case 'skill':
-                      return 'var(--vscode-charts-cyan)';
-                    default:
-                      return 'var(--vscode-foreground)';
-                  }
-                }}
-                maskColor="rgba(0, 0, 0, 0.5)"
-                style={{
-                  backgroundColor: 'var(--vscode-editor-background)',
-                  border: '1px solid var(--vscode-panel-border)',
-                  width: isCompact ? 120 : 200,
-                  height: isCompact ? 80 : 150,
-                }}
-              />
+
+              {/* Mini map with container */}
+              <Panel position="bottom-right">
+                <MinimapContainer>
+                  <MiniMap
+                    nodeColor={(node) => {
+                      switch (node.type) {
+                        case 'subAgent':
+                          return 'var(--vscode-charts-blue)';
+                        case 'askUserQuestion':
+                          return 'var(--vscode-charts-orange)';
+                        case 'branch':
+                        case 'ifElse':
+                        case 'switch':
+                          return 'var(--vscode-charts-yellow)';
+                        case 'start':
+                          return 'var(--vscode-charts-green)';
+                        case 'end':
+                          return 'var(--vscode-charts-red)';
+                        case 'prompt':
+                        case 'subAgentFlowRef':
+                          return 'var(--vscode-charts-purple)';
+                        case 'skill':
+                          return 'var(--vscode-charts-cyan)';
+                        default:
+                          return 'var(--vscode-foreground)';
+                      }
+                    }}
+                    maskColor="rgba(0, 0, 0, 0.5)"
+                    style={{
+                      position: 'relative',
+                      backgroundColor: 'var(--vscode-editor-background)',
+                      width: isCompact ? 120 : 200,
+                      height: isCompact ? 80 : 150,
+                    }}
+                  />
+                </MinimapContainer>
+              </Panel>
+
+              {/* Interaction Mode Toggle */}
               <Panel position="top-left">
                 <InteractionModeToggle />
               </Panel>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -32,6 +32,10 @@ export interface WebviewTranslationKeys {
   'toolbar.interactionMode.switchToPan': string;
   'toolbar.interactionMode.switchToSelection': string;
 
+  // Toolbar minimap toggle
+  'toolbar.minimapToggle.show': string;
+  'toolbar.minimapToggle.hide': string;
+
   // Toolbar errors
   'toolbar.error.workflowNameRequired': string;
   'toolbar.error.workflowNameRequiredForExport': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -34,6 +34,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToPan': 'Switch to Hand Tool mode',
   'toolbar.interactionMode.switchToSelection': 'Switch to Selection mode',
 
+  // Toolbar minimap toggle
+  'toolbar.minimapToggle.show': 'Show Minimap',
+  'toolbar.minimapToggle.hide': 'Hide Minimap',
+
   // Toolbar errors
   'toolbar.error.workflowNameRequired': 'Workflow name is required',
   'toolbar.error.workflowNameRequiredForExport': 'Workflow name is required for export',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -34,6 +34,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToPan': '手のひらモードに切り替え',
   'toolbar.interactionMode.switchToSelection': '範囲選択モードに切り替え',
 
+  // Toolbar minimap toggle
+  'toolbar.minimapToggle.show': 'ミニマップを表示',
+  'toolbar.minimapToggle.hide': 'ミニマップを非表示',
+
   // Toolbar errors
   'toolbar.error.workflowNameRequired': 'ワークフロー名は必須です',
   'toolbar.error.workflowNameRequiredForExport': 'エクスポートにはワークフロー名が必要です',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -34,6 +34,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToPan': '손바닥 모드로 전환',
   'toolbar.interactionMode.switchToSelection': '선택 모드로 전환',
 
+  // Toolbar minimap toggle
+  'toolbar.minimapToggle.show': '미니맵 표시',
+  'toolbar.minimapToggle.hide': '미니맵 숨기기',
+
   // Toolbar errors
   'toolbar.error.workflowNameRequired': '워크플로 이름이 필요합니다',
   'toolbar.error.workflowNameRequiredForExport': '내보내기에는 워크플로 이름이 필요합니다',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -34,6 +34,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToPan': '切换到手掌模式',
   'toolbar.interactionMode.switchToSelection': '切换到选择模式',
 
+  // Toolbar minimap toggle
+  'toolbar.minimapToggle.show': '显示迷你地图',
+  'toolbar.minimapToggle.hide': '隐藏迷你地图',
+
   // Toolbar errors
   'toolbar.error.workflowNameRequired': '工作流名称必填',
   'toolbar.error.workflowNameRequiredForExport': '导出需要工作流名称',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -34,6 +34,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToPan': '切換到手掌模式',
   'toolbar.interactionMode.switchToSelection': '切換到選擇模式',
 
+  // Toolbar minimap toggle
+  'toolbar.minimapToggle.show': '顯示迷你地圖',
+  'toolbar.minimapToggle.hide': '隱藏迷你地圖',
+
   // Toolbar errors
   'toolbar.error.workflowNameRequired': '工作流名稱為必填',
   'toolbar.error.workflowNameRequiredForExport': '匯出需要工作流名稱',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -46,6 +46,7 @@ interface WorkflowStore {
   interactionMode: InteractionMode;
   workflowName: string;
   isPropertyPanelOpen: boolean;
+  isMinimapVisible: boolean;
 
   // Sub-Agent Flow State (Feature: 089-subworkflow)
   subAgentFlows: SubAgentFlow[];
@@ -66,6 +67,7 @@ interface WorkflowStore {
   setWorkflowName: (name: string) => void;
   openPropertyPanel: () => void;
   closePropertyPanel: () => void;
+  toggleMinimapVisibility: () => void;
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
@@ -224,6 +226,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   interactionMode: 'pan', // Default: pan mode
   workflowName: 'my-workflow', // Default workflow name
   isPropertyPanelOpen: true, // Property panel is open by default
+  isMinimapVisible: true, // Minimap is visible by default
 
   // Sub-Agent Flow Initial State (Feature: 089-subworkflow)
   subAgentFlows: [],
@@ -306,6 +309,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   openPropertyPanel: () => set({ isPropertyPanelOpen: true }),
 
   closePropertyPanel: () => set({ isPropertyPanelOpen: false }),
+
+  toggleMinimapVisibility: () => {
+    set({ isMinimapVisible: !get().isMinimapVisible });
+  },
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => {


### PR DESCRIPTION
## Summary

Add a minimap visibility toggle feature with an intuitive container-based UI design.

- Minimap is wrapped in a semi-transparent container frame
- Minimize button (−) positioned at top-right corner, integrated into the frame
- Click minimize to collapse, click Map icon to expand
- Works on both WorkflowEditor and SubAgentFlowDialog canvases

## Changes

### New Component
- `MinimapContainer.tsx`: Container component wrapping MiniMap with toggle functionality

### Modified Files
- `WorkflowEditor.tsx`: Integrate MinimapContainer
- `SubAgentFlowDialog.tsx`: Integrate MinimapContainer  
- `workflow-store.ts`: Add `isMinimapVisible` state and `toggleMinimapVisibility` action
- Translation files (5 languages): Add minimap toggle labels

## UI Design

### Visible State
```
┌──────────────────[−]┐
│                     │
│      MiniMap        │
│                     │
└─────────────────────┘
```
- Semi-transparent frame (20% opacity)
- Minimize button with left-bottom radius, blends into frame

### Minimized State
```
                 [Map]
```
- Only Map icon button visible

## Impact

- UX improvement for canvas workspace management
- No breaking changes
- State is session-only (not persisted)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)