### PR TITLE
feat: add session continuation support for AI refinement

### DIFF
--- a/src/extension/commands/workflow-refinement.ts
+++ b/src/extension/commands/workflow-refinement.ts
@@ -170,12 +170,13 @@ export async function handleRefineWorkflow(
         timestamp: new Date().toISOString(),
       };
 
-      // Update conversation history
+      // Update conversation history with session ID for continuity
       const updatedHistory = {
         ...conversationHistory,
         messages: [...conversationHistory.messages, userMessageObj, aiMessage],
         currentIteration: conversationHistory.currentIteration + 1,
         updatedAt: new Date().toISOString(),
+        sessionId: result.newSessionId || conversationHistory.sessionId,
       };
 
       log('INFO', 'Sending clarification request to webview', {
@@ -234,12 +235,13 @@ export async function handleRefineWorkflow(
       timestamp: new Date().toISOString(),
     };
 
-    // Update conversation history
+    // Update conversation history with session ID for continuity
     const updatedHistory = {
       ...conversationHistory,
       messages: [...conversationHistory.messages, userMessageObj, aiMessage],
       currentIteration: conversationHistory.currentIteration + 1,
       updatedAt: new Date().toISOString(),
+      sessionId: result.newSessionId || conversationHistory.sessionId,
     };
 
     // Attach updated conversation history to refined workflow
@@ -427,12 +429,13 @@ async function handleRefineSubAgentFlow(
         timestamp: new Date().toISOString(),
       };
 
-      // Update conversation history
+      // Update conversation history with session ID for continuity
       const updatedHistory = {
         ...conversationHistory,
         messages: [...conversationHistory.messages, userMessageObj, aiMessage],
         currentIteration: conversationHistory.currentIteration + 1,
         updatedAt: new Date().toISOString(),
+        sessionId: result.newSessionId || conversationHistory.sessionId,
       };
 
       log('INFO', 'Sending clarification request for SubAgentFlow to webview', {
@@ -493,12 +496,13 @@ async function handleRefineSubAgentFlow(
       timestamp: new Date().toISOString(),
     };
 
-    // Update conversation history
+    // Update conversation history with session ID for continuity
     const updatedHistory = {
       ...conversationHistory,
       messages: [...conversationHistory.messages, userMessageObj, aiMessage],
       currentIteration: conversationHistory.currentIteration + 1,
       updatedAt: new Date().toISOString(),
+      sessionId: result.newSessionId || conversationHistory.sessionId,
     };
 
     log('INFO', 'SubAgentFlow refinement successful', {

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -404,6 +404,8 @@ export interface ConversationHistory {
   createdAt: string;
   /** Last update timestamp (ISO 8601) */
   updatedAt: string;
+  /** Claude Code CLI session ID for context continuation (optional) */
+  sessionId?: string;
 }
 
 // ============================================================================

--- a/src/webview/src/components/dialogs/RefinementChatPanel.tsx
+++ b/src/webview/src/components/dialogs/RefinementChatPanel.tsx
@@ -222,12 +222,6 @@ export function RefinementChatPanel({
           if (payload.explanatoryText !== undefined) {
             latestExplanatoryText = payload.explanatoryText;
           }
-          console.log('[RefinementChatPanel] onProgress:', {
-            hasReceivedProgress,
-            accumulatedTextLength: payload.accumulatedText.length,
-            explanatoryTextLength: payload.explanatoryText?.length ?? 0,
-            latestExplanatoryTextLength: latestExplanatoryText.length,
-          });
         };
 
         const result = await refineWorkflow(
@@ -246,13 +240,6 @@ export function RefinementChatPanel({
         if (result.type === 'success') {
           updateWorkflow(result.payload.refinedWorkflow);
 
-          console.log('[RefinementChatPanel] handleSend success:', {
-            hasReceivedProgress,
-            latestExplanatoryTextLength: latestExplanatoryText.length,
-            latestExplanatoryTextPreview: latestExplanatoryText.substring(0, 100),
-            willUseFinishProcessing: hasReceivedProgress && latestExplanatoryText.length > 0,
-          });
-
           if (hasReceivedProgress && latestExplanatoryText) {
             // Streaming occurred with explanatory text
             // Replace display text with explanatory text only (remove tool info)
@@ -266,11 +253,10 @@ export function RefinementChatPanel({
             updateMessageLoadingState(completionMessageId, false);
 
             // Preserve frontend messages (don't overwrite with server history)
-            console.log('[RefinementChatPanel] handleSend: Using finishProcessing');
-            finishProcessing();
+            // Pass sessionId for session continuation support
+            finishProcessing(result.payload.updatedConversationHistory?.sessionId);
           } else {
             // No streaming or no explanatory text: just show completion message
-            console.log('[RefinementChatPanel] handleSend: Using handleRefinementSuccess');
             updateMessageContent(aiMessageId, result.payload.aiMessage.content);
             updateMessageLoadingState(aiMessageId, false);
 
@@ -286,7 +272,8 @@ export function RefinementChatPanel({
 
           if (hasReceivedProgress) {
             // Streaming occurred, use finishProcessing to preserve frontend messages
-            finishProcessing();
+            // Pass sessionId for session continuation support
+            finishProcessing(result.payload.updatedConversationHistory?.sessionId);
           } else {
             // No streaming, update conversation history normally
             handleRefinementSuccess(
@@ -419,12 +406,6 @@ export function RefinementChatPanel({
           if (payload.explanatoryText !== undefined) {
             latestExplanatoryText = payload.explanatoryText;
           }
-          console.log('[RefinementChatPanel] onProgress:', {
-            hasReceivedProgress,
-            accumulatedTextLength: payload.accumulatedText.length,
-            explanatoryTextLength: payload.explanatoryText?.length ?? 0,
-            latestExplanatoryTextLength: latestExplanatoryText.length,
-          });
         };
 
         const result = await refineWorkflow(
@@ -457,7 +438,8 @@ export function RefinementChatPanel({
             updateMessageLoadingState(completionMessageId, false);
 
             // Preserve frontend messages (don't overwrite with server history)
-            finishProcessing();
+            // Pass sessionId for session continuation support
+            finishProcessing(result.payload.updatedConversationHistory?.sessionId);
           } else {
             // No streaming or no explanatory text: just show completion message
             updateMessageContent(aiMessageId, result.payload.aiMessage.content);
@@ -475,7 +457,8 @@ export function RefinementChatPanel({
 
           if (hasReceivedProgress) {
             // Streaming occurred, use finishProcessing to preserve frontend messages
-            finishProcessing();
+            // Pass sessionId for session continuation support
+            finishProcessing(result.payload.updatedConversationHistory?.sessionId);
           } else {
             // No streaming, update conversation history normally
             handleRefinementSuccess(

--- a/src/webview/src/types/refinement-chat-state.ts
+++ b/src/webview/src/types/refinement-chat-state.ts
@@ -45,7 +45,7 @@ export interface RefinementChatState {
   removeMessage: (messageId: string) => void;
   clearHistory: () => void;
   startProcessing: (requestId: string) => void;
-  finishProcessing: () => void;
+  finishProcessing: (sessionId?: string) => void;
   handleRefinementSuccess: (
     aiMessage: ConversationMessage,
     updatedHistory: ConversationHistory


### PR DESCRIPTION
## Problem

When using AI-assisted workflow refinement, the AI cannot remember context from previous conversation turns. This happens because each refinement request spawns a new Claude Code CLI process without session continuity.

### Current Behavior
1. User asks AI to add a node
2. AI responds and adds the node
3. ❌ User asks "delete the node you just added"
4. ❌ AI doesn't know what "the node you just added" refers to

### Expected Behavior
1. User asks AI to add a node
2. AI responds and adds the node
3. ✅ User asks "delete the node you just added"
4. ✅ AI remembers the previous context and deletes the correct node

## Solution

Use Claude Code CLI's `--resume <session_id>` option to maintain session continuity across conversation turns.

### Changes

**Extension Host:**
- `src/shared/types/workflow-definition.ts`: Add `sessionId` to `ConversationHistory` type
- `src/extension/services/claude-code-service.ts`: Add `--resume` CLI arg support, extract session ID from init message
- `src/extension/services/refinement-service.ts`: Pass session ID to CLI, implement fallback for invalid sessions
- `src/extension/commands/workflow-refinement.ts`: Propagate session ID through the refinement flow

**Webview:**
- `src/webview/src/stores/refinement-store.ts`: Update `finishProcessing` to accept and save sessionId
- `src/webview/src/types/refinement-chat-state.ts`: Update type definition
- `src/webview/src/components/dialogs/RefinementChatPanel.tsx`: Pass sessionId when calling `finishProcessing` for streaming cases

### Key Implementation Details

1. **Session ID Extraction**: Extract `session_id` from CLI init message (`{"type":"system","subtype":"init","session_id":"..."}`)
2. **Session Continuation**: Pass `--resume <session_id>` to CLI for subsequent requests
3. **Fallback Handling**: If session resume fails, retry with full prompt (new session)
4. **Streaming Fix**: When streaming occurs, `finishProcessing(sessionId)` now saves the sessionId to conversationHistory

## Impact

- ✅ AI remembers previous conversation context
- ✅ More natural conversation flow ("the node you added", "that file you read", etc.)
- ✅ Reduced token usage (session continuation doesn't require full prompt)
- ✅ sessionId persisted to workflow JSON file for continuity after save/reload

## Testing

- [x] T001: Basic session continuation (in-session)
- [x] T002: File investigation continuity (in-session)
- [x] T003: Session reset on history clear
- [x] T004: sessionId persistence after save/reload
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

Fixes #407

🤖 Generated with [Claude Code](https://claude.ai/code)