### PR TITLE
improvement: add delete button to edge connections

### DIFF
--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -44,6 +44,9 @@ const App: React.FC = () => {
     pendingDeleteNodeIds,
     confirmDeleteNodes,
     cancelDeleteNodes,
+    pendingDeleteEdgeIds,
+    confirmDeleteEdges,
+    cancelDeleteEdges,
     activeWorkflow,
     setNodes,
     setEdges,
@@ -324,6 +327,17 @@ const App: React.FC = () => {
         cancelLabel={t('dialog.deleteNode.cancel')}
         onConfirm={confirmDeleteNodes}
         onCancel={cancelDeleteNodes}
+      />
+
+      {/* Delete Edge Confirmation Dialog */}
+      <ConfirmDialog
+        isOpen={pendingDeleteEdgeIds.length > 0}
+        title={t('dialog.deleteEdge.title')}
+        message={t('dialog.deleteEdge.message')}
+        confirmLabel={t('dialog.deleteEdge.confirm')}
+        cancelLabel={t('dialog.deleteEdge.cancel')}
+        onConfirm={confirmDeleteEdges}
+        onCancel={cancelDeleteEdges}
       />
 
       {/* Slack Share Dialog */}

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -21,6 +21,8 @@ import ReactFlow, {
 } from 'reactflow';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useWorkflowStore } from '../stores/workflow-store';
+// Custom edge with delete button
+import { DeletableEdge } from './edges/DeletableEdge';
 import { InteractionModeToggle } from './InteractionModeToggle';
 import { MinimapContainer } from './MinimapContainer';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
@@ -66,9 +68,11 @@ const defaultEdgeOptions: DefaultEdgeOptions = {
 };
 
 /**
- * Edge types (can be customized later)
+ * Edge types - custom edge with delete button
  */
-const edgeTypes: EdgeTypes = {};
+const edgeTypes: EdgeTypes = {
+  default: DeletableEdge,
+};
 
 /**
  * WorkflowEditor Component Props

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -33,6 +33,8 @@ import {
 import { useWorkflowStore } from '../../stores/workflow-store';
 import { EditableNameField } from '../common/EditableNameField';
 import { StyledTooltip } from '../common/StyledTooltip';
+// Custom edge with delete button
+import { DeletableEdge } from '../edges/DeletableEdge';
 import { InteractionModeToggle } from '../InteractionModeToggle';
 import { MinimapContainer } from '../MinimapContainer';
 import { NodePalette } from '../NodePalette';
@@ -48,6 +50,7 @@ import { SubAgentFlowNodeComponent } from '../nodes/SubAgentFlowNode';
 import { SubAgentNodeComponent } from '../nodes/SubAgentNode';
 import { SwitchNodeComponent } from '../nodes/SwitchNode';
 import { PropertyOverlay } from '../PropertyOverlay';
+import { ConfirmDialog } from './ConfirmDialog';
 import { RefinementChatPanel } from './RefinementChatPanel';
 
 /**
@@ -76,9 +79,11 @@ const defaultEdgeOptions: DefaultEdgeOptions = {
 };
 
 /**
- * Edge types
+ * Edge types - custom edge with delete button
  */
-const edgeTypes: EdgeTypes = {};
+const edgeTypes: EdgeTypes = {
+  default: DeletableEdge,
+};
 
 interface SubAgentFlowDialogProps {
   isOpen: boolean;
@@ -107,6 +112,9 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
     mainWorkflowSnapshot,
     updateActiveWorkflowMetadata,
     ensureActiveWorkflow,
+    pendingDeleteEdgeIds,
+    confirmDeleteEdges,
+    cancelDeleteEdges,
   } = useWorkflowStore();
 
   // Local state for panel display (independent from main canvas)
@@ -706,6 +714,17 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                 </Collapsible.Content>
               </Collapsible.Root>
             </div>
+
+            {/* Delete Edge Confirmation Dialog */}
+            <ConfirmDialog
+              isOpen={pendingDeleteEdgeIds.length > 0}
+              title={t('dialog.deleteEdge.title')}
+              message={t('dialog.deleteEdge.message')}
+              confirmLabel={t('dialog.deleteEdge.confirm')}
+              cancelLabel={t('dialog.deleteEdge.cancel')}
+              onConfirm={confirmDeleteEdges}
+              onCancel={cancelDeleteEdges}
+            />
           </Dialog.Content>
         </Dialog.Overlay>
       </Dialog.Portal>

--- a/src/webview/src/components/edges/DeletableEdge.tsx
+++ b/src/webview/src/components/edges/DeletableEdge.tsx
@@ -1,0 +1,112 @@
+/**
+ * DeletableEdge Component
+ *
+ * Custom edge component with delete button.
+ * Shows delete button only when edge is selected.
+ */
+
+import type React from 'react';
+import { BaseEdge, type EdgeProps, getBezierPath } from 'reactflow';
+import { useWorkflowStore } from '../../stores/workflow-store';
+
+/**
+ * Deletable edge component
+ *
+ * Extends React Flow's default edge to show delete button when selected.
+ */
+export const DeletableEdge: React.FC<EdgeProps> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  selected,
+  style,
+  markerEnd,
+}) => {
+  const { requestDeleteEdge } = useWorkflowStore();
+
+  // Calculate bezier curve path and center coordinates
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  // Delete button click handler
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent edge selection event
+    requestDeleteEdge(id);
+  };
+
+  return (
+    <>
+      {/* Base edge */}
+      <BaseEdge path={edgePath} style={style} markerEnd={markerEnd} />
+
+      {/* Show delete button only when selected */}
+      {selected && (
+        <foreignObject
+          x={labelX - 9}
+          y={labelY - 9}
+          width={18}
+          height={18}
+          className="edgebutton-foreignobject"
+          requiredExtensions="http://www.w3.org/1999/xhtml"
+        >
+          <button
+            type="button"
+            onClick={handleDeleteClick}
+            style={{
+              width: '18px',
+              height: '18px',
+              borderRadius: '3px',
+              backgroundColor: 'var(--vscode-errorForeground)',
+              color: 'white',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '14px',
+              fontWeight: 'bold',
+              padding: 0,
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.opacity = '0.8';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.opacity = '1';
+            }}
+            title="Delete connection"
+          >
+            <svg
+              width="8"
+              height="8"
+              viewBox="0 0 8 8"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              style={{ display: 'block' }}
+              aria-labelledby="delete-edge-icon-title"
+            >
+              <title id="delete-edge-icon-title">Delete</title>
+              <path
+                d="M1 1L7 7M7 1L1 7"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </foreignObject>
+      )}
+    </>
+  );
+};
+
+export default DeletableEdge;

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -275,6 +275,12 @@ export interface WebviewTranslationKeys {
   'dialog.deleteNode.confirm': string;
   'dialog.deleteNode.cancel': string;
 
+  // Delete Edge Confirmation Dialog
+  'dialog.deleteEdge.title': string;
+  'dialog.deleteEdge.message': string;
+  'dialog.deleteEdge.confirm': string;
+  'dialog.deleteEdge.cancel': string;
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': string;
   'toolbar.focusMode': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -303,6 +303,12 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': 'Delete',
   'dialog.deleteNode.cancel': 'Cancel',
 
+  // Delete Edge Confirmation Dialog
+  'dialog.deleteEdge.title': 'Delete Connection',
+  'dialog.deleteEdge.message': 'Are you sure you want to delete this connection?',
+  'dialog.deleteEdge.confirm': 'Delete',
+  'dialog.deleteEdge.cancel': 'Cancel',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'Reset Workflow',
   'toolbar.focusMode': 'Focus Mode',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -303,6 +303,12 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '削除',
   'dialog.deleteNode.cancel': 'キャンセル',
 
+  // Delete Edge Confirmation Dialog
+  'dialog.deleteEdge.title': '接続を削除',
+  'dialog.deleteEdge.message': 'この接続を削除してもよろしいですか？',
+  'dialog.deleteEdge.confirm': '削除',
+  'dialog.deleteEdge.cancel': 'キャンセル',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'ワークフローをリセット',
   'toolbar.focusMode': '集中モード',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -305,6 +305,12 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '삭제',
   'dialog.deleteNode.cancel': '취소',
 
+  // Delete Edge Confirmation Dialog
+  'dialog.deleteEdge.title': '연결 삭제',
+  'dialog.deleteEdge.message': '이 연결을 삭제하시겠습니까?',
+  'dialog.deleteEdge.confirm': '삭제',
+  'dialog.deleteEdge.cancel': '취소',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '워크플로우 초기화',
   'toolbar.focusMode': '집중 모드',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -293,6 +293,12 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '删除',
   'dialog.deleteNode.cancel': '取消',
 
+  // Delete Edge Confirmation Dialog
+  'dialog.deleteEdge.title': '删除连接',
+  'dialog.deleteEdge.message': '确定要删除此连接吗？',
+  'dialog.deleteEdge.confirm': '删除',
+  'dialog.deleteEdge.cancel': '取消',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重置工作流',
   'toolbar.focusMode': '专注模式',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -293,6 +293,12 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '刪除',
   'dialog.deleteNode.cancel': '取消',
 
+  // Delete Edge Confirmation Dialog
+  'dialog.deleteEdge.title': '刪除連接',
+  'dialog.deleteEdge.message': '確定要刪除此連接嗎？',
+  'dialog.deleteEdge.confirm': '刪除',
+  'dialog.deleteEdge.cancel': '取消',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重設工作流程',
   'toolbar.focusMode': '專注模式',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -42,6 +42,7 @@ interface WorkflowStore {
   edges: Edge[];
   selectedNodeId: string | null;
   pendingDeleteNodeIds: string[];
+  pendingDeleteEdgeIds: string[];
   activeWorkflow: Workflow | null;
   interactionMode: InteractionMode;
   workflowName: string;
@@ -78,6 +79,9 @@ interface WorkflowStore {
   requestDeleteNode: (nodeId: string) => void;
   confirmDeleteNodes: () => void;
   cancelDeleteNodes: () => void;
+  requestDeleteEdge: (edgeId: string) => void;
+  confirmDeleteEdges: () => void;
+  cancelDeleteEdges: () => void;
   clearWorkflow: () => void;
   addGeneratedWorkflow: (workflow: Workflow) => void;
   updateWorkflow: (workflow: Workflow) => void;
@@ -225,6 +229,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   edges: [],
   selectedNodeId: null,
   pendingDeleteNodeIds: [],
+  pendingDeleteEdgeIds: [],
   activeWorkflow: null,
   interactionMode: 'pan', // Default: pan mode
   workflowName: 'my-workflow', // Default workflow name
@@ -391,6 +396,26 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
 
   cancelDeleteNodes: () => {
     set({ pendingDeleteNodeIds: [] });
+  },
+
+  requestDeleteEdge: (edgeId: string) => {
+    // Request edge deletion (show confirmation dialog)
+    set({ pendingDeleteEdgeIds: [edgeId] });
+  },
+
+  confirmDeleteEdges: () => {
+    const edgeIds = get().pendingDeleteEdgeIds;
+    if (edgeIds.length === 0) return;
+
+    // Delete all pending edges
+    set({
+      edges: get().edges.filter((edge) => !edgeIds.includes(edge.id)),
+      pendingDeleteEdgeIds: [],
+    });
+  },
+
+  cancelDeleteEdges: () => {
+    set({ pendingDeleteEdgeIds: [] });
   },
 
   clearWorkflow: () => {


### PR DESCRIPTION
## Problem

Users can only delete edge connections using Backspace/Delete keys, but many users are unaware of this functionality.

### Current Behavior
1. Select an edge connection
2. ❌ No visual indication of how to delete it
3. Users must know to press Backspace/Delete key

### Expected Behavior
1. Select an edge connection
2. ✅ Delete button (×) appears on the edge
3. Click button to delete with confirmation dialog

## Solution

Add a delete button to edge connections, similar to node delete buttons.

### Changes

- **New file**: `src/webview/src/components/edges/DeletableEdge.tsx`
  - Custom edge component with delete button
  - Shows × button when edge is selected
  - Positioned at center of edge

- **Modified**: `src/webview/src/stores/workflow-store.ts`
  - Added `pendingDeleteEdgeIds` state
  - Added `requestDeleteEdge`, `confirmDeleteEdges`, `cancelDeleteEdges` actions

- **Modified**: `src/webview/src/components/WorkflowEditor.tsx`
  - Registered `DeletableEdge` as default edge type

- **Modified**: `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`
  - Added `DeletableEdge` for Sub-Agent Flow editing
  - Added confirmation dialog inside the dialog

- **Modified**: `src/webview/src/App.tsx`
  - Added edge deletion confirmation dialog

- **i18n**: Added translations for 5 languages (en, ja, ko, zh-CN, zh-TW)

## Impact

- UX improvement: Users can now visually see and click to delete connections
- Consistent with node deletion behavior (confirmation dialog)
- No breaking changes

## Testing

- [x] Edge selection shows delete button
- [x] Click delete button shows confirmation dialog
- [x] Confirm deletes the edge
- [x] Cancel keeps the edge
- [x] Works in main canvas
- [x] Works in Sub-Agent Flow editing dialog
- [x] Backspace/Delete key still works
- [x] Code quality checks passed (format, lint, check, build)

Related to #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)