### PR TITLE
fix: migrate all custom dialogs to Radix UI

### DIFF
--- a/src/webview/src/components/dialogs/McpNodeEditDialog.tsx
+++ b/src/webview/src/components/dialogs/McpNodeEditDialog.tsx
@@ -7,6 +7,7 @@
  * Based on: specs/001-mcp-natural-language-mode/tasks.md T022-T023
  */
 
+import * as Dialog from '@radix-ui/react-dialog';
 import type { McpNodeData, ToolParameter } from '@shared/types/mcp-node';
 import { useEffect, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
@@ -98,14 +99,14 @@ export function McpNodeEditDialog({ isOpen, nodeId, onClose }: McpNodeEditDialog
     initializeDialog();
   }, [isOpen, nodeData, currentMode, t]);
 
-  if (!isOpen || !node || !nodeData) {
-    return null;
-  }
-
   /**
    * Handle save button click
    */
   const handleSave = () => {
+    if (!node || !nodeData) {
+      return;
+    }
+
     // Enable validation display
     setShowValidation(true);
 
@@ -225,228 +226,231 @@ export function McpNodeEditDialog({ isOpen, nodeId, onClose }: McpNodeEditDialog
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-      }}
-      onClick={handleClose}
-      role="presentation"
-    >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation, not for click actions */}
-      <div
-        style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '6px',
-          padding: '24px',
-          maxWidth: '700px',
-          width: '90%',
-          maxHeight: '80vh',
-          overflow: 'auto',
-        }}
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-      >
-        {/* Dialog Header */}
-        <div
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
           style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
             display: 'flex',
-            justifyContent: 'space-between',
             alignItems: 'center',
-            marginBottom: '16px',
+            justifyContent: 'center',
+            zIndex: 9999,
           }}
         >
-          <div
+          <Dialog.Content
             style={{
-              fontSize: '16px',
-              fontWeight: 'bold',
-              color: 'var(--vscode-foreground)',
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '6px',
+              padding: '24px',
+              maxWidth: '700px',
+              width: '90%',
+              maxHeight: '80vh',
+              overflow: 'auto',
             }}
           >
-            {t('mcp.editDialog.title')}
-          </div>
-          {/* Mode Badge */}
-          <ModeIndicatorBadge mode={currentMode} />
-        </div>
-
-        {/* Tool Information */}
-        <div
-          style={{
-            marginBottom: '16px',
-            padding: '12px',
-            backgroundColor: 'var(--vscode-list-inactiveSelectionBackground)',
-            border: '1px solid var(--vscode-panel-border)',
-            borderRadius: '4px',
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              marginBottom: '8px',
-            }}
-          >
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: '13px', color: 'var(--vscode-disabledForeground)' }}>
-                <strong>{t('property.mcp.serverId')}:</strong> {nodeData.serverId}
-              </div>
-              {(currentMode === 'manualParameterConfig' || currentMode === 'aiParameterConfig') && (
-                <div
-                  style={{
-                    fontSize: '13px',
-                    color: 'var(--vscode-disabledForeground)',
-                    marginTop: '4px',
-                  }}
-                >
-                  <strong>{t('property.mcp.toolName')}:</strong> {nodeData.toolName}
-                </div>
-              )}
-            </div>
-            {/* Refresh Button */}
-            {currentMode !== 'aiToolSelection' && (
-              <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={refreshing || loading}
-                style={{
-                  padding: '4px 8px',
-                  fontSize: '12px',
-                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                  color: 'var(--vscode-button-secondaryForeground)',
-                  border: '1px solid var(--vscode-panel-border)',
-                  borderRadius: '3px',
-                  cursor: refreshing || loading ? 'wait' : 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                  flexShrink: 0,
-                }}
-                title={t('mcp.action.refresh')}
-              >
-                <span>{refreshing ? t('mcp.refreshing') : t('mcp.action.refresh')}</span>
-              </button>
-            )}
-          </div>
-          {nodeData.toolDescription && currentMode === 'manualParameterConfig' && (
+            {/* Dialog Header */}
             <div
               style={{
-                fontSize: '12px',
-                color: 'var(--vscode-disabledForeground)',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '16px',
               }}
             >
-              {nodeData.toolDescription}
+              <Dialog.Title
+                style={{
+                  fontSize: '16px',
+                  fontWeight: 'bold',
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('mcp.editDialog.title')}
+              </Dialog.Title>
+              {/* Mode Badge */}
+              <ModeIndicatorBadge mode={currentMode} />
             </div>
-          )}
-        </div>
 
-        {/* Loading State */}
-        {loading && <IndeterminateProgressBar label={t('mcp.editDialog.loading')} />}
+            {/* Hidden description for accessibility */}
+            <Dialog.Description style={{ display: 'none' }}>
+              {t('mcp.editDialog.title')}
+            </Dialog.Description>
 
-        {/* Error State */}
-        {error && !loading && (
-          <div
-            style={{
-              padding: '16px',
-              marginBottom: '16px',
-              color: 'var(--vscode-errorForeground)',
-              backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-              border: '1px solid var(--vscode-inputValidation-errorBorder)',
-              borderRadius: '4px',
-            }}
-          >
-            {error}
-          </div>
-        )}
-
-        {/* Mode-specific Edit UI */}
-        {!loading && !error && (
-          <>
-            {currentMode === 'manualParameterConfig' && (
-              <ParameterFormGenerator
-                parameters={parameters}
-                parameterValues={parameterValues}
-                onChange={setParameterValues}
-                showValidation={showValidation}
-              />
+            {/* Tool Information */}
+            {nodeData && (
+              <div
+                style={{
+                  marginBottom: '16px',
+                  padding: '12px',
+                  backgroundColor: 'var(--vscode-list-inactiveSelectionBackground)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '4px',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    marginBottom: '8px',
+                  }}
+                >
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontSize: '13px', color: 'var(--vscode-disabledForeground)' }}>
+                      <strong>{t('property.mcp.serverId')}:</strong> {nodeData.serverId}
+                    </div>
+                    {(currentMode === 'manualParameterConfig' ||
+                      currentMode === 'aiParameterConfig') && (
+                      <div
+                        style={{
+                          fontSize: '13px',
+                          color: 'var(--vscode-disabledForeground)',
+                          marginTop: '4px',
+                        }}
+                      >
+                        <strong>{t('property.mcp.toolName')}:</strong> {nodeData.toolName}
+                      </div>
+                    )}
+                  </div>
+                  {/* Refresh Button */}
+                  {currentMode !== 'aiToolSelection' && (
+                    <button
+                      type="button"
+                      onClick={handleRefresh}
+                      disabled={refreshing || loading}
+                      style={{
+                        padding: '4px 8px',
+                        fontSize: '12px',
+                        backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                        color: 'var(--vscode-button-secondaryForeground)',
+                        border: '1px solid var(--vscode-panel-border)',
+                        borderRadius: '3px',
+                        cursor: refreshing || loading ? 'wait' : 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '4px',
+                        flexShrink: 0,
+                      }}
+                      title={t('mcp.action.refresh')}
+                    >
+                      <span>{refreshing ? t('mcp.refreshing') : t('mcp.action.refresh')}</span>
+                    </button>
+                  )}
+                </div>
+                {nodeData.toolDescription && currentMode === 'manualParameterConfig' && (
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--vscode-disabledForeground)',
+                    }}
+                  >
+                    {nodeData.toolDescription}
+                  </div>
+                )}
+              </div>
             )}
 
