### PR TITLE
fix: use cross-platform path separator for agent file detection

### DIFF
--- a/src/extension/commands/export-workflow.ts
+++ b/src/extension/commands/export-workflow.ts
@@ -74,7 +74,7 @@ export async function handleExportWorkflow(
     for (const filePath of exportedFiles) {
       try {
         const content = await fileService.readFile(filePath);
-        const fileType = filePath.includes('/agents/') ? 'subAgent' : 'slashCommand';
+        const fileType = /[/\\]agents[/\\]/.test(filePath) ? 'subAgent' : 'slashCommand';
         validateClaudeFileFormat(content, fileType);
       } catch (error) {
         const fileName = path.basename(filePath);
@@ -188,7 +188,7 @@ export async function handleExportWorkflowForExecution(
     for (const filePath of exportedFiles) {
       try {
         const content = await fileService.readFile(filePath);
-        const fileType = filePath.includes('/agents/') ? 'subAgent' : 'slashCommand';
+        const fileType = /[/\\]agents[/\\]/.test(filePath) ? 'subAgent' : 'slashCommand';
         validateClaudeFileFormat(content, fileType);
       } catch (error) {
         const fileName = path.basename(filePath);


### PR DESCRIPTION
## Problem

### Current Behavior
1. Create a workflow with Sub-Agent node and configure tools (e.g., `Read,Edit,Bash`)
2. Click "Convert" to export
3. ❌ Error appears: `SlashCommand file missing required field: allowed-tools`

### Expected Behavior
1. Create a workflow with Sub-Agent node
2. Click "Convert" to export
3. ✅ Export succeeds without errors

### Root Cause

The file type detection uses Unix-style path separator only:

```typescript
const fileType = filePath.includes('/agents/') ? 'subAgent' : 'slashCommand';
```

- macOS/Linux: `/agents/` → correctly identified as `subAgent`
- Windows: `\agents\` → incorrectly identified as `slashCommand`

## Solution

Use a regex that matches both Unix (`/`) and Windows (`\`) path separators:

```typescript
const fileType = /[/\\]agents[/\\]/.test(filePath) ? 'subAgent' : 'slashCommand';
```

### Changes

**File**: `src/extension/commands/export-workflow.ts`

- Line 77: Updated path detection regex
- Line 191: Updated path detection regex (same change)

## Impact

- ✅ Fixes export validation on Windows
- ✅ No breaking changes
- ✅ Backward compatible with macOS/Linux

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

Closes #345