### PR TITLE
improvement: prevent dropdown menu from closing on settings selection

### DIFF
--- a/src/webview/src/components/chat/SettingsDropdown.tsx
+++ b/src/webview/src/components/chat/SettingsDropdown.tsx
@@ -230,14 +230,15 @@ export function SettingsDropdown({ onClearHistoryClick, hasMessages }: SettingsD
                   padding: '4px',
                 }}
               >
-                <DropdownMenu.RadioGroup
-                  value={selectedModel}
-                  onValueChange={(value) => setSelectedModel(value as ClaudeModel)}
-                >
+                <DropdownMenu.RadioGroup value={selectedModel}>
                   {MODEL_PRESETS.map((preset) => (
                     <DropdownMenu.RadioItem
                       key={preset.value}
                       value={preset.value}
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        setSelectedModel(preset.value);
+                      }}
                       style={{
                         padding: '6px 12px',
                         fontSize: `${FONT_SIZES.small}px`,
@@ -314,14 +315,15 @@ export function SettingsDropdown({ onClearHistoryClick, hasMessages }: SettingsD
                   padding: '4px',
                 }}
               >
-                <DropdownMenu.RadioGroup
-                  value={String(timeoutSeconds)}
-                  onValueChange={(value) => setTimeoutSeconds(Number(value))}
-                >
+                <DropdownMenu.RadioGroup value={String(timeoutSeconds)}>
                   {TIMEOUT_PRESETS.map((preset) => (
                     <DropdownMenu.RadioItem
                       key={preset.seconds}
                       value={String(preset.seconds)}
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        setTimeoutSeconds(preset.seconds);
+                      }}
                       style={{
                         padding: '6px 12px',
                         fontSize: `${FONT_SIZES.small}px`,
@@ -469,7 +471,10 @@ export function SettingsDropdown({ onClearHistoryClick, hasMessages }: SettingsD
                 />
 
                 <DropdownMenu.Item
-                  onSelect={resetAllowedTools}
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    resetAllowedTools();
+                  }}
                   style={{
                     padding: '6px 12px',
                     fontSize: `${FONT_SIZES.small}px`,


### PR DESCRIPTION
## Problem

In the AI editing settings dropdown menu, clicking on Model, Timeout, or Allowed Tools submenu items closes the dropdown menu immediately after selection.

### Current Behavior
1. Open Settings dropdown
2. Navigate to Model/Timeout/Allowed Tools submenu
3. ❌ Click an option → Dropdown closes

### Expected Behavior
1. Open Settings dropdown
2. Navigate to Model/Timeout/Allowed Tools submenu
3. ✅ Click an option → Dropdown stays open for further adjustments

## Solution

Add `event.preventDefault()` to prevent default menu closing behavior on selection.

### Changes

**File**: `src/webview/src/components/chat/SettingsDropdown.tsx`

- Add `event.preventDefault()` to Model submenu RadioItems
- Add `event.preventDefault()` to Timeout submenu RadioItems
- Add `event.preventDefault()` to Reset to Default button

## Impact

- Improved UX: Users can make multiple setting changes without reopening the dropdown
- Consistent behavior with Allowed Tools checkboxes (which already had this fix)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)