### PR TITLE
fix: apply CLI path detection to MCP CLI service

### DIFF
--- a/src/extension/services/claude-cli-path.ts
+++ b/src/extension/services/claude-cli-path.ts
@@ -1,0 +1,144 @@
+/**
+ * Claude CLI Path Detection Service
+ *
+ * Shared module for detecting Claude CLI executable path.
+ * Handles cases where VSCode Extension Host doesn't have the user's shell PATH settings
+ * (e.g., when launched from GUI instead of terminal).
+ *
+ * Issue #375: https://github.com/breaking-brake/cc-wf-studio/issues/375
+ * PR #376: https://github.com/breaking-brake/cc-wf-studio/pull/376
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import nanoSpawn from 'nano-spawn';
+import { log } from '../extension';
+
+interface Result {
+  stdout: string;
+  stderr: string;
+  output: string;
+  command: string;
+  durationMs: number;
+}
+
+const spawn =
+  nanoSpawn.default ||
+  (nanoSpawn as (
+    file: string,
+    args?: readonly string[],
+    options?: Record<string, unknown>
+  ) => Promise<Result>);
+
+/**
+ * Known Claude CLI installation paths
+ * These are checked explicitly to handle cases where VSCode Extension Host
+ * doesn't have the user's shell PATH settings (e.g., when launched from GUI)
+ */
+const CLAUDE_KNOWN_PATHS = [
+  // Native install (macOS/Linux/WSL) - curl -fsSL https://claude.ai/install.sh | bash
+  path.join(os.homedir(), '.local', 'bin', 'claude'),
+  // Homebrew (Apple Silicon Mac)
+  '/opt/homebrew/bin/claude',
+  // Homebrew (Intel Mac) / npm global default
+  '/usr/local/bin/claude',
+  // npm custom prefix (common configuration)
+  path.join(os.homedir(), '.npm-global', 'bin', 'claude'),
+];
+
+/**
+ * Find Claude CLI executable in known installation paths
+ *
+ * @returns Full path to claude executable if found, null otherwise
+ */
+function findClaudeCliInKnownPaths(): string | null {
+  for (const p of CLAUDE_KNOWN_PATHS) {
+    if (fs.existsSync(p)) {
+      log('DEBUG', 'Found Claude CLI at known path', { path: p });
+      return p;
+    }
+  }
+  return null;
+}
+
+/**
+ * Cached Claude CLI path
+ * undefined = not checked yet
+ * null = not found (use npx fallback)
+ * string = path to claude executable
+ */
+let cachedClaudePath: string | null | undefined;
+
+/**
+ * Get the path to Claude CLI executable
+ * First checks known installation paths, then falls back to PATH lookup
+ *
+ * @returns Path to claude executable ('claude' for PATH, full path for known locations, null for npx fallback)
+ */
+export async function getClaudeCliPath(): Promise<string | null> {
+  // Return cached result if available
+  if (cachedClaudePath !== undefined) {
+    return cachedClaudePath;
+  }
+
+  // 1. Check known installation paths first (handles GUI-launched VSCode)
+  const knownPath = findClaudeCliInKnownPaths();
+  if (knownPath) {
+    try {
+      const result = await spawn(knownPath, ['--version'], { timeout: 5000 });
+      log('INFO', 'Claude CLI found at known path', {
+        path: knownPath,
+        version: result.stdout.trim().substring(0, 50),
+      });
+      cachedClaudePath = knownPath;
+      return knownPath;
+    } catch (error) {
+      // Path exists but execution failed - log and continue to PATH check
+      log('WARN', 'Claude CLI found but not executable at known path', {
+        path: knownPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  // 2. Fall back to PATH lookup (terminal-launched VSCode or other installations)
+  try {
+    const result = await spawn('claude', ['--version'], { timeout: 5000 });
+    log('INFO', 'Claude CLI found in PATH', {
+      version: result.stdout.trim().substring(0, 50),
+    });
+    cachedClaudePath = 'claude';
+    return 'claude';
+  } catch {
+    log('INFO', 'Claude CLI not found, will use npx fallback');
+    cachedClaudePath = null;
+    return null;
+  }
+}
+
+/**
+ * Clear Claude CLI path cache
+ * Useful for testing or when user installs Claude CLI during session
+ */
+export function clearClaudeCliPathCache(): void {
+  cachedClaudePath = undefined;
+}
+
+/**
+ * Get the command and args for spawning Claude CLI
+ * Uses claude directly if available (from known paths or PATH), otherwise falls back to 'npx claude'
+ *
+ * @param args - CLI arguments (without 'claude' command itself)
+ * @returns command and args for spawn
+ */
+export async function getClaudeSpawnCommand(
+  args: string[]
+): Promise<{ command: string; args: string[] }> {
+  const claudePath = await getClaudeCliPath();
+
+  if (claudePath) {
+    return { command: claudePath, args };
+  }
+  return { command: 'npx', args: ['claude', ...args] };
+}

--- a/src/extension/services/claude-code-service.ts
+++ b/src/extension/services/claude-code-service.ts
@@ -9,12 +9,13 @@
  */
 
 import type { ChildProcess } from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import nanoSpawn from 'nano-spawn';
 import type { ClaudeModel } from '../../shared/types/messages';
 import { log } from '../extension';
+import { clearClaudeCliPathCache, getClaudeSpawnCommand } from './claude-cli-path';
+
+// Re-export for external use
+export { clearClaudeCliPathCache };
 
 /**
  * nano-spawn type definitions (manually defined for compatibility)
@@ -60,117 +61,6 @@ const spawn =
  * Key: requestId, Value: subprocess and start time
  */
 const activeProcesses = new Map<string, { subprocess: Subprocess; startTime: number }>();
-
-/**
- * Known Claude CLI installation paths
- * These are checked explicitly to handle cases where VSCode Extension Host
- * doesn't have the user's shell PATH settings (e.g., when launched from GUI)
- *
- * Issue #375: https://github.com/breaking-brake/cc-wf-studio/issues/375
- */
-const CLAUDE_KNOWN_PATHS = [
-  // Native install (macOS/Linux/WSL) - curl -fsSL https://claude.ai/install.sh | bash
-  path.join(os.homedir(), '.local', 'bin', 'claude'),
-  // Homebrew (Apple Silicon Mac)
-  '/opt/homebrew/bin/claude',
-  // Homebrew (Intel Mac) / npm global default
-  '/usr/local/bin/claude',
-  // npm custom prefix (common configuration)
-  path.join(os.homedir(), '.npm-global', 'bin', 'claude'),
-];
-
-/**
- * Find Claude CLI executable in known installation paths
- *
- * @returns Full path to claude executable if found, null otherwise
- */
-function findClaudeCliInKnownPaths(): string | null {
-  for (const p of CLAUDE_KNOWN_PATHS) {
-    if (fs.existsSync(p)) {
-      log('DEBUG', 'Found Claude CLI at known path', { path: p });
-      return p;
-    }
-  }
-  return null;
-}
-
-/**
- * Cached Claude CLI path
- * undefined = not checked yet
- * null = not found (use npx fallback)
- * string = path to claude executable
- */
-let cachedClaudePath: string | null | undefined;
-
-/**
- * Get the path to Claude CLI executable
- * First checks known installation paths, then falls back to PATH lookup
- *
- * @returns Path to claude executable ('claude' for PATH, full path for known locations, null for npx fallback)
- */
-async function getClaudeCliPath(): Promise<string | null> {
-  // Return cached result if available
-  if (cachedClaudePath !== undefined) {
-    return cachedClaudePath;
-  }
-
-  // 1. Check known installation paths first (handles GUI-launched VSCode)
-  const knownPath = findClaudeCliInKnownPaths();
-  if (knownPath) {
-    try {
-      const result = await spawn(knownPath, ['--version'], { timeout: 5000 });
-      log('INFO', 'Claude CLI found at known path', {
-        path: knownPath,
-        version: result.stdout.trim().substring(0, 50),
-      });
-      cachedClaudePath = knownPath;
-      return knownPath;
-    } catch (error) {
-      // Path exists but execution failed - log and continue to PATH check
-      log('WARN', 'Claude CLI found but not executable at known path', {
-        path: knownPath,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-  // 2. Fall back to PATH lookup (terminal-launched VSCode or other installations)
-  try {
-    const result = await spawn('claude', ['--version'], { timeout: 5000 });
-    log('INFO', 'Claude CLI found in PATH', {
-      version: result.stdout.trim().substring(0, 50),
-    });
-    cachedClaudePath = 'claude';
-    return 'claude';
-  } catch {
-    log('INFO', 'Claude CLI not found, will use npx fallback');
-    cachedClaudePath = null;
-    return null;
-  }
-}
-
-/**
- * Clear Claude CLI path cache (for testing purposes)
- */
-export function clearClaudeCliPathCache(): void {
-  cachedClaudePath = undefined;
-}
-
-/**
- * Get the command and args for spawning Claude CLI
- * Uses claude directly if available (from known paths or PATH), otherwise falls back to 'npx claude'
- *
- * @param args - CLI arguments (without 'claude' command itself)
- * @returns command and args for spawn
- */
-async function getClaudeSpawnCommand(args: string[]): Promise<{ command: string; args: string[] }> {
-  const claudePath = await getClaudeCliPath();
-
-  if (claudePath) {
-    return { command: claudePath, args };
-  }
-  return { command: 'npx', args: ['claude', ...args] };
-}
 
 export interface ClaudeCodeExecutionResult {
   success: boolean;


### PR DESCRIPTION
## Problem

PR #376 fixed Claude CLI detection for GUI-launched VSCode in `claude-code-service.ts`, but the same fix was not applied to `mcp-cli-service.ts`.

### Current Behavior
1. User launches VSCode from GUI (not terminal)
2. Extension Host doesn't inherit user's shell PATH
3. ❌ MCP CLI commands (`claude mcp list`, `claude mcp get`) fail because they always use `npx claude`

### Expected Behavior
1. User launches VSCode from GUI
2. ✅ MCP CLI commands use known installation paths first, then PATH, then npx fallback

## Solution

Extract shared CLI path detection module and apply to both services.

### Changes

**New File**: `src/extension/services/claude-cli-path.ts`
- Extracted `getClaudeCliPath()`, `getClaudeSpawnCommand()`, `clearClaudeCliPathCache()` from claude-code-service.ts
- Shared module for consistent CLI detection across services

**File**: `src/extension/services/claude-code-service.ts`
- Removed local CLI path detection logic
- Import from shared module

**File**: `src/extension/services/mcp-cli-service.ts`
- Import `getClaudeSpawnCommand` from shared module
- Updated `executeClaudeMcpCommand()` to use shared detection logic

## Impact

- `listServers()` and `getServerDetails()` now work correctly in GUI-launched VSCode
- No breaking changes
- Consistent CLI detection behavior across all services

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (format, lint, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)