### PR TITLE
improvement: pass validation errors to AI on refinement retry

### DIFF
--- a/src/extension/commands/workflow-refinement.ts
+++ b/src/extension/commands/workflow-refinement.ts
@@ -54,6 +54,7 @@ export async function handleRefineWorkflow(
     subAgentFlowId,
     model = 'sonnet',
     allowedTools,
+    previousValidationErrors,
   } = payload;
   const startTime = Date.now();
 
@@ -72,6 +73,8 @@ export async function handleRefineWorkflow(
     subAgentFlowId,
     model,
     allowedTools,
+    hasPreviousErrors: !!previousValidationErrors && previousValidationErrors.length > 0,
+    previousErrorCount: previousValidationErrors?.length ?? 0,
   });
 
   // Route to SubAgentFlow refinement if targetType is 'subAgentFlow'
@@ -137,7 +140,8 @@ export async function handleRefineWorkflow(
       workspaceRoot,
       onProgress,
       model,
-      allowedTools
+      allowedTools,
+      previousValidationErrors
     );
 
     // Check if AI is asking for clarification
@@ -197,6 +201,7 @@ export async function handleRefineWorkflow(
         workflowId,
         errorCode: result.error?.code,
         errorMessage: result.error?.message,
+        validationErrors: result.validationErrors,
         executionTimeMs: result.executionTimeMs,
       });
 
@@ -207,6 +212,7 @@ export async function handleRefineWorkflow(
         },
         executionTimeMs: result.executionTimeMs,
         timestamp: new Date().toISOString(),
+        validationErrors: result.validationErrors,
       });
       return;
     }

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -287,6 +287,12 @@ export interface RefineWorkflowPayload {
   model?: ClaudeModel;
   /** Allowed tools for Claude Code CLI (optional, e.g., ['Read', 'Grep', 'Glob', 'WebSearch', 'WebFetch']) */
   allowedTools?: string[];
+  /** Previous validation errors from failed refinement attempt (for retry with error context) */
+  previousValidationErrors?: Array<{
+    code: string;
+    message: string;
+    field?: string;
+  }>;
 }
 
 export interface RefinementSuccessPayload {
@@ -326,6 +332,12 @@ export interface RefinementFailedPayload {
   executionTimeMs: number;
   /** Error timestamp */
   timestamp: string; // ISO 8601
+  /** Validation errors for VALIDATION_ERROR code (used for retry with error context) */
+  validationErrors?: Array<{
+    code: string;
+    message: string;
+    field?: string;
+  }>;
 }
 
 export interface ClearConversationPayload {


### PR DESCRIPTION
## Problem

When AI workflow refinement fails due to validation errors (e.g., invalid node names with characters like hyphens in wrong positions), users can click "Retry" to regenerate. However, the AI has no context about what went wrong in the previous attempt, leading to repeated failures with the same validation errors.

### Current Behavior
1. User requests workflow refinement
2. AI generates workflow with validation errors (e.g., `INVALID_NODE_NAME`)
3. ❌ User clicks "Retry"
4. ❌ AI regenerates without knowing previous errors
5. ❌ Same validation errors occur again

### Expected Behavior
1. User requests workflow refinement
2. AI generates workflow with validation errors
3. ✅ User clicks "Retry"
4. ✅ AI receives context about previous validation errors
5. ✅ AI generates corrected workflow avoiding previous mistakes

## Solution

Store validation errors from failed attempts and pass them to the AI prompt when the user retries. The AI receives structured error information with recovery instructions.

### Changes

**`src/shared/types/messages.ts`**
- Added `previousValidationErrors` field to `RefineWorkflowPayload`
- Added `validationErrors` field to `RefinementFailedPayload`

**`src/extension/services/refinement-service.ts`**
- Added `ValidationErrorInfo` interface
- Updated `refineWorkflow()` to accept and return validation errors

**`src/extension/services/refinement-prompt-builder.ts`**
- Added error context section to TOON prompt when previous errors exist
- Includes `errorRecoveryInstructions` with specific guidance (e.g., node naming patterns)

**`src/extension/commands/workflow-refinement.ts`**
- Extract and pass validation errors through the refinement flow

**`src/webview/src/services/refinement-service.ts`**
- Added `ValidationErrorInfo` type export
- Updated `WorkflowRefinementError` to include validation errors
- Updated `refineWorkflow()` function signature

**`src/webview/src/components/dialogs/RefinementChatPanel.tsx`**
- Store validation errors in a React ref (Map by message ID)
- Retrieve and pass errors when user clicks "Retry"
- Clear stored errors after use to prevent stale context

## Impact

- Significantly improves retry success rate for validation-related failures
- No breaking changes to existing functionality
- Minimal token overhead (error context only added when retrying after failure)

## Testing

- [x] Manual E2E testing completed
  - Triggered validation error (invalid node name)
  - Clicked Retry
  - Verified AI received error context in prompt
  - Confirmed corrected output generation
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build verified (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)