### PR TITLE
Release: v3.12.5

### DIFF
--- a/src/extension/services/claude-code-service.ts
+++ b/src/extension/services/claude-code-service.ts
@@ -9,6 +9,9 @@
  */
 
 import type { ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import nanoSpawn from 'nano-spawn';
 import type { ClaudeModel } from '../../shared/types/messages';
 import { log } from '../extension';
@@ -59,36 +62,112 @@ const spawn =
 const activeProcesses = new Map<string, { subprocess: Subprocess; startTime: number }>();
 
 /**
- * Check if claude command is directly available in PATH
- * Checks every time to handle dynamic PATH changes
+ * Known Claude CLI installation paths
+ * These are checked explicitly to handle cases where VSCode Extension Host
+ * doesn't have the user's shell PATH settings (e.g., when launched from GUI)
  *
- * @returns true if claude is available, false if npx should be used
+ * Issue #375: https://github.com/breaking-brake/cc-wf-studio/issues/375
  */
-async function isClaudeCommandAvailable(): Promise<boolean> {
+const CLAUDE_KNOWN_PATHS = [
+  // Native install (macOS/Linux/WSL) - curl -fsSL https://claude.ai/install.sh | bash
+  path.join(os.homedir(), '.local', 'bin', 'claude'),
+  // Homebrew (Apple Silicon Mac)
+  '/opt/homebrew/bin/claude',
+  // Homebrew (Intel Mac) / npm global default
+  '/usr/local/bin/claude',
+  // npm custom prefix (common configuration)
+  path.join(os.homedir(), '.npm-global', 'bin', 'claude'),
+];
+
+/**
+ * Find Claude CLI executable in known installation paths
+ *
+ * @returns Full path to claude executable if found, null otherwise
+ */
+function findClaudeCliInKnownPaths(): string | null {
+  for (const p of CLAUDE_KNOWN_PATHS) {
+    if (fs.existsSync(p)) {
+      log('DEBUG', 'Found Claude CLI at known path', { path: p });
+      return p;
+    }
+  }
+  return null;
+}
+
+/**
+ * Cached Claude CLI path
+ * undefined = not checked yet
+ * null = not found (use npx fallback)
+ * string = path to claude executable
+ */
+let cachedClaudePath: string | null | undefined;
+
+/**
+ * Get the path to Claude CLI executable
+ * First checks known installation paths, then falls back to PATH lookup
+ *
+ * @returns Path to claude executable ('claude' for PATH, full path for known locations, null for npx fallback)
+ */
+async function getClaudeCliPath(): Promise<string | null> {
+  // Return cached result if available
+  if (cachedClaudePath !== undefined) {
+    return cachedClaudePath;
+  }
+
+  // 1. Check known installation paths first (handles GUI-launched VSCode)
+  const knownPath = findClaudeCliInKnownPaths();
+  if (knownPath) {
+    try {
+      const result = await spawn(knownPath, ['--version'], { timeout: 5000 });
+      log('INFO', 'Claude CLI found at known path', {
+        path: knownPath,
+        version: result.stdout.trim().substring(0, 50),
+      });
+      cachedClaudePath = knownPath;
+      return knownPath;
+    } catch (error) {
+      // Path exists but execution failed - log and continue to PATH check
+      log('WARN', 'Claude CLI found but not executable at known path', {
+        path: knownPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // 2. Fall back to PATH lookup (terminal-launched VSCode or other installations)
   try {
     const result = await spawn('claude', ['--version'], { timeout: 5000 });
-    log('INFO', 'Claude CLI check: using claude directly', {
+    log('INFO', 'Claude CLI found in PATH', {
       version: result.stdout.trim().substring(0, 50),
     });
-    return true;
+    cachedClaudePath = 'claude';
+    return 'claude';
   } catch {
-    log('INFO', 'Claude CLI check: using npx fallback');
-    return false;
+    log('INFO', 'Claude CLI not found, will use npx fallback');
+    cachedClaudePath = null;
+    return null;
   }
 }
 
 /**
+ * Clear Claude CLI path cache (for testing purposes)
+ */
+export function clearClaudeCliPathCache(): void {
+  cachedClaudePath = undefined;
+}
+
+/**
  * Get the command and args for spawning Claude CLI
- * Uses 'claude' directly if available, otherwise falls back to 'npx claude'
+ * Uses claude directly if available (from known paths or PATH), otherwise falls back to 'npx claude'
  *
  * @param args - CLI arguments (without 'claude' command itself)
  * @returns command and args for spawn
  */
 async function getClaudeSpawnCommand(args: string[]): Promise<{ command: string; args: string[] }> {
-  const useDirectClaude = await isClaudeCommandAvailable();
+  const claudePath = await getClaudeCliPath();
 
-  if (useDirectClaude) {
-    return { command: 'claude', args };
+  if (claudePath) {
+    return { command: claudePath, args };
   }
   return { command: 'npx', args: ['claude', ...args] };
 }


### PR DESCRIPTION
## Summary

Merge latest changes from `main` to `production` for automated release v3.12.5.

## Included Changes

### Bug Fixes
- fix: detect Claude CLI in known installation paths (#376)
  - Add explicit path checks for `~/.local/bin/claude`, `/opt/homebrew/bin/claude`, etc.
  - Fixes issue where VSCode launched from GUI doesn't inherit shell PATH
  - Cache CLI path for performance

## Release Version Calculation

**v3.12.5** (patch bump)

Semantic Release will analyze commits since the last release (v3.12.4) and will bump the version based on:
- ✅ `fix: detect Claude CLI in known installation paths` (#376) → **patch bump**

Result: **3.12.4 + patch = 3.12.5**

## CHANGELOG.md Contents

The following bug fixes will be included:
- detect Claude CLI in known installation paths (#376)

## Release Automation

This merge will trigger the automated release workflow which will:
1. Analyze commit messages to determine version bump (3.12.4 → 3.12.5)
2. Update version in package.json files
3. Generate CHANGELOG.md with bug fixes
4. Create GitHub release with release notes
5. Build and upload VSIX package
6. Sync version changes back to main branch

## Merge Strategy

**Use merge commit** (not squash) to preserve all individual commits and their history for proper Semantic Release analysis.