### PR TITLE
improvement: add resizable width to AI editing panel

### DIFF
--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -421,9 +421,7 @@ const App: React.FC = () => {
 
         {/* Refinement Panel with Radix Collapsible for slide animation */}
         <Collapsible.Root open={isRefinementPanelOpen}>
-          <Collapsible.Content
-            className={`refinement-panel-collapsible${isCompact ? ' compact' : ''}`}
-          >
+          <Collapsible.Content className="refinement-panel-collapsible">
             <RefinementChatPanel chatState={mainChatState} onClose={handleCloseRefinementPanel} />
           </Collapsible.Content>
         </Collapsible.Root>
@@ -618,40 +616,34 @@ const App: React.FC = () => {
 
           /* Refinement Panel Collapsible Animation */
           .refinement-panel-collapsible {
-            --refinement-width: 320px;
             overflow: hidden;
             height: 100%;
-          }
-
-          .refinement-panel-collapsible.compact {
-            --refinement-width: 280px;
+            flex-shrink: 0;
           }
 
           .refinement-panel-collapsible[data-state='open'] {
-            width: var(--refinement-width);
-            animation: slideOpenFromRight 150ms ease-out;
+            animation: slideOpenFromRight 150ms ease-out forwards;
           }
 
           .refinement-panel-collapsible[data-state='closed'] {
-            width: 0px;
-            animation: slideCloseToRight 150ms ease-out;
+            animation: slideCloseToRight 150ms ease-out forwards;
           }
 
           @keyframes slideOpenFromRight {
             from {
-              width: 0px;
+              transform: translateX(100%);
             }
             to {
-              width: var(--refinement-width);
+              transform: translateX(0);
             }
           }
 
           @keyframes slideCloseToRight {
             from {
-              width: var(--refinement-width);
+              transform: translateX(0);
             }
             to {
-              width: 0px;
+              transform: translateX(100%);
             }
           }
         `}

--- a/src/webview/src/components/dialogs/RefinementChatPanel.tsx
+++ b/src/webview/src/components/dialogs/RefinementChatPanel.tsx
@@ -14,8 +14,8 @@
 import { PanelRightClose } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { ResponsiveFontProvider } from '../../contexts/ResponsiveFontContext';
+import { useResizablePanel } from '../../hooks/useResizablePanel';
 import { useResponsiveFontSizes } from '../../hooks/useResponsiveFontSizes';
-import { useIsCompactMode } from '../../hooks/useWindowWidth';
 import { useTranslation } from '../../i18n/i18n-context';
 import {
   clearConversation,
@@ -32,11 +32,14 @@ import { MessageInput } from '../chat/MessageInput';
 import { MessageList } from '../chat/MessageList';
 import { SettingsDropdown } from '../chat/SettingsDropdown';
 import { WarningBanner } from '../chat/WarningBanner';
+import { ResizeHandle } from '../common/ResizeHandle';
 import { ConfirmDialog } from './ConfirmDialog';
 
-// Fixed panel widths (like Node Palette)
-const PANEL_WIDTH_NORMAL = 320;
-const PANEL_WIDTH_COMPACT = 280;
+// Resizable panel configuration
+const PANEL_MIN_WIDTH = 280;
+const PANEL_MAX_WIDTH = 600;
+const PANEL_DEFAULT_WIDTH = 320;
+const PANEL_STORAGE_KEY = 'cc-wf-studio.refinementPanelWidth';
 
 /**
  * Props for RefinementChatPanel
@@ -60,8 +63,12 @@ export function RefinementChatPanel({
   onClose,
 }: RefinementChatPanelProps) {
   const { t } = useTranslation();
-  const isCompact = useIsCompactMode();
-  const width = isCompact ? PANEL_WIDTH_COMPACT : PANEL_WIDTH_NORMAL;
+  const { width, handleMouseDown } = useResizablePanel({
+    minWidth: PANEL_MIN_WIDTH,
+    maxWidth: PANEL_MAX_WIDTH,
+    defaultWidth: PANEL_DEFAULT_WIDTH,
+    storageKey: PANEL_STORAGE_KEY,
+  });
   const fontSizes = useResponsiveFontSizes(width);
 
   // Destructure chatState for easier access
@@ -579,6 +586,9 @@ export function RefinementChatPanel({
         overflow: 'hidden',
       }}
     >
+      {/* Resize Handle - draggable left edge */}
+      <ResizeHandle onMouseDown={handleMouseDown} />
+
       <ResponsiveFontProvider width={width}>
         {/* Header - Single row layout (simplified after Settings dropdown consolidation) */}
         <div

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -702,9 +702,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
 
               {/* Refinement Panel with Radix Collapsible for slide animation */}
               <Collapsible.Root open={isLocalRefinementPanelOpen}>
-                <Collapsible.Content
-                  className={`refinement-panel-collapsible${isCompact ? ' compact' : ''}`}
-                >
+                <Collapsible.Content className="refinement-panel-collapsible">
                   <RefinementChatPanel
                     chatState={localChatState}
                     mode="subAgentFlow"


### PR DESCRIPTION
## Problem

When there is a lot of conversation content in the AI editing panel (RefinementChatPanel), the fixed narrow width makes it difficult to read.

### Current Behavior
1. AI editing panel has fixed width (320px normal, 280px compact mode)
2. ❌ Users cannot adjust the panel width to accommodate longer content

### Expected Behavior
1. AI editing panel width can be adjusted by dragging
2. ✅ Users can drag the left edge to resize the panel to their preferred width

## Solution

Add drag-to-resize functionality to the AI editing panel using the existing `useResizablePanel` hook and `ResizeHandle` component.

### Key Design Decisions

- **Self-contained component**: RefinementChatPanel manages its own width internally
- **Simple animation**: Uses `transform: translateX` for slide open/close animation
- **Reusable hook**: Extended `useResizablePanel` to accept configurable parameters

## Changes

**File**: `src/webview/src/hooks/useResizablePanel.ts`
- Extended to accept optional configuration parameters (minWidth, maxWidth, defaultWidth, storageKey)
- Maintains backward compatibility with default values

**File**: `src/webview/src/components/dialogs/RefinementChatPanel.tsx`
- Uses `useResizablePanel` hook with custom configuration
- Added `ResizeHandle` component for drag-to-resize
- Width constraints: 280px - 600px
- localStorage key: `cc-wf-studio.refinementPanelWidth`

**File**: `src/webview/src/App.tsx`
- Updated animation to use `transform: translateX` for slide effect
- Simplified RefinementChatPanel usage (no resize props needed)

**File**: `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`
- Same simplification as App.tsx

## Impact

- UX improvement: Users can adjust AI editing panel width for better readability
- Panel width is persisted to localStorage across sessions
- No breaking changes to existing functionality

## Testing

- [x] Drag left edge to resize panel width
- [x] Width constrained between 280px and 600px
- [x] Width persisted after page reload
- [x] Slide animation works correctly on open/close
- [x] Resize handle highlights on hover
- [x] Cursor changes to `ew-resize` during drag
- [x] Code quality checks passed (`npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)