### PR TITLE
fix: use correct CLI flag --allowedTools instead of --allowed-tools

### DIFF
--- a/src/extension/services/claude-code-service.ts
+++ b/src/extension/services/claude-code-service.ts
@@ -149,12 +149,12 @@ export async function executeClaudeCodeCLI(
     // Build CLI arguments
     const args = ['-p', '-', '--model', modelName];
 
-    // Add --tools and --allowed-tools flags if provided
+    // Add --tools and --allowedTools flags if provided
     // --tools: whitelist restriction (only these tools available)
-    // --allowed-tools: no permission prompt for these tools
+    // --allowedTools: no permission prompt for these tools
     if (allowedTools && allowedTools.length > 0) {
       args.push('--tools', allowedTools.join(','));
-      args.push('--allowed-tools', allowedTools.join(','));
+      args.push('--allowedTools', allowedTools.join(','));
     }
 
     // Spawn Claude Code CLI process using nano-spawn (cross-platform compatible)
@@ -470,12 +470,12 @@ export async function executeClaudeCodeCLIStreaming(
     // Build CLI arguments
     const args = ['-p', '-', '--output-format', 'stream-json', '--verbose', '--model', modelName];
 
-    // Add --tools and --allowed-tools flags if provided
+    // Add --tools and --allowedTools flags if provided
     // --tools: whitelist restriction (only these tools available)
-    // --allowed-tools: no permission prompt for these tools
+    // --allowedTools: no permission prompt for these tools
     if (allowedTools && allowedTools.length > 0) {
       args.push('--tools', allowedTools.join(','));
-      args.push('--allowed-tools', allowedTools.join(','));
+      args.push('--allowedTools', allowedTools.join(','));
     }
 
     // Spawn Claude Code CLI with streaming output format


### PR DESCRIPTION
## Summary

Fix the Claude Code CLI flag format from kebab-case to camelCase.

Supersedes #363

## Problem

The CLI was using `--allowed-tools` (kebab-case) which is not a valid flag.

### Current Behavior
```bash
claude -p --tools "Read,Grep" --allowed-tools "Read,Grep" "query"
# Error: unknown option '--allowed-tools'
```

### Expected Behavior
```bash
claude -p --tools "Read,Grep" --allowedTools "Read,Grep" "query"
# Works correctly
```

## Solution

Changed `--allowed-tools` to `--allowedTools` (camelCase) while keeping `--tools` flag.

### Why keep both flags?

Per [official documentation](https://docs.anthropic.com/en/docs/claude-code/cli-reference):

| Flag | Purpose |
|------|---------|
| `--tools` | Restricts which tools are **available** to the AI |
| `--allowedTools` | Tools that execute **without permission prompts** |

These serve different purposes and both are needed.

## Changes

**File**: `src/extension/services/claude-code-service.ts`

- Changed `--allowed-tools` → `--allowedTools` in `executeClaudeCodeCLI()`
- Changed `--allowed-tools` → `--allowedTools` in `executeClaudeCodeCLIStreaming()`
- Updated comments to reflect correct flag name

## Impact

- Fixes CLI errors in Claude Code 1.0.48+
- No breaking changes to existing functionality

## Testing

- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)
- [x] Manual E2E testing with AI refinement feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)