### PR TITLE
improvement: consolidate toolbar actions into More dropdown menu

### DIFF
--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -63,6 +63,7 @@ const App: React.FC = () => {
   const [connectionRequiredWorkspaceName, setConnectionRequiredWorkspaceName] = useState<
     string | undefined
   >(undefined);
+  const [isMoreActionsOpen, setIsMoreActionsOpen] = useState(false);
 
   const handleError = (errorData: ErrorPayload) => {
     setError(errorData);
@@ -192,6 +193,8 @@ const App: React.FC = () => {
         onError={handleError}
         onStartTour={handleStartTour}
         onShareToSlack={handleShareToSlack}
+        moreActionsOpen={isMoreActionsOpen}
+        onMoreActionsOpenChange={setIsMoreActionsOpen}
       />
 
       {/* Main Content: 3-column layout */}

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -5,7 +5,7 @@
  */
 
 import type { Workflow } from '@shared/types/messages';
-import { FileDown, Save, Share2, SquareSlash, Trash2 } from 'lucide-react';
+import { FileDown, Save, SquareSlash } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
@@ -24,14 +24,23 @@ import { EditableNameField } from './common/EditableNameField';
 import { ProcessingOverlay } from './common/ProcessingOverlay';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
 import { ConfirmDialog } from './dialogs/ConfirmDialog';
+import { MoreActionsDropdown } from './toolbar/MoreActionsDropdown';
 
 interface ToolbarProps {
   onError: (error: { code: string; message: string; details?: unknown }) => void;
   onStartTour: () => void;
   onShareToSlack: () => void;
+  moreActionsOpen?: boolean;
+  onMoreActionsOpenChange?: (open: boolean) => void;
 }
 
-export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareToSlack }) => {
+export const Toolbar: React.FC<ToolbarProps> = ({
+  onError,
+  onStartTour,
+  onShareToSlack,
+  moreActionsOpen,
+  onMoreActionsOpenChange,
+}) => {
   const { t, locale } = useTranslation();
   const isCompact = useIsCompactMode();
   const {
@@ -407,70 +416,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({ onError, onStartTour, onShareT
           }}
         />
 
-        {/* Share to Slack Button - Phase 3.1 (Beta feature, placed before help button) */}
-        <StyledTooltipItem content={t('slack.share.tooltip')}>
-          <button
-            type="button"
-            onClick={onShareToSlack}
-            data-tour="slack-share-button"
-            style={{
-              padding: isCompact ? '4px 8px' : '4px 12px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
-              whiteSpace: 'nowrap',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '4px',
-            }}
-          >
-            {isCompact ? <Share2 size={16} /> : t('slack.share.title')}
-          </button>
-        </StyledTooltipItem>
-
-        {/* Reset Workflow Button */}
-        <StyledTooltipItem content={t('toolbar.resetWorkflow')}>
-          <button
-            type="button"
-            onClick={() => setShowResetConfirm(true)}
-            style={{
-              padding: '4px 8px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '4px',
-            }}
-          >
-            <Trash2 size={16} />
-          </button>
-        </StyledTooltipItem>
-
-        {/* Help Button */}
-        <button
-          type="button"
-          onClick={onStartTour}
-          title="Start Tour"
-          data-tour="help-button"
-          style={{
-            padding: '4px 8px',
-            backgroundColor: 'var(--vscode-button-secondaryBackground)',
-            color: 'var(--vscode-button-secondaryForeground)',
-            border: 'none',
-            borderRadius: '2px',
-            cursor: 'pointer',
-            fontSize: '13px',
-          }}
-        >
-          ?
-        </button>
+        {/* More Actions Dropdown */}
+        <MoreActionsDropdown
+          onShareToSlack={onShareToSlack}
+          onResetWorkflow={() => setShowResetConfirm(true)}
+          onStartTour={onStartTour}
+          open={moreActionsOpen}
+          onOpenChange={onMoreActionsOpenChange}
+        />
 
         {/* Processing Overlay (Phase 3.10) */}
         <ProcessingOverlay isVisible={isProcessing} />

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -1,0 +1,146 @@
+/**
+ * More Actions Dropdown Component
+ *
+ * Consolidates additional toolbar actions into a single dropdown menu:
+ * - Share to Slack
+ * - Reset Workflow
+ * - Help (Start Tour)
+ */
+
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { HelpCircle, MoreHorizontal, Share2, Trash2 } from 'lucide-react';
+import { useIsCompactMode } from '../../hooks/useWindowWidth';
+import { useTranslation } from '../../i18n/i18n-context';
+
+// Fixed font sizes for dropdown menu (not responsive)
+const FONT_SIZES = {
+  small: 11,
+} as const;
+
+interface MoreActionsDropdownProps {
+  onShareToSlack: () => void;
+  onResetWorkflow: () => void;
+  onStartTour: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function MoreActionsDropdown({
+  onShareToSlack,
+  onResetWorkflow,
+  onStartTour,
+  open,
+  onOpenChange,
+}: MoreActionsDropdownProps) {
+  const { t } = useTranslation();
+  const isCompact = useIsCompactMode();
+
+  return (
+    <DropdownMenu.Root open={open} onOpenChange={onOpenChange}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          data-tour="more-actions-button"
+          style={{
+            padding: '4px 8px',
+            backgroundColor: 'var(--vscode-button-secondaryBackground)',
+            color: 'var(--vscode-button-secondaryForeground)',
+            border: 'none',
+            borderRadius: '2px',
+            cursor: 'pointer',
+            fontSize: '13px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+          }}
+        >
+          <MoreHorizontal size={16} />
+          {!isCompact && <span>{t('toolbar.moreActions')}</span>}
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          sideOffset={4}
+          align="end"
+          style={{
+            backgroundColor: 'var(--vscode-dropdown-background)',
+            border: '1px solid var(--vscode-dropdown-border)',
+            borderRadius: '4px',
+            boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+            zIndex: 9999,
+            minWidth: '160px',
+            padding: '4px',
+          }}
+        >
+          {/* Share to Slack */}
+          <DropdownMenu.Item
+            onSelect={onShareToSlack}
+            data-tour="slack-share-button"
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <Share2 size={14} />
+            <span>{t('slack.share.title')}</span>
+          </DropdownMenu.Item>
+
+          {/* Reset Workflow */}
+          <DropdownMenu.Item
+            onSelect={onResetWorkflow}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <Trash2 size={14} />
+            <span>{t('toolbar.resetWorkflow')}</span>
+          </DropdownMenu.Item>
+
+          <DropdownMenu.Separator
+            style={{
+              height: '1px',
+              backgroundColor: 'var(--vscode-panel-border)',
+              margin: '4px 0',
+            }}
+          />
+
+          {/* Help / Start Tour */}
+          <DropdownMenu.Item
+            onSelect={onStartTour}
+            data-tour="help-button"
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <HelpCircle size={14} />
+            <span>{t('toolbar.help')}</span>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -213,19 +213,10 @@ export const getTourSteps = (
     },
   },
   {
-    element: '[data-tour="slack-share-button"]',
+    element: '[data-tour="more-actions-button"]',
     popover: {
       title: '',
-      description: t('tour.slackShare'),
-      side: 'bottom',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="help-button"]',
-    popover: {
-      title: '',
-      description: t('tour.helpButton'),
+      description: t('tour.moreActions'),
       side: 'bottom',
       align: 'start',
     },

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -50,7 +50,10 @@ export interface WebviewTranslationKeys {
   'toolbar.save.tooltip': string;
   'toolbar.convert.iconTooltip': string;
   'toolbar.load.tooltip': string;
-  'slack.share.tooltip': string;
+
+  // Toolbar more actions dropdown
+  'toolbar.moreActions': string;
+  'toolbar.help': string;
 
   // Node Palette
   'palette.title': string;
@@ -244,8 +247,7 @@ export interface WebviewTranslationKeys {
   'tour.loadWorkflow': string;
   'tour.exportWorkflow': string;
   'tour.refineWithAI': string;
-  'tour.slackShare': string;
-  'tour.helpButton': string;
+  'tour.moreActions': string;
 
   // Tour buttons
   'tour.button.back': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -54,7 +54,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.save.tooltip': 'Save workflow',
   'toolbar.convert.iconTooltip': 'Convert to Slash Command',
   'toolbar.load.tooltip': 'Load saved workflow',
-  'slack.share.tooltip': 'Share to Slack',
+
+  // Toolbar more actions dropdown
+  'toolbar.moreActions': 'More',
+  'toolbar.help': 'Help',
 
   // Node Palette
   'palette.title': 'Node Palette',
@@ -270,10 +273,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
     'Click the "Export" button to export in a format executable by Claude Code.\n\nSub-Agents go to `.claude/agents/` and SlashCommands to `.claude/commands/`.',
   'tour.refineWithAI':
     'Use the "Edit with AI" button to create or improve workflows through an interactive chat with AI.\n\nYou can start from an empty canvas or edit existing workflows conversationally.',
-  'tour.slackShare':
-    'Click the "Share to Slack" button to share your workflow with your team.\n\nYou can post workflows to Slack channels for easy collaboration.',
-  'tour.helpButton':
-    'To see this tour again, click the help button (?).\n\nEnjoy creating workflows!',
+  'tour.moreActions':
+    'The "More" menu provides additional actions:<br><br>• Share to Slack - Share workflows with your team<br>• Reset Workflow - Clear the canvas<br>• Help - View this tour again<br><br>Enjoy creating workflows!',
 
   // Tour buttons
   'tour.button.back': 'Back',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -54,7 +54,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.save.tooltip': 'ワークフローを保存',
   'toolbar.convert.iconTooltip': 'Slash Commandに変換',
   'toolbar.load.tooltip': '保存したワークフローを読み込む',
-  'slack.share.tooltip': 'Slackに共有',
+
+  // Toolbar more actions dropdown
+  'toolbar.moreActions': 'その他',
+  'toolbar.help': 'ヘルプ',
 
   // Node Palette
   'palette.title': 'ノードパレット',
@@ -270,10 +273,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
     '「エクスポート」ボタンをクリックすると、Claude Codeで実行可能な形式にエクスポートされます。\n\nSub-Agentは`.claude/agents/`に、SlashCommandは`.claude/commands/`に出力されます。',
   'tour.refineWithAI':
     '「AI編集」ボタンで、AIとチャットしながらワークフローを生成・改善できます。\n\n空のキャンバスから新規作成も、既存のワークフローの修正も対話的に行えます。',
-  'tour.slackShare':
-    '「Slackに共有」ボタンをクリックすると、チームとワークフローを共有できます。\n\nSlackチャンネルにワークフローを投稿して、簡単にコラボレーションできます。',
-  'tour.helpButton':
-    'このツアーをもう一度見たい場合は、ヘルプボタン(?)をクリックしてください。\n\nそれでは、ワークフロー作成を楽しんでください！',
+  'tour.moreActions':
+    '「その他」メニューから追加の操作が利用できます：<br><br>• Slackに共有 - チームとワークフローを共有<br>• リセット - キャンバスをクリア<br>• ヘルプ - このツアーを再表示<br><br>それでは、ワークフロー作成を楽しんでください！',
 
   // Tour buttons
   'tour.button.back': '戻る',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -54,7 +54,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.save.tooltip': '워크플로 저장',
   'toolbar.convert.iconTooltip': 'Slash Command로 변환',
   'toolbar.load.tooltip': '저장된 워크플로 불러오기',
-  'slack.share.tooltip': 'Slack에 공유',
+
+  // Toolbar more actions dropdown
+  'toolbar.moreActions': '더보기',
+  'toolbar.help': '도움말',
 
   // Node Palette
   'palette.title': '노드 팔레트',
@@ -272,10 +275,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
     '"내보내기" 버튼을 클릭하면 Claude Code에서 실행 가능한 형식으로 내보내집니다.\n\nSub-Agent는 `.claude/agents/`로, SlashCommand는 `.claude/commands/`로 이동합니다.',
   'tour.refineWithAI':
     '"AI로 편집" 버튼을 사용하여 AI와 대화하며 워크플로우를 생성하거나 개선할 수 있습니다.\n\n빈 캔버스에서 시작하거나 기존 워크플로우를 대화형으로 수정할 수 있습니다.',
-  'tour.slackShare':
-    '"Slack에 공유" 버튼을 클릭하여 팀과 워크플로우를 공유하세요.\n\nSlack 채널에 워크플로우를 게시하여 쉽게 협업할 수 있습니다.',
-  'tour.helpButton':
-    '이 투어를 다시 보려면 도움말 버튼(?)을 클릭하세요.\n\n워크플로우 생성을 즐기세요!',
+  'tour.moreActions':
+    '"더보기" 메뉴에서 추가 작업을 사용할 수 있습니다:<br><br>• Slack에 공유 - 팀과 워크플로우 공유<br>• 초기화 - 캔버스 지우기<br>• 도움말 - 이 투어 다시 보기<br><br>워크플로우 생성을 즐기세요!',
 
   // Tour buttons
   'tour.button.back': '뒤로',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -52,7 +52,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.save.tooltip': '保存工作流',
   'toolbar.convert.iconTooltip': '转换为Slash Command',
   'toolbar.load.tooltip': '加载已保存的工作流',
-  'slack.share.tooltip': '分享到Slack',
+
+  // Toolbar more actions dropdown
+  'toolbar.moreActions': '更多',
+  'toolbar.help': '帮助',
 
   // Node Palette
   'palette.title': '节点面板',
@@ -260,9 +263,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
     '点击"导出"按钮以Claude Code可执行的格式导出。\n\nSub-Agent导出到`.claude/agents/`，SlashCommand导出到`.claude/commands/`。',
   'tour.refineWithAI':
     '使用"AI编辑"按钮通过与AI对话创建或改进工作流。\n\n可以从空画布开始或以对话方式编辑现有工作流。',
-  'tour.slackShare':
-    '点击"分享到Slack"按钮与团队分享您的工作流。\n\n可以将工作流发布到Slack频道以便于协作。',
-  'tour.helpButton': '要再次查看此导览，请点击帮助按钮(?)。\n\n享受创建工作流的乐趣！',
+  'tour.moreActions':
+    '"更多"菜单提供以下功能：<br><br>• 分享到Slack - 与团队分享工作流<br>• 重置 - 清空画布<br>• 帮助 - 再次查看此导览<br><br>享受创建工作流的乐趣！',
 
   // Tour buttons
   'tour.button.back': '返回',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -52,7 +52,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.save.tooltip': '儲存工作流程',
   'toolbar.convert.iconTooltip': '轉換為Slash Command',
   'toolbar.load.tooltip': '載入已儲存的工作流程',
-  'slack.share.tooltip': '分享到Slack',
+
+  // Toolbar more actions dropdown
+  'toolbar.moreActions': '更多',
+  'toolbar.help': '說明',
 
   // Node Palette
   'palette.title': '節點面板',
@@ -260,9 +263,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
     '點擊「匯出」按鈕以Claude Code可執行的格式匯出。\n\nSub-Agent匯出到`.claude/agents/`，SlashCommand匯出到`.claude/commands/`。',
   'tour.refineWithAI':
     '使用「AI編輯」按鈕透過與AI對話建立或改善工作流程。\n\n可以從空白畫布開始或以對話方式編輯現有工作流程。',
-  'tour.slackShare':
-    '點擊「分享到Slack」按鈕與團隊分享您的工作流程。\n\n可以將工作流程發布到Slack頻道以便於協作。',
-  'tour.helpButton': '要再次檢視此導覽，請點擊說明按鈕(?)。\n\n享受建立工作流程的樂趣！',
+  'tour.moreActions':
+    '「更多」選單提供以下功能：<br><br>• 分享到Slack - 與團隊分享工作流程<br>• 重置 - 清空畫布<br>• 說明 - 再次檢視此導覽<br><br>享受建立工作流程的樂趣！',
 
   // Tour buttons
   'tour.button.back': '返回',


### PR DESCRIPTION
## Summary

Consolidate Slack share, Reset workflow, and Help buttons from the toolbar into a single "More" (その他) dropdown menu for a cleaner UI.

## Changes

### New Component
- **`MoreActionsDropdown.tsx`**: New dropdown component using `@radix-ui/react-dropdown-menu`
  - Contains Share to Slack, Reset Workflow, and Help menu items
  - Supports responsive icon-only mode in compact view via `useIsCompactMode` hook

### Toolbar Simplification
- **`Toolbar.tsx`**: Removed individual Slack, Reset, Help buttons
  - Added controllable dropdown state props for future extensibility

### Guided Tour Update
- **`tour-steps.ts`**: Combined `tour.slackShare` and `tour.helpButton` steps into single `tour.moreActions` step
  - Avoids complexity of programmatically opening dropdown during tour
  - Tour now highlights the More button and explains available actions

### Translation Updates
- Added `tour.moreActions` key with proper HTML line breaks (`<br>`) for Driver.js
- Removed unused tooltip keys: `slack.share.tooltip`, `toolbar.resetWorkflow.tooltip`, `toolbar.help.tooltip`, `toolbar.moreActions.tooltip`
- Updated all 5 language files (en, ja, ko, zh-CN, zh-TW)

## Impact

- Cleaner toolbar UI with fewer buttons
- Simpler guided tour without complex dropdown control logic
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Build passes (`npm run build`)
- [x] Code quality checks pass (`npm run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)