### PR TITLE
feat: add Focus Mode for compact UI display

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -57,6 +57,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setWorkflowName,
     clearWorkflow,
     subAgentFlows,
+    isFocusMode,
+    toggleFocusMode,
   } = useWorkflowStore();
   const {
     isProcessing,
@@ -675,6 +677,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               onShareToSlack={onShareToSlack}
               onResetWorkflow={() => setShowResetConfirm(true)}
               onStartTour={onStartTour}
+              isFocusMode={isFocusMode}
+              onToggleFocusMode={toggleFocusMode}
               open={moreActionsOpen}
               onOpenChange={onMoreActionsOpenChange}
             />

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { HelpCircle, MoreHorizontal, Share2, Trash2 } from 'lucide-react';
+import { Check, Focus, HelpCircle, MoreHorizontal, Share2, Trash2 } from 'lucide-react';
 import { useIsCompactMode } from '../../hooks/useWindowWidth';
 import { useTranslation } from '../../i18n/i18n-context';
 
@@ -21,6 +21,8 @@ interface MoreActionsDropdownProps {
   onShareToSlack: () => void;
   onResetWorkflow: () => void;
   onStartTour: () => void;
+  isFocusMode: boolean;
+  onToggleFocusMode: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -29,6 +31,8 @@ export function MoreActionsDropdown({
   onShareToSlack,
   onResetWorkflow,
   onStartTour,
+  isFocusMode,
+  onToggleFocusMode,
   open,
   onOpenChange,
 }: MoreActionsDropdownProps) {
@@ -110,6 +114,26 @@ export function MoreActionsDropdown({
           >
             <Trash2 size={14} />
             <span>{t('toolbar.resetWorkflow')}</span>
+          </DropdownMenu.Item>
+
+          {/* Focus Mode Toggle */}
+          <DropdownMenu.Item
+            onSelect={onToggleFocusMode}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <Focus size={14} />
+            <span style={{ flex: 1 }}>{t('toolbar.focusMode')}</span>
+            {isFocusMode && <Check size={14} />}
           </DropdownMenu.Item>
 
           <DropdownMenu.Separator

--- a/src/webview/src/hooks/useWindowWidth.ts
+++ b/src/webview/src/hooks/useWindowWidth.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { useWorkflowStore } from '../stores/workflow-store';
 
 const RESPONSIVE_BREAKPOINT = 900;
 
@@ -25,9 +26,10 @@ export function useWindowWidth(): number {
 }
 
 /**
- * Hook to check if window is in compact mode (width <= 900px)
+ * Hook to check if window is in compact mode (width <= 900px or Focus Mode enabled)
  */
 export function useIsCompactMode(): boolean {
   const width = useWindowWidth();
-  return width <= RESPONSIVE_BREAKPOINT;
+  const isFocusMode = useWorkflowStore((state) => state.isFocusMode);
+  return isFocusMode || width <= RESPONSIVE_BREAKPOINT;
 }

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -277,6 +277,7 @@ export interface WebviewTranslationKeys {
 
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': string;
+  'toolbar.focusMode': string;
   'dialog.resetWorkflow.title': string;
   'dialog.resetWorkflow.message': string;
   'dialog.resetWorkflow.confirm': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -305,6 +305,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'Reset Workflow',
+  'toolbar.focusMode': 'Focus Mode',
   'dialog.resetWorkflow.title': 'Reset Workflow',
   'dialog.resetWorkflow.message':
     'Are you sure you want to reset the workflow? All nodes except Start and End will be removed.',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -305,6 +305,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'ワークフローをリセット',
+  'toolbar.focusMode': '集中モード',
   'dialog.resetWorkflow.title': 'ワークフローをリセット',
   'dialog.resetWorkflow.message':
     'ワークフローをリセットしてもよろしいですか？Start と End 以外のすべてのノードが削除されます。',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -307,6 +307,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '워크플로우 초기화',
+  'toolbar.focusMode': '집중 모드',
   'dialog.resetWorkflow.title': '워크플로우 초기화',
   'dialog.resetWorkflow.message':
     '워크플로우를 초기화하시겠습니까? Start와 End를 제외한 모든 노드가 삭제됩니다.',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -295,6 +295,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重置工作流',
+  'toolbar.focusMode': '专注模式',
   'dialog.resetWorkflow.title': '重置工作流',
   'dialog.resetWorkflow.message': '确定要重置工作流吗？除 Start 和 End 外的所有节点都将被删除。',
   'dialog.resetWorkflow.confirm': '重置',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -295,6 +295,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重設工作流程',
+  'toolbar.focusMode': '專注模式',
   'dialog.resetWorkflow.title': '重設工作流程',
   'dialog.resetWorkflow.message': '確定要重設工作流程嗎？除 Start 和 End 外的所有節點都將被刪除。',
   'dialog.resetWorkflow.confirm': '重設',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -47,6 +47,7 @@ interface WorkflowStore {
   workflowName: string;
   isPropertyOverlayOpen: boolean;
   isMinimapVisible: boolean;
+  isFocusMode: boolean;
 
   // Sub-Agent Flow State (Feature: 089-subworkflow)
   subAgentFlows: SubAgentFlow[];
@@ -68,6 +69,7 @@ interface WorkflowStore {
   openPropertyOverlay: () => void;
   closePropertyOverlay: () => void;
   toggleMinimapVisibility: () => void;
+  toggleFocusMode: () => void;
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
@@ -231,6 +233,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     const saved = localStorage.getItem('cc-wf-studio.minimapVisible');
     return saved !== null ? saved === 'true' : true; // Default: visible
   })(),
+  isFocusMode: (() => {
+    const saved = localStorage.getItem('cc-wf-studio.focusMode');
+    return saved !== null ? saved === 'true' : false; // Default: off
+  })(),
 
   // Sub-Agent Flow Initial State (Feature: 089-subworkflow)
   subAgentFlows: [],
@@ -318,6 +324,12 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     const newValue = !get().isMinimapVisible;
     localStorage.setItem('cc-wf-studio.minimapVisible', newValue.toString());
     set({ isMinimapVisible: newValue });
+  },
+
+  toggleFocusMode: () => {
+    const newValue = !get().isFocusMode;
+    localStorage.setItem('cc-wf-studio.focusMode', newValue.toString());
+    set({ isFocusMode: newValue });
   },
 
   // Custom Actions


### PR DESCRIPTION
## Summary

Add Focus Mode feature that forces compact UI display regardless of window width.

- When Focus Mode is ON:
  - Toolbar shows icons only (no text labels)
  - Node Palette displays in compact width (100px)
  - AI Edit Panel displays in compact width (280px)
- Toggle via More Actions dropdown menu with checkbox indicator
- Setting persists in localStorage

## Changes

### State Management
- **workflow-store.ts**: Added `isFocusMode` state and `toggleFocusMode` action with localStorage persistence

### Responsive Hook
- **useWindowWidth.ts**: Extended `useIsCompactMode()` to return `true` when Focus Mode is enabled

### UI Components
- **MoreActionsDropdown.tsx**: Added Focus Mode toggle menu item with Focus icon and checkmark
- **Toolbar.tsx**: Connected Focus Mode state to dropdown props

### Internationalization
- Added `toolbar.focusMode` translation key for 5 languages (en, ja, ko, zh-CN, zh-TW)

## Testing

- [x] Manual E2E testing completed
- [x] Focus Mode toggle switches UI to compact display
- [x] Setting persists after page reload
- [x] All 5 language translations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)