### PR TITLE
improvement: add Toggle component and enhance CodebaseSettingsDialog UX

### DIFF
--- a/src/webview/src/components/common/Toggle.tsx
+++ b/src/webview/src/components/common/Toggle.tsx
@@ -84,9 +84,7 @@ export const Toggle: React.FC<ToggleProps> = ({
           fontSize: `${dimensions.fontSize}px`,
           fontWeight: 600,
           // ON: white text on green / OFF: dark text on gray for light theme compatibility
-          color: checked
-            ? 'var(--vscode-button-foreground)'
-            : 'var(--vscode-foreground)',
+          color: checked ? 'var(--vscode-button-foreground)' : 'var(--vscode-foreground)',
           pointerEvents: 'none',
           transition: 'left 100ms, right 100ms, color 100ms',
           userSelect: 'none',

--- a/src/webview/src/components/dialogs/CodebaseSettingsDialog.tsx
+++ b/src/webview/src/components/dialogs/CodebaseSettingsDialog.tsx
@@ -11,14 +11,9 @@
  */
 
 import type React from 'react';
-import { useCallback, useEffect, useId, useRef } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
-import {
-  buildIndex,
-  cancelIndexBuild,
-  clearIndex,
-  getIndexStatus,
-} from '../../services/codebase-search-service';
+import { buildIndex, clearIndex, getIndexStatus } from '../../services/codebase-search-service';
 import { useRefinementStore } from '../../stores/refinement-store';
 import { Toggle } from '../common/Toggle';
 
@@ -36,7 +31,6 @@ export const CodebaseSettingsDialog: React.FC<CodebaseSettingsDialogProps> = ({
   const titleId = useId();
 
   const {
-    indexStatus,
     isIndexBuilding,
     indexBuildProgress,
     setIndexStatus,
@@ -44,6 +38,42 @@ export const CodebaseSettingsDialog: React.FC<CodebaseSettingsDialogProps> = ({
     useCodebaseSearch,
     toggleUseCodebaseSearch,
   } = useRefinementStore();
+
+  // Progress bar display state for minimum display duration & completion message
+  const [showProgress, setShowProgress] = useState(false);
+  const [progressPhase, setProgressPhase] = useState<'building' | 'complete'>('building');
+  const buildStartTimeRef = useRef<number>(0);
+  const MINIMUM_DISPLAY_MS = 1000;
+  const COMPLETION_DISPLAY_MS = 1000;
+
+  // Handle progress bar visibility with minimum display duration
+  useEffect(() => {
+    if (isIndexBuilding) {
+      // Start building
+      buildStartTimeRef.current = Date.now();
+      setShowProgress(true);
+      setProgressPhase('building');
+    } else if (showProgress && progressPhase === 'building') {
+      // Build finished - ensure minimum display time then show completion
+      const elapsed = Date.now() - buildStartTimeRef.current;
+      const remainingMinTime = Math.max(0, MINIMUM_DISPLAY_MS - elapsed);
+
+      const showCompletion = () => {
+        setProgressPhase('complete');
+        // Hide after showing completion
+        setTimeout(() => {
+          setShowProgress(false);
+          setProgressPhase('building');
+        }, COMPLETION_DISPLAY_MS);
+      };
+
+      if (remainingMinTime > 0) {
+        const timer = setTimeout(showCompletion, remainingMinTime);
+        return () => clearTimeout(timer);
+      }
+      showCompletion();
+    }
+  }, [isIndexBuilding, showProgress, progressPhase]);
 
   // Focus dialog when opened
   useEffect(() => {
@@ -96,18 +126,25 @@ export const CodebaseSettingsDialog: React.FC<CodebaseSettingsDialogProps> = ({
     }
   }, [setIndexStatus]);
 
-  const handleCancelBuild = useCallback(() => {
-    cancelIndexBuild();
-    setIndexBuilding(false, 0);
-  }, [setIndexBuilding]);
+  // Handle toggle change: ON builds index, OFF clears index
+  const handleToggleChange = useCallback(
+    async (checked: boolean) => {
+      toggleUseCodebaseSearch();
+
+      if (checked) {
+        // ON: Build index
+        await handleBuildIndex();
+      } else {
+        // OFF: Clear index
+        await handleClearIndex();
+      }
+    },
+    [toggleUseCodebaseSearch, handleBuildIndex, handleClearIndex]
+  );
 
   if (!isOpen) {
     return null;
   }
-
-  const isReady = indexStatus?.state === 'ready';
-  const documentCount = indexStatus?.documentCount ?? 0;
-  const fileCount = indexStatus?.fileCount ?? 0;
 
   return (
     <div
@@ -228,11 +265,55 @@ export const CodebaseSettingsDialog: React.FC<CodebaseSettingsDialogProps> = ({
             </div>
             <Toggle
               checked={useCodebaseSearch}
-              onChange={toggleUseCodebaseSearch}
+              onChange={handleToggleChange}
+              disabled={showProgress}
               ariaLabel={t('codebaseIndex.enableReference')}
               size="small"
             />
           </div>
+
+          {/* Progress bar (with minimum display duration & completion message) */}
+          {showProgress && (
+            <div style={{ marginTop: '12px' }}>
+              <div
+                style={{
+                  width: '100%',
+                  height: '4px',
+                  backgroundColor: 'var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  overflow: 'hidden',
+                }}
+              >
+                <div
+                  style={{
+                    width: progressPhase === 'complete' ? '100%' : `${indexBuildProgress}%`,
+                    height: '100%',
+                    backgroundColor:
+                      progressPhase === 'complete'
+                        ? 'var(--vscode-testing-iconPassed)'
+                        : 'var(--vscode-charts-yellow)',
+                    transition: 'width 0.3s, background-color 0.3s',
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  fontSize: '12px',
+                  color:
+                    progressPhase === 'complete'
+                      ? 'var(--vscode-testing-iconPassed)'
+                      : 'var(--vscode-descriptionForeground)',
+                  marginTop: '4px',
+                  fontWeight: progressPhase === 'complete' ? 600 : 400,
+                }}
+              >
+                {progressPhase === 'complete'
+                  ? 'Complete'
+                  : `Building index... ${indexBuildProgress}%`}
+              </div>
+            </div>
+          )}
+
           <ul
             style={{
               margin: '8px 0 0 0',
@@ -245,203 +326,6 @@ export const CodebaseSettingsDialog: React.FC<CodebaseSettingsDialogProps> = ({
             <li>{t('codebaseIndex.settings.description1')}</li>
             <li>{t('codebaseIndex.settings.description2')}</li>
           </ul>
-        </div>
-
-        {/* Index Status Section */}
-        <div
-          style={{
-            padding: '16px',
-            backgroundColor: 'var(--vscode-input-background)',
-            borderRadius: '4px',
-            marginBottom: '16px',
-          }}
-        >
-          {/* Status header with badge */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              marginBottom: isIndexBuilding ? '12px' : isReady && documentCount > 0 ? '12px' : '0',
-            }}
-          >
-            <span
-              style={{
-                fontSize: '13px',
-                fontWeight: 500,
-                color: 'var(--vscode-foreground)',
-              }}
-            >
-              {t('codebaseIndex.settings.status')}:
-            </span>
-            <span
-              style={{
-                padding: '2px 8px',
-                borderRadius: '4px',
-                fontSize: '12px',
-                fontWeight: 500,
-                backgroundColor: isIndexBuilding
-                  ? 'var(--vscode-charts-yellow)'
-                  : isReady && documentCount > 0
-                    ? 'var(--vscode-charts-green)'
-                    : 'var(--vscode-badge-background)',
-                color: isIndexBuilding
-                  ? 'var(--vscode-editor-background)'
-                  : isReady && documentCount > 0
-                    ? 'var(--vscode-editor-background)'
-                    : 'var(--vscode-badge-foreground)',
-              }}
-            >
-              {isIndexBuilding
-                ? t('codebaseIndex.building')
-                : isReady && documentCount > 0
-                  ? t('codebaseIndex.ready')
-                  : t('codebaseIndex.noIndex')}
-            </span>
-          </div>
-
-          {/* Progress bar (only when building) */}
-          {isIndexBuilding && (
-            <div>
-              <div
-                style={{
-                  width: '100%',
-                  height: '4px',
-                  backgroundColor: 'var(--vscode-input-border)',
-                  borderRadius: '2px',
-                  overflow: 'hidden',
-                }}
-              >
-                <div
-                  style={{
-                    width: `${indexBuildProgress}%`,
-                    height: '100%',
-                    backgroundColor: 'var(--vscode-charts-yellow)',
-                    transition: 'width 0.3s',
-                  }}
-                />
-              </div>
-              <div
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--vscode-descriptionForeground)',
-                  marginTop: '4px',
-                }}
-              >
-                {indexBuildProgress}%
-              </div>
-            </div>
-          )}
-
-          {/* Document/File counts (only when ready) */}
-          {isReady && documentCount > 0 && (
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: '8px',
-                fontSize: '12px',
-                color: 'var(--vscode-descriptionForeground)',
-              }}
-            >
-              <div>
-                {t('codebaseIndex.documents')}: <strong>{documentCount.toLocaleString()}</strong>
-              </div>
-              <div>
-                {t('codebaseIndex.files')}: <strong>{fileCount.toLocaleString()}</strong>
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Action Buttons */}
-        <div
-          style={{
-            display: 'flex',
-            gap: '8px',
-          }}
-        >
-          {isIndexBuilding ? (
-            <button
-              type="button"
-              onClick={handleCancelBuild}
-              style={{
-                flex: 1,
-                padding: '8px 16px',
-                backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                color: 'var(--vscode-button-secondaryForeground)',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                fontSize: '13px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: '6px',
-              }}
-            >
-              {t('codebaseIndex.cancel')}
-            </button>
-          ) : (
-            <>
-              <button
-                type="button"
-                onClick={handleBuildIndex}
-                style={{
-                  flex: 1,
-                  padding: '8px 16px',
-                  backgroundColor: 'var(--vscode-button-background)',
-                  color: 'var(--vscode-button-foreground)',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  fontSize: '13px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '6px',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-                }}
-              >
-                {isReady ? t('codebaseIndex.rebuild') : t('codebaseIndex.build')}
-              </button>
-
-              {isReady && documentCount > 0 && (
-                <button
-                  type="button"
-                  onClick={handleClearIndex}
-                  style={{
-                    padding: '8px 16px',
-                    backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                    color: 'var(--vscode-button-secondaryForeground)',
-                    border: 'none',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontSize: '13px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: '6px',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.backgroundColor =
-                      'var(--vscode-button-secondaryHoverBackground)';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.backgroundColor =
-                      'var(--vscode-button-secondaryBackground)';
-                  }}
-                >
-                  {t('codebaseIndex.clear')}
-                </button>
-              )}
-            </>
-          )}
         </div>
       </div>
     </div>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -693,16 +693,12 @@ export interface WebviewTranslationKeys {
   'codebaseIndex.rebuild': string;
   'codebaseIndex.build': string;
   'codebaseIndex.clear': string;
-  'codebaseIndex.documents': string;
-  'codebaseIndex.files': string;
-  'codebaseIndex.noIndex': string;
   'codebaseIndex.cancel': string;
   'codebaseIndex.button': string;
   'codebaseIndex.enableReference': string;
   'codebaseIndex.settings.title': string;
   'codebaseIndex.settings.description1': string;
   'codebaseIndex.settings.description2': string;
-  'codebaseIndex.settings.status': string;
   'codebaseIndex.settings.disabled': string;
 
   // Codebase Reference (Issue #265)

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -767,9 +767,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'codebaseIndex.rebuild': 'Rebuild Index',
   'codebaseIndex.build': 'Build Index',
   'codebaseIndex.clear': 'Clear Index',
-  'codebaseIndex.documents': 'Documents',
-  'codebaseIndex.files': 'Files',
-  'codebaseIndex.noIndex': 'Not built',
   'codebaseIndex.cancel': 'Cancel',
   'codebaseIndex.button': 'Codebase Reference (β)',
   'codebaseIndex.enableReference': 'Enable codebase reference',
@@ -778,7 +775,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
     'When enabled, AI responses will include related code snippets from your codebase. You can also use @codebase command to search explicitly.',
   'codebaseIndex.settings.description2':
     'Currently implemented with keyword search (BM25), with plans to upgrade to semantic search using vector DB in the future.',
-  'codebaseIndex.settings.status': 'Index Status',
   'codebaseIndex.settings.disabled': 'Codebase reference is disabled',
 
   // Codebase Reference (Issue #265)

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -760,9 +760,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'codebaseIndex.rebuild': 'インデックスを再構築',
   'codebaseIndex.build': 'インデックスを構築',
   'codebaseIndex.clear': 'インデックスをクリア',
-  'codebaseIndex.documents': 'ドキュメント数',
-  'codebaseIndex.files': 'ファイル数',
-  'codebaseIndex.noIndex': '未作成',
   'codebaseIndex.cancel': 'キャンセル',
   'codebaseIndex.button': 'コードベース参照(β)',
   'codebaseIndex.enableReference': 'コードベース参照を有効化',
@@ -771,7 +768,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
     '有効にすると、AI応答にコードベースから関連するコードスニペットが含まれます。@codebase コマンドで明示的に検索することもできます。',
   'codebaseIndex.settings.description2':
     '現在はキーワード検索（BM25）で実装されており、将来的にはベクトルDBによる意味検索にアップグレード予定です。',
-  'codebaseIndex.settings.status': 'インデックスの状態',
   'codebaseIndex.settings.disabled': 'コードベース参照は無効です',
 
   // Codebase Reference (Issue #265)

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -760,9 +760,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'codebaseIndex.rebuild': '인덱스 재구축',
   'codebaseIndex.build': '인덱스 구축',
   'codebaseIndex.clear': '인덱스 삭제',
-  'codebaseIndex.documents': '문서',
-  'codebaseIndex.files': '파일',
-  'codebaseIndex.noIndex': '미구축',
   'codebaseIndex.cancel': '취소',
   'codebaseIndex.button': '코드베이스 참조(β)',
   'codebaseIndex.enableReference': '코드베이스 참조 활성화',
@@ -771,7 +768,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
     '활성화하면 AI 응답에 코드베이스에서 관련 코드 스니펫이 포함됩니다. @codebase 명령을 사용하여 명시적으로 검색할 수도 있습니다.',
   'codebaseIndex.settings.description2':
     '현재는 키워드 검색(BM25)으로 구현되어 있으며, 향후 벡터 DB를 사용한 의미 검색으로 업그레이드할 예정입니다.',
-  'codebaseIndex.settings.status': '인덱스 상태',
   'codebaseIndex.settings.disabled': '코드베이스 참조가 비활성화되어 있습니다',
 
   // Codebase Reference (Issue #265)

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -731,9 +731,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'codebaseIndex.rebuild': '重建索引',
   'codebaseIndex.build': '构建索引',
   'codebaseIndex.clear': '清除索引',
-  'codebaseIndex.documents': '文档',
-  'codebaseIndex.files': '文件',
-  'codebaseIndex.noIndex': '未构建',
   'codebaseIndex.cancel': '取消',
   'codebaseIndex.button': '代码库参照(β)',
   'codebaseIndex.enableReference': '启用代码库参照',
@@ -742,7 +739,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
     '启用后，AI响应将包含代码库中的相关代码片段。您也可以使用@codebase命令进行显式搜索。',
   'codebaseIndex.settings.description2':
     '目前使用关键词搜索（BM25）实现，未来计划升级为使用向量数据库的语义搜索。',
-  'codebaseIndex.settings.status': '索引状态',
   'codebaseIndex.settings.disabled': '代码库参照已禁用',
 
   // Codebase Reference (Issue #265)

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -731,9 +731,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'codebaseIndex.rebuild': '重建索引',
   'codebaseIndex.build': '建立索引',
   'codebaseIndex.clear': '清除索引',
-  'codebaseIndex.documents': '文件',
-  'codebaseIndex.files': '檔案',
-  'codebaseIndex.noIndex': '未建立',
   'codebaseIndex.cancel': '取消',
   'codebaseIndex.button': '程式碼庫參照(β)',
   'codebaseIndex.enableReference': '啟用程式碼庫參照',
@@ -742,7 +739,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
     '啟用後，AI回應將包含程式碼庫中的相關程式碼片段。您也可以使用@codebase指令進行明確搜尋。',
   'codebaseIndex.settings.description2':
     '目前使用關鍵詞搜尋（BM25）實現，未來計劃升級為使用向量資料庫的語義搜尋。',
-  'codebaseIndex.settings.status': '索引狀態',
   'codebaseIndex.settings.disabled': '程式碼庫參照已停用',
 
   // Codebase Reference (Issue #265)


### PR DESCRIPTION
## Summary

- Add reusable Toggle component with OFF/ON labels (iOS-style design)
- Simplify CodebaseSettingsDialog by removing Index Status section
- Enhance progress bar UX with minimum display duration and completion message

## Changes

### New: Toggle Component
- `src/webview/src/components/common/Toggle.tsx`
- Based on radix-ui Switch with OFF/ON labels displayed inside
- VSCode theme color integration (works with light/dark themes)
- Two sizes: small (54x26px), medium (64x30px)

### CodebaseSettingsDialog Improvements
- Replace checkbox with Toggle component
- Auto-build index when toggle ON, auto-clear when OFF
- Remove Index Status section (badge, document/file counts) - simplifies UI
- Progress bar enhancements:
  - Minimum 1s display duration (prevents "flash" on fast builds)
  - Shows "Building index... X%" during build
  - Shows green "Complete" message for 1s after completion

### Removed
- Unused translation keys: `codebaseIndex.documents`, `codebaseIndex.files`, `codebaseIndex.noIndex`, `codebaseIndex.settings.status`

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check)
- [x] Build successful

## Related

- Cancel button feature deferred to #269 due to async race condition complexity