### PR TITLE
feat: add Run as Slash Command feature with toolbar UI improvements

### DIFF
--- a/src/extension/commands/export-workflow.ts
+++ b/src/extension/commands/export-workflow.ts
@@ -7,7 +7,11 @@
 import * as path from 'node:path';
 import type { Webview } from 'vscode';
 import * as vscode from 'vscode';
-import type { ExportSuccessPayload, ExportWorkflowPayload } from '../../shared/types/messages';
+import type {
+  ExportSuccessPayload,
+  ExportWorkflowPayload,
+  Workflow,
+} from '../../shared/types/messages';
 import {
   checkExistingFiles,
   exportWorkflow,
@@ -116,5 +120,99 @@ export async function handleExportWorkflow(
     vscode.window.showErrorMessage(
       `Failed to export workflow: ${error instanceof Error ? error.message : 'Unknown error'}`
     );
+  }
+}
+
+/**
+ * Result of export for execution
+ */
+export interface ExportForExecutionResult {
+  success: boolean;
+  cancelled?: boolean;
+  exportedFiles?: string[];
+  error?: string;
+}
+
+/**
+ * Export workflow for terminal execution (without UI notifications)
+ *
+ * This function exports the workflow to .claude format for use with
+ * the "Execute as Slash Command" feature. Unlike handleExportWorkflow,
+ * it does not show UI notifications and returns the result directly.
+ *
+ * @param workflow - Workflow to export
+ * @param fileService - File service instance
+ * @returns Export result with success status and exported files
+ */
+export async function handleExportWorkflowForExecution(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<ExportForExecutionResult> {
+  try {
+    // Validate workflow structure before export
+    const validationResult = validateAIGeneratedWorkflow(workflow);
+    if (!validationResult.valid) {
+      const errorMessages = validationResult.errors.map((err) => err.message).join('\n');
+      return {
+        success: false,
+        error: `Workflow validation failed:\n${errorMessages}`,
+      };
+    }
+
+    // Check if files already exist
+    const existingFiles = await checkExistingFiles(workflow, fileService);
+
+    if (existingFiles.length > 0) {
+      // Show warning dialog for overwrite confirmation
+      const fileList = existingFiles.map((f) => `  - ${f}`).join('\n');
+      const answer = await vscode.window.showWarningMessage(
+        `The following files already exist:\n${fileList}\n\nDo you want to overwrite them?`,
+        { modal: true },
+        'Overwrite'
+      );
+
+      if (answer !== 'Overwrite') {
+        // User cancelled
+        return {
+          success: false,
+          cancelled: true,
+        };
+      }
+    }
+
+    // Export workflow
+    const exportedFiles = await exportWorkflow(workflow, fileService);
+
+    // Validate exported files
+    const validationErrors: string[] = [];
+    for (const filePath of exportedFiles) {
+      try {
+        const content = await fileService.readFile(filePath);
+        const fileType = filePath.includes('/agents/') ? 'subAgent' : 'slashCommand';
+        validateClaudeFileFormat(content, fileType);
+      } catch (error) {
+        const fileName = path.basename(filePath);
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        validationErrors.push(`${fileName}: ${errorMessage}`);
+      }
+    }
+
+    // If validation errors occurred, report them
+    if (validationErrors.length > 0) {
+      return {
+        success: false,
+        error: `Exported files have validation errors:\n${validationErrors.join('\n')}`,
+      };
+    }
+
+    return {
+      success: true,
+      exportedFiles,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to export workflow',
+    };
   }
 }

--- a/src/extension/services/terminal-execution-service.ts
+++ b/src/extension/services/terminal-execution-service.ts
@@ -1,0 +1,61 @@
+/**
+ * Claude Code Workflow Studio - Terminal Execution Service
+ *
+ * Handles execution of slash commands in VSCode integrated terminal
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Options for executing a slash command in terminal
+ */
+export interface TerminalExecutionOptions {
+  /** Workflow name (used for terminal tab name and slash command) */
+  workflowName: string;
+  /** Working directory for the terminal */
+  workingDirectory: string;
+}
+
+/**
+ * Result of terminal execution
+ */
+export interface TerminalExecutionResult {
+  /** Name of the created terminal */
+  terminalName: string;
+  /** Reference to the VSCode terminal instance */
+  terminal: vscode.Terminal;
+}
+
+/**
+ * Execute a slash command in a new VSCode integrated terminal
+ *
+ * Creates a new terminal with the workflow name as the tab title,
+ * sets the working directory to the workspace root, and executes
+ * the Claude Code CLI with the slash command.
+ *
+ * @param options - Terminal execution options
+ * @returns Terminal execution result
+ */
+export function executeSlashCommandInTerminal(
+  options: TerminalExecutionOptions
+): TerminalExecutionResult {
+  const terminalName = `Workflow: ${options.workflowName}`;
+
+  // Create a new terminal with the workflow name
+  const terminal = vscode.window.createTerminal({
+    name: terminalName,
+    cwd: options.workingDirectory,
+  });
+
+  // Show the terminal and focus on it
+  terminal.show(true);
+
+  // Execute the Claude Code CLI with the slash command
+  // Using double quotes to handle workflow names with spaces
+  terminal.sendText(`claude "/${options.workflowName}"`);
+
+  return {
+    terminalName,
+    terminal,
+  };
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -89,6 +89,31 @@ export interface CancelRefinementPayload {
 }
 
 // ============================================================================
+// Run as Slash Command Payloads
+// ============================================================================
+
+/**
+ * Run workflow as slash command request payload
+ * Converts workflow to slash command and runs it in VSCode terminal
+ */
+export interface RunAsSlashCommandPayload {
+  /** Workflow to run */
+  workflow: Workflow;
+}
+
+/**
+ * Run as slash command success payload
+ */
+export interface RunAsSlashCommandSuccessPayload {
+  /** Workflow name that was run */
+  workflowName: string;
+  /** Terminal name where command is running */
+  terminalName: string;
+  /** Timestamp of run */
+  timestamp: string; // ISO 8601
+}
+
+// ============================================================================
 // Skill Node Payloads (001-skill-node)
 // ============================================================================
 
@@ -593,7 +618,9 @@ export type ExtensionMessage =
   | Message<SlackDescriptionFailedPayload, 'SLACK_DESCRIPTION_FAILED'>
   | Message<WorkflowNameSuccessPayload, 'WORKFLOW_NAME_SUCCESS'>
   | Message<WorkflowNameFailedPayload, 'WORKFLOW_NAME_FAILED'>
-  | Message<void, 'FILE_PICKER_CANCELLED'>;
+  | Message<void, 'FILE_PICKER_CANCELLED'>
+  | Message<RunAsSlashCommandSuccessPayload, 'RUN_AS_SLASH_COMMAND_SUCCESS'>
+  | Message<void, 'RUN_AS_SLASH_COMMAND_CANCELLED'>;
 
 // ============================================================================
 // AI Slack Description Generation Payloads
@@ -1052,7 +1079,8 @@ export type WebviewMessage =
   | Message<SetLastSharedChannelPayload, 'SET_LAST_SHARED_CHANNEL'>
   | Message<GenerateSlackDescriptionPayload, 'GENERATE_SLACK_DESCRIPTION'>
   | Message<GenerateWorkflowNamePayload, 'GENERATE_WORKFLOW_NAME'>
-  | Message<void, 'OPEN_FILE_PICKER'>;
+  | Message<void, 'OPEN_FILE_PICKER'>
+  | Message<RunAsSlashCommandPayload, 'RUN_AS_SLASH_COMMAND'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -46,10 +46,9 @@ export interface WebviewTranslationKeys {
   'toolbar.generateNameWithAI': string;
   'toolbar.error.nameGenerationFailed': string;
 
-  // Toolbar responsive tooltips
-  'toolbar.save.tooltip': string;
-  'toolbar.convert.iconTooltip': string;
-  'toolbar.load.tooltip': string;
+  // Toolbar slash command group
+  'toolbar.run': string;
+  'toolbar.running': string;
 
   // Toolbar more actions dropdown
   'toolbar.moreActions': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -18,7 +18,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.workflowNamePlaceholder': 'Workflow name',
   'toolbar.save': 'Save',
   'toolbar.saving': 'Saving...',
-  'toolbar.convert': 'Convert to Slash Command',
+  'toolbar.convert': 'Convert',
   'toolbar.convert.tooltip': 'Convert to Slash Command and save to .claude/commands/',
   'toolbar.converting': 'Converting...',
   'toolbar.refineWithAI': 'Edit with AI',
@@ -50,10 +50,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.nameGenerationFailed':
     'Failed to generate workflow name. Please try again or enter manually.',
 
-  // Toolbar responsive tooltips
-  'toolbar.save.tooltip': 'Save workflow',
-  'toolbar.convert.iconTooltip': 'Convert to Slash Command',
-  'toolbar.load.tooltip': 'Load saved workflow',
+  // Toolbar slash command group
+  'toolbar.run': 'Run',
+  'toolbar.running': 'Running...',
 
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'More',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -18,7 +18,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.workflowNamePlaceholder': 'ワークフロー名',
   'toolbar.save': '保存',
   'toolbar.saving': '保存中...',
-  'toolbar.convert': 'Slash Commandに変換',
+  'toolbar.convert': '変換',
   'toolbar.convert.tooltip': 'Slash Commandに変換して.claude/commands/に保存',
   'toolbar.converting': '変換中...',
   'toolbar.refineWithAI': 'AI編集',
@@ -50,10 +50,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.nameGenerationFailed':
     'ワークフロー名の生成に失敗しました。再度お試しいただくか、手動で入力してください。',
 
-  // Toolbar responsive tooltips
-  'toolbar.save.tooltip': 'ワークフローを保存',
-  'toolbar.convert.iconTooltip': 'Slash Commandに変換',
-  'toolbar.load.tooltip': '保存したワークフローを読み込む',
+  // Toolbar slash command group
+  'toolbar.run': '実行',
+  'toolbar.running': '実行中...',
 
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'その他',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -18,7 +18,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.workflowNamePlaceholder': '워크플로 이름',
   'toolbar.save': '저장',
   'toolbar.saving': '저장 중...',
-  'toolbar.convert': 'Slash Command로 변환',
+  'toolbar.convert': '변환',
   'toolbar.convert.tooltip': 'Slash Command로 변환하여 .claude/commands/에 저장',
   'toolbar.converting': '변환 중...',
   'toolbar.refineWithAI': 'AI로 편집',
@@ -50,10 +50,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.error.nameGenerationFailed':
     '워크플로 이름 생성에 실패했습니다. 다시 시도하거나 수동으로 입력하세요.',
 
-  // Toolbar responsive tooltips
-  'toolbar.save.tooltip': '워크플로 저장',
-  'toolbar.convert.iconTooltip': 'Slash Command로 변환',
-  'toolbar.load.tooltip': '저장된 워크플로 불러오기',
+  // Toolbar slash command group
+  'toolbar.run': '실행',
+  'toolbar.running': '실행 중...',
 
   // Toolbar more actions dropdown
   'toolbar.moreActions': '더보기',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -18,7 +18,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.workflowNamePlaceholder': '工作流名称',
   'toolbar.save': '保存',
   'toolbar.saving': '保存中...',
-  'toolbar.convert': '转换为 Slash Command',
+  'toolbar.convert': '转换',
   'toolbar.convert.tooltip': '转换为 Slash Command 并保存到 .claude/commands/',
   'toolbar.converting': '转换中...',
   'toolbar.refineWithAI': 'AI编辑',
@@ -48,10 +48,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.generateNameWithAI': '使用AI生成名称',
   'toolbar.error.nameGenerationFailed': '生成工作流名称失败。请重试或手动输入。',
 
-  // Toolbar responsive tooltips
-  'toolbar.save.tooltip': '保存工作流',
-  'toolbar.convert.iconTooltip': '转换为Slash Command',
-  'toolbar.load.tooltip': '加载已保存的工作流',
+  // Toolbar slash command group
+  'toolbar.run': '执行',
+  'toolbar.running': '执行中...',
 
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -18,7 +18,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.workflowNamePlaceholder': '工作流名稱',
   'toolbar.save': '儲存',
   'toolbar.saving': '儲存中...',
-  'toolbar.convert': '轉換為 Slash Command',
+  'toolbar.convert': '轉換',
   'toolbar.convert.tooltip': '轉換為 Slash Command 並儲存到 .claude/commands/',
   'toolbar.converting': '轉換中...',
   'toolbar.refineWithAI': 'AI編輯',
@@ -48,10 +48,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.generateNameWithAI': '使用AI生成名稱',
   'toolbar.error.nameGenerationFailed': '生成工作流名稱失敗。請重試或手動輸入。',
 
-  // Toolbar responsive tooltips
-  'toolbar.save.tooltip': '儲存工作流程',
-  'toolbar.convert.iconTooltip': '轉換為Slash Command',
-  'toolbar.load.tooltip': '載入已儲存的工作流程',
+  // Toolbar slash command group
+  'toolbar.run': '執行',
+  'toolbar.running': '執行中...',
 
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',

--- a/src/webview/src/services/vscode-bridge.ts
+++ b/src/webview/src/services/vscode-bridge.ts
@@ -8,6 +8,7 @@
 import type {
   ExportWorkflowPayload,
   ExtensionMessage,
+  RunAsSlashCommandPayload,
   SaveWorkflowPayload,
   Workflow,
 } from '@shared/types/messages';
@@ -165,5 +166,54 @@ export function sendStateUpdate(
       edges,
       selectedNodeId,
     },
+  });
+}
+
+/**
+ * Run workflow as slash command in VSCode terminal
+ *
+ * This function exports the workflow to .claude format and then
+ * runs it as a slash command in a new VSCode integrated terminal.
+ *
+ * @param workflow - Workflow to run
+ * @returns Promise that resolves when run starts successfully
+ */
+export function runAsSlashCommand(workflow: Workflow): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const requestId = `req-${Date.now()}-${Math.random()}`;
+
+    // Register response handler
+    const handler = (event: MessageEvent) => {
+      const message: ExtensionMessage = event.data;
+
+      if (message.requestId === requestId) {
+        window.removeEventListener('message', handler);
+
+        if (message.type === 'RUN_AS_SLASH_COMMAND_SUCCESS') {
+          resolve();
+        } else if (message.type === 'RUN_AS_SLASH_COMMAND_CANCELLED') {
+          // User cancelled run - resolve silently without showing error
+          resolve();
+        } else if (message.type === 'ERROR') {
+          reject(new Error(message.payload?.message || 'Failed to run workflow'));
+        }
+      }
+    };
+
+    window.addEventListener('message', handler);
+
+    // Send request
+    const payload: RunAsSlashCommandPayload = { workflow };
+    vscode.postMessage({
+      type: 'RUN_AS_SLASH_COMMAND',
+      requestId,
+      payload,
+    });
+
+    // Timeout after 30 seconds (export + terminal creation may take time)
+    setTimeout(() => {
+      window.removeEventListener('message', handler);
+      reject(new Error('Request timed out'));
+    }, 30000);
   });
 }


### PR DESCRIPTION
## Summary

Add "Run as Slash Command" feature that allows users to directly run their workflows as Claude Code slash commands in the VSCode integrated terminal. Also includes comprehensive toolbar UI improvements with grouped button labels.

## Changes

### New Feature: Run as Slash Command
- Added Run button in the Slash Command group
- Exports workflow to `.claude/commands/` format
- Opens VSCode integrated terminal and runs the slash command
- Proper cancel handling (no timeout error when user cancels overwrite dialog)

### Toolbar UI Improvements
- Grouped toolbar buttons under descriptive labels:
  - **Workflow**: Name input, Save, Load
  - **Slash Command**: Convert, Run
  - **Other**: More actions dropdown
- Group labels visible in both normal and compact mode
- Removed tooltips since group labels now provide sufficient context
- Increased divider height for better visual separation
- Added spacing between Convert and Run buttons

### Files Changed
- `src/extension/commands/export-workflow.ts` - Added `handleExportWorkflowForExecution()` with cancel handling
- `src/extension/commands/open-editor.ts` - Added `RUN_AS_SLASH_COMMAND` message handler
- `src/extension/services/terminal-execution-service.ts` - New service for terminal execution
- `src/shared/types/messages.ts` - Added new message types and payloads
- `src/webview/src/components/Toolbar.tsx` - UI restructuring with group labels
- `src/webview/src/services/vscode-bridge.ts` - Added `runAsSlashCommand()` function
- Translation files (en, ja, ko, zh-CN, zh-TW) - Updated labels and removed unused tooltip keys

## Testing

- [x] Manual E2E testing completed
- [x] Run button correctly exports and runs workflow in terminal
- [x] Cancel handling works correctly (no timeout error)
- [x] Group labels display in both normal and compact mode
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)