### PR TITLE
fix: treat non-JSON AI response as clarification message

### DIFF
--- a/src/extension/services/refinement-service.ts
+++ b/src/extension/services/refinement-service.ts
@@ -73,12 +73,32 @@ interface AISubAgentFlowResponse {
 /**
  * Parse AI refinement response with structured format
  *
+ * Includes fallback handling for non-JSON text responses:
+ * When AI responds with conversational text instead of JSON
+ * (especially common when user sends vague/initial messages),
+ * treat it as a clarification response to maintain UX.
+ *
  * @param output - Raw CLI output string
  * @returns Parsed AIRefinementResponse or null if parsing fails
  */
 function parseRefinementResponse(output: string): AIRefinementResponse | null {
   const parsed = parseClaudeCodeOutput(output);
+
+  // Fallback: If parsing fails but we have text content, treat it as clarification
+  // This handles cases where AI responds with conversational text instead of JSON
+  // (common with non-English locales or vague initial user messages)
   if (!parsed || typeof parsed !== 'object') {
+    const trimmedOutput = output.trim();
+    if (trimmedOutput.length > 0) {
+      log('INFO', 'Treating non-JSON AI response as clarification message', {
+        outputLength: trimmedOutput.length,
+        outputPreview: trimmedOutput.substring(0, 100),
+      });
+      return {
+        status: 'clarification',
+        message: trimmedOutput,
+      };
+    }
     return null;
   }
 
@@ -95,12 +115,27 @@ function parseRefinementResponse(output: string): AIRefinementResponse | null {
 /**
  * Parse AI SubAgentFlow refinement response with structured format
  *
+ * Includes fallback handling for non-JSON text responses (same as parseRefinementResponse).
+ *
  * @param output - Raw CLI output string
  * @returns Parsed AISubAgentFlowResponse or null if parsing fails
  */
 function parseSubAgentFlowResponse(output: string): AISubAgentFlowResponse | null {
   const parsed = parseClaudeCodeOutput(output);
+
+  // Fallback: If parsing fails but we have text content, treat it as clarification
   if (!parsed || typeof parsed !== 'object') {
+    const trimmedOutput = output.trim();
+    if (trimmedOutput.length > 0) {
+      log('INFO', 'Treating non-JSON SubAgentFlow AI response as clarification message', {
+        outputLength: trimmedOutput.length,
+        outputPreview: trimmedOutput.substring(0, 100),
+      });
+      return {
+        status: 'clarification',
+        message: trimmedOutput,
+      };
+    }
     return null;
   }
 


### PR DESCRIPTION
## Problem

### Current Behavior
1. User opens AI Refinement Chat
2. User sends an initial or vague message (e.g., "hello", "こんにちは")
3. AI responds with conversational text instead of structured JSON
4. ❌ `PARSE_ERROR: Failed to parse AI response` is displayed

### Expected Behavior
1. User opens AI Refinement Chat
2. User sends an initial or vague message
3. AI responds with conversational text
4. ✅ Text is displayed as a clarification message in chat UI

## Solution

Added fallback handling in `parseRefinementResponse` and `parseSubAgentFlowResponse` functions to treat non-JSON text responses as clarification messages.

### Changes

**File**: `src/extension/services/refinement-service.ts`

- Added fallback logic when JSON parsing fails
- If text content exists, wrap it as a clarification response
- Added logging for debugging purposes

```typescript
// Fallback: If parsing fails but we have text content, treat it as clarification
if (!parsed || typeof parsed !== 'object') {
  const trimmedOutput = output.trim();
  if (trimmedOutput.length > 0) {
    log('INFO', 'Treating non-JSON AI response as clarification message', {...});
    return {
      status: 'clarification',
      message: trimmedOutput,
    };
  }
  return null;
}
```

## Impact

- Users will no longer see PARSE_ERROR when AI responds with conversational text
- Conversational responses are now displayed as clarification messages
- Users can continue the conversation by providing more specific requests
- No breaking changes

## Testing

- [x] Code quality checks passed (format, lint, check)
- [x] Build succeeded
- [x] Manual E2E testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)