### PR TITLE
fix: add z-index to Radix UI dialogs for proper stacking

### DIFF
--- a/src/webview/src/components/dialogs/McpNodeDialog.tsx
+++ b/src/webview/src/components/dialogs/McpNodeDialog.tsx
@@ -366,6 +366,7 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            zIndex: 9999,
           }}
         >
           <Dialog.Content

--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -211,6 +211,7 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            zIndex: 9999,
           }}
         >
           <Dialog.Content


### PR DESCRIPTION
## Problem

When opening Skill reference or MCP Tool configuration dialogs from a node's property dialog, the property dialog incorrectly appears in front of the newly opened dialog.

### Current Behavior
1. Open a node's property dialog
2. Click to open Skill Browser or MCP Node dialog
3. ❌ Property dialog appears in front, blocking the new dialog

### Expected Behavior
1. Open a node's property dialog
2. Click to open Skill Browser or MCP Node dialog
3. ✅ New dialog appears in front of the property dialog

## Solution

Added explicit `zIndex: 9999` to Radix UI Dialog overlays to ensure proper stacking order.

### Root Cause
- `SlackShareDialog` (works correctly) uses custom implementation with explicit `zIndex: 9999`
- `SkillBrowserDialog` and `McpNodeDialog` use Radix UI Dialog with Portal but had no explicit z-index
- Radix UI's automatic z-index management doesn't work reliably in VSCode Webview environment

### Changes

**File**: `src/webview/src/components/dialogs/SkillBrowserDialog.tsx`
- Added `zIndex: 9999` to `Dialog.Overlay` style

**File**: `src/webview/src/components/dialogs/McpNodeDialog.tsx`
- Added `zIndex: 9999` to `Dialog.Overlay` style

```tsx
<Dialog.Overlay
  style={{
    position: 'fixed',
    inset: 0,
    backgroundColor: 'rgba(0, 0, 0, 0.5)',
    display: 'flex',
    alignItems: 'center',
    justifyContent: 'center',
    zIndex: 9999,  // Added
  }}
>
```

## Impact

- UI stacking fix only
- No functional changes
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)