### PR TITLE
fix: resolve ConfirmDialog z-index issue in SubAgentFlowDialog

### DIFF
--- a/src/webview/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/webview/src/components/dialogs/ConfirmDialog.tsx
@@ -2,10 +2,11 @@
  * ConfirmDialog Component
  *
  * シンプルな確認ダイアログコンポーネント
+ * Radix UI Dialogを使用してz-indexの競合を解決
  */
 
+import * as Dialog from '@radix-ui/react-dialog';
 import type React from 'react';
-import { useEffect, useId, useRef } from 'react';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -29,137 +30,115 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   onConfirm,
   onCancel,
 }) => {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
-
-  // ダイアログが開いたときに自動的にフォーカス
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
-    }
-  }, [isOpen]);
-
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 9999,
-      }}
-      onClick={onCancel}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          onCancel();
-        }
-      }}
-    >
-      <div
-        ref={dialogRef}
-        tabIndex={-1}
-        style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '4px',
-          padding: '24px',
-          minWidth: '400px',
-          maxWidth: '600px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-          outline: 'none',
-        }}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        {/* Title */}
-        <div
-          id={titleId}
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
           style={{
-            fontSize: '16px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-            marginBottom: '16px',
-          }}
-        >
-          {title}
-        </div>
-
-        {/* Message */}
-        <div
-          style={{
-            fontSize: '13px',
-            color: 'var(--vscode-descriptionForeground)',
-            marginBottom: '24px',
-            lineHeight: '1.5',
-          }}
-        >
-          {message}
-        </div>
-
-        {/* Buttons */}
-        <div
-          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
             display: 'flex',
-            gap: '8px',
-            justifyContent: 'flex-end',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 10001,
           }}
         >
-          <button
-            type="button"
-            onClick={onCancel}
+          <Dialog.Content
             style={{
-              padding: '6px 16px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '24px',
+              minWidth: '400px',
+              maxWidth: '600px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
             }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor =
-                'var(--vscode-button-secondaryHoverBackground)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryBackground)';
-            }}
+            onEscapeKeyDown={onCancel}
           >
-            {cancelLabel}
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            style={{
-              padding: '6px 16px',
-              backgroundColor: 'var(--vscode-errorForeground)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
-              fontWeight: 500,
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.opacity = '0.9';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.opacity = '1';
-            }}
-          >
-            {confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
+            {/* Title */}
+            <Dialog.Title
+              style={{
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '16px',
+              }}
+            >
+              {title}
+            </Dialog.Title>
+
+            {/* Message */}
+            <Dialog.Description
+              style={{
+                fontSize: '13px',
+                color: 'var(--vscode-descriptionForeground)',
+                marginBottom: '24px',
+                lineHeight: '1.5',
+              }}
+            >
+              {message}
+            </Dialog.Description>
+
+            {/* Buttons */}
+            <div
+              style={{
+                display: 'flex',
+                gap: '8px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={onCancel}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryHoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryBackground)';
+                }}
+              >
+                {cancelLabel}
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-errorForeground)',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.opacity = '0.9';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.opacity = '1';
+                }}
+              >
+                {confirmLabel}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 


### PR DESCRIPTION
## Problem

### Current Behavior
1. Open SubAgentFlowDialog by double-clicking a SubAgentFlow node
2. Add a node (e.g., Prompt node) inside the dialog
3. Select the node and press Delete key
4. ❌ ConfirmDialog appears visually in front, but buttons are unclickable
5. ❌ SubAgentFlowDialog captures mouse events instead

### Expected Behavior
1. Open SubAgentFlowDialog
2. Add and select a node, press Delete key
3. ✅ ConfirmDialog appears and buttons are clickable
4. ✅ Delete/Cancel actions work correctly

## Root Cause

| Component | Implementation | z-index | Issue |
|---|---|---|---|
| SubAgentFlowDialog | Radix UI Dialog.Portal | Auto-managed | Creates isolated stacking context |
| ConfirmDialog | Manual position: fixed | 9999 | Independent from Radix UI Portal system |

Radix UI's `Dialog.Portal` renders elements directly under `<body>` with its own stacking context. The manual z-index management in ConfirmDialog conflicts with this system.

## Solution

Migrate ConfirmDialog from manual implementation to Radix UI Dialog:
- Use `Dialog.Portal` + `Dialog.Overlay` for proper stacking context integration
- Set `z-index: 10001` (higher than TermsOfUseDialog at 10000)
- Preserve existing styling and props interface

### Changes

**File**: `src/webview/src/components/dialogs/ConfirmDialog.tsx`

- Replaced manual `<div>` implementation with Radix UI `Dialog` components
- Added `Dialog.Root`, `Dialog.Portal`, `Dialog.Overlay`, `Dialog.Content`
- Used `Dialog.Title` and `Dialog.Description` for accessibility
- Maintained all existing button styling and hover effects

## Impact

- **No breaking changes**: Props interface (isOpen, title, message, etc.) unchanged
- **Accessibility improvement**: Radix UI provides automatic focus trap and ESC key handling
- **Consistent behavior**: Now uses same dialog system as other components (SkillBrowserDialog, McpNodeDialog)

## Testing

- [x] Manual E2E testing completed
  - [x] SubAgentFlowDialog: Delete confirmation works correctly
  - [x] Main canvas: Node deletion works correctly (regression test)
  - [x] RefinementChatPanel: Clear confirmation works correctly (regression test)
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)