### PR TITLE
chore: update biome.json schema version to match 2.3.10

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "files": {
     "includes": ["**", "!**/out", "!**/dist", "!**/node_modules", "!**/.vscode"]
   },


### PR DESCRIPTION
## Summary

Updates the `$schema` in `biome.json` to match the installed Biome version 2.3.10.

This was missed in PR #318 which updated the `@biomejs/biome` package.

## Changes

- Updated `$schema` URL from `2.3.8` to `2.3.10`

## Testing

- [x] `npm run check` passes without schema version mismatch warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)