### PR TITLE
fix: clear conversation history and sub-agent flows on workflow reset

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -54,7 +54,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setWorkflowName,
     clearWorkflow,
   } = useWorkflowStore();
-  const { isProcessing } = useRefinementStore();
+  const { isProcessing, clearHistory } = useRefinementStore();
   const [isSaving, setIsSaving] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isLoadingFile, setIsLoadingFile] = useState(false);
@@ -65,8 +65,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   // Handle reset workflow
   const handleResetWorkflow = useCallback(() => {
     clearWorkflow();
+    clearHistory(); // Clear AI refinement chat history
     setShowResetConfirm(false);
-  }, [clearWorkflow]);
+  }, [clearWorkflow, clearHistory]);
 
   const handleSave = async () => {
     if (!workflowName.trim()) {

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -381,11 +381,25 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   clearWorkflow: () => {
+    const { activeWorkflow } = get();
+
     // StartノードとEndノードは保持し、他のノードとすべてのエッジをクリア
     set({
       nodes: [DEFAULT_START_NODE, DEFAULT_END_NODE],
       edges: [],
       selectedNodeId: null,
+      // Sub-Agent Flow関連の状態をクリア
+      subAgentFlows: [],
+      activeSubAgentFlowId: null,
+      mainWorkflowSnapshot: null,
+      // activeWorkflow の conversationHistory と subAgentFlows をクリア
+      activeWorkflow: activeWorkflow
+        ? {
+            ...activeWorkflow,
+            conversationHistory: undefined,
+            subAgentFlows: undefined,
+          }
+        : null,
     });
   },
 


### PR DESCRIPTION
## Problem

When users reset a workflow using the "Reset Workflow" button in the toolbar, the AI refinement conversation history and SubAgentFlows were not being cleared.

### Current Behavior
1. User clicks "Reset Workflow" in the toolbar
2. Canvas nodes and edges are reset
3. ❌ AI refinement chat history remains visible in the AI edit panel
4. ❌ SubAgentFlows remain in the workflow definition

### Expected Behavior
1. User clicks "Reset Workflow" in the toolbar
2. Canvas nodes and edges are reset
3. ✅ AI refinement chat history is immediately cleared (even if the panel is open)
4. ✅ All SubAgentFlows are removed from the workflow

## Solution

Enhanced the `clearWorkflow()` method and added synchronization between workflow-store and refinement-store.

### Changes

**File**: `src/webview/src/stores/workflow-store.ts`

- Modified `clearWorkflow()` method (lines 383-404)
- Clear `activeWorkflow.conversationHistory` and `activeWorkflow.subAgentFlows`
- Clear SubAgentFlow-related state: `subAgentFlows`, `activeSubAgentFlowId`, `mainWorkflowSnapshot`

```typescript
clearWorkflow: () => {
  const { activeWorkflow } = get();
  
  set({
    nodes: [DEFAULT_START_NODE, DEFAULT_END_NODE],
    edges: [],
    selectedNodeId: null,
    // Sub-Agent Flow関連の状態をクリア
    subAgentFlows: [],
    activeSubAgentFlowId: null,
    mainWorkflowSnapshot: null,
    // activeWorkflow の conversationHistory と subAgentFlows をクリア
    activeWorkflow: activeWorkflow
      ? {
          ...activeWorkflow,
          conversationHistory: undefined,
          subAgentFlows: undefined,
        }
      : null,
  });
},
```

**File**: `src/webview/src/components/Toolbar.tsx`

- Modified `handleResetWorkflow()` to also call `clearHistory()` from refinement-store
- This ensures immediate UI update when the AI edit panel is open

```typescript
const handleResetWorkflow = useCallback(() => {
  clearWorkflow();
  clearHistory(); // Clear AI refinement chat history
  setShowResetConfirm(false);
}, [clearWorkflow, clearHistory]);
```

## Impact

- **UX Improvement**: AI refinement chat history is now immediately cleared when the panel is open during reset
- **Data Consistency**: SubAgentFlows are completely removed from both the workflow definition and store state
- **No Breaking Changes**: Existing workflow functionality remains unchanged

## Testing

- [x] Manual E2E testing completed
  - [x] Reset workflow with AI chat history → Chat history cleared immediately
  - [x] Reset workflow with AI edit panel open → Panel updates in real-time
  - [x] Reset workflow with SubAgentFlows → All SubAgentFlows removed
  - [x] Save workflow after reset → conversationHistory and subAgentFlows not included in JSON
- [x] Code quality checks passed
  - [x] `npm run format` - no issues
  - [x] `npm run lint` - no issues
  - [x] `npm run check` - no issues
  - [x] `npm run build` - successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)