### PR TITLE
chore: update qs to 6.14.1 to fix CVE-2025-15284

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8452,9 +8452,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary

Updates `qs` from 6.14.0 to 6.14.1 to fix a high severity security vulnerability.

## Security Issue

- **CVE**: CVE-2025-15284
- **Severity**: High
- **Type**: Allocation of Resources Without Limits or Throttling (CWE-770)
- **Issue**: `arrayLimit` option not properly enforced, allowing memory exhaustion attacks

Fixes [Code scanning alert #3](https://github.com/breaking-brake/cc-wf-studio/security/code-scanning/3).

## Changes

- Updated `qs` in package-lock.json: 6.14.0 → 6.14.1

## Testing

- [x] `npm audit` shows 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)