### PR TITLE
chore: use GitHub App token for semantic-release branch protection bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -39,7 +46,7 @@ jobs:
       - name: Semantic Release
         id: semantic_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
@@ -59,7 +66,7 @@ jobs:
       - name: Upload VSIX to release
         if: steps.semantic_release.outcome == 'success'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEW_VERSION=$(node -p "require('./package.json').version")
           VSIX_FILE=$(ls *.vsix)
@@ -68,7 +75,7 @@ jobs:
       - name: Sync version to main branch
         if: github.ref == 'refs/heads/production' && steps.semantic_release.outcome == 'success'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

Semantic Release workflow fails when pushing release commits to the `production` branch due to GitHub Repository Rules.

### Error
```
remote: error: GH013: Repository rule violations found for refs/heads/production.
remote: - Changes must be made through a pull request.
remote: - Required status check "Snyk Security Scan" is expected.
```

### Root Cause
- `@semantic-release/git` plugin attempts to push directly to protected branches
- `github-actions[bot]` (using `GITHUB_TOKEN`) cannot be added to bypass list

## Solution

Use a custom GitHub App with branch protection bypass permissions.

### Changes

**File**: `.github/workflows/release.yml`

- Added `Generate GitHub App Token` step using `actions/create-github-app-token@v2`
- Replaced `secrets.GITHUB_TOKEN` with `steps.app-token.outputs.token` in:
  - Semantic Release step
  - Upload VSIX to release step
  - Sync version to main branch step

### Required Setup (Completed)

- [x] Created GitHub App: `cc-wf-studio-release-bot`
- [x] Installed App on repository
- [x] Added secrets: `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`
- [x] Added App to bypass list for `production` and `main` branch rules

## Impact

- Enables automated releases to work with protected branches
- No breaking changes to existing workflow behavior

## Testing

- [ ] Merge to `main`, then create release PR to `production`
- [ ] Verify release workflow completes successfully

Fixes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)