### PR TITLE
improvement: remove unnecessary info message from editor

### DIFF
--- a/src/extension/commands/text-editor.ts
+++ b/src/extension/commands/text-editor.ts
@@ -48,7 +48,7 @@ export async function handleOpenInEditor(
   payload: OpenInEditorPayload,
   webview: vscode.Webview
 ): Promise<void> {
-  const { sessionId, content, label, language = 'markdown' } = payload;
+  const { sessionId, content, language = 'markdown' } = payload;
 
   try {
     // Create a temporary file with the content
@@ -126,12 +126,6 @@ export async function handleOpenInEditor(
 
     // Store session
     activeSessions.set(sessionId, { filePath, webview, disposables });
-
-    // Show info message with instructions
-    const tabLabel = label || 'Edit Text';
-    vscode.window.showInformationMessage(
-      `Editing "${tabLabel}". Save (Ctrl+S / :w) to apply changes, or close the tab to cancel.`
-    );
   } catch (error) {
     // Send error back to webview
     webview.postMessage({


### PR DESCRIPTION
## Problem

When opening text in VSCode Editor, an information message is displayed:
> "Editing '...'. Save (Ctrl+S / :w) to apply changes, or close the tab to cancel."

This message is unnecessary and interrupts the user experience.

## Solution

Remove the `showInformationMessage` call and the unused `label` variable.

## Changes

**File**: `src/extension/commands/text-editor.ts`

- Removed info message notification on editor open
- Removed unused `label` variable from destructuring

## Impact

- UX improvement: No more unnecessary notification popup
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run check`)
- [x] Build verified (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)