### PR TITLE
improvement: auto-focus canvas on newly added nodes

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -19,6 +19,7 @@ import ReactFlow, {
   type NodeTypes,
   Panel,
 } from 'reactflow';
+import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { DescriptionPanel } from './DescriptionPanel';
@@ -91,6 +92,9 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   onExpandNodePalette,
 }) => {
   const isCompact = useIsCompactMode();
+
+  // Auto-focus on newly added nodes
+  useAutoFocusNode();
 
   // Get state and handlers from Zustand store
   const {

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -23,6 +23,7 @@ import ReactFlow, {
   Panel,
   ReactFlowProvider,
 } from 'reactflow';
+import { useAutoFocusNode } from '../../hooks/useAutoFocusNode';
 import { useLocalRefinementChatState } from '../../hooks/useLocalRefinementChatState';
 import { useIsCompactMode } from '../../hooks/useWindowWidth';
 import { useTranslation } from '../../i18n/i18n-context';
@@ -96,6 +97,9 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
   const { t, locale } = useTranslation();
   const isCompact = useIsCompactMode();
   const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Auto-focus on newly added nodes
+  useAutoFocusNode();
 
   const {
     nodes,

--- a/src/webview/src/hooks/useAutoFocusNode.ts
+++ b/src/webview/src/hooks/useAutoFocusNode.ts
@@ -1,0 +1,54 @@
+/**
+ * Auto-focus hook for newly added nodes
+ *
+ * Watches for new node additions and automatically pans
+ * the canvas to center on the new node.
+ */
+
+import { useEffect } from 'react';
+import { useReactFlow } from 'reactflow';
+import { useWorkflowStore } from '../stores/workflow-store';
+
+// Constants for node dimensions (approximate center offset)
+const NODE_WIDTH_HALF = 100;
+const NODE_HEIGHT_HALF = 40;
+const ANIMATION_DURATION = 300;
+
+/**
+ * Custom hook that automatically focuses (pans) the canvas
+ * to a newly added node.
+ *
+ * Uses React Flow's setCenter() method to pan while preserving
+ * the current zoom level.
+ */
+export function useAutoFocusNode(): void {
+  const { setCenter, getZoom } = useReactFlow();
+  const lastAddedNodeId = useWorkflowStore((state) => state.lastAddedNodeId);
+  const nodes = useWorkflowStore((state) => state.nodes);
+  const clearLastAddedNodeId = useWorkflowStore((state) => state.clearLastAddedNodeId);
+
+  useEffect(() => {
+    if (!lastAddedNodeId) return;
+
+    // Find the newly added node
+    const newNode = nodes.find((n) => n.id === lastAddedNodeId);
+    if (!newNode) {
+      clearLastAddedNodeId();
+      return;
+    }
+
+    // Calculate center of the node
+    const centerX = newNode.position.x + NODE_WIDTH_HALF;
+    const centerY = newNode.position.y + NODE_HEIGHT_HALF;
+
+    // Pan to the node while preserving current zoom level
+    const currentZoom = getZoom();
+    setCenter(centerX, centerY, {
+      zoom: currentZoom,
+      duration: ANIMATION_DURATION,
+    });
+
+    // Clear the tracking after focus is complete
+    clearLastAddedNodeId();
+  }, [lastAddedNodeId, nodes, setCenter, getZoom, clearLastAddedNodeId]);
+}

--- a/src/webview/src/main.tsx
+++ b/src/webview/src/main.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ReactFlowProvider } from 'reactflow';
 import App from './App';
 import { I18nProvider } from './i18n/i18n-context';
 import 'reactflow/dist/style.css';
@@ -69,7 +70,9 @@ const locale = window.initialLocale || 'en';
 root.render(
   <React.StrictMode>
     <I18nProvider locale={locale}>
-      <App />
+      <ReactFlowProvider>
+        <App />
+      </ReactFlowProvider>
     </I18nProvider>
   </React.StrictMode>
 );

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -50,6 +50,7 @@ interface WorkflowStore {
   isMinimapVisible: boolean;
   isDescriptionPanelVisible: boolean;
   isFocusMode: boolean;
+  lastAddedNodeId: string | null;
 
   // Sub-Agent Flow State (Feature: 089-subworkflow)
   subAgentFlows: SubAgentFlow[];
@@ -78,6 +79,7 @@ interface WorkflowStore {
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
   addNode: (node: Node) => void;
+  clearLastAddedNodeId: () => void;
   removeNode: (nodeId: string) => void;
   requestDeleteNode: (nodeId: string) => void;
   confirmDeleteNodes: () => void;
@@ -246,6 +248,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     const saved = localStorage.getItem('cc-wf-studio.focusMode');
     return saved !== null ? saved === 'true' : false; // Default: off
   })(),
+  lastAddedNodeId: null,
 
   // Sub-Agent Flow Initial State (Feature: 089-subworkflow)
   subAgentFlows: [],
@@ -361,7 +364,14 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   addNode: (node: Node) => {
     set({
       nodes: [...get().nodes, node],
+      lastAddedNodeId: node.id,
+      selectedNodeId: node.id,
+      isPropertyOverlayOpen: true,
     });
+  },
+
+  clearLastAddedNodeId: () => {
+    set({ lastAddedNodeId: null });
   },
 
   removeNode: (nodeId: string) => {


### PR DESCRIPTION
## Problem

When adding a node to the canvas, users cannot easily locate the newly added node, especially when:
- The canvas is zoomed out
- The canvas is panned to a different area
- Multiple nodes already exist on the canvas

### Current Behavior
1. User clicks a node type in NodePalette
2. ❌ Node is added at a calculated position, but canvas doesn't move
3. ❌ User must manually search for the new node

### Expected Behavior
1. User clicks a node type in NodePalette
2. ✅ Node is added and canvas automatically pans to show the new node
3. ✅ Node is selected and property panel opens

## Solution

Implement auto-focus functionality using React Flow's `setCenter()` method with smooth animation.

### Changes

**New File**: `src/webview/src/hooks/useAutoFocusNode.ts`
- Custom hook that watches `lastAddedNodeId` state
- Uses React Flow's `setCenter()` with 300ms animation
- Preserves current zoom level

**File**: `src/webview/src/main.tsx`
- Wrap App with `ReactFlowProvider` to enable `useReactFlow()` hook

**File**: `src/webview/src/stores/workflow-store.ts`
- Add `lastAddedNodeId` state tracking
- Modify `addNode()` to set `lastAddedNodeId`, auto-select node, and open property panel
- Add `clearLastAddedNodeId()` action

**File**: `src/webview/src/components/WorkflowEditor.tsx`
- Use `useAutoFocusNode` hook

**File**: `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`
- Use `useAutoFocusNode` hook for SubAgentFlow editing

## Impact

- Improved UX: Users can immediately see newly added nodes
- No breaking changes
- Works for all node addition methods (NodePalette, MCP dialog, Skill dialog)

## Testing

- [x] Manual E2E testing completed
  - [x] Add node from NodePalette → canvas pans to node
  - [x] Add node in SubAgentFlow dialog → canvas pans to node
  - [x] Zoom level preserved after pan
  - [x] Rapid node additions → focuses on last node
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)