-            {currentMode === 'aiParameterConfig' && (
-              <AiParameterConfigInput
-                value={aiParameterConfigDescription}
-                onChange={setAiParameterConfigDescription}
-                showValidation={showValidation}
-              />
+            {/* Loading State */}
+            {loading && <IndeterminateProgressBar label={t('mcp.editDialog.loading')} />}
+
+            {/* Error State */}
+            {error && !loading && (
+              <div
+                style={{
+                  padding: '16px',
+                  marginBottom: '16px',
+                  color: 'var(--vscode-errorForeground)',
+                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                  borderRadius: '4px',
+                }}
+              >
+                {error}
+              </div>
             )}
 
-            {currentMode === 'aiToolSelection' && (
-              <AiToolSelectionInput
-                value={naturalLanguageTaskDescription}
-                onChange={setNaturalLanguageTaskDescription}
-                showValidation={showValidation}
-              />
-            )}
-          </>
-        )}
+            {/* Mode-specific Edit UI */}
+            {!loading && !error && (
+              <>
+                {currentMode === 'manualParameterConfig' && (
+                  <ParameterFormGenerator
+                    parameters={parameters}
+                    parameterValues={parameterValues}
+                    onChange={setParameterValues}
+                    showValidation={showValidation}
+                  />
+                )}
 
-        {/* Dialog Actions */}
-        <div
-          style={{
-            marginTop: '24px',
-            display: 'flex',
-            gap: '12px',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <button
-            type="button"
-            onClick={handleClose}
-            style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-            }}
-          >
-            {t('mcp.editDialog.cancelButton')}
-          </button>
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={loading || !!error}
-            style={{
-              padding: '8px 16px',
-              fontSize: '13px',
-              backgroundColor:
-                loading || error
-                  ? 'var(--vscode-button-secondaryBackground)'
-                  : 'var(--vscode-button-background)',
-              color:
-                loading || error
-                  ? 'var(--vscode-button-secondaryForeground)'
-                  : 'var(--vscode-button-foreground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: loading || error ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {t('mcp.editDialog.saveButton')}
-          </button>
-        </div>
-      </div>
-    </div>
+                {currentMode === 'aiParameterConfig' && (
+                  <AiParameterConfigInput
+                    value={aiParameterConfigDescription}
+                    onChange={setAiParameterConfigDescription}
+                    showValidation={showValidation}
+                  />
+                )}
+
+                {currentMode === 'aiToolSelection' && (
+                  <AiToolSelectionInput
+                    value={naturalLanguageTaskDescription}
+                    onChange={setNaturalLanguageTaskDescription}
+                    showValidation={showValidation}
+                  />
+                )}
+              </>
+            )}
+
+            {/* Dialog Actions */}
+            <div
+              style={{
+                marginTop: '24px',
+                display: 'flex',
+                gap: '12px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={handleClose}
+                style={{
+                  padding: '8px 16px',
+                  fontSize: '13px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                }}
+              >
+                {t('mcp.editDialog.cancelButton')}
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={loading || !!error}
+                style={{
+                  padding: '8px 16px',
+                  fontSize: '13px',
+                  backgroundColor:
+                    loading || error
+                      ? 'var(--vscode-button-secondaryBackground)'
+                      : 'var(--vscode-button-background)',
+                  color:
+                    loading || error
+                      ? 'var(--vscode-button-secondaryForeground)'
+                      : 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: loading || error ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {t('mcp.editDialog.saveButton')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/src/webview/src/components/dialogs/SkillCreationDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillCreationDialog.tsx
@@ -119,6 +119,7 @@ export function SkillCreationDialog({ isOpen, onClose, onSubmit }: SkillCreation
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            zIndex: 10000,
           }}
         >
           <Dialog.Content

--- a/src/webview/src/components/dialogs/SlackConnectionRequiredDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackConnectionRequiredDialog.tsx
@@ -4,8 +4,8 @@
  * Slack未接続時にインポート元ワークスペースへの接続を促すダイアログ
  */
 
+import * as Dialog from '@radix-ui/react-dialog';
 import type React from 'react';
-import { useEffect, useId, useRef } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 
 interface SlackConnectionRequiredDialogProps {
@@ -26,19 +26,6 @@ export const SlackConnectionRequiredDialog: React.FC<SlackConnectionRequiredDial
   workspaceName,
 }) => {
   const { t } = useTranslation();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
-
-  // ダイアログが開いたときに自動的にフォーカス
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
-    }
-  }, [isOpen]);
-
-  if (!isOpen) {
-    return null;
-  }
 
   const handleConnectClick = () => {
     onConnectSlack();
@@ -46,158 +33,149 @@ export const SlackConnectionRequiredDialog: React.FC<SlackConnectionRequiredDial
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 9999,
-      }}
-      onClick={onClose}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          onClose();
-        }
-      }}
-    >
-      <div
-        ref={dialogRef}
-        tabIndex={-1}
-        style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '4px',
-          padding: '24px',
-          minWidth: '450px',
-          maxWidth: '550px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-          outline: 'none',
-        }}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        {/* Title with Warning Icon */}
-        <div
-          id={titleId}
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
           style={{
-            fontSize: '16px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-            marginBottom: '16px',
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
             display: 'flex',
             alignItems: 'center',
-            gap: '8px',
+            justifyContent: 'center',
+            zIndex: 9999,
           }}
         >
-          <span style={{ color: 'var(--vscode-notificationsWarningIcon-foreground)' }}>⚠️</span>
-          {t('slack.import.connectionRequired.title')}
-        </div>
-
-        {/* Message */}
-        <div
-          style={{
-            fontSize: '13px',
-            color: 'var(--vscode-descriptionForeground)',
-            marginBottom: '16px',
-            lineHeight: '1.6',
-          }}
-        >
-          {t('slack.import.connectionRequired.message')}
-        </div>
-
-        {/* Workspace Info (if available) */}
-        {workspaceName && (
-          <div
+          <Dialog.Content
             style={{
-              padding: '12px',
-              backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+              backgroundColor: 'var(--vscode-editor-background)',
               border: '1px solid var(--vscode-panel-border)',
               borderRadius: '4px',
-              marginBottom: '16px',
+              padding: '24px',
+              minWidth: '450px',
+              maxWidth: '550px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
             }}
           >
-            <div
+            {/* Title with Warning Icon */}
+            <Dialog.Title
               style={{
-                fontSize: '12px',
-                color: 'var(--vscode-descriptionForeground)',
-                marginBottom: '4px',
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '16px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
               }}
             >
-              {t('slack.import.connectionRequired.workspaceInfo')}
-            </div>
-            <div
+              <span style={{ color: 'var(--vscode-notificationsWarningIcon-foreground)' }}>⚠️</span>
+              {t('slack.import.connectionRequired.title')}
+            </Dialog.Title>
+
+            {/* Message */}
+            <Dialog.Description
               style={{
                 fontSize: '13px',
-                color: 'var(--vscode-foreground)',
-                fontWeight: 500,
+                color: 'var(--vscode-descriptionForeground)',
+                marginBottom: '16px',
+                lineHeight: '1.6',
               }}
             >
-              {workspaceName}
-            </div>
-          </div>
-        )}
+              {t('slack.import.connectionRequired.message')}
+            </Dialog.Description>
 
-        {/* Buttons */}
-        <div
-          style={{
-            display: 'flex',
-            gap: '8px',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <button
-            type="button"
-            onClick={onClose}
-            style={{
-              padding: '6px 16px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor =
-                'var(--vscode-button-secondaryHoverBackground)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryBackground)';
-            }}
-          >
-            {t('common.close')}
-          </button>
-          <button
-            type="button"
-            onClick={handleConnectClick}
-            style={{
-              padding: '6px 16px',
-              backgroundColor: 'var(--vscode-button-background)',
-              color: 'var(--vscode-button-foreground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
-              fontWeight: 500,
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-            }}
-          >
-            {t('slack.import.connectionRequired.connectButton')}
-          </button>
-        </div>
-      </div>
-    </div>
+            {/* Workspace Info (if available) */}
+            {workspaceName && (
+              <div
+                style={{
+                  padding: '12px',
+                  backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '4px',
+                  marginBottom: '16px',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    marginBottom: '4px',
+                  }}
+                >
+                  {t('slack.import.connectionRequired.workspaceInfo')}
+                </div>
+                <div
+                  style={{
+                    fontSize: '13px',
+                    color: 'var(--vscode-foreground)',
+                    fontWeight: 500,
+                  }}
+                >
+                  {workspaceName}
+                </div>
+              </div>
+            )}
+
+            {/* Buttons */}
+            <div
+              style={{
+                display: 'flex',
+                gap: '8px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={onClose}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryHoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryBackground)';
+                }}
+              >
+                {t('common.close')}
+              </button>
+              <button
+                type="button"
+                onClick={handleConnectClick}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+                }}
+              >
+                {t('slack.import.connectionRequired.connectButton')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 

--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -8,7 +8,8 @@
  * Based on specs/001-slack-workflow-sharing OAuth implementation plan
  */
 
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 import {
   cancelSlackOAuth,
@@ -18,6 +19,7 @@ import {
   listSlackWorkspaces,
   openExternalUrl,
 } from '../../services/slack-integration-service';
+import { ConfirmDialog } from './ConfirmDialog';
 
 interface SlackManualTokenDialogProps {
   isOpen: boolean;
@@ -34,8 +36,6 @@ export function SlackManualTokenDialog({
   onSuccess,
 }: SlackManualTokenDialogProps) {
   const { t } = useTranslation();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
 
   // Tab state
   const [activeTab, setActiveTab] = useState<AuthTab>('oauth');
@@ -74,33 +74,6 @@ export function SlackManualTokenDialog({
         .catch(() => {
           setHasStoredToken(false);
         });
-    }
-  }, [isOpen]);
-
-  // Handle Escape key to close dialog
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        if (oauthStatus === 'polling') {
-          handleCancelOAuth();
-        } else {
-          onClose();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose, oauthStatus, handleCancelOAuth]);
-
-  // Focus dialog when opened
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
     }
   }, [isOpen]);
 
@@ -189,751 +162,669 @@ export function SlackManualTokenDialog({
     }
   };
 
-  if (!isOpen) {
-    return null;
-  }
+  const handleClose = () => {
+    if (oauthStatus === 'polling' || oauthStatus === 'initiated') {
+      handleCancelOAuth();
+    }
+    onClose();
+  };
 
   const isOAuthLoading = oauthStatus === 'initiated' || oauthStatus === 'polling';
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 9999,
-      }}
-      onClick={() => {
-        if (isOAuthLoading) {
-          // Cancel OAuth and close dialog when clicking outside during loading
-          handleCancelOAuth();
-        }
-        onClose();
-      }}
-      role="presentation"
-    >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation, not for click actions */}
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-labelledby={titleId}
-        aria-modal="true"
-        tabIndex={-1}
-        style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '4px',
-          padding: '24px',
-          minWidth: '500px',
-          maxWidth: '600px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-          outline: 'none',
-        }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Title */}
-        <div
-          id={titleId}
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
           style={{
-            fontSize: '16px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-            marginBottom: '16px',
-          }}
-        >
-          {t('slack.connect.title')}
-        </div>
-
-        {/* Tab Buttons */}
-        <div
-          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
             display: 'flex',
-            gap: '4px',
-            marginBottom: '16px',
-            borderBottom: '1px solid var(--vscode-panel-border)',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 10000,
           }}
         >
-          <button
-            type="button"
-            onClick={() => setActiveTab('oauth')}
-            disabled={loading || isOAuthLoading}
+          <Dialog.Content
             style={{
-              padding: '8px 16px',
-              backgroundColor: 'transparent',
-              color:
-                activeTab === 'oauth'
-                  ? 'var(--vscode-foreground)'
-                  : 'var(--vscode-descriptionForeground)',
-              border: 'none',
-              borderBottom:
-                activeTab === 'oauth'
-                  ? '2px solid var(--vscode-focusBorder)'
-                  : '2px solid transparent',
-              cursor: loading || isOAuthLoading ? 'not-allowed' : 'pointer',
-              fontSize: '13px',
-              fontWeight: activeTab === 'oauth' ? 600 : 400,
-              opacity: loading || isOAuthLoading ? 0.5 : 1,
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '24px',
+              minWidth: '500px',
+              maxWidth: '600px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
             }}
           >
