### PR TITLE
fix: dialog positioning broken by NodePalette transform

### DIFF
--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -9,7 +9,9 @@
       "version": "3.8.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-portal": "^1.1.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-toggle-group": "^1.1.11",
@@ -62,6 +64,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -885,6 +888,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -1110,6 +1143,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -1143,12 +1200,12 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.10.tgz",
+      "integrity": "sha512-4kY9IVa6+9nJPsYmngK5Uk2kUmZnv7ChhHAFeQ5oaj8jrR1bIi3xww8nH71pz1/Ve4d/cXO3YxT8eikt1B0a8w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-primitive": "2.1.4",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
@@ -1162,6 +1219,47 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1271,6 +1369,30 @@
         "@radix-ui/react-visually-hidden": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1406,6 +1528,30 @@
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2514,6 +2660,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2524,6 +2671,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2652,6 +2800,7 @@
       "integrity": "sha512-fvDz8o7SQpFLoSBo6Cudv+fE85/fPCkwTnLAN85M+Jv7k59w2mSIjT9Q5px7XwGrmYqqKBEYxh/09IBGd1E7AQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.14",
         "fflate": "^0.8.2",
@@ -2734,6 +2883,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2856,6 +3006,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3222,6 +3373,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3263,6 +3415,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3272,6 +3425,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3640,6 +3794,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3715,6 +3870,7 @@
       "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.14",
         "@vitest/mocker": "4.0.14",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -13,7 +13,9 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-portal": "^1.1.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-toggle-group": "^1.1.11",

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -5,6 +5,7 @@
  * Based on: /specs/001-cc-wf-studio/plan.md
  */
 
+import * as Collapsible from '@radix-ui/react-collapsible';
 import type {
   ErrorPayload,
   ImportWorkflowFromSlackPayload,
@@ -214,31 +215,21 @@ const App: React.FC = () => {
           overflow: 'hidden',
         }}
       >
-        {/* Left Panel: Node Palette with collapse/expand animation */}
-        <div
+        {/* Left Panel: Node Palette with Radix Collapsible */}
+        <Collapsible.Root
+          open={!isNodePaletteCollapsed}
           style={{
             position: 'relative',
             display: 'flex',
             flexDirection: 'column',
-            width: isNodePaletteCollapsed ? '0px' : '200px',
-            minWidth: isNodePaletteCollapsed ? '0px' : '200px',
-            transition: 'width 150ms ease-out, min-width 150ms ease-out',
-            overflow: 'hidden',
           }}
         >
-          {/* NodePalette with slide animation */}
-          <div
-            style={{
-              transform: isNodePaletteCollapsed ? 'translateX(-100%)' : 'translateX(0)',
-              pointerEvents: isNodePaletteCollapsed ? 'none' : 'auto',
-              transition: 'transform 150ms ease-out',
-            }}
-          >
+          <Collapsible.Content className="node-palette-collapsible">
             <NodePalette onCollapse={toggleNodePalette} />
-          </div>
+          </Collapsible.Content>
           {/* Simple overlay for Left Panel */}
           <SimpleOverlay isVisible={isProcessing} />
-        </div>
+        </Collapsible.Root>
 
         {/* Center: Workflow Editor with processing overlay (Phase 3.10 - modified) */}
         <div style={{ flex: 1, position: 'relative' }}>
