### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -41,7 +41,7 @@ jobs:
 
       # ルートプロジェクトのスキャン
       - name: Run Snyk to check root project
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1.0.0
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
 
       # Webviewプロジェクトのスキャン
       - name: Run Snyk to check webview project
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1.0.0
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
 
       # SARIF形式でのスキャン（GitHub Code Scanning用）
       - name: Run Snyk to generate SARIF file
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1.0.0
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
 
       # すべてのプロジェクトのモニタリング（継続的な監視）
       - name: Monitor all projects with Snyk
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v1.0.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Update external GitHub Actions to their latest versions for improved security and compatibility.

## Changes

### Updated Actions

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| snyk/actions/node | @master | @v1.0.0 |

### Files Modified

- `.github/workflows/security-scan.yml` (6 changes)
- `.github/workflows/release.yml` (2 changes)

## Why

- **actions/checkout@v6** and **actions/setup-node@v6**: Released Nov 2025, includes Node 24 support and security updates
- **snyk/actions/node@v1.0.0**: Pin to stable release instead of floating `@master` branch for reproducibility

## Impact

- No breaking changes expected
- Requires GitHub Actions Runner v2.329.0+ (ubuntu-latest meets this requirement)

## Testing

- [ ] Security scan workflow runs successfully
- [ ] Release workflow runs successfully (verified on next production merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)