### PR TITLE
improvement: add server name filter to MCP server list

### DIFF
--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -30,6 +30,7 @@ export function McpServerList({
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [servers, setServers] = useState<McpServerReference[]>([]);
+  const [filterText, setFilterText] = useState('');
 
   const loadServers = async () => {
     setLoading(true);
@@ -155,8 +156,32 @@ export function McpServerList({
     );
   }
 
+  // Filter servers by name
+  const filterLower = filterText.toLowerCase().trim();
+  const filteredServers = filterLower
+    ? servers.filter((server) => server.name.toLowerCase().includes(filterLower))
+    : servers;
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      {/* Filter Input */}
+      <input
+        type="text"
+        placeholder={t('mcp.search.serverPlaceholder')}
+        value={filterText}
+        onChange={(e) => setFilterText(e.target.value)}
+        style={{
+          width: '100%',
+          padding: '8px 12px',
+          fontSize: '13px',
+          backgroundColor: 'var(--vscode-input-background)',
+          color: 'var(--vscode-input-foreground)',
+          border: '1px solid var(--vscode-input-border)',
+          borderRadius: '4px',
+          outline: 'none',
+        }}
+      />
+
       {/* Refresh Button */}
       <button
         type="button"
@@ -179,8 +204,21 @@ export function McpServerList({
         <span>{refreshing ? t('mcp.refreshing') : t('mcp.action.refresh')}</span>
       </button>
 
+      {/* No results message */}
+      {filteredServers.length === 0 && filterText && (
+        <div
+          style={{
+            padding: '16px',
+            textAlign: 'center',
+            color: 'var(--vscode-descriptionForeground)',
+          }}
+        >
+          {t('mcp.search.noServers', { query: filterText })}
+        </div>
+      )}
+
       {/* Server List */}
-      {servers.map((server) => (
+      {filteredServers.map((server) => (
         <button
           key={server.id}
           type="button"

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -466,6 +466,8 @@ export interface WebviewTranslationKeys {
   // MCP Tool Search
   'mcp.search.placeholder': string;
   'mcp.search.noResults': string;
+  'mcp.search.serverPlaceholder': string;
+  'mcp.search.noServers': string;
 
   // MCP Node Dialog
   'mcp.dialog.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -517,6 +517,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // MCP Tool Search
   'mcp.search.placeholder': 'Search tools by name or description...',
   'mcp.search.noResults': 'No tools found matching "{query}"',
+  'mcp.search.serverPlaceholder': 'Filter servers by name...',
+  'mcp.search.noServers': 'No servers found matching "{query}"',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool Configuration',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -515,6 +515,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // MCP Tool Search
   'mcp.search.placeholder': 'ツール名または説明で検索...',
   'mcp.search.noResults': '"{query}" に一致するツールが見つかりません',
+  'mcp.search.serverPlaceholder': 'サーバー名でフィルタ...',
+  'mcp.search.noServers': '"{query}" に一致するサーバーが見つかりません',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Toolの設定',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -514,6 +514,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // MCP Tool Search
   'mcp.search.placeholder': '이름이나 설명으로 도구 검색...',
   'mcp.search.noResults': '"{query}"와 일치하는 도구를 찾을 수 없습니다',
+  'mcp.search.serverPlaceholder': '서버 이름으로 필터...',
+  'mcp.search.noServers': '"{query}"와 일치하는 서버를 찾을 수 없습니다',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool 설정',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -494,6 +494,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // MCP Tool Search
   'mcp.search.placeholder': '按名称或描述搜索工具...',
   'mcp.search.noResults': '未找到与"{query}"匹配的工具',
+  'mcp.search.serverPlaceholder': '按名称筛选服务器...',
+  'mcp.search.noServers': '未找到与"{query}"匹配的服务器',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool配置',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -494,6 +494,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // MCP Tool Search
   'mcp.search.placeholder': '按名稱或描述搜尋工具...',
   'mcp.search.noResults': '未找到與"{query}"匹配的工具',
+  'mcp.search.serverPlaceholder': '按名稱篩選伺服器...',
+  'mcp.search.noServers': '未找到與"{query}"匹配的伺服器',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool配置',


### PR DESCRIPTION
## Summary

Added a name filter input to the MCP Server List component, allowing users to quickly find servers by name.

## Changes

**File**: `src/webview/src/components/mcp/McpServerList.tsx`
- Added `filterText` state for filter input
- Added filter input UI before refresh button
- Added filtering logic to filter servers by name
- Added "no results" message when filter matches nothing

**i18n** (5 languages + type definition):
- Added `mcp.search.serverPlaceholder` key
- Added `mcp.search.noServers` key

## Impact

- Improved UX: Users can now quickly filter MCP servers by name
- Consistent with existing tool search functionality
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)