@@ -361,6 +352,39 @@ const App: React.FC = () => {
           @keyframes spin {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
+          }
+
+          /* Node Palette Collapsible Animation */
+          .node-palette-collapsible {
+            overflow: hidden;
+          }
+
+          .node-palette-collapsible[data-state='open'] {
+            width: 200px;
+            animation: slideOpen 150ms ease-out;
+          }
+
+          .node-palette-collapsible[data-state='closed'] {
+            width: 0px;
+            animation: slideClose 150ms ease-out;
+          }
+
+          @keyframes slideOpen {
+            from {
+              width: 0px;
+            }
+            to {
+              width: 200px;
+            }
+          }
+
+          @keyframes slideClose {
+            from {
+              width: 200px;
+            }
+            to {
+              width: 0px;
+            }
           }
         `}
       </style>

--- a/src/webview/src/components/dialogs/McpNodeDialog.tsx
+++ b/src/webview/src/components/dialogs/McpNodeDialog.tsx
@@ -7,6 +7,7 @@
  * Based on: specs/001-mcp-natural-language-mode/tasks.md T017, T048
  */
 
+import * as Portal from '@radix-ui/react-portal';
 import type { McpToolReference } from '@shared/types/mcp-node';
 import { NodeType } from '@shared/types/workflow-definition';
 import { useEffect, useState } from 'react';
@@ -358,115 +359,99 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
     }
   };
 
+  // Portal ensures dialog renders at document.body, avoiding transform containment issues
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-      }}
-      onClick={handleClose}
-      role="presentation"
-    >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation, not for click actions */}
+    <Portal.Root>
       <div
         style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '6px',
-          padding: '24px',
-          maxWidth: '600px',
-          width: '90%',
-          maxHeight: '90vh',
-          overflow: 'auto',
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000,
         }}
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
+        onClick={handleClose}
+        role="presentation"
       >
-        {/* Dialog Header */}
-        <h2
-          style={{
-            margin: '0 0 8px 0',
-            fontSize: '18px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-          }}
-        >
-          {t('mcp.dialog.title')}
-        </h2>
-
-        {/* Step Indicator */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation, not for click actions */}
         <div
           style={{
-            marginBottom: '20px',
-            fontSize: '12px',
-            color: 'var(--vscode-descriptionForeground)',
+            backgroundColor: 'var(--vscode-editor-background)',
+            border: '1px solid var(--vscode-panel-border)',
+            borderRadius: '6px',
+            padding: '24px',
+            maxWidth: '600px',
+            width: '90%',
+            maxHeight: '90vh',
+            overflow: 'auto',
           }}
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
         >
-          {t('mcp.dialog.wizardStep', {
-            current: wizard.state.currentStep.toString(),
-            total: '7',
-          })}
-        </div>
+          {/* Dialog Header */}
+          <h2
+            style={{
+              margin: '0 0 8px 0',
+              fontSize: '18px',
+              fontWeight: 600,
+              color: 'var(--vscode-foreground)',
+            }}
+          >
+            {t('mcp.dialog.title')}
+          </h2>
 
-        {/* Error Message */}
-        {error && (
+          {/* Step Indicator */}
           <div
             style={{
-              marginBottom: '16px',
-              padding: '12px',
-              backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-              border: '1px solid var(--vscode-inputValidation-errorBorder)',
-              borderRadius: '4px',
-              color: 'var(--vscode-errorForeground)',
+              marginBottom: '20px',
+              fontSize: '12px',
+              color: 'var(--vscode-descriptionForeground)',
             }}
           >
-            {error}
+            {t('mcp.dialog.wizardStep', {
+              current: wizard.state.currentStep.toString(),
+              total: '7',
+            })}
           </div>
-        )}
 
-        {/* Step Content */}
-        <div style={{ marginBottom: '20px', minHeight: '300px' }}>{renderStepContent()}</div>
+          {/* Error Message */}
+          {error && (
+            <div
+              style={{
+                marginBottom: '16px',
+                padding: '12px',
+                backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                borderRadius: '4px',
+                color: 'var(--vscode-errorForeground)',
+              }}
+            >
+              {error}
+            </div>
+          )}
 
-        {/* Dialog Actions */}
-        <div
-          style={{
-            display: 'flex',
-            gap: '12px',
-            justifyContent: 'flex-end',
-            paddingTop: '20px',
-            borderTop: '1px solid var(--vscode-panel-border)',
-          }}
-        >
-          <button
-            type="button"
-            onClick={handleClose}
+          {/* Step Content */}
+          <div style={{ marginBottom: '20px', minHeight: '300px' }}>{renderStepContent()}</div>
+
+          {/* Dialog Actions */}
+          <div
             style={{
-              padding: '8px 16px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              fontSize: '13px',
+              display: 'flex',
+              gap: '12px',
+              justifyContent: 'flex-end',
+              paddingTop: '20px',
+              borderTop: '1px solid var(--vscode-panel-border)',
             }}
           >
-            {t('mcp.dialog.cancelButton')}
-          </button>
-
-          {/* Back Button */}
-          {wizard.state.currentStep !== WizardStep.ServerSelection && (
             <button
               type="button"
-              onClick={wizard.prevStep}
+              onClick={handleClose}
               style={{
                 padding: '8px 16px',
                 backgroundColor: 'var(--vscode-button-secondaryBackground)',
@@ -477,34 +462,53 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
                 fontSize: '13px',
               }}
             >
-              {t('mcp.dialog.backButton')}
+              {t('mcp.dialog.cancelButton')}
             </button>
-          )}
 
-          {/* Next/Save Button */}
-          <button
-            type="button"
-            onClick={handleActionButton}
-            disabled={!wizard.canProceed}
-            style={{
-              padding: '8px 16px',
-              backgroundColor: wizard.canProceed
-                ? 'var(--vscode-button-background)'
-                : 'var(--vscode-button-secondaryBackground)',
-              color: wizard.canProceed
-                ? 'var(--vscode-button-foreground)'
-                : 'var(--vscode-descriptionForeground)',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: wizard.canProceed ? 'pointer' : 'not-allowed',
-              fontSize: '13px',
-              opacity: wizard.canProceed ? 1 : 0.6,
-            }}
-          >
-            {getActionButtonLabel()}
-          </button>
+            {/* Back Button */}
+            {wizard.state.currentStep !== WizardStep.ServerSelection && (
+              <button
+                type="button"
+                onClick={wizard.prevStep}
+                style={{
+                  padding: '8px 16px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+              >
+                {t('mcp.dialog.backButton')}
+              </button>
+            )}
+
+            {/* Next/Save Button */}
+            <button
+              type="button"
+              onClick={handleActionButton}
+              disabled={!wizard.canProceed}
+              style={{
+                padding: '8px 16px',
+                backgroundColor: wizard.canProceed
+                  ? 'var(--vscode-button-background)'
+                  : 'var(--vscode-button-secondaryBackground)',
+                color: wizard.canProceed
+                  ? 'var(--vscode-button-foreground)'
+                  : 'var(--vscode-descriptionForeground)',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: wizard.canProceed ? 'pointer' : 'not-allowed',
+                fontSize: '13px',
+                opacity: wizard.canProceed ? 1 : 0.6,
+              }}
+            >
+              {getActionButtonLabel()}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Portal.Root>
   );
 }

--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -7,6 +7,7 @@
  * Based on: specs/001-skill-node/design.md Section 6.2
  */
 
+import * as Portal from '@radix-ui/react-portal';
 import type { SkillReference } from '@shared/types/messages';
 import { NodeType } from '@shared/types/workflow-definition';
 import { useEffect, useState } from 'react';
@@ -182,390 +183,393 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
 
   const currentSkills = activeTab === 'personal' ? personalSkills : projectSkills;
 
+  // Portal ensures dialog renders at document.body, avoiding transform containment issues
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-      }}
-      onClick={handleClose}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          handleClose();
-        }
-      }}
-      role="presentation"
-    >
+    <Portal.Root>
       <div
         style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '6px',
-          padding: '24px',
-          maxWidth: '700px',
-          width: '90%',
-          maxHeight: '80vh',
-          overflow: 'auto',
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000,
         }}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
+        onClick={handleClose}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            handleClose();
+          }
+        }}
+        role="presentation"
       >
-        {/* Header */}
-        <h2
-          style={{
-            margin: '0 0 8px 0',
-            fontSize: '18px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-          }}
-        >
-          {t('skill.browser.title')}
-        </h2>
-        <p
-          style={{
-            margin: '0 0 20px 0',
-            fontSize: '13px',
-            color: 'var(--vscode-descriptionForeground)',
-            lineHeight: '1.5',
-          }}
-        >
-          {t('skill.browser.description')}
-        </p>
-
-        {/* Tabs */}
         <div
           style={{
-            display: 'flex',
-            gap: '8px',
-            marginBottom: '16px',
-            borderBottom: '1px solid var(--vscode-panel-border)',
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => setActiveTab('personal')}
-            style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              background: 'none',
-              border: 'none',
-              borderBottom:
-                activeTab === 'personal' ? '2px solid var(--vscode-focusBorder)' : 'none',
-              color:
-                activeTab === 'personal'
-                  ? 'var(--vscode-foreground)'
-                  : 'var(--vscode-descriptionForeground)',
-              cursor: 'pointer',
-              fontWeight: activeTab === 'personal' ? 600 : 400,
-            }}
-          >
-            {t('skill.browser.personalTab')} ({personalSkills.length})
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveTab('project')}
-            style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              background: 'none',
-              border: 'none',
-              borderBottom:
-                activeTab === 'project' ? '2px solid var(--vscode-focusBorder)' : 'none',
-              color:
-                activeTab === 'project'
-                  ? 'var(--vscode-foreground)'
-                  : 'var(--vscode-descriptionForeground)',
-              cursor: 'pointer',
-              fontWeight: activeTab === 'project' ? 600 : 400,
-            }}
-          >
-            {t('skill.browser.projectTab')} ({projectSkills.length})
-          </button>
-        </div>
-
-        {/* Refresh Button */}
-        <button
-          type="button"
-          onClick={handleRefresh}
-          disabled={refreshing || loading}
-          style={{
-            width: '100%',
-            padding: '8px 12px',
-            marginBottom: '16px',
-            fontSize: '13px',
-            backgroundColor: 'var(--vscode-button-secondaryBackground)',
-            color: 'var(--vscode-button-secondaryForeground)',
+            backgroundColor: 'var(--vscode-editor-background)',
             border: '1px solid var(--vscode-panel-border)',
-            borderRadius: '4px',
-            cursor: refreshing || loading ? 'wait' : 'pointer',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: '6px',
+            borderRadius: '6px',
+            padding: '24px',
+            maxWidth: '700px',
+            width: '90%',
+            maxHeight: '80vh',
+            overflow: 'auto',
           }}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
         >
-          <span>{refreshing ? t('skill.refreshing') : t('skill.action.refresh')}</span>
-        </button>
-
-        {/* Loading State */}
-        {loading && (
-          <div
+          {/* Header */}
+          <h2
             style={{
-              textAlign: 'center',
-              padding: '40px',
-              color: 'var(--vscode-descriptionForeground)',
+              margin: '0 0 8px 0',
+              fontSize: '18px',
+              fontWeight: 600,
+              color: 'var(--vscode-foreground)',
             }}
           >
-            {t('skill.browser.loading')}
-          </div>
-        )}
-
-        {/* Error State */}
-        {error && !loading && (
-          <div
+            {t('skill.browser.title')}
+          </h2>
+          <p
             style={{
-              padding: '12px',
-              backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-              border: '1px solid var(--vscode-inputValidation-errorBorder)',
-              borderRadius: '4px',
-              marginBottom: '16px',
+              margin: '0 0 20px 0',
               fontSize: '13px',
-              color: 'var(--vscode-inputValidation-errorForeground)',
-            }}
-          >
-            {error}
-          </div>
-        )}
-
-        {/* Skills List */}
-        {!loading && !error && currentSkills.length === 0 && (
-          <div
-            style={{
-              textAlign: 'center',
-              padding: '40px',
               color: 'var(--vscode-descriptionForeground)',
+              lineHeight: '1.5',
             }}
           >
-            {t('skill.browser.noSkills')}
-          </div>
-        )}
+            {t('skill.browser.description')}
+          </p>
 
-        {!loading && !error && currentSkills.length > 0 && (
+          {/* Tabs */}
           <div
             style={{
-              border: '1px solid var(--vscode-panel-border)',
-              borderRadius: '4px',
-              maxHeight: '400px',
-              overflow: 'auto',
+              display: 'flex',
+              gap: '8px',
+              marginBottom: '16px',
+              borderBottom: '1px solid var(--vscode-panel-border)',
             }}
           >
-            {currentSkills.map((skill) => (
-              <div
-                key={skill.skillPath}
-                onClick={() => setSelectedSkill(skill)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    setSelectedSkill(skill);
-                  }
-                }}
-                role="button"
-                tabIndex={0}
-                style={{
-                  padding: '12px',
-                  borderBottom: '1px solid var(--vscode-panel-border)',
-                  cursor: 'pointer',
-                  backgroundColor:
-                    selectedSkill?.skillPath === skill.skillPath
-                      ? 'var(--vscode-list-activeSelectionBackground)'
-                      : 'transparent',
-                }}
-                onMouseEnter={(e) => {
-                  if (selectedSkill?.skillPath !== skill.skillPath) {
-                    e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (selectedSkill?.skillPath !== skill.skillPath) {
-                    e.currentTarget.style.backgroundColor = 'transparent';
-                  }
-                }}
-              >
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    marginBottom: '4px',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <span
-                      style={{
-                        fontSize: '14px',
-                        fontWeight: 600,
-                        color: 'var(--vscode-foreground)',
-                      }}
-                    >
-                      {skill.name}
-                    </span>
-                    <span
-                      style={{
-                        fontSize: '10px',
-                        padding: '2px 6px',
-                        borderRadius: '3px',
-                        backgroundColor:
-                          skill.scope === 'personal'
-                            ? 'var(--vscode-badge-background)'
-                            : 'var(--vscode-button-secondaryBackground)',
-                        color:
-                          skill.scope === 'personal'
-                            ? 'var(--vscode-badge-foreground)'
-                            : 'var(--vscode-button-secondaryForeground)',
-                        fontWeight: 500,
-                      }}
-                    >
-                      {skill.scope === 'personal'
-                        ? t('skill.browser.personalTab')
-                        : t('skill.browser.projectTab')}
-                    </span>
-                  </div>
-                  <span
-                    style={{
-                      fontSize: '11px',
-                      color:
-                        skill.validationStatus === 'valid'
-                          ? 'var(--vscode-testing-iconPassed)'
-                          : skill.validationStatus === 'missing'
-                            ? 'var(--vscode-editorWarning-foreground)'
-                            : 'var(--vscode-errorForeground)',
-                    }}
-                  >
-                    {skill.validationStatus === 'valid'
-                      ? '✓'
-                      : skill.validationStatus === 'missing'
-                        ? '⚠'
-                        : '✗'}
-                  </span>
-                </div>
-                <div
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-descriptionForeground)',
-                    marginBottom: '4px',
-                  }}
-                >
-                  {skill.description}
-                </div>
-                {skill.allowedTools && (
-                  <div
-                    style={{
-                      fontSize: '11px',
-                      color: 'var(--vscode-descriptionForeground)',
-                    }}
-                  >
-                    🔧 {skill.allowedTools}
-                  </div>
-                )}
-              </div>
-            ))}
+            <button
+              type="button"
+              onClick={() => setActiveTab('personal')}
+              style={{
+                padding: '8px 16px',
+                fontSize: '13px',
+                background: 'none',
+                border: 'none',
+                borderBottom:
+                  activeTab === 'personal' ? '2px solid var(--vscode-focusBorder)' : 'none',
+                color:
+                  activeTab === 'personal'
+                    ? 'var(--vscode-foreground)'
+                    : 'var(--vscode-descriptionForeground)',
+                cursor: 'pointer',
+                fontWeight: activeTab === 'personal' ? 600 : 400,
+              }}
+            >
+              {t('skill.browser.personalTab')} ({personalSkills.length})
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('project')}
+              style={{
+                padding: '8px 16px',
+                fontSize: '13px',
+                background: 'none',
+                border: 'none',
+                borderBottom:
+                  activeTab === 'project' ? '2px solid var(--vscode-focusBorder)' : 'none',
+                color:
+                  activeTab === 'project'
+                    ? 'var(--vscode-foreground)'
+                    : 'var(--vscode-descriptionForeground)',
+                cursor: 'pointer',
+                fontWeight: activeTab === 'project' ? 600 : 400,
+              }}
+            >
+              {t('skill.browser.projectTab')} ({projectSkills.length})
+            </button>
           </div>
-        )}
 
-        {/* Create New Skill Button */}
-        {!loading && (
+          {/* Refresh Button */}
           <button
             type="button"
-            onClick={() => setIsSkillCreationOpen(true)}
+            onClick={handleRefresh}
+            disabled={refreshing || loading}
             style={{
               width: '100%',
-              padding: '12px',
-              marginTop: '16px',
+              padding: '8px 12px',
+              marginBottom: '16px',
               fontSize: '13px',
-              border: '1px solid var(--vscode-button-border)',
-              borderRadius: '4px',
               backgroundColor: 'var(--vscode-button-secondaryBackground)',
               color: 'var(--vscode-button-secondaryForeground)',
-              cursor: 'pointer',
-              textAlign: 'center',
-              fontWeight: 500,
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor =
-                'var(--vscode-button-secondaryHoverBackground)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryBackground)';
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              cursor: refreshing || loading ? 'wait' : 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '6px',
             }}
           >
-            + Create New Skill
+            <span>{refreshing ? t('skill.refreshing') : t('skill.action.refresh')}</span>
           </button>
-        )}
 
-        {/* Actions */}
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: '8px',
-            marginTop: '20px',
-          }}
-        >
-          <button
-            type="button"
-            onClick={handleClose}
+          {/* Loading State */}
+          {loading && (
+            <div
+              style={{
+                textAlign: 'center',
+                padding: '40px',
+                color: 'var(--vscode-descriptionForeground)',
+              }}
+            >
+              {t('skill.browser.loading')}
+            </div>
+          )}
+
+          {/* Error State */}
+          {error && !loading && (
+            <div
+              style={{
+                padding: '12px',
+                backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                borderRadius: '4px',
+                marginBottom: '16px',
+                fontSize: '13px',
+                color: 'var(--vscode-inputValidation-errorForeground)',
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          {/* Skills List */}
+          {!loading && !error && currentSkills.length === 0 && (
+            <div
+              style={{
+                textAlign: 'center',
+                padding: '40px',
+                color: 'var(--vscode-descriptionForeground)',
+              }}
+            >
+              {t('skill.browser.noSkills')}
+            </div>
+          )}
+
+          {!loading && !error && currentSkills.length > 0 && (
+            <div
+              style={{
+                border: '1px solid var(--vscode-panel-border)',
+                borderRadius: '4px',
+                maxHeight: '400px',
+                overflow: 'auto',
+              }}
+            >
+              {currentSkills.map((skill) => (
+                <div
+                  key={skill.skillPath}
+                  onClick={() => setSelectedSkill(skill)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setSelectedSkill(skill);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  style={{
+                    padding: '12px',
+                    borderBottom: '1px solid var(--vscode-panel-border)',
+                    cursor: 'pointer',
+                    backgroundColor:
+                      selectedSkill?.skillPath === skill.skillPath
+                        ? 'var(--vscode-list-activeSelectionBackground)'
+                        : 'transparent',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (selectedSkill?.skillPath !== skill.skillPath) {
+                      e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (selectedSkill?.skillPath !== skill.skillPath) {
+                      e.currentTarget.style.backgroundColor = 'transparent';
+                    }
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      marginBottom: '4px',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <span
+                        style={{
+                          fontSize: '14px',
+                          fontWeight: 600,
+                          color: 'var(--vscode-foreground)',
+                        }}
+                      >
+                        {skill.name}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          padding: '2px 6px',
+                          borderRadius: '3px',
+                          backgroundColor:
+                            skill.scope === 'personal'
+                              ? 'var(--vscode-badge-background)'
+                              : 'var(--vscode-button-secondaryBackground)',
+                          color:
+                            skill.scope === 'personal'
+                              ? 'var(--vscode-badge-foreground)'
+                              : 'var(--vscode-button-secondaryForeground)',
+                          fontWeight: 500,
+                        }}
+                      >
+                        {skill.scope === 'personal'
+                          ? t('skill.browser.personalTab')
+                          : t('skill.browser.projectTab')}
+                      </span>
+                    </div>
+                    <span
+                      style={{
+                        fontSize: '11px',
+                        color:
+                          skill.validationStatus === 'valid'
+                            ? 'var(--vscode-testing-iconPassed)'
+                            : skill.validationStatus === 'missing'
+                              ? 'var(--vscode-editorWarning-foreground)'
+                              : 'var(--vscode-errorForeground)',
+                      }}
+                    >
+                      {skill.validationStatus === 'valid'
+                        ? '✓'
+                        : skill.validationStatus === 'missing'
+                          ? '⚠'
+                          : '✗'}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--vscode-descriptionForeground)',
+                      marginBottom: '4px',
+                    }}
+                  >
+                    {skill.description}
+                  </div>
+                  {skill.allowedTools && (
+                    <div
+                      style={{
+                        fontSize: '11px',
+                        color: 'var(--vscode-descriptionForeground)',
+                      }}
+                    >
+                      🔧 {skill.allowedTools}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Create New Skill Button */}
+          {!loading && (
+            <button
+              type="button"
+              onClick={() => setIsSkillCreationOpen(true)}
+              style={{
+                width: '100%',
+                padding: '12px',
+                marginTop: '16px',
+                fontSize: '13px',
+                border: '1px solid var(--vscode-button-border)',
+                borderRadius: '4px',
+                backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                color: 'var(--vscode-button-secondaryForeground)',
+                cursor: 'pointer',
+                textAlign: 'center',
+                fontWeight: 500,
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor =
+                  'var(--vscode-button-secondaryHoverBackground)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryBackground)';
+              }}
+            >
+              + Create New Skill
+            </button>
+          )}
+
+          {/* Actions */}
+          <div
             style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              border: '1px solid var(--vscode-button-border)',
-              borderRadius: '4px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              cursor: 'pointer',
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: '8px',
+              marginTop: '20px',
             }}
           >
-            {t('skill.browser.cancelButton')}
-          </button>
-          <button
-            type="button"
-            onClick={handleAddSkill}
-            disabled={!selectedSkill || loading}
-            style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              border: 'none',
-              borderRadius: '4px',
-              backgroundColor: selectedSkill
-                ? 'var(--vscode-button-background)'
-                : 'var(--vscode-button-secondaryBackground)',
-              color: selectedSkill
-                ? 'var(--vscode-button-foreground)'
-                : 'var(--vscode-descriptionForeground)',
-              cursor: selectedSkill ? 'pointer' : 'not-allowed',
-              opacity: selectedSkill ? 1 : 0.5,
-            }}
-          >
-            {t('skill.browser.selectButton')}
-          </button>
+            <button
+              type="button"
+              onClick={handleClose}
+              style={{
+                padding: '8px 16px',
+                fontSize: '13px',
+                border: '1px solid var(--vscode-button-border)',
+                borderRadius: '4px',
+                backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                color: 'var(--vscode-button-secondaryForeground)',
+                cursor: 'pointer',
+              }}
+            >
+              {t('skill.browser.cancelButton')}
+            </button>
+            <button
+              type="button"
+              onClick={handleAddSkill}
+              disabled={!selectedSkill || loading}
+              style={{
+                padding: '8px 16px',
+                fontSize: '13px',
+                border: 'none',
+                borderRadius: '4px',
+                backgroundColor: selectedSkill
+                  ? 'var(--vscode-button-background)'
+                  : 'var(--vscode-button-secondaryBackground)',
+                color: selectedSkill
+                  ? 'var(--vscode-button-foreground)'
+                  : 'var(--vscode-descriptionForeground)',
+                cursor: selectedSkill ? 'pointer' : 'not-allowed',
+                opacity: selectedSkill ? 1 : 0.5,
+              }}
+            >
+              {t('skill.browser.selectButton')}
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* Skill Creation Dialog */}
-      <SkillCreationDialog
-        isOpen={isSkillCreationOpen}
-        onClose={() => setIsSkillCreationOpen(false)}
-        onSubmit={handleSkillCreate}
-      />
-    </div>
+        {/* Skill Creation Dialog */}
+        <SkillCreationDialog
+          isOpen={isSkillCreationOpen}
+          onClose={() => setIsSkillCreationOpen(false)}
+          onSubmit={handleSkillCreate}
+        />
+      </div>
+    </Portal.Root>
   );
 }


### PR DESCRIPTION
## Problem

PR#285 introduced collapsible NodePalette with `transform: translateX()` for slide animation. Due to CSS specification, elements with `transform` become containing blocks for `position: fixed` descendants.

### Current Behavior
1. Click Skill or MCP Tool button in NodePalette
2. ❌ Dialog appears inside NodePalette area (offset from center)

### Expected Behavior
1. Click Skill or MCP Tool button in NodePalette
2. ✅ Dialog appears centered on screen

## Solution

Use Radix UI components to properly handle both collapse animation and dialog positioning.

### Changes

**Dependencies** (`src/webview/package.json`):
- Added `@radix-ui/react-portal` - Renders content at document.body
- Added `@radix-ui/react-collapsible` - Accessible collapse/expand without transform

**Dialog Fixes** (`SkillBrowserDialog.tsx`, `McpNodeDialog.tsx`):
- Wrapped dialog content with `<Portal.Root>` to render at document.body
- Bypasses any parent transform containment

**NodePalette Collapse** (`App.tsx`):
- Replaced manual CSS transform animation with Radix Collapsible
- Removed `transform: translateX()` that broke `position: fixed`
- Added CSS keyframe animation for horizontal collapse

## Impact

- ✅ Dialogs now render at screen center regardless of NodePalette state
- ✅ NodePalette collapse animation preserved
- ✅ Vertical scrollbar in NodePalette works correctly
- ✅ No breaking changes to existing functionality

## Testing

- [x] SkillBrowserDialog displays centered on screen
- [x] McpNodeDialog displays centered on screen
- [x] SkillCreationDialog (nested) displays correctly
- [x] NodePalette expand/collapse animation works
- [x] NodePalette scrollbar appears when content overflows
- [x] Build passes
- [x] Code quality checks pass (format, lint, check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)