### PR TITLE
fix: skills not detected on Windows due to CRLF line endings

### DIFF
--- a/src/extension/services/yaml-parser.ts
+++ b/src/extension/services/yaml-parser.ts
@@ -42,7 +42,8 @@ export interface SkillMetadata {
  */
 export function parseSkillFrontmatter(content: string): SkillMetadata | null {
   // Extract frontmatter block (delimited by ---)
-  const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
+  // Support both LF (\n) and CRLF (\r\n) line endings for cross-platform compatibility
+  const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---/;
   const match = content.match(frontmatterRegex);
 
   if (!match) {


### PR DESCRIPTION
## Problem

Skills located in `~/.claude/skills/` were not being detected on Windows.

### Root Cause

The YAML frontmatter parser regex only supported LF (`\n`) line endings:

```typescript
const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
```

On Windows, SKILL.md files may use CRLF (`\r\n`) line endings, causing the regex to fail and return `null`, which resulted in skills being silently skipped.

## Solution

Updated the regex to support both LF and CRLF line endings:

```typescript
const frontmatterRegex = /^---\r?\n([\s\S]*?)\r?\n---/;
```

## Testing

- [x] Verified on Windows: Skills now detected correctly
- [x] Verified on Mac: No regression, skills still work

## Impact

- Fixes skill detection for all scopes (user, project, plugin) on Windows
- No breaking changes

Closes #361