-            {t('slack.connect.tab.oauth')}
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveTab('manual')}
-            disabled={loading || isOAuthLoading}
-            style={{
-              padding: '8px 16px',
-              backgroundColor: 'transparent',
-              color:
-                activeTab === 'manual'
-                  ? 'var(--vscode-foreground)'
-                  : 'var(--vscode-descriptionForeground)',
-              border: 'none',
-              borderBottom:
-                activeTab === 'manual'
-                  ? '2px solid var(--vscode-focusBorder)'
-                  : '2px solid transparent',
-              cursor: loading || isOAuthLoading ? 'not-allowed' : 'pointer',
-              fontSize: '13px',
-              fontWeight: activeTab === 'manual' ? 600 : 400,
-              opacity: loading || isOAuthLoading ? 0.5 : 1,
-            }}
-          >
-            {t('slack.connect.tab.manual')}
-          </button>
-        </div>
-
-        {/* OAuth Tab Content */}
-        {activeTab === 'oauth' && (
-          <div>
-            {/* Review Notice */}
-            <div
+            {/* Title */}
+            <Dialog.Title
               style={{
-                marginBottom: '12px',
-                padding: '12px',
-                backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-                border: '1px solid var(--vscode-panel-border)',
-                borderRadius: '4px',
-                fontSize: '11px',
-                color: 'var(--vscode-descriptionForeground)',
-                lineHeight: '1.6',
-                whiteSpace: 'pre-line',
-              }}
-            >
-              {t('slack.oauth.reviewNotice.message')}
-            </div>
-
-            {/* Description */}
-            <div
-              style={{
-                fontSize: '13px',
-                color: 'var(--vscode-descriptionForeground)',
-                marginBottom: '12px',
-                whiteSpace: 'pre-line',
-              }}
-            >
-              {t('slack.oauth.description')}
-            </div>
-
-            {/* Links */}
-            <ul
-              style={{
-                listStyle: 'disc',
-                paddingLeft: '20px',
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
                 marginBottom: '16px',
-                fontSize: '12px',
               }}
             >
-              <li>
-                <button
-                  type="button"
-                  onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-textLink-foreground)',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.textDecoration = 'underline';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.textDecoration = 'none';
-                  }}
-                >
-                  {t('slack.oauth.termsOfService')}
-                </button>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-textLink-foreground)',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.textDecoration = 'underline';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.textDecoration = 'none';
-                  }}
-                >
-                  {t('slack.oauth.privacyPolicy')}
-                </button>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  onClick={() =>
-                    openExternalUrl(
-                      'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
-                    )
-                  }
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-textLink-foreground)',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.textDecoration = 'underline';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.textDecoration = 'none';
-                  }}
-                >
-                  {t('slack.oauth.supportPage')}
-                </button>
-              </li>
-            </ul>
+              {t('slack.connect.title')}
+            </Dialog.Title>
 
-            {/* OAuth Status Display */}
-            {isOAuthLoading && (
-              <div
-                style={{
-                  padding: '16px',
-                  backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-                  border: '1px solid var(--vscode-panel-border)',
-                  borderRadius: '4px',
-                  marginBottom: '16px',
-                }}
-              >
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: '8px',
-                    fontSize: '14px',
-                    color: 'var(--vscode-foreground)',
-                    marginBottom: '8px',
-                  }}
-                >
-                  {/* Spinner */}
-                  <div
-                    style={{
-                      width: '16px',
-                      height: '16px',
-                      border: '2px solid var(--vscode-progressBar-background)',
-                      borderTopColor: 'transparent',
-                      borderRadius: '50%',
-                      animation: 'oauth-spinner 1s linear infinite',
-                      flexShrink: 0,
-                    }}
-                  />
-                  <span>
-                    {oauthStatus === 'initiated'
-                      ? t('slack.oauth.status.initiated')
-                      : t('slack.oauth.status.polling')}
-                  </span>
-                </div>
-                <div
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-descriptionForeground)',
-                    textAlign: 'center',
-                  }}
-                >
-                  {t('slack.oauth.status.waitingHint')}
-                </div>
-                <style>
-                  {`
-                    @keyframes oauth-spinner {
-                      0% { transform: rotate(0deg); }
-                      100% { transform: rotate(360deg); }
-                    }
-                  `}
-                </style>
-              </div>
-            )}
+            {/* Hidden description for accessibility */}
+            <Dialog.Description style={{ display: 'none' }}>
+              {t('slack.connect.title')}
+            </Dialog.Description>
 
-            {/* OAuth Error */}
-            {oauthError && (
-              <div
-                style={{
-                  padding: '8px 12px',
-                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
-                  borderRadius: '2px',
-                  marginBottom: '16px',
-                  fontSize: '12px',
-                  color: 'var(--vscode-errorForeground)',
-                }}
-              >
-                {oauthError}
-              </div>
-            )}
-
-            {/* OAuth Buttons */}
+            {/* Tab Buttons */}
             <div
               style={{
                 display: 'flex',
-                gap: '8px',
-                justifyContent: 'space-between',
-                alignItems: 'center',
+                gap: '4px',
+                marginBottom: '16px',
+                borderBottom: '1px solid var(--vscode-panel-border)',
               }}
             >
