### PR TITLE
chore: align Allowed Tools submenu style with other submenus

### DIFF
--- a/src/webview/src/components/chat/SettingsDropdown.tsx
+++ b/src/webview/src/components/chat/SettingsDropdown.tsx
@@ -413,14 +413,23 @@ export function SettingsDropdown({ onClearHistoryClick, hasMessages }: SettingsD
                   cursor: isProcessing ? 'not-allowed' : 'pointer',
                   display: 'flex',
                   alignItems: 'center',
+                  justifyContent: 'space-between',
                   gap: '8px',
                   outline: 'none',
                   borderRadius: '2px',
                   opacity: isProcessing ? 0.5 : 1,
                 }}
               >
-                <Wrench size={14} />
-                <span>Allowed Tools</span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                  <ChevronLeft size={14} />
+                  <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                    {allowedTools.length} tools
+                  </span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <Wrench size={14} />
+                  <span>Allowed Tools</span>
+                </div>
               </DropdownMenu.SubTrigger>
 
               <DropdownMenu.Portal>


### PR DESCRIPTION
## Problem

### Current Behavior
The Allowed Tools submenu trigger in the settings dropdown has inconsistent styling compared to other submenus (Model, Timeout):
- Missing chevron icon on the left
- Not right-aligned (lacks justifyContent: space-between)
- No tool count display

### Expected Behavior
All submenu triggers should have consistent styling:
- Chevron icon on the left
- Right-aligned layout
- Item count/value display in description color

## Solution

Aligned the Allowed Tools submenu trigger style to match Model and Timeout submenus.

## Changes

**File**: src/webview/src/components/chat/SettingsDropdown.tsx

- Added justifyContent: space-between to SubTrigger for proper alignment
- Added left section with ChevronLeft icon and tool count
- Added right section with Wrench icon and label
- Used description foreground color for tool count

## Impact

- UX: Consistent submenu styling improves visual coherence
- No breaking changes
- No side effects

## Testing

- Manual E2E testing completed
  - Verified chevron icon appears
  - Verified tool count displays correctly
  - Verified right-aligned layout matches other submenus
  - Verified no visual regression on Model/Timeout submenus