### PR TITLE
improvement: fix tour Load button focus and add Run step

### DIFF
--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -186,7 +186,7 @@ export const getTourSteps = (
     },
   },
   {
-    element: '[data-tour="workflow-selector"]',
+    element: '[data-tour="load-button"]',
     popover: {
       title: '',
       description: t('tour.loadWorkflow'),
@@ -199,6 +199,15 @@ export const getTourSteps = (
     popover: {
       title: '',
       description: t('tour.exportWorkflow'),
+      side: 'bottom',
+      align: 'start',
+    },
+  },
+  {
+    element: '[data-tour="run-button"]',
+    popover: {
+      title: '',
+      description: t('tour.runSlashCommand'),
       side: 'bottom',
       align: 'start',
     },

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -245,6 +245,7 @@ export interface WebviewTranslationKeys {
   'tour.saveWorkflow': string;
   'tour.loadWorkflow': string;
   'tour.exportWorkflow': string;
+  'tour.runSlashCommand': string;
   'tour.refineWithAI': string;
   'tour.moreActions': string;
 

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -269,7 +269,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'tour.loadWorkflow':
     'To load a saved workflow, select it from the dropdown menu and click the "Load" button.',
   'tour.exportWorkflow':
-    'Click the "Export" button to export in a format executable by Claude Code.\n\nSub-Agents go to `.claude/agents/` and SlashCommands to `.claude/commands/`.',
+    'Click the "Convert" button to convert your workflow to a Slash Command format.\n\nThe converted files are saved to the .claude/commands/ directory.',
+  'tour.runSlashCommand':
+    'Click the "Run" button to convert your workflow to a Slash Command and immediately execute it in Claude Code.\n\nThis combines conversion and execution in a single action.',
   'tour.refineWithAI':
     'Use the "Edit with AI" button to create or improve workflows through an interactive chat with AI.\n\nYou can start from an empty canvas or edit existing workflows conversationally.',
   'tour.moreActions':

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -269,7 +269,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'tour.loadWorkflow':
     '保存したワークフローを読み込むには、ドロップダウンメニューからワークフローを選択し、「読み込み」ボタンをクリックします。',
   'tour.exportWorkflow':
-    '「エクスポート」ボタンをクリックすると、Claude Codeで実行可能な形式にエクスポートされます。\n\nSub-Agentは`.claude/agents/`に、SlashCommandは`.claude/commands/`に出力されます。',
+    '「Convert」ボタンをクリックすると、ワークフローをSlash Command形式に変換できます。\n\n変換されたファイルは .claude/commands/ ディレクトリに保存されます。',
+  'tour.runSlashCommand':
+    '「Run」ボタンをクリックすると、ワークフローをSlash Commandに変換し、即座にClaude Codeで実行できます。\n\n変換と実行を一度に行えます。',
   'tour.refineWithAI':
     '「AI編集」ボタンで、AIとチャットしながらワークフローを生成・改善できます。\n\n空のキャンバスから新規作成も、既存のワークフローの修正も対話的に行えます。',
   'tour.moreActions':

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -271,7 +271,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'tour.loadWorkflow':
     '저장된 워크플로우를 로드하려면 드롭다운 메뉴에서 워크플로우를 선택하고 "불러오기" 버튼을 클릭하세요.',
   'tour.exportWorkflow':
-    '"내보내기" 버튼을 클릭하면 Claude Code에서 실행 가능한 형식으로 내보내집니다.\n\nSub-Agent는 `.claude/agents/`로, SlashCommand는 `.claude/commands/`로 이동합니다.',
+    '"Convert" 버튼을 클릭하면 워크플로우를 Slash Command 형식으로 변환합니다.\n\n변환된 파일은 .claude/commands/ 디렉토리에 저장됩니다.',
+  'tour.runSlashCommand':
+    '"Run" 버튼을 클릭하면 워크플로우를 Slash Command로 변환하고 즉시 Claude Code에서 실행합니다.\n\n변환과 실행을 한 번에 수행합니다.',
   'tour.refineWithAI':
     '"AI로 편집" 버튼을 사용하여 AI와 대화하며 워크플로우를 생성하거나 개선할 수 있습니다.\n\n빈 캔버스에서 시작하거나 기존 워크플로우를 대화형으로 수정할 수 있습니다.',
   'tour.moreActions':

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -259,7 +259,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
     '点击"保存"按钮将工作流以JSON格式保存到`.vscode/workflows/`目录。\n\n稍后可以加载并继续编辑。',
   'tour.loadWorkflow': '要加载已保存的工作流，请从下拉菜单中选择工作流并点击"加载"按钮。',
   'tour.exportWorkflow':
-    '点击"导出"按钮以Claude Code可执行的格式导出。\n\nSub-Agent导出到`.claude/agents/`，SlashCommand导出到`.claude/commands/`。',
+    '点击"Convert"按钮可将工作流转换为Slash Command格式。\n\n转换后的文件保存在.claude/commands/目录中。',
+  'tour.runSlashCommand':
+    '点击"Run"按钮可将工作流转换为Slash Command并立即在Claude Code中执行。\n\n一键完成转换和执行。',
   'tour.refineWithAI':
     '使用"AI编辑"按钮通过与AI对话创建或改进工作流。\n\n可以从空画布开始或以对话方式编辑现有工作流。',
   'tour.moreActions':

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -259,7 +259,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
     '點擊「儲存」按鈕將工作流程以JSON格式儲存到`.vscode/workflows/`目錄。\n\n稍後可以載入並繼續編輯。',
   'tour.loadWorkflow': '要載入已儲存的工作流程，請從下拉選單中選擇工作流程並點擊「載入」按鈕。',
   'tour.exportWorkflow':
-    '點擊「匯出」按鈕以Claude Code可執行的格式匯出。\n\nSub-Agent匯出到`.claude/agents/`，SlashCommand匯出到`.claude/commands/`。',
+    '點擊「Convert」按鈕可將工作流程轉換為Slash Command格式。\n\n轉換後的檔案儲存在.claude/commands/目錄中。',
+  'tour.runSlashCommand':
+    '點擊「Run」按鈕可將工作流程轉換為Slash Command並立即在Claude Code中執行。\n\n一鍵完成轉換和執行。',
   'tour.refineWithAI':
     '使用「AI編輯」按鈕透過與AI對話建立或改善工作流程。\n\n可以從空白畫布開始或以對話方式編輯現有工作流程。',
   'tour.moreActions':


### PR DESCRIPTION
## Problem

### Issue 1: Load Button Focus Lost in Onboarding Tour
- **Root Cause**: Tour step 16 targets `[data-tour="workflow-selector"]` which does not exist
- **Actual Element**: Load button has `data-tour="load-button"` attribute
- **Result**: Tour spotlight fails to highlight the Load button

### Issue 2: Missing Run Button Explanation
- **Current State**: Run button has `data-tour="run-button"` attribute but no corresponding tour step
- **Context**: Run as Slash Command feature was added in #309 without tour step

## Solution

### 1. Fix Load Button Target
Changed tour step target from `workflow-selector` to `load-button`

### 2. Add Run Button Tour Step
Added new tour step after Convert button to explain the Run feature

### 3. Update Export → Convert Text
Updated `tour.exportWorkflow` translation text to use "Convert" instead of "Export" to match current button label

## Changes

| File | Changes |
|------|---------|
| `tour-steps.ts` | Fix target selector, add Run step |
| `translation-keys.ts` | Add `tour.runSlashCommand` type |
| `en.ts`, `ja.ts`, `ko.ts`, `zh-CN.ts`, `zh-TW.ts` | Add Run step translation, update Export→Convert |

## Impact

- Tour step count: 19 → 20
- No breaking changes
- All 5 languages updated

## Testing

- [x] Code quality checks passed (format, lint, check)
- [x] Build succeeded
- [x] Manual E2E testing of onboarding tour

🤖 Generated with [Claude Code](https://claude.com/claude-code)