### PR TITLE
improvement: remove edge deletion confirmation dialog

### DIFF
--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -44,9 +44,6 @@ const App: React.FC = () => {
     pendingDeleteNodeIds,
     confirmDeleteNodes,
     cancelDeleteNodes,
-    pendingDeleteEdgeIds,
-    confirmDeleteEdges,
-    cancelDeleteEdges,
     activeWorkflow,
     setNodes,
     setEdges,
@@ -327,17 +324,6 @@ const App: React.FC = () => {
         cancelLabel={t('dialog.deleteNode.cancel')}
         onConfirm={confirmDeleteNodes}
         onCancel={cancelDeleteNodes}
-      />
-
-      {/* Delete Edge Confirmation Dialog */}
-      <ConfirmDialog
-        isOpen={pendingDeleteEdgeIds.length > 0}
-        title={t('dialog.deleteEdge.title')}
-        message={t('dialog.deleteEdge.message')}
-        confirmLabel={t('dialog.deleteEdge.confirm')}
-        cancelLabel={t('dialog.deleteEdge.cancel')}
-        onConfirm={confirmDeleteEdges}
-        onCancel={cancelDeleteEdges}
       />
 
       {/* Slack Share Dialog */}

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -50,7 +50,6 @@ import { SubAgentFlowNodeComponent } from '../nodes/SubAgentFlowNode';
 import { SubAgentNodeComponent } from '../nodes/SubAgentNode';
 import { SwitchNodeComponent } from '../nodes/SwitchNode';
 import { PropertyOverlay } from '../PropertyOverlay';
-import { ConfirmDialog } from './ConfirmDialog';
 import { RefinementChatPanel } from './RefinementChatPanel';
 
 /**
@@ -112,9 +111,6 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
     mainWorkflowSnapshot,
     updateActiveWorkflowMetadata,
     ensureActiveWorkflow,
-    pendingDeleteEdgeIds,
-    confirmDeleteEdges,
-    cancelDeleteEdges,
   } = useWorkflowStore();
 
   // Local state for panel display (independent from main canvas)
@@ -714,17 +710,6 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                 </Collapsible.Content>
               </Collapsible.Root>
             </div>
-
-            {/* Delete Edge Confirmation Dialog */}
-            <ConfirmDialog
-              isOpen={pendingDeleteEdgeIds.length > 0}
-              title={t('dialog.deleteEdge.title')}
-              message={t('dialog.deleteEdge.message')}
-              confirmLabel={t('dialog.deleteEdge.confirm')}
-              cancelLabel={t('dialog.deleteEdge.cancel')}
-              onConfirm={confirmDeleteEdges}
-              onCancel={cancelDeleteEdges}
-            />
           </Dialog.Content>
         </Dialog.Overlay>
       </Dialog.Portal>

--- a/src/webview/src/components/edges/DeletableEdge.tsx
+++ b/src/webview/src/components/edges/DeletableEdge.tsx
@@ -6,8 +6,7 @@
  */
 
 import type React from 'react';
-import { BaseEdge, type EdgeProps, getBezierPath } from 'reactflow';
-import { useWorkflowStore } from '../../stores/workflow-store';
+import { BaseEdge, type EdgeProps, getBezierPath, useReactFlow } from 'reactflow';
 
 /**
  * Deletable edge component
@@ -26,7 +25,7 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
   style,
   markerEnd,
 }) => {
-  const { requestDeleteEdge } = useWorkflowStore();
+  const { setEdges } = useReactFlow();
 
   // Calculate bezier curve path and center coordinates
   const [edgePath, labelX, labelY] = getBezierPath({
@@ -38,10 +37,10 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
     targetPosition,
   });
 
-  // Delete button click handler
+  // Delete button click handler - delete immediately without confirmation
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent edge selection event
-    requestDeleteEdge(id);
+    setEdges((edges) => edges.filter((edge) => edge.id !== id));
   };
 
   return (

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -275,12 +275,6 @@ export interface WebviewTranslationKeys {
   'dialog.deleteNode.confirm': string;
   'dialog.deleteNode.cancel': string;
 
-  // Delete Edge Confirmation Dialog
-  'dialog.deleteEdge.title': string;
-  'dialog.deleteEdge.message': string;
-  'dialog.deleteEdge.confirm': string;
-  'dialog.deleteEdge.cancel': string;
-
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': string;
   'toolbar.focusMode': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -303,12 +303,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': 'Delete',
   'dialog.deleteNode.cancel': 'Cancel',
 
-  // Delete Edge Confirmation Dialog
-  'dialog.deleteEdge.title': 'Delete Connection',
-  'dialog.deleteEdge.message': 'Are you sure you want to delete this connection?',
-  'dialog.deleteEdge.confirm': 'Delete',
-  'dialog.deleteEdge.cancel': 'Cancel',
-
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'Reset Workflow',
   'toolbar.focusMode': 'Focus Mode',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -303,12 +303,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '削除',
   'dialog.deleteNode.cancel': 'キャンセル',
 
-  // Delete Edge Confirmation Dialog
-  'dialog.deleteEdge.title': '接続を削除',
-  'dialog.deleteEdge.message': 'この接続を削除してもよろしいですか？',
-  'dialog.deleteEdge.confirm': '削除',
-  'dialog.deleteEdge.cancel': 'キャンセル',
-
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'ワークフローをリセット',
   'toolbar.focusMode': '集中モード',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -305,12 +305,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '삭제',
   'dialog.deleteNode.cancel': '취소',
 
-  // Delete Edge Confirmation Dialog
-  'dialog.deleteEdge.title': '연결 삭제',
-  'dialog.deleteEdge.message': '이 연결을 삭제하시겠습니까?',
-  'dialog.deleteEdge.confirm': '삭제',
-  'dialog.deleteEdge.cancel': '취소',
-
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '워크플로우 초기화',
   'toolbar.focusMode': '집중 모드',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -293,12 +293,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '删除',
   'dialog.deleteNode.cancel': '取消',
 
-  // Delete Edge Confirmation Dialog
-  'dialog.deleteEdge.title': '删除连接',
-  'dialog.deleteEdge.message': '确定要删除此连接吗？',
-  'dialog.deleteEdge.confirm': '删除',
-  'dialog.deleteEdge.cancel': '取消',
-
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重置工作流',
   'toolbar.focusMode': '专注模式',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -293,12 +293,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'dialog.deleteNode.confirm': '刪除',
   'dialog.deleteNode.cancel': '取消',
 
-  // Delete Edge Confirmation Dialog
-  'dialog.deleteEdge.title': '刪除連接',
-  'dialog.deleteEdge.message': '確定要刪除此連接嗎？',
-  'dialog.deleteEdge.confirm': '刪除',
-  'dialog.deleteEdge.cancel': '取消',
-
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重設工作流程',
   'toolbar.focusMode': '專注模式',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -42,7 +42,6 @@ interface WorkflowStore {
   edges: Edge[];
   selectedNodeId: string | null;
   pendingDeleteNodeIds: string[];
-  pendingDeleteEdgeIds: string[];
   activeWorkflow: Workflow | null;
   interactionMode: InteractionMode;
   workflowName: string;
@@ -79,9 +78,6 @@ interface WorkflowStore {
   requestDeleteNode: (nodeId: string) => void;
   confirmDeleteNodes: () => void;
   cancelDeleteNodes: () => void;
-  requestDeleteEdge: (edgeId: string) => void;
-  confirmDeleteEdges: () => void;
-  cancelDeleteEdges: () => void;
   clearWorkflow: () => void;
   addGeneratedWorkflow: (workflow: Workflow) => void;
   updateWorkflow: (workflow: Workflow) => void;
@@ -229,7 +225,6 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   edges: [],
   selectedNodeId: null,
   pendingDeleteNodeIds: [],
-  pendingDeleteEdgeIds: [],
   activeWorkflow: null,
   interactionMode: 'pan', // Default: pan mode
   workflowName: 'my-workflow', // Default workflow name
@@ -396,26 +391,6 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
 
   cancelDeleteNodes: () => {
     set({ pendingDeleteNodeIds: [] });
-  },
-
-  requestDeleteEdge: (edgeId: string) => {
-    // Request edge deletion (show confirmation dialog)
-    set({ pendingDeleteEdgeIds: [edgeId] });
-  },
-
-  confirmDeleteEdges: () => {
-    const edgeIds = get().pendingDeleteEdgeIds;
-    if (edgeIds.length === 0) return;
-
-    // Delete all pending edges
-    set({
-      edges: get().edges.filter((edge) => !edgeIds.includes(edge.id)),
-      pendingDeleteEdgeIds: [],
-    });
-  },
-
-  cancelDeleteEdges: () => {
-    set({ pendingDeleteEdgeIds: [] });
   },
 
   clearWorkflow: () => {


### PR DESCRIPTION
## Summary

- Remove confirmation dialog when deleting edge connections
- Edge now deletes immediately when × button is clicked

## Rationale

- Reconnecting edges is easy if deleted by mistake (low cost of error recovery)
- Confirmation dialog for every edge deletion is tedious for users

## Changes

- **DeletableEdge.tsx**: Use `useReactFlow().setEdges` for direct deletion
- **workflow-store.ts**: Remove `pendingDeleteEdgeIds`, `requestDeleteEdge`, `confirmDeleteEdges`, `cancelDeleteEdges`
- **App.tsx**: Remove edge deletion confirmation dialog
- **SubAgentFlowDialog.tsx**: Remove edge deletion confirmation dialog and unused ConfirmDialog import
- **i18n files**: Remove `dialog.deleteEdge.*` keys from all 5 languages (en, ja, ko, zh-CN, zh-TW)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)