### PR TITLE
improvement: add model, tools, and color settings to SubAgentFlow nodes

### DIFF
--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -209,6 +209,12 @@ export interface SubAgentFlowNodeData {
   description?: string;
   /** Number of output ports (fixed at 1 for SubAgentFlow nodes) */
   outputPorts: 1;
+  /** Model to use for this sub-agent flow execution */
+  model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  /** Comma-separated list of allowed tools */
+  tools?: string;
+  /** Visual color for the node */
+  color?: keyof typeof SUB_AGENT_COLORS;
 }
 
 export interface McpNodeData {

--- a/src/webview/src/components/PropertyPanel.tsx
+++ b/src/webview/src/components/PropertyPanel.tsx
@@ -6,7 +6,6 @@
  * Updated: Phase 3.3 - Added resizable width functionality
  */
 
-import * as Select from '@radix-ui/react-select';
 import type { McpNodeData } from '@shared/types/mcp-node';
 import type {
   AskUserQuestionData,
@@ -17,7 +16,6 @@ import type {
   SubAgentFlowNodeData,
   SwitchNodeData,
 } from '@shared/types/workflow-definition';
-import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
 import type React from 'react';
 import { useState } from 'react';
 import type { Node } from 'reactflow';
@@ -27,6 +25,7 @@ import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import type { PromptNodeData } from '../types/node-types';
 import { extractVariables } from '../utils/template-utils';
+import { ColorPicker } from './common/ColorPicker';
 import { ResizeHandle } from './common/ResizeHandle';
 import { McpNodeEditDialog } from './dialogs/McpNodeEditDialog';
 
@@ -461,131 +460,7 @@ const SubAgentProperties: React.FC<{
       </div>
 
       {/* Color */}
-      <div>
-        <label
-          htmlFor="color-select"
-          style={{
-            display: 'block',
-            fontSize: '12px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-            marginBottom: '6px',
-          }}
-        >
-          {t('properties.subAgent.color')}
-        </label>
-        <Select.Root
-          value={data.color || 'none'}
-          onValueChange={(value) =>
-            updateNodeData(node.id, {
-              color: value === 'none' ? undefined : (value as SubAgentData['color']),
-            })
-          }
-        >
-          <Select.Trigger
-            className="nodrag"
-            style={{
-              width: '100%',
-              padding: '6px 8px',
-              backgroundColor: 'var(--vscode-input-background)',
-              color: 'var(--vscode-input-foreground)',
-              border: '1px solid var(--vscode-input-border)',
-              borderRadius: '2px',
-              fontSize: '13px',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              cursor: 'pointer',
-            }}
-          >
-            <Select.Value placeholder={t('properties.subAgent.colorPlaceholder')}>
-              {data.color && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  <div
-                    style={{
-                      width: '14px',
-                      height: '14px',
-                      backgroundColor: SUB_AGENT_COLORS[data.color],
-                      borderRadius: '2px',
-                    }}
-                  />
-                  <span style={{ textTransform: 'capitalize' }}>{data.color}</span>
-                </div>
-              )}
-            </Select.Value>
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Content
-              position="popper"
-              sideOffset={4}
-              style={{
-                backgroundColor: 'var(--vscode-dropdown-background)',
-                border: '1px solid var(--vscode-dropdown-border)',
-                borderRadius: '2px',
-                boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
-                zIndex: 9999,
-                minWidth: '200px',
-              }}
-            >
-              <Select.Viewport style={{ padding: '4px' }}>
-                <Select.Item
-                  value="none"
-                  style={{
-                    padding: '6px 8px',
-                    fontSize: '13px',
-                    color: 'var(--vscode-foreground)',
-                    cursor: 'pointer',
-                    outline: 'none',
-                    borderRadius: '2px',
-                  }}
-                >
-                  <Select.ItemText>{t('properties.subAgent.colorNone')}</Select.ItemText>
-                </Select.Item>
-                {(Object.keys(SUB_AGENT_COLORS) as Array<keyof typeof SUB_AGENT_COLORS>).map(
-                  (colorKey) => (
-                    <Select.Item
-                      key={colorKey}
-                      value={colorKey}
-                      style={{
-                        padding: '6px 8px',
-                        fontSize: '13px',
-                        color: 'var(--vscode-foreground)',
-                        cursor: 'pointer',
-                        outline: 'none',
-                        borderRadius: '2px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                      }}
-                    >
-                      <div
-                        style={{
-                          width: '14px',
-                          height: '14px',
-                          backgroundColor: SUB_AGENT_COLORS[colorKey],
-                          borderRadius: '2px',
-                        }}
-                      />
-                      <Select.ItemText>
-                        <span style={{ textTransform: 'capitalize' }}>{colorKey}</span>
-                      </Select.ItemText>
-                    </Select.Item>
-                  )
-                )}
-              </Select.Viewport>
-            </Select.Content>
-          </Select.Portal>
-        </Select.Root>
-        <div
-          style={{
-            fontSize: '11px',
-            color: 'var(--vscode-descriptionForeground)',
-            marginTop: '4px',
-          }}
-        >
-          {t('properties.subAgent.colorHelp')}
-        </div>
-      </div>
+      <ColorPicker value={data.color} onChange={(color) => updateNodeData(node.id, { color })} />
     </div>
   );
 };
@@ -2450,7 +2325,7 @@ const McpProperties: React.FC<{
 const SubAgentFlowProperties: React.FC<{
   node: Node<SubAgentFlowNodeData>;
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
-}> = ({ node }) => {
+}> = ({ node, updateNodeData }) => {
   const { t } = useTranslation();
   const { subAgentFlows, setActiveSubAgentFlowId } = useWorkflowStore();
   const data = node.data;
@@ -2529,6 +2404,91 @@ const SubAgentFlowProperties: React.FC<{
           </button>
         </>
       )}
+
+      {/* Model */}
+      <div>
+        <label
+          htmlFor="subagentflow-model-select"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('property.model')}
+        </label>
+        <select
+          id="subagentflow-model-select"
+          value={data.model || 'sonnet'}
+          onChange={(e) =>
+            updateNodeData(node.id, {
+              model: e.target.value as 'sonnet' | 'opus' | 'haiku' | 'inherit',
+            })
+          }
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        >
+          <option value="sonnet">Sonnet</option>
+          <option value="opus">Opus</option>
+          <option value="haiku">Haiku</option>
+          <option value="inherit">Inherit</option>
+        </select>
+      </div>
+
+      {/* Tools */}
+      <div>
+        <label
+          htmlFor="subagentflow-tools-input"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('property.tools')}
+        </label>
+        <input
+          id="subagentflow-tools-input"
+          type="text"
+          value={data.tools || ''}
+          onChange={(e) => updateNodeData(node.id, { tools: e.target.value })}
+          placeholder={t('property.tools.placeholder')}
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        />
+        <div
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+            marginTop: '4px',
+          }}
+        >
+          {t('property.tools.help')}
+        </div>
+      </div>
+
+      {/* Color */}
+      <ColorPicker value={data.color} onChange={(color) => updateNodeData(node.id, { color })} />
     </div>
   );
 };

--- a/src/webview/src/components/common/ColorPicker.tsx
+++ b/src/webview/src/components/common/ColorPicker.tsx
@@ -1,0 +1,147 @@
+/**
+ * ColorPicker Component
+ *
+ * Reusable color picker using Radix UI Select with color preview.
+ * Used by SubAgent and SubAgentFlow nodes.
+ */
+
+import * as Select from '@radix-ui/react-select';
+import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
+import type React from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
+
+export type SubAgentColor = keyof typeof SUB_AGENT_COLORS;
+
+export interface ColorPickerProps {
+  value: SubAgentColor | undefined;
+  onChange: (color: SubAgentColor | undefined) => void;
+  disabled?: boolean;
+}
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange, disabled = false }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <label
+        htmlFor="color-select"
+        style={{
+          display: 'block',
+          fontSize: '12px',
+          fontWeight: 600,
+          color: 'var(--vscode-foreground)',
+          marginBottom: '6px',
+        }}
+      >
+        {t('properties.subAgent.color')}
+      </label>
+      <Select.Root
+        value={value || 'none'}
+        onValueChange={(val) => onChange(val === 'none' ? undefined : (val as SubAgentColor))}
+        disabled={disabled}
+      >
+        <Select.Trigger
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            opacity: disabled ? 0.6 : 1,
+          }}
+        >
+          <Select.Value placeholder={t('properties.subAgent.colorPlaceholder')}>
+            {value && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <div
+                  style={{
+                    width: '14px',
+                    height: '14px',
+                    backgroundColor: SUB_AGENT_COLORS[value],
+                    borderRadius: '2px',
+                  }}
+                />
+                <span style={{ textTransform: 'capitalize' }}>{value}</span>
+              </div>
+            )}
+          </Select.Value>
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content
+            position="popper"
+            sideOffset={4}
+            style={{
+              backgroundColor: 'var(--vscode-dropdown-background)',
+              border: '1px solid var(--vscode-dropdown-border)',
+              borderRadius: '2px',
+              boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+              zIndex: 9999,
+              minWidth: '200px',
+            }}
+          >
+            <Select.Viewport style={{ padding: '4px' }}>
+              <Select.Item
+                value="none"
+                style={{
+                  padding: '6px 8px',
+                  fontSize: '13px',
+                  color: 'var(--vscode-foreground)',
+                  cursor: 'pointer',
+                  outline: 'none',
+                  borderRadius: '2px',
+                }}
+              >
+                <Select.ItemText>{t('properties.subAgent.colorNone')}</Select.ItemText>
+              </Select.Item>
+              {(Object.keys(SUB_AGENT_COLORS) as SubAgentColor[]).map((colorKey) => (
+                <Select.Item
+                  key={colorKey}
+                  value={colorKey}
+                  style={{
+                    padding: '6px 8px',
+                    fontSize: '13px',
+                    color: 'var(--vscode-foreground)',
+                    cursor: 'pointer',
+                    outline: 'none',
+                    borderRadius: '2px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: '14px',
+                      height: '14px',
+                      backgroundColor: SUB_AGENT_COLORS[colorKey],
+                      borderRadius: '2px',
+                    }}
+                  />
+                  <Select.ItemText>
+                    <span style={{ textTransform: 'capitalize' }}>{colorKey}</span>
+                  </Select.ItemText>
+                </Select.Item>
+              ))}
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+      <div
+        style={{
+          fontSize: '11px',
+          color: 'var(--vscode-descriptionForeground)',
+          marginTop: '4px',
+        }}
+      >
+        {t('properties.subAgent.colorHelp')}
+      </div>
+    </div>
+  );
+};

--- a/src/webview/src/components/nodes/SubAgentFlowNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentFlowNode.tsx
@@ -9,6 +9,7 @@
  */
 
 import type { SubAgentFlowNodeData } from '@shared/types/workflow-definition';
+import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
 import { GitBranch } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
@@ -110,21 +111,40 @@ export const SubAgentFlowNodeComponent: React.FC<NodeProps<SubAgentFlowNodeData>
         )}
 
         {/* Sub-Agent Flow Info Badge */}
-        {isLinked && (
-          <div
-            style={{
-              fontSize: '10px',
-              color: 'var(--vscode-badge-foreground)',
-              backgroundColor: 'var(--vscode-badge-background)',
-              padding: '2px 6px',
-              borderRadius: '3px',
-              display: 'inline-block',
-              fontWeight: 600,
-            }}
-          >
-            {nodeCount} nodes
-          </div>
-        )}
+        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+          {isLinked && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: 'var(--vscode-badge-foreground)',
+                backgroundColor: 'var(--vscode-badge-background)',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                fontWeight: 600,
+              }}
+            >
+              {nodeCount} nodes
+            </div>
+          )}
+
+          {/* Color Badge */}
+          {data.color && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: '#ffffff',
+                backgroundColor: SUB_AGENT_COLORS[data.color],
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                textTransform: 'capitalize',
+              }}
+            >
+              {data.color}
+            </div>
+          )}
+        </div>
 
         {/* Not linked warning */}
         {!isLinked && data.subAgentFlowId && (


### PR DESCRIPTION
## Summary

Add model, tools, and color configuration options to SubAgentFlow nodes, matching the existing SubAgent node capabilities.

## Changes

### New Component
- **`src/webview/src/components/common/ColorPicker.tsx`** - Reusable color picker component extracted from SubAgent properties

### Modified Files
- **`src/shared/types/workflow-definition.ts`** - Add `model`, `tools`, `color` fields to `SubAgentFlowNodeData`
- **`src/webview/src/components/PropertyPanel.tsx`**
  - Refactor SubAgentProperties to use ColorPicker component (~100 lines reduced)
  - Add Model/Tools/Color settings to SubAgentFlowProperties
- **`src/webview/src/components/nodes/SubAgentFlowNode.tsx`** - Display color badge on canvas
- **`src/extension/services/export-service.ts`** - Apply model/tools/color to exported agent files

## Impact

- SubAgentFlow nodes now have the same configuration options as SubAgent nodes
- ColorPicker is now a reusable component for future node types
- Exported `.claude/agents/*.md` files include the configured model, tools, and color settings

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)