### PR TITLE
chore: exclude new demo GIFs from VSIX bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -48,6 +48,8 @@ CLAUDE.md
 # Heavy assets (for README only, not needed in VSIX)
 resources/ai-refinement-demo-1.gif
 resources/ai-refinement-demo-2.gif
+resources/demo_edit_with_ai.gif
+resources/demo_run_workflow.gif
 resources/export-demo.gif
 resources/slack-export-demo.gif
 resources/slack-import-demo.gif


### PR DESCRIPTION
## Problem

The v3.10.0 VSIX bundle incorrectly includes large GIF files that are only used for README documentation:

- `resources/demo_edit_with_ai.gif` (5.4MB)
- `resources/demo_run_workflow.gif` (1.5MB)

These files were added in recent commits but not added to `.vscodeignore`, causing the VSIX size to increase by ~7MB.

## Solution

Add the missing GIF files to `.vscodeignore` to exclude them from the VSIX bundle.

## Changes

**File**: `.vscodeignore`

Added two entries to the "Heavy assets" section:
- `resources/demo_edit_with_ai.gif`
- `resources/demo_run_workflow.gif`

## Impact

- VSIX size reduction: ~7MB
- No version bump (chore commit)
- No CHANGELOG entry

## Recovery Plan

After this PR is merged:
1. Delete GitHub Release v3.10.0 and tag
2. Merge main to production to re-trigger release
3. v3.10.0 will be re-released with correct VSIX bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)