### PR TITLE
improvement: add node name constraint to AI refinement prompts

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -394,7 +394,11 @@
   },
   "validationRules": {
     "workflow": { "maxNodes": 50, "nameMaxLength": 100, "versionPattern": "^\\d+\\.\\d+\\.\\d+$" },
-    "node": { "nameMaxLength": 50, "namePattern": "^[a-zA-Z0-9_-]+$" }
+    "node": {
+      "nameMaxLength": 50,
+      "namePattern": "^[a-zA-Z0-9_-]+$",
+      "namePatternDescription": "IMPORTANT: Node names must use ASCII alphanumeric characters, hyphens, and underscores only. NO spaces or non-ASCII characters allowed."
+    }
   },
   "subAgentFlowConstraints": {
     "description": "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed.",

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -373,6 +373,7 @@ validationRules:
   node:
     nameMaxLength: 50
     namePattern: "^[a-zA-Z0-9_-]+$"
+    namePatternDescription: "IMPORTANT: Node names must use ASCII alphanumeric characters, hyphens, and underscores only. NO spaces or non-ASCII characters allowed."
 subAgentFlowConstraints:
   description: "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed."
   maxNodes: 30

--- a/src/extension/services/refinement-prompt-builder.ts
+++ b/src/extension/services/refinement-prompt-builder.ts
@@ -80,6 +80,7 @@ export class RefinementPromptBuilder {
         'Maintain workflow connectivity and validity',
         'Respect node IDs - do not regenerate IDs for unchanged nodes',
         'Update only what the user requested',
+        'Node names must match pattern /^[a-zA-Z0-9_-]+$/ (ASCII alphanumeric, hyphens, underscores only - NO spaces or non-ASCII characters)',
       ],
       nodePositioningGuidelines: [
         'Horizontal spacing: 300px',

--- a/src/extension/services/refinement-service.ts
+++ b/src/extension/services/refinement-service.ts
@@ -935,6 +935,7 @@ ${userMessage}
 5. Respect node IDs - do not regenerate IDs for unchanged nodes
 6. Update only what the user requested - minimize unnecessary changes
 7. **NEVER add subAgent, subAgentFlow, or askUserQuestion nodes**
+8. **Node names must match pattern /^[a-zA-Z0-9_-]+$/** (ASCII alphanumeric, hyphens, underscores only - NO spaces or non-ASCII characters)
 
 **Node Positioning Guidelines**:
 1. Horizontal spacing between regular nodes: Use 300px (e.g., x: 350, 650, 950, 1250, 1550)


### PR DESCRIPTION
## Problem

AI-generated workflows sometimes produce node names with full-width characters (Japanese, Chinese, Korean, etc.), which causes validation errors.

- `NODE.NAME_PATTERN = /^[a-zA-Z0-9_-]+$/` rejects non-ASCII characters (`workflow-definition.ts:454`)

## Solution

Add explicit node name constraints to AI prompts to prevent non-ASCII characters at generation time.

## Changes

### `src/extension/services/refinement-prompt-builder.ts`
- Added constraint to `refinementGuidelines` array

### `src/extension/services/refinement-service.ts`
- Added constraint to SubAgentFlow refinement prompt

### `resources/workflow-schema.json`
- Added `namePatternDescription` field for clearer documentation

## Impact

- AI will be instructed to use ASCII-only node names during workflow generation/refinement
- No breaking changes
- Reduces validation errors from AI-generated workflows

## Testing

- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)