-              {/* Delete Token Button (left side) */}
-              {hasStoredToken && !isOAuthLoading && (
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteConfirm(true)}
-                  disabled={loading}
+              <button
+                type="button"
+                onClick={() => setActiveTab('oauth')}
+                disabled={loading || isOAuthLoading}
+                style={{
+                  padding: '8px 16px',
+                  backgroundColor: 'transparent',
+                  color:
+                    activeTab === 'oauth'
+                      ? 'var(--vscode-foreground)'
+                      : 'var(--vscode-descriptionForeground)',
+                  border: 'none',
+                  borderBottom:
+                    activeTab === 'oauth'
+                      ? '2px solid var(--vscode-focusBorder)'
+                      : '2px solid transparent',
+                  cursor: loading || isOAuthLoading ? 'not-allowed' : 'pointer',
+                  fontSize: '13px',
+                  fontWeight: activeTab === 'oauth' ? 600 : 400,
+                  opacity: loading || isOAuthLoading ? 0.5 : 1,
+                }}
+              >
+                {t('slack.connect.tab.oauth')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('manual')}
+                disabled={loading || isOAuthLoading}
+                style={{
+                  padding: '8px 16px',
+                  backgroundColor: 'transparent',
+                  color:
+                    activeTab === 'manual'
+                      ? 'var(--vscode-foreground)'
+                      : 'var(--vscode-descriptionForeground)',
+                  border: 'none',
+                  borderBottom:
+                    activeTab === 'manual'
+                      ? '2px solid var(--vscode-focusBorder)'
+                      : '2px solid transparent',
+                  cursor: loading || isOAuthLoading ? 'not-allowed' : 'pointer',
+                  fontSize: '13px',
+                  fontWeight: activeTab === 'manual' ? 600 : 400,
+                  opacity: loading || isOAuthLoading ? 0.5 : 1,
+                }}
+              >
+                {t('slack.connect.tab.manual')}
+              </button>
+            </div>
+
+            {/* OAuth Tab Content */}
+            {activeTab === 'oauth' && (
+              <div>
+                {/* Review Notice */}
+                <div
                   style={{
-                    padding: '6px 12px',
-                    backgroundColor: 'transparent',
-                    color: 'var(--vscode-errorForeground)',
-                    border: '1px solid var(--vscode-errorForeground)',
-                    borderRadius: '2px',
-                    cursor: loading ? 'not-allowed' : 'pointer',
-                    fontSize: '12px',
-                    opacity: loading ? 0.5 : 1,
+                    marginBottom: '12px',
+                    padding: '12px',
+                    backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                    border: '1px solid var(--vscode-panel-border)',
+                    borderRadius: '4px',
+                    fontSize: '11px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    lineHeight: '1.6',
+                    whiteSpace: 'pre-line',
                   }}
                 >
-                  {t('slack.manualToken.deleteButton')}
-                </button>
-              )}
+                  {t('slack.oauth.reviewNotice.message')}
+                </div>
 
-              {/* Right side buttons */}
-              <div style={{ display: 'flex', gap: '8px', marginLeft: 'auto' }}>
-                {isOAuthLoading ? (
-                  <button
-                    type="button"
-                    onClick={handleCancelOAuth}
+                {/* Description */}
+                <div
+                  style={{
+                    fontSize: '13px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    marginBottom: '12px',
+                    whiteSpace: 'pre-line',
+                  }}
+                >
+                  {t('slack.oauth.description')}
+                </div>
+
+                {/* Links */}
+                <ul
+                  style={{
+                    listStyle: 'disc',
+                    paddingLeft: '20px',
+                    marginBottom: '16px',
+                    fontSize: '12px',
+                  }}
+                >
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-textLink-foreground)',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = 'underline';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = 'none';
+                      }}
+                    >
+                      {t('slack.oauth.termsOfService')}
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-textLink-foreground)',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = 'underline';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = 'none';
+                      }}
+                    >
+                      {t('slack.oauth.privacyPolicy')}
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openExternalUrl(
+                          'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
+                        )
+                      }
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-textLink-foreground)',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = 'underline';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = 'none';
+                      }}
+                    >
+                      {t('slack.oauth.supportPage')}
+                    </button>
+                  </li>
+                </ul>
+
+                {/* OAuth Status Display */}
+                {isOAuthLoading && (
+                  <div
                     style={{
-                      padding: '6px 16px',
-                      backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                      color: 'var(--vscode-button-secondaryForeground)',
-                      border: 'none',
-                      borderRadius: '2px',
-                      cursor: 'pointer',
-                      fontSize: '13px',
+                      padding: '16px',
+                      backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                      border: '1px solid var(--vscode-panel-border)',
+                      borderRadius: '4px',
+                      marginBottom: '16px',
                     }}
                   >
-                    {t('cancel')}
-                  </button>
-                ) : (
-                  <>
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: '8px',
+                        fontSize: '14px',
+                        color: 'var(--vscode-foreground)',
+                        marginBottom: '8px',
+                      }}
+                    >
+                      {/* Spinner */}
+                      <div
+                        style={{
+                          width: '16px',
+                          height: '16px',
+                          border: '2px solid var(--vscode-progressBar-background)',
+                          borderTopColor: 'transparent',
+                          borderRadius: '50%',
+                          animation: 'oauth-spinner 1s linear infinite',
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span>
+                        {oauthStatus === 'initiated'
+                          ? t('slack.oauth.status.initiated')
+                          : t('slack.oauth.status.polling')}
+                      </span>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-descriptionForeground)',
+                        textAlign: 'center',
+                      }}
+                    >
+                      {t('slack.oauth.status.waitingHint')}
+                    </div>
+                    <style>
+                      {`
+                        @keyframes oauth-spinner {
+                          0% { transform: rotate(0deg); }
+                          100% { transform: rotate(360deg); }
+                        }
+                      `}
+                    </style>
+                  </div>
+                )}
+
+                {/* OAuth Error */}
+                {oauthError && (
+                  <div
+                    style={{
+                      padding: '8px 12px',
+                      backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                      border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                      borderRadius: '2px',
+                      marginBottom: '16px',
+                      fontSize: '12px',
+                      color: 'var(--vscode-errorForeground)',
+                    }}
+                  >
+                    {oauthError}
+                  </div>
+                )}
+
+                {/* OAuth Buttons */}
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: '8px',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  {/* Delete Token Button (left side) */}
+                  {hasStoredToken && !isOAuthLoading && (
+                    <button
+                      type="button"
+                      onClick={() => setShowDeleteConfirm(true)}
+                      disabled={loading}
+                      style={{
+                        padding: '6px 12px',
+                        backgroundColor: 'transparent',
+                        color: 'var(--vscode-errorForeground)',
+                        border: '1px solid var(--vscode-errorForeground)',
+                        borderRadius: '2px',
+                        cursor: loading ? 'not-allowed' : 'pointer',
+                        fontSize: '12px',
+                        opacity: loading ? 0.5 : 1,
+                      }}
+                    >
+                      {t('slack.manualToken.deleteButton')}
+                    </button>
+                  )}
+
+                  {/* Right side buttons */}
+                  <div style={{ display: 'flex', gap: '8px', marginLeft: 'auto' }}>
+                    {isOAuthLoading ? (
+                      <button
+                        type="button"
+                        onClick={handleCancelOAuth}
+                        style={{
+                          padding: '6px 16px',
+                          backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                          color: 'var(--vscode-button-secondaryForeground)',
+                          border: 'none',
+                          borderRadius: '2px',
+                          cursor: 'pointer',
+                          fontSize: '13px',
+                        }}
+                      >
+                        {t('cancel')}
+                      </button>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          onClick={onClose}
+                          style={{
+                            padding: '6px 16px',
+                            backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                            color: 'var(--vscode-button-secondaryForeground)',
+                            border: 'none',
+                            borderRadius: '2px',
+                            cursor: 'pointer',
+                            fontSize: '13px',
+                          }}
+                        >
+                          {t('cancel')}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleOAuthConnect}
+                          style={{
+                            padding: '6px 16px',
+                            backgroundColor: 'var(--vscode-button-background)',
+                            color: 'var(--vscode-button-foreground)',
+                            border: 'none',
+                            borderRadius: '2px',
+                            cursor: 'pointer',
+                            fontSize: '13px',
+                            fontWeight: 500,
+                          }}
+                        >
+                          {t('slack.oauth.connectButton')}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Manual Token Tab Content */}
+            {activeTab === 'manual' && (
+              <div>
+                {/* Description */}
+                <div
+                  style={{
+                    fontSize: '13px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    marginBottom: '16px',
+                  }}
+                >
+                  {t('slack.manualToken.description')}
+                </div>
+
+                {/* How to Get User Token Box */}
+                <div
+                  style={{
+                    marginBottom: '12px',
+                    padding: '12px',
+                    backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                    border: '1px solid var(--vscode-panel-border)',
+                    borderRadius: '4px',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      fontWeight: 600,
+                      color: 'var(--vscode-foreground)',
+                      marginBottom: '8px',
+                    }}
+                  >
+                    {t('slack.manualToken.howToGet.title')}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '11px',
+                      color: 'var(--vscode-descriptionForeground)',
+                      lineHeight: '1.6',
+                    }}
+                  >
+                    <div>1. {t('slack.manualToken.howToGet.step1')}</div>
+                    <div>
+                      2. {t('slack.manualToken.howToGet.step2')}
+                      <ul style={{ margin: '4px 0 4px 20px', paddingLeft: '0', listStyle: 'disc' }}>
+                        <li>chat:write ({t('slack.scopes.chatWrite.reason')})</li>
+                        <li>files:read ({t('slack.scopes.filesRead.reason')})</li>
+                        <li>files:write ({t('slack.scopes.filesWrite.reason')})</li>
+                        <li>channels:read ({t('slack.scopes.channelsRead.reason')})</li>
+                        <li>groups:read ({t('slack.scopes.groupsRead.reason')})</li>
+                      </ul>
+                    </div>
+                    <div>3. {t('slack.manualToken.howToGet.step3')}</div>
+                    <div>4. {t('slack.manualToken.howToGet.step4')}</div>
+                  </div>
+                </div>
+
+                {/* Links */}
+                <ul
+                  style={{
+                    listStyle: 'disc',
+                    paddingLeft: '20px',
+                    marginBottom: '16px',
+                    fontSize: '12px',
+                  }}
+                >
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-textLink-foreground)',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = 'underline';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = 'none';
+                      }}
+                    >
+                      {t('slack.oauth.termsOfService')}
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-textLink-foreground)',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = 'underline';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = 'none';
+                      }}
+                    >
+                      {t('slack.oauth.privacyPolicy')}
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openExternalUrl(
+                          'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
+                        )
+                      }
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--vscode-textLink-foreground)',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.textDecoration = 'underline';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.textDecoration = 'none';
+                      }}
+                    >
+                      {t('slack.oauth.supportPage')}
+                    </button>
+                  </li>
+                </ul>
+
+                {/* User Token Input */}
+                <div style={{ marginBottom: '16px' }}>
+                  <label
+                    htmlFor="user-token"
+                    style={{
+                      display: 'block',
+                      fontSize: '13px',
+                      color: 'var(--vscode-foreground)',
+                      marginBottom: '8px',
+                      fontWeight: 500,
+                    }}
+                  >
+                    {t('slack.manualToken.userToken.label')}
+                  </label>
+                  <input
+                    id="user-token"
+                    type="password"
+                    value={userToken}
+                    onChange={(e) => setUserToken(e.target.value)}
+                    placeholder="xoxp-..."
+                    disabled={loading}
+                    style={{
+                      width: '100%',
+                      padding: '6px 8px',
+                      backgroundColor: 'var(--vscode-input-background)',
+                      color: 'var(--vscode-input-foreground)',
+                      border: '1px solid var(--vscode-input-border)',
+                      borderRadius: '2px',
+                      fontSize: '13px',
+                      fontFamily: 'monospace',
+                    }}
+                  />
+                </div>
+
+                {/* Error Message */}
+                {error && (
+                  <div
+                    style={{
+                      padding: '8px 12px',
+                      backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                      border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                      borderRadius: '2px',
+                      marginBottom: '16px',
+                      fontSize: '12px',
+                      color: 'var(--vscode-errorForeground)',
+                    }}
+                  >
+                    {error}
+                  </div>
+                )}
+
+                {/* Buttons */}
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: '8px',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  {/* Delete Token Button (left side) */}
+                  {hasStoredToken && (
+                    <button
+                      type="button"
+                      onClick={() => setShowDeleteConfirm(true)}
+                      disabled={loading}
+                      style={{
+                        padding: '6px 12px',
+                        backgroundColor: 'transparent',
+                        color: 'var(--vscode-errorForeground)',
+                        border: '1px solid var(--vscode-errorForeground)',
+                        borderRadius: '2px',
+                        cursor: loading ? 'not-allowed' : 'pointer',
+                        fontSize: '12px',
+                        opacity: loading ? 0.5 : 1,
+                      }}
+                    >
+                      {t('slack.manualToken.deleteButton')}
+                    </button>
+                  )}
+
+                  {/* Right side buttons */}
+                  <div style={{ display: 'flex', gap: '8px', marginLeft: 'auto' }}>
                     <button
                       type="button"
                       onClick={onClose}
+                      disabled={loading}
                       style={{
                         padding: '6px 16px',
                         backgroundColor: 'var(--vscode-button-secondaryBackground)',
                         color: 'var(--vscode-button-secondaryForeground)',
                         border: 'none',
                         borderRadius: '2px',
-                        cursor: 'pointer',
+                        cursor: loading ? 'not-allowed' : 'pointer',
                         fontSize: '13px',
+                        opacity: loading ? 0.5 : 1,
                       }}
                     >
                       {t('cancel')}
                     </button>
                     <button
                       type="button"
-                      onClick={handleOAuthConnect}
+                      onClick={handleConnect}
+                      disabled={loading || !userToken.trim()}
                       style={{
                         padding: '6px 16px',
                         backgroundColor: 'var(--vscode-button-background)',
                         color: 'var(--vscode-button-foreground)',
                         border: 'none',
                         borderRadius: '2px',
-                        cursor: 'pointer',
+                        cursor: loading || !userToken.trim() ? 'not-allowed' : 'pointer',
                         fontSize: '13px',
                         fontWeight: 500,
+                        opacity: loading || !userToken.trim() ? 0.5 : 1,
                       }}
                     >
-                      {t('slack.oauth.connectButton')}
+                      {loading ? t('slack.manualToken.connecting') : t('slack.manualToken.connect')}
                     </button>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Manual Token Tab Content */}
-        {activeTab === 'manual' && (
-          <div>
-            {/* Description */}
-            <div
-              style={{
-                fontSize: '13px',
-                color: 'var(--vscode-descriptionForeground)',
-                marginBottom: '16px',
-              }}
-            >
-              {t('slack.manualToken.description')}
-            </div>
-
-            {/* How to Get User Token Box */}
-            <div
-              style={{
-                marginBottom: '12px',
-                padding: '12px',
-                backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-                border: '1px solid var(--vscode-panel-border)',
-                borderRadius: '4px',
-              }}
-            >
-              <div
-                style={{
-                  fontSize: '12px',
-                  fontWeight: 600,
-                  color: 'var(--vscode-foreground)',
-                  marginBottom: '8px',
-                }}
-              >
-                {t('slack.manualToken.howToGet.title')}
-              </div>
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--vscode-descriptionForeground)',
-                  lineHeight: '1.6',
-                }}
-              >
-                <div>1. {t('slack.manualToken.howToGet.step1')}</div>
-                <div>
-                  2. {t('slack.manualToken.howToGet.step2')}
-                  <ul style={{ margin: '4px 0 4px 20px', paddingLeft: '0', listStyle: 'disc' }}>
-                    <li>chat:write ({t('slack.scopes.chatWrite.reason')})</li>
-                    <li>files:read ({t('slack.scopes.filesRead.reason')})</li>
-                    <li>files:write ({t('slack.scopes.filesWrite.reason')})</li>
-                    <li>channels:read ({t('slack.scopes.channelsRead.reason')})</li>
-                    <li>groups:read ({t('slack.scopes.groupsRead.reason')})</li>
-                  </ul>
+                  </div>
                 </div>
-                <div>3. {t('slack.manualToken.howToGet.step3')}</div>
-                <div>4. {t('slack.manualToken.howToGet.step4')}</div>
-              </div>
-            </div>
-
-            {/* Links */}
-            <ul
-              style={{
-                listStyle: 'disc',
-                paddingLeft: '20px',
-                marginBottom: '16px',
-                fontSize: '12px',
-              }}
-            >
-              <li>
-                <button
-                  type="button"
-                  onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-textLink-foreground)',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.textDecoration = 'underline';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.textDecoration = 'none';
-                  }}
-                >
-                  {t('slack.oauth.termsOfService')}
-                </button>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-textLink-foreground)',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.textDecoration = 'underline';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.textDecoration = 'none';
-                  }}
-                >
-                  {t('slack.oauth.privacyPolicy')}
-                </button>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  onClick={() =>
-                    openExternalUrl(
-                      'https://github.com/breaking-brake/cc-wf-studio/issues/new/choose'
-                    )
-                  }
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--vscode-textLink-foreground)',
-                    background: 'none',
-                    border: 'none',
-                    padding: 0,
-                    cursor: 'pointer',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.textDecoration = 'underline';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.textDecoration = 'none';
-                  }}
-                >
-                  {t('slack.oauth.supportPage')}
-                </button>
-              </li>
-            </ul>
-
-            {/* User Token Input */}
-            <div style={{ marginBottom: '16px' }}>
-              <label
-                htmlFor="user-token"
-                style={{
-                  display: 'block',
-                  fontSize: '13px',
-                  color: 'var(--vscode-foreground)',
-                  marginBottom: '8px',
-                  fontWeight: 500,
-                }}
-              >
-                {t('slack.manualToken.userToken.label')}
-              </label>
-              <input
-                id="user-token"
-                type="password"
-                value={userToken}
-                onChange={(e) => setUserToken(e.target.value)}
-                placeholder="xoxp-..."
-                disabled={loading}
-                style={{
-                  width: '100%',
-                  padding: '6px 8px',
-                  backgroundColor: 'var(--vscode-input-background)',
-                  color: 'var(--vscode-input-foreground)',
-                  border: '1px solid var(--vscode-input-border)',
-                  borderRadius: '2px',
-                  fontSize: '13px',
-                  fontFamily: 'monospace',
-                }}
-              />
-            </div>
-
-            {/* Error Message */}
-            {error && (
-              <div
-                style={{
-                  padding: '8px 12px',
-                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
-                  borderRadius: '2px',
-                  marginBottom: '16px',
-                  fontSize: '12px',
-                  color: 'var(--vscode-errorForeground)',
-                }}
-              >
-                {error}
               </div>
             )}
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
 
-            {/* Buttons */}
-            <div
-              style={{
-                display: 'flex',
-                gap: '8px',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              }}
-            >
-              {/* Delete Token Button (left side) */}
-              {hasStoredToken && (
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteConfirm(true)}
-                  disabled={loading}
-                  style={{
-                    padding: '6px 12px',
-                    backgroundColor: 'transparent',
-                    color: 'var(--vscode-errorForeground)',
-                    border: '1px solid var(--vscode-errorForeground)',
-                    borderRadius: '2px',
-                    cursor: loading ? 'not-allowed' : 'pointer',
-                    fontSize: '12px',
-                    opacity: loading ? 0.5 : 1,
-                  }}
-                >
-                  {t('slack.manualToken.deleteButton')}
-                </button>
-              )}
-
-              {/* Right side buttons */}
-              <div style={{ display: 'flex', gap: '8px', marginLeft: 'auto' }}>
-                <button
-                  type="button"
-                  onClick={onClose}
-                  disabled={loading}
-                  style={{
-                    padding: '6px 16px',
-                    backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                    color: 'var(--vscode-button-secondaryForeground)',
-                    border: 'none',
-                    borderRadius: '2px',
-                    cursor: loading ? 'not-allowed' : 'pointer',
-                    fontSize: '13px',
-                    opacity: loading ? 0.5 : 1,
-                  }}
-                >
-                  {t('cancel')}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConnect}
-                  disabled={loading || !userToken.trim()}
-                  style={{
-                    padding: '6px 16px',
-                    backgroundColor: 'var(--vscode-button-background)',
-                    color: 'var(--vscode-button-foreground)',
-                    border: 'none',
-                    borderRadius: '2px',
-                    cursor: loading || !userToken.trim() ? 'not-allowed' : 'pointer',
-                    fontSize: '13px',
-                    fontWeight: 500,
-                    opacity: loading || !userToken.trim() ? 0.5 : 1,
-                  }}
-                >
-                  {loading ? t('slack.manualToken.connecting') : t('slack.manualToken.connect')}
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Delete Confirmation Dialog */}
-        {showDeleteConfirm && (
-          <div
-            style={{
-              position: 'fixed',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              backgroundColor: 'rgba(0, 0, 0, 0.6)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              zIndex: 10000,
-            }}
-            onClick={() => setShowDeleteConfirm(false)}
-            role="presentation"
-          >
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation */}
-            <div
-              style={{
-                backgroundColor: 'var(--vscode-editor-background)',
-                border: '1px solid var(--vscode-panel-border)',
-                borderRadius: '4px',
-                padding: '20px',
-                minWidth: '400px',
-                boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-              }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div
-                style={{
-                  fontSize: '14px',
-                  fontWeight: 600,
-                  color: 'var(--vscode-foreground)',
-                  marginBottom: '12px',
-                }}
-              >
-                {t('slack.manualToken.deleteConfirm.title')}
-              </div>
-              <div
-                style={{
-                  fontSize: '13px',
-                  color: 'var(--vscode-descriptionForeground)',
-                  marginBottom: '16px',
-                }}
-              >
-                {t('slack.manualToken.deleteConfirm.message')}
-              </div>
-              <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteConfirm(false)}
-                  style={{
-                    padding: '6px 16px',
-                    backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                    color: 'var(--vscode-button-secondaryForeground)',
-                    border: 'none',
-                    borderRadius: '2px',
-                    cursor: 'pointer',
-                    fontSize: '13px',
-                  }}
-                >
-                  {t('slack.manualToken.deleteConfirm.cancel')}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleDeleteToken}
-                  style={{
-                    padding: '6px 16px',
-                    backgroundColor: 'var(--vscode-errorForeground)',
-                    color: 'var(--vscode-editor-background)',
-                    border: 'none',
-                    borderRadius: '2px',
-                    cursor: 'pointer',
-                    fontSize: '13px',
-                    fontWeight: 500,
-                  }}
-                >
-                  {t('slack.manualToken.deleteConfirm.confirm')}
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
+      {/* Delete Confirmation Dialog - using ConfirmDialog component with z-index 10001 */}
+      <ConfirmDialog
+        isOpen={showDeleteConfirm}
+        title={t('slack.manualToken.deleteConfirm.title')}
+        message={t('slack.manualToken.deleteConfirm.message')}
+        confirmLabel={t('slack.manualToken.deleteConfirm.confirm')}
+        cancelLabel={t('slack.manualToken.deleteConfirm.cancel')}
+        onConfirm={handleDeleteToken}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
+    </Dialog.Root>
   );
 }

--- a/src/webview/src/components/dialogs/SlackShareDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackShareDialog.tsx
@@ -8,7 +8,8 @@
  * Based on specs/001-slack-workflow-sharing/plan.md
  */
 
-import { useEffect, useId, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { useEffect, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 import type { WebviewTranslationKeys } from '../../i18n/translation-keys';
 import type {
@@ -37,8 +38,6 @@ interface SlackShareDialogProps {
 
 export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDialogProps) {
   const { t } = useTranslation();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
 
   /**
    * Format error message from SlackError with i18n support
@@ -150,13 +149,6 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
   const handleChannelChange = (channelId: string) => {
     setSelectedChannelId(channelId);
   };
-
-  // Auto-focus dialog when opened
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
-    }
-  }, [isOpen]);
 
   const handleOpenManualTokenDialog = () => {
     setIsManualTokenDialogOpen(true);
@@ -290,423 +282,416 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
     onClose();
   };
 
-  if (!isOpen) {
-    return null;
-  }
-
   // Sensitive data warning dialog
   if (sensitiveDataWarning) {
     return (
-      <div
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.5)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          zIndex: 9999,
-        }}
-        onClick={handleClose}
-        role="presentation"
-      >
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation, not for click actions */}
-        <div
-          ref={dialogRef}
-          tabIndex={-1}
-          style={{
-            backgroundColor: 'var(--vscode-editor-background)',
-            border: '1px solid var(--vscode-panel-border)',
-            borderRadius: '4px',
-            padding: '24px',
-            minWidth: '500px',
-            maxWidth: '700px',
-            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-            outline: 'none',
-          }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {/* Warning Title */}
-          <div
+      <Dialog.Root open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+        <Dialog.Portal>
+          <Dialog.Overlay
             style={{
-              fontSize: '16px',
-              fontWeight: 600,
-              color: 'var(--vscode-errorForeground)',
-              marginBottom: '16px',
+              position: 'fixed',
+              inset: 0,
+              backgroundColor: 'rgba(0, 0, 0, 0.5)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 9999,
             }}
           >
-            {t('slack.sensitiveData.warning.title')}
-          </div>
-
-          {/* Warning Message */}
-          <div
-            style={{
-              fontSize: '13px',
-              color: 'var(--vscode-descriptionForeground)',
-              marginBottom: '16px',
-            }}
-          >
-            {t('slack.sensitiveData.warning.message')}
-          </div>
-
-          {/* Findings List */}
-          <div
-            style={{
-              backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-              border: '1px solid var(--vscode-panel-border)',
-              borderRadius: '2px',
-              padding: '12px',
-              marginBottom: '24px',
-              maxHeight: '200px',
-              overflowY: 'auto',
-            }}
-          >
-            {sensitiveDataWarning.map((finding, index) => (
-              <div
-                key={`${finding.type}-${finding.position}`}
+            <Dialog.Content
+              style={{
+                backgroundColor: 'var(--vscode-editor-background)',
+                border: '1px solid var(--vscode-panel-border)',
+                borderRadius: '4px',
+                padding: '24px',
+                minWidth: '500px',
+                maxWidth: '700px',
+                boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+                outline: 'none',
+              }}
+            >
+              {/* Warning Title */}
+              <Dialog.Title
                 style={{
-                  marginBottom: index < sensitiveDataWarning.length - 1 ? '8px' : '0',
-                  fontSize: '12px',
+                  fontSize: '16px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-errorForeground)',
+                  marginBottom: '16px',
                 }}
               >
-                <div
-                  style={{
-                    color: 'var(--vscode-foreground)',
-                    fontWeight: 500,
-                    marginBottom: '4px',
-                  }}
-                >
-                  {finding.type} ({finding.severity})
-                </div>
-                <div
-                  style={{
-                    color: 'var(--vscode-descriptionForeground)',
-                    fontFamily: 'monospace',
-                  }}
-                >
-                  {finding.maskedValue}
-                </div>
-              </div>
-            ))}
-          </div>
+                {t('slack.sensitiveData.warning.title')}
+              </Dialog.Title>
 
-          {/* Warning Buttons */}
-          <div
-            style={{
-              display: 'flex',
-              gap: '8px',
-              justifyContent: 'flex-end',
-            }}
-          >
-            <button
-              type="button"
-              onClick={handleClose}
-              disabled={loading}
-              style={{
-                padding: '6px 16px',
-                backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                color: 'var(--vscode-button-secondaryForeground)',
-                border: 'none',
-                borderRadius: '2px',
-                cursor: loading ? 'not-allowed' : 'pointer',
-                fontSize: '13px',
-                opacity: loading ? 0.5 : 1,
-              }}
-            >
-              {t('slack.sensitiveData.warning.cancel')}
-            </button>
-            <button
-              type="button"
-              onClick={handleShareOverride}
-              disabled={loading}
-              style={{
-                padding: '6px 16px',
-                backgroundColor: 'var(--vscode-button-background)',
-                color: 'var(--vscode-button-foreground)',
-                border: 'none',
-                borderRadius: '2px',
-                cursor: loading ? 'not-allowed' : 'pointer',
-                fontSize: '13px',
-                fontWeight: 500,
-                opacity: loading ? 0.5 : 1,
-              }}
-            >
-              {loading ? t('slack.share.sharing') : t('slack.sensitiveData.warning.continue')}
-            </button>
-          </div>
-        </div>
-      </div>
+              {/* Warning Message */}
+              <Dialog.Description
+                style={{
+                  fontSize: '13px',
+                  color: 'var(--vscode-descriptionForeground)',
+                  marginBottom: '16px',
+                }}
+              >
+                {t('slack.sensitiveData.warning.message')}
+              </Dialog.Description>
+
+              {/* Findings List */}
+              <div
+                style={{
+                  backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '2px',
+                  padding: '12px',
+                  marginBottom: '24px',
+                  maxHeight: '200px',
+                  overflowY: 'auto',
+                }}
+              >
+                {sensitiveDataWarning.map((finding, index) => (
+                  <div
+                    key={`${finding.type}-${finding.position}`}
+                    style={{
+                      marginBottom: index < sensitiveDataWarning.length - 1 ? '8px' : '0',
+                      fontSize: '12px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        color: 'var(--vscode-foreground)',
+                        fontWeight: 500,
+                        marginBottom: '4px',
+                      }}
+                    >
+                      {finding.type} ({finding.severity})
+                    </div>
+                    <div
+                      style={{
+                        color: 'var(--vscode-descriptionForeground)',
+                        fontFamily: 'monospace',
+                      }}
+                    >
+                      {finding.maskedValue}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Warning Buttons */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '8px',
+                  justifyContent: 'flex-end',
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  disabled={loading}
+                  style={{
+                    padding: '6px 16px',
+                    backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                    color: 'var(--vscode-button-secondaryForeground)',
+                    border: 'none',
+                    borderRadius: '2px',
+                    cursor: loading ? 'not-allowed' : 'pointer',
+                    fontSize: '13px',
+                    opacity: loading ? 0.5 : 1,
+                  }}
+                >
+                  {t('slack.sensitiveData.warning.cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleShareOverride}
+                  disabled={loading}
+                  style={{
+                    padding: '6px 16px',
+                    backgroundColor: 'var(--vscode-button-background)',
+                    color: 'var(--vscode-button-foreground)',
+                    border: 'none',
+                    borderRadius: '2px',
+                    cursor: loading ? 'not-allowed' : 'pointer',
+                    fontSize: '13px',
+                    fontWeight: 500,
+                    opacity: loading ? 0.5 : 1,
+                  }}
+                >
+                  {loading ? t('slack.share.sharing') : t('slack.sensitiveData.warning.continue')}
+                </button>
+              </div>
+            </Dialog.Content>
+          </Dialog.Overlay>
+        </Dialog.Portal>
+      </Dialog.Root>
     );
   }
 
   // Main share dialog
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 9999,
-      }}
-      onClick={handleClose}
-      role="presentation"
-    >
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: onClick is only used to stop event propagation, not for click actions */}
-      <div
-        ref={dialogRef}
-        tabIndex={-1}
-        style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '4px',
-          padding: '24px',
-          minWidth: '500px',
-          maxWidth: '700px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-          outline: 'none',
-        }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Title */}
-        <div
-          id={titleId}
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
           style={{
-            fontSize: '16px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-            marginBottom: '8px',
-          }}
-        >
-          {t('slack.share.title')}
-        </div>
-
-        {/* Workflow Name */}
-        <div
-          style={{
-            fontSize: '13px',
-            color: 'var(--vscode-descriptionForeground)',
-            marginBottom: '24px',
-          }}
-        >
-          {workflowName}
-        </div>
-
-        {/* Connection Status Section */}
-        {!loadingWorkspace && !workspace && (
-          <div
-            style={{
-              marginBottom: '24px',
-              padding: '16px',
-              backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-              border: '1px solid var(--vscode-panel-border)',
-              borderRadius: '4px',
-            }}
-          >
-            <div
-              style={{
-                fontSize: '13px',
-                color: 'var(--vscode-descriptionForeground)',
-                marginBottom: '12px',
-              }}
-            >
-              {t('slack.connect.description')}
-            </div>
-            <button
-              type="button"
-              onClick={handleOpenManualTokenDialog}
-              style={{
-                width: '100%',
-                padding: '8px 16px',
-                backgroundColor: 'var(--vscode-button-background)',
-                color: 'var(--vscode-button-foreground)',
-                border: 'none',
-                borderRadius: '2px',
-                cursor: 'pointer',
-                fontSize: '13px',
-                fontWeight: 500,
-              }}
-            >
-              {t('slack.connect.button')}
-            </button>
-          </div>
-        )}
-
-        {!loadingWorkspace && workspace && (
-          <div
-            style={{
-              marginBottom: '24px',
-              padding: '12px',
-              backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
-              border: '1px solid var(--vscode-panel-border)',
-              borderRadius: '4px',
-            }}
-          >
-            <div
-              style={{
-                fontSize: '12px',
-                color: 'var(--vscode-descriptionForeground)',
-                marginBottom: '8px',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '8px',
-              }}
-            >
-              <span style={{ color: 'var(--vscode-testing-iconPassed)' }}>✓</span>
-              <span>
-                Connected to{' '}
-                <strong style={{ color: 'var(--vscode-foreground)' }}>
-                  {workspace.workspaceName}
-                </strong>
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={handleOpenManualTokenDialog}
-              style={{
-                padding: '6px 12px',
-                backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                color: 'var(--vscode-button-secondaryForeground)',
-                border: 'none',
-                borderRadius: '2px',
-                cursor: 'pointer',
-                fontSize: '12px',
-              }}
-            >
-              {t('slack.reconnect.button')}
-            </button>
-          </div>
-        )}
-
-        {/* Channel Selection */}
-        <div style={{ marginBottom: '16px' }}>
-          <label
-            htmlFor="channel-select"
-            style={{
-              display: 'block',
-              fontSize: '13px',
-              color: 'var(--vscode-foreground)',
-              marginBottom: '8px',
-              fontWeight: 500,
-            }}
-          >
-            {t('slack.share.selectChannel')}
-          </label>
-          <select
-            id="channel-select"
-            value={selectedChannelId}
-            onChange={(e) => handleChannelChange(e.target.value)}
-            disabled={loadingChannels || loading}
-            style={{
-              width: '100%',
-              padding: '6px 8px',
-              backgroundColor: 'var(--vscode-input-background)',
-              color: 'var(--vscode-input-foreground)',
-              border: '1px solid var(--vscode-input-border)',
-              borderRadius: '2px',
-              fontSize: '13px',
-              cursor: loadingChannels || loading ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {loadingChannels ? (
-              <option value="">{t('loading')}...</option>
-            ) : channels.length === 0 ? (
-              <option value="">{t('slack.error.noChannels')}</option>
-            ) : (
-              channels.map((channel) => (
-                <option key={channel.id} value={channel.id}>
-                  {channel.isPrivate ? '🔒' : '#'} {channel.name}
-                </option>
-              ))
-            )}
-          </select>
-        </div>
-
-        {/* Error Message */}
-        {error && (
-          <div
-            style={{
-              padding: '8px 12px',
-              backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-              border: '1px solid var(--vscode-inputValidation-errorBorder)',
-              borderRadius: '2px',
-              marginBottom: '16px',
-              fontSize: '12px',
-              color: 'var(--vscode-errorForeground)',
-            }}
-          >
-            {error}
-          </div>
-        )}
-
-        {/* Progress Bar - shown when sharing to Slack */}
-        {loading && (
-          <div style={{ marginBottom: '16px' }}>
-            <IndeterminateProgressBar label={t('slack.share.sharing')} />
-          </div>
-        )}
-
-        {/* Buttons */}
-        <div
-          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
             display: 'flex',
-            gap: '8px',
-            justifyContent: 'flex-end',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
           }}
         >
-          <button
-            type="button"
-            onClick={handleClose}
-            disabled={loading}
+          <Dialog.Content
             style={{
-              padding: '6px 16px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: loading ? 'not-allowed' : 'pointer',
-              fontSize: '13px',
-              opacity: loading ? 0.5 : 1,
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '24px',
+              minWidth: '500px',
+              maxWidth: '700px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
             }}
           >
-            {t('cancel')}
-          </button>
-          <button
-            type="button"
-            onClick={handleShare}
-            disabled={
-              loading || loadingWorkspace || loadingChannels || !workspace || !selectedChannelId
-            }
-            style={{
-              padding: '6px 16px',
-              backgroundColor: 'var(--vscode-button-background)',
-              color: 'var(--vscode-button-foreground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor:
-                loading || loadingWorkspace || loadingChannels || !workspace || !selectedChannelId
-                  ? 'not-allowed'
-                  : 'pointer',
-              fontSize: '13px',
-              fontWeight: 500,
-              opacity:
-                loading || loadingWorkspace || loadingChannels || !workspace || !selectedChannelId
-                  ? 0.5
-                  : 1,
-            }}
-          >
-            {loading ? t('slack.share.sharing') : t('slack.share.button')}
-          </button>
-        </div>
-      </div>
+            {/* Title */}
+            <Dialog.Title
+              style={{
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '8px',
+              }}
+            >
+              {t('slack.share.title')}
+            </Dialog.Title>
+
+            {/* Workflow Name */}
+            <Dialog.Description
+              style={{
+                fontSize: '13px',
+                color: 'var(--vscode-descriptionForeground)',
+                marginBottom: '24px',
+              }}
+            >
+              {workflowName}
+            </Dialog.Description>
+
+            {/* Connection Status Section */}
+            {!loadingWorkspace && !workspace && (
+              <div
+                style={{
+                  marginBottom: '24px',
+                  padding: '16px',
+                  backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '4px',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '13px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    marginBottom: '12px',
+                  }}
+                >
+                  {t('slack.connect.description')}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleOpenManualTokenDialog}
+                  style={{
+                    width: '100%',
+                    padding: '8px 16px',
+                    backgroundColor: 'var(--vscode-button-background)',
+                    color: 'var(--vscode-button-foreground)',
+                    border: 'none',
+                    borderRadius: '2px',
+                    cursor: 'pointer',
+                    fontSize: '13px',
+                    fontWeight: 500,
+                  }}
+                >
+                  {t('slack.connect.button')}
+                </button>
+              </div>
+            )}
+
+            {!loadingWorkspace && workspace && (
+              <div
+                style={{
+                  marginBottom: '24px',
+                  padding: '12px',
+                  backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '4px',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    marginBottom: '8px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                  }}
+                >
+                  <span style={{ color: 'var(--vscode-testing-iconPassed)' }}>✓</span>
+                  <span>
+                    Connected to{' '}
+                    <strong style={{ color: 'var(--vscode-foreground)' }}>
+                      {workspace.workspaceName}
+                    </strong>
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleOpenManualTokenDialog}
+                  style={{
+                    padding: '6px 12px',
+                    backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                    color: 'var(--vscode-button-secondaryForeground)',
+                    border: 'none',
+                    borderRadius: '2px',
+                    cursor: 'pointer',
+                    fontSize: '12px',
+                  }}
+                >
+                  {t('slack.reconnect.button')}
+                </button>
+              </div>
+            )}
+
+            {/* Channel Selection */}
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="channel-select"
+                style={{
+                  display: 'block',
+                  fontSize: '13px',
+                  color: 'var(--vscode-foreground)',
+                  marginBottom: '8px',
+                  fontWeight: 500,
+                }}
+              >
+                {t('slack.share.selectChannel')}
+              </label>
+              <select
+                id="channel-select"
+                value={selectedChannelId}
+                onChange={(e) => handleChannelChange(e.target.value)}
+                disabled={loadingChannels || loading}
+                style={{
+                  width: '100%',
+                  padding: '6px 8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  fontSize: '13px',
+                  cursor: loadingChannels || loading ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {loadingChannels ? (
+                  <option value="">{t('loading')}...</option>
+                ) : channels.length === 0 ? (
+                  <option value="">{t('slack.error.noChannels')}</option>
+                ) : (
+                  channels.map((channel) => (
+                    <option key={channel.id} value={channel.id}>
+                      {channel.isPrivate ? '🔒' : '#'} {channel.name}
+                    </option>
+                  ))
+                )}
+              </select>
+            </div>
+
+            {/* Error Message */}
+            {error && (
+              <div
+                style={{
+                  padding: '8px 12px',
+                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                  borderRadius: '2px',
+                  marginBottom: '16px',
+                  fontSize: '12px',
+                  color: 'var(--vscode-errorForeground)',
+                }}
+              >
+                {error}
+              </div>
+            )}
+
+            {/* Progress Bar - shown when sharing to Slack */}
+            {loading && (
+              <div style={{ marginBottom: '16px' }}>
+                <IndeterminateProgressBar label={t('slack.share.sharing')} />
+              </div>
+            )}
+
+            {/* Buttons */}
+            <div
+              style={{
+                display: 'flex',
+                gap: '8px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={loading}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: loading ? 'not-allowed' : 'pointer',
+                  fontSize: '13px',
+                  opacity: loading ? 0.5 : 1,
+                }}
+              >
+                {t('cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={handleShare}
+                disabled={
+                  loading || loadingWorkspace || loadingChannels || !workspace || !selectedChannelId
+                }
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor:
+                    loading ||
+                    loadingWorkspace ||
+                    loadingChannels ||
+                    !workspace ||
+                    !selectedChannelId
+                      ? 'not-allowed'
+                      : 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  opacity:
+                    loading ||
+                    loadingWorkspace ||
+                    loadingChannels ||
+                    !workspace ||
+                    !selectedChannelId
+                      ? 0.5
+                      : 1,
+                }}
+              >
+                {loading ? t('slack.share.sharing') : t('slack.share.button')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
 
       {/* Manual Token Dialog */}
       <SlackManualTokenDialog
@@ -714,6 +699,6 @@ export function SlackShareDialog({ isOpen, onClose, workflowId }: SlackShareDial
         onClose={handleManualTokenClose}
         onSuccess={handleManualTokenSuccess}
       />
-    </div>
+    </Dialog.Root>
   );
 }

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -448,6 +448,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            zIndex: 9999,
           }}
         >
           <Dialog.Content

--- a/src/webview/src/components/dialogs/TermsOfUseDialog.tsx
+++ b/src/webview/src/components/dialogs/TermsOfUseDialog.tsx
@@ -4,8 +4,9 @@
  * Terms of Use dialog for first-time users
  */
 
+import * as Dialog from '@radix-ui/react-dialog';
 import type React from 'react';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 
 interface TermsOfUseDialogProps {
@@ -23,16 +24,7 @@ export const TermsOfUseDialog: React.FC<TermsOfUseDialogProps> = ({
   onCancel,
 }) => {
   const { t } = useTranslation();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const titleId = useId();
   const [agreed, setAgreed] = useState(false);
-
-  // ダイアログが開いたときに自動的にフォーカス
-  useEffect(() => {
-    if (isOpen && dialogRef.current) {
-      dialogRef.current.focus();
-    }
-  }, [isOpen]);
 
   // ダイアログが閉じたときに状態をリセット
   useEffect(() => {
@@ -41,186 +33,178 @@ export const TermsOfUseDialog: React.FC<TermsOfUseDialogProps> = ({
     }
   }, [isOpen]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 10000,
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          onCancel();
-        }
-      }}
-    >
-      <div
-        ref={dialogRef}
-        tabIndex={-1}
-        style={{
-          backgroundColor: 'var(--vscode-editor-background)',
-          border: '1px solid var(--vscode-panel-border)',
-          borderRadius: '4px',
-          padding: '32px',
-          minWidth: '500px',
-          maxWidth: '600px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-          outline: 'none',
-        }}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
-        {/* Title */}
-        <div
-          id={titleId}
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
           style={{
-            fontSize: '18px',
-            fontWeight: 600,
-            color: 'var(--vscode-foreground)',
-            marginBottom: '20px',
-          }}
-        >
-          {t('terms.title')}
-        </div>
-
-        {/* Content */}
-        <div
-          style={{
-            fontSize: '13px',
-            color: 'var(--vscode-descriptionForeground)',
-            marginBottom: '24px',
-            lineHeight: '1.6',
-          }}
-        >
-          {/* Introduction */}
-          <p style={{ marginBottom: '16px' }}>{t('terms.introduction')}</p>
-
-          {/* Prohibited Uses */}
-          <p style={{ marginBottom: '8px', fontWeight: 500 }}>{t('terms.prohibitedUse')}</p>
-          <ul style={{ marginLeft: '20px', marginBottom: '16px' }}>
-            <li style={{ marginBottom: '4px' }}>{t('terms.cyberAttack')}</li>
-            <li style={{ marginBottom: '4px' }}>{t('terms.malware')}</li>
-            <li style={{ marginBottom: '4px' }}>{t('terms.personalDataTheft')}</li>
-            <li style={{ marginBottom: '4px' }}>{t('terms.otherIllegalActs')}</li>
-          </ul>
-
-          {/* Liability */}
-          <p style={{ marginBottom: '16px', fontWeight: 500 }}>{t('terms.liability')}</p>
-        </div>
-
-        {/* Checkbox */}
-        <div
-          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
             display: 'flex',
             alignItems: 'center',
-            marginBottom: '24px',
-            cursor: 'pointer',
-            userSelect: 'none',
-          }}
-          onClick={() => setAgreed(!agreed)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setAgreed(!agreed);
-            }
+            justifyContent: 'center',
+            zIndex: 10000,
           }}
         >
-          <input
-            type="checkbox"
-            checked={agreed}
-            onChange={(e) => setAgreed(e.target.checked)}
-            onClick={(e) => e.stopPropagation()}
+          <Dialog.Content
             style={{
-              marginRight: '8px',
-              cursor: 'pointer',
-            }}
-          />
-          <span
-            style={{
-              fontSize: '13px',
-              color: 'var(--vscode-foreground)',
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '32px',
+              minWidth: '500px',
+              maxWidth: '600px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
             }}
           >
-            {t('terms.agree')}
-          </span>
-        </div>
+            {/* Title */}
+            <Dialog.Title
+              style={{
+                fontSize: '18px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '20px',
+              }}
+            >
+              {t('terms.title')}
+            </Dialog.Title>
 
-        {/* Buttons */}
-        <div
-          style={{
-            display: 'flex',
-            gap: '8px',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <button
-            type="button"
-            onClick={onCancel}
-            style={{
-              padding: '8px 20px',
-              backgroundColor: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: 'pointer',
-              fontSize: '13px',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor =
-                'var(--vscode-button-secondaryHoverBackground)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryBackground)';
-            }}
-          >
-            {t('terms.cancelButton')}
-          </button>
-          <button
-            type="button"
-            onClick={onAccept}
-            disabled={!agreed}
-            style={{
-              padding: '8px 20px',
-              backgroundColor: agreed
-                ? 'var(--vscode-button-background)'
-                : 'var(--vscode-button-secondaryBackground)',
-              color: agreed
-                ? 'var(--vscode-button-foreground)'
-                : 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              borderRadius: '2px',
-              cursor: agreed ? 'pointer' : 'not-allowed',
-              fontSize: '13px',
-              fontWeight: 500,
-              opacity: agreed ? 1 : 0.5,
-            }}
-            onMouseEnter={(e) => {
-              if (agreed) {
-                e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-              }
-            }}
-            onMouseLeave={(e) => {
-              if (agreed) {
-                e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-              }
-            }}
-          >
-            {t('terms.agreeButton')}
-          </button>
-        </div>
-      </div>
-    </div>
+            {/* Content */}
+            <Dialog.Description asChild>
+              <div
+                style={{
+                  fontSize: '13px',
+                  color: 'var(--vscode-descriptionForeground)',
+                  marginBottom: '24px',
+                  lineHeight: '1.6',
+                }}
+              >
+                {/* Introduction */}
+                <p style={{ marginBottom: '16px' }}>{t('terms.introduction')}</p>
+
+                {/* Prohibited Uses */}
+                <p style={{ marginBottom: '8px', fontWeight: 500 }}>{t('terms.prohibitedUse')}</p>
+                <ul style={{ marginLeft: '20px', marginBottom: '16px' }}>
+                  <li style={{ marginBottom: '4px' }}>{t('terms.cyberAttack')}</li>
+                  <li style={{ marginBottom: '4px' }}>{t('terms.malware')}</li>
+                  <li style={{ marginBottom: '4px' }}>{t('terms.personalDataTheft')}</li>
+                  <li style={{ marginBottom: '4px' }}>{t('terms.otherIllegalActs')}</li>
+                </ul>
+
+                {/* Liability */}
+                <p style={{ marginBottom: '16px', fontWeight: 500 }}>{t('terms.liability')}</p>
+              </div>
+            </Dialog.Description>
+
+            {/* Checkbox */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                marginBottom: '24px',
+                cursor: 'pointer',
+                userSelect: 'none',
+              }}
+              onClick={() => setAgreed(!agreed)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setAgreed(!agreed);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <input
+                type="checkbox"
+                checked={agreed}
+                onChange={(e) => setAgreed(e.target.checked)}
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                  marginRight: '8px',
+                  cursor: 'pointer',
+                }}
+              />
+              <span
+                style={{
+                  fontSize: '13px',
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('terms.agree')}
+              </span>
+            </div>
+
+            {/* Buttons */}
+            <div
+              style={{
+                display: 'flex',
+                gap: '8px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={onCancel}
+                style={{
+                  padding: '8px 20px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryHoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryBackground)';
+                }}
+              >
+                {t('terms.cancelButton')}
+              </button>
+              <button
+                type="button"
+                onClick={onAccept}
+                disabled={!agreed}
+                style={{
+                  padding: '8px 20px',
+                  backgroundColor: agreed
+                    ? 'var(--vscode-button-background)'
+                    : 'var(--vscode-button-secondaryBackground)',
+                  color: agreed
+                    ? 'var(--vscode-button-foreground)'
+                    : 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: agreed ? 'pointer' : 'not-allowed',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  opacity: agreed ? 1 : 0.5,
+                }}
+                onMouseEnter={(e) => {
+                  if (agreed) {
+                    e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (agreed) {
+                    e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+                  }
+                }}
+              >
+                {t('terms.agreeButton')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 


### PR DESCRIPTION
## Problem

### Current Behavior
1. Several dialog components use custom implementations instead of Radix UI Dialog
2. ❌ z-index values are inconsistent across dialogs (some missing, some using 1000)
3. ❌ Nested dialogs don't layer correctly (Issue #402: SkillCreationDialog not appearing on top)

### Expected Behavior
1. All dialogs use `@radix-ui/react-dialog` for consistency and accessibility
2. ✅ z-index follows 3-layer hierarchy: Base (9999) → Nested (10000) → Confirm (10001)
3. ✅ Nested dialogs layer correctly

## Solution

Migrate all custom dialog implementations to Radix UI Dialog and standardize z-index values.

### Changes

**Migrated to Radix UI Dialog:**
- `SlackConnectionRequiredDialog.tsx` (z-index: 9999)
- `TermsOfUseDialog.tsx` (z-index: 10000)
- `McpNodeEditDialog.tsx` (z-index: 9999)
- `SlackShareDialog.tsx` (z-index: 9999)
- `SlackManualTokenDialog.tsx` (z-index: 10000)

**z-index fixes for existing Radix UI dialogs:**
- `SkillCreationDialog.tsx` - Added zIndex: 10000 (fixes Issue #402)
- `SubAgentFlowDialog.tsx` - Added zIndex: 9999

**Documentation:**
- Updated `CLAUDE.md` dialog status table to reflect all dialogs as migrated

### Migration Pattern

```tsx
// Before (Custom implementation)
if (!isOpen) return null;
return (
  <div style={{ position: 'fixed', zIndex: 9999, ... }} onClick={onClose}>
    <div onClick={(e) => e.stopPropagation()}>
      {/* content */}
    </div>
  </div>
);

// After (Radix UI)
return (
  <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
    <Dialog.Portal>
      <Dialog.Overlay style={{ ..., zIndex: 9999 }}>
        <Dialog.Content>
          <Dialog.Title>{title}</Dialog.Title>
          <Dialog.Description>{description}</Dialog.Description>
          {/* content */}
        </Dialog.Content>
      </Dialog.Overlay>
    </Dialog.Portal>
  </Dialog.Root>
);
```

## Impact

- **Accessibility**: Radix UI provides automatic ARIA attributes, focus management, and keyboard navigation
- **Consistency**: All dialogs now follow the same implementation pattern
- **z-index layering**: Nested dialogs (child dialogs, confirmation dialogs) now display correctly on top
- **No breaking changes**: External API (props) remains unchanged

## Testing

- [x] Manual E2E testing completed
  - [x] SlackConnectionRequiredDialog: open/close, ESC key, overlay click
  - [x] TermsOfUseDialog: open/close, checkbox, agree button state
  - [x] McpNodeEditDialog: open/close, mode-specific UI
  - [x] SlackShareDialog: open/close, nested SlackManualTokenDialog layering
  - [x] SlackManualTokenDialog: open/close, delete confirmation dialog (ConfirmDialog)
  - [x] SkillCreationDialog: appears on top of SkillBrowserDialog (Issue #402 fix verified)
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)

## Related

- Fixes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)