### PR TITLE
improvement: reduce MiniMap vertical margin

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -289,6 +289,7 @@ export const WorkflowEditor: React.FC = () => {
                 backgroundColor: 'var(--vscode-editor-background)',
                 width: isCompact ? 120 : 200,
                 height: isCompact ? 80 : 150,
+                margin: '4px 16px',
               }}
             />
           </MinimapContainer>


### PR DESCRIPTION
## Problem

The MiniMap component had excessive vertical margins (15px default from React Flow), making the minimap appear further from the canvas edge than desired.

## Solution

Override the default React Flow MiniMap margin with a reduced value.

### Changes

**File**: `src/webview/src/components/WorkflowEditor.tsx`

- Added explicit `margin: '4px 16px'` to MiniMap style
- Top/bottom margins reduced from 15px to 4px
- Left/right margins slightly increased from 15px to 16px

## Impact

- Minimap now sits closer to the bottom-right corner
- Better use of canvas space
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)