### PR TITLE
fix: close property dialog when node is deleted

### DIFF
--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -373,9 +373,13 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       return;
     }
 
+    // Clear selection if the deleted node is currently selected
+    const shouldClearSelection = get().selectedNodeId === nodeId;
+
     set({
       nodes: get().nodes.filter((node) => node.id !== nodeId),
       edges: get().edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId),
+      ...(shouldClearSelection && { selectedNodeId: null }),
     });
   },
 
@@ -396,6 +400,11 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     const nodeIds = get().pendingDeleteNodeIds;
     if (nodeIds.length === 0) return;
 
+    // Clear selection if the deleted node is currently selected
+    const currentSelectedNodeId = get().selectedNodeId;
+    const shouldClearSelection =
+      currentSelectedNodeId !== null && nodeIds.includes(currentSelectedNodeId);
+
     // Delete all pending nodes
     set({
       nodes: get().nodes.filter((node) => !nodeIds.includes(node.id)),
@@ -403,6 +412,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
         (edge) => !nodeIds.includes(edge.source) && !nodeIds.includes(edge.target)
       ),
       pendingDeleteNodeIds: [],
+      ...(shouldClearSelection && { selectedNodeId: null }),
     });
   },
 


### PR DESCRIPTION
## Problem

### Current Behavior
1. Add any node to the canvas
2. Select the node to open the property dialog
3. Delete the node
4. ❌ Property dialog remains visible but empty

### Expected Behavior
1. Add any node to the canvas
2. Select the node to open the property dialog
3. Delete the node
4. ✅ Property dialog closes automatically

## Solution

Clear `selectedNodeId` when a node is deleted if the deleted node is currently selected.

### Changes

**File**: `src/webview/src/stores/workflow-store.ts`

- `removeNode()`: Added check to clear `selectedNodeId` when deleted node is selected
- `confirmDeleteNodes()`: Added check to clear `selectedNodeId` when deleted node is selected

```typescript
// Added to both functions:
const shouldClearSelection = get().selectedNodeId === nodeId;
set({
  ...
  ...(shouldClearSelection && { selectedNodeId: null }),
});
```

## Impact

- **UX**: Property dialog now closes when its associated node is deleted
- **Breaking changes**: None
- **Side effects**: None (only clears selection)

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)