### PR TITLE
docs: add Star History chart and badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Claude Code Workflow Studio
 
 <p align="center">
+  <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
   <a href="https://snyk.io/test/github/breaking-brake/cc-wf-studio"><img src="https://snyk.io/test/github/breaking-brake/cc-wf-studio/badge.svg" alt="Known Vulnerabilities" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
+  <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
 </p>
 
 <p align="center">
@@ -464,6 +467,10 @@ See the [LICENSE](./LICENSE) file for the full license text.
 - Commercial use is allowed, but proprietary modifications are not
 
 Copyright (c) 2025 breaking-brake
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=breaking-brake/cc-wf-studio&type=Date)](https://star-history.com/#breaking-brake/cc-wf-studio&Date)
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

Add badges and Star History chart to improve README visibility and provide quick access to important links.

## Changes

### Badges Added (top of README)
1. **GitHub Stars** - Links to stargazers page
2. **VS Code Marketplace** - Shows version, links to marketplace
3. **OpenVSX** - Shows version, links to OpenVSX registry

### Star History Section Added
- Live SVG chart showing star count over time
- Powered by star-history.com
- Located before Acknowledgments section

## Impact

- Better visibility of project popularity and availability
- Quick access to installation sources (VS Marketplace / OpenVSX)
- Visual representation of project growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)