### PR TITLE
fix: use correct CLI flag --allowedTools instead of --tools

### DIFF
--- a/src/extension/services/claude-code-service.ts
+++ b/src/extension/services/claude-code-service.ts
@@ -149,12 +149,9 @@ export async function executeClaudeCodeCLI(
     // Build CLI arguments
     const args = ['-p', '-', '--model', modelName];
 
-    // Add --tools and --allowed-tools flags if provided
-    // --tools: whitelist restriction (only these tools available)
-    // --allowed-tools: no permission prompt for these tools
+    // Add --allowedTools flag if provided (no permission prompt for these tools)
     if (allowedTools && allowedTools.length > 0) {
-      args.push('--tools', allowedTools.join(','));
-      args.push('--allowed-tools', allowedTools.join(','));
+      args.push('--allowedTools', allowedTools.join(','));
     }
 
     // Spawn Claude Code CLI process using nano-spawn (cross-platform compatible)
@@ -470,12 +467,9 @@ export async function executeClaudeCodeCLIStreaming(
     // Build CLI arguments
     const args = ['-p', '-', '--output-format', 'stream-json', '--verbose', '--model', modelName];
 
-    // Add --tools and --allowed-tools flags if provided
-    // --tools: whitelist restriction (only these tools available)
-    // --allowed-tools: no permission prompt for these tools
+    // Add --allowedTools flag if provided (no permission prompt for these tools)
     if (allowedTools && allowedTools.length > 0) {
-      args.push('--tools', allowedTools.join(','));
-      args.push('--allowed-tools', allowedTools.join(','));
+      args.push('--allowedTools', allowedTools.join(','));
     }
 
     // Spawn Claude Code CLI with streaming output format


### PR DESCRIPTION
## Summary
- Changed `--tools` to `--allowedTools` (correct camelCase format)
- Changed `--allowed-tools` to `--allowedTools`
- Fixes "unknown option '--tools'" error in Claude CLI 1.0.48+

## Problem
The extension was using incorrect CLI flags:
- `--tools` (doesn't exist)
- `--allowed-tools` (wrong format)

The correct flag is `--allowedTools` (camelCase).

## Test plan
- [x] Verified with `claude --help` that `--allowedTools` is the correct flag
- [ ] Test "Edit with AI" workflow in Cursor/VSCode

🤖 Generated with [Claude Code](https://claude.com/claude-code)