### PR TITLE
improvement: add session reconnection warning dialog for AI refinement

### DIFF
--- a/src/extension/commands/workflow-refinement.ts
+++ b/src/extension/commands/workflow-refinement.ts
@@ -191,6 +191,7 @@ export async function handleRefineWorkflow(
         updatedConversationHistory: updatedHistory,
         executionTimeMs: result.executionTimeMs,
         timestamp: new Date().toISOString(),
+        sessionReconnected: result.sessionReconnected,
       });
       return;
     }
@@ -261,6 +262,7 @@ export async function handleRefineWorkflow(
       updatedConversationHistory: updatedHistory,
       executionTimeMs: result.executionTimeMs,
       timestamp: new Date().toISOString(),
+      sessionReconnected: result.sessionReconnected,
     });
   } catch (error) {
     const executionTimeMs = Date.now() - startTime;
@@ -451,6 +453,7 @@ async function handleRefineSubAgentFlow(
         updatedConversationHistory: updatedHistory,
         executionTimeMs: result.executionTimeMs,
         timestamp: new Date().toISOString(),
+        sessionReconnected: result.sessionReconnected,
       });
       return;
     }
@@ -522,6 +525,7 @@ async function handleRefineSubAgentFlow(
       updatedConversationHistory: updatedHistory,
       executionTimeMs: result.executionTimeMs,
       timestamp: new Date().toISOString(),
+      sessionReconnected: result.sessionReconnected,
     });
   } catch (error) {
     const executionTimeMs = Date.now() - startTime;

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -308,6 +308,8 @@ export interface RefinementSuccessPayload {
   executionTimeMs: number;
   /** Response timestamp */
   timestamp: string; // ISO 8601
+  /** Whether session was reconnected due to session expiration (fallback occurred) */
+  sessionReconnected?: boolean;
 }
 
 export interface RefinementFailedPayload {
@@ -366,6 +368,8 @@ export interface RefinementClarificationPayload {
   executionTimeMs: number;
   /** Response timestamp */
   timestamp: string; // ISO 8601
+  /** Whether session was reconnected due to session expiration (fallback occurred) */
+  sessionReconnected?: boolean;
 }
 
 export interface RefinementProgressPayload {
@@ -401,6 +405,8 @@ export interface SubAgentFlowRefinementSuccessPayload {
   executionTimeMs: number;
   /** Response timestamp */
   timestamp: string; // ISO 8601
+  /** Whether session was reconnected due to session expiration (fallback occurred) */
+  sessionReconnected?: boolean;
 }
 
 // ============================================================================

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -72,6 +72,7 @@ const App: React.FC = () => {
     () => ({
       conversationHistory: refinementStore.conversationHistory,
       isProcessing: refinementStore.isProcessing,
+      sessionStatus: refinementStore.sessionStatus,
       currentInput: refinementStore.currentInput,
       currentRequestId: refinementStore.currentRequestId,
       setInput: refinementStore.setInput,

--- a/src/webview/src/components/dialogs/AlertDialog.tsx
+++ b/src/webview/src/components/dialogs/AlertDialog.tsx
@@ -1,0 +1,126 @@
+/**
+ * AlertDialog Component
+ *
+ * シンプルな警告ダイアログコンポーネント
+ * OKボタンのみで、ユーザーに情報を通知する用途
+ * Radix UI Dialogを使用
+ */
+
+import * as Dialog from '@radix-ui/react-dialog';
+import type React from 'react';
+
+interface AlertDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  okLabel: string;
+  onClose: () => void;
+  /** Optional icon to display before title */
+  icon?: React.ReactNode;
+}
+
+/**
+ * 警告ダイアログコンポーネント
+ */
+export const AlertDialog: React.FC<AlertDialogProps> = ({
+  isOpen,
+  title,
+  message,
+  okLabel,
+  onClose,
+  icon,
+}) => {
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 10001,
+          }}
+        >
+          <Dialog.Content
+            style={{
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '24px',
+              minWidth: '400px',
+              maxWidth: '500px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
+            }}
+            onEscapeKeyDown={onClose}
+          >
+            {/* Title with optional icon */}
+            <Dialog.Title
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '16px',
+              }}
+            >
+              {icon}
+              {title}
+            </Dialog.Title>
+
+            {/* Message */}
+            <Dialog.Description
+              style={{
+                fontSize: '13px',
+                color: 'var(--vscode-descriptionForeground)',
+                marginBottom: '24px',
+                lineHeight: '1.6',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {message}
+            </Dialog.Description>
+
+            {/* OK Button */}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={onClose}
+                style={{
+                  padding: '6px 20px',
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+                }}
+              >
+                {okLabel}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default AlertDialog;

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -416,6 +416,11 @@ export interface WebviewTranslationKeys {
   // Refinement Success Messages
   'refinement.success.defaultMessage': string;
 
+  // Refinement Session Status
+  'refinement.session.warningDialog.title': string;
+  'refinement.session.warningDialog.message': string;
+  'refinement.session.warningDialog.ok': string;
+
   // Refinement Errors
   'refinement.error.emptyMessage': string;
   'refinement.error.messageTooLong': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -458,6 +458,12 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Success Messages
   'refinement.success.defaultMessage': 'Workflow has been updated.',
 
+  // Refinement Session Status
+  'refinement.session.warningDialog.title': 'AI Editing Session Reconnected',
+  'refinement.session.warningDialog.message':
+    'The AI conversation session could not be continued due to reasons such as loading a workflow shared by others or session expiration, so a new conversation session was started.\n\nAdditional context that the AI remembered in the previous conversation session (file contents, tool execution results, etc.) may have been lost.\n\nPlease re-share any relevant information in your message if needed.',
+  'refinement.session.warningDialog.ok': 'OK',
+
   // Refinement Errors
   'refinement.error.emptyMessage': 'Please enter a message',
   'refinement.error.messageTooLong': 'Message is too long (max {max} characters)',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -457,6 +457,12 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Success Messages
   'refinement.success.defaultMessage': 'ワークフローを編集しました。',
 
+  // Refinement Session Status
+  'refinement.session.warningDialog.title': 'AI編集のセッションが再接続されました',
+  'refinement.session.warningDialog.message':
+    '他者から共有されたワークフローの読み込みや、セッションの有効期限切れなどの理由で、AI会話セッションを継続できなかったため、新しい会話セッションを開始しました。\n\n前の会話セッションでAIが記憶していた追加のコンテキスト（ファイルの内容、ツール実行結果など）は失われている可能性があります。\n\n必要に応じて、関連する情報を改めてメッセージで伝えてください。',
+  'refinement.session.warningDialog.ok': 'OK',
+
   // Refinement Errors
   'refinement.error.emptyMessage': 'メッセージを入力してください',
   'refinement.error.messageTooLong': 'メッセージが長すぎます（最大{max}文字）',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -458,6 +458,12 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Success Messages
   'refinement.success.defaultMessage': '워크플로를 편집했습니다.',
 
+  // Refinement Session Status
+  'refinement.session.warningDialog.title': 'AI 편집 세션이 재연결되었습니다',
+  'refinement.session.warningDialog.message':
+    '다른 사용자가 공유한 워크플로우를 불러오거나 세션 만료 등의 이유로 AI 대화 세션을 계속할 수 없어 새 대화 세션을 시작했습니다.\n\n이전 대화 세션에서 AI가 기억하고 있던 추가 컨텍스트(파일 내용, 도구 실행 결과 등)는 손실되었을 수 있습니다.\n\n필요한 경우 관련 정보를 메시지로 다시 전달해 주세요.',
+  'refinement.session.warningDialog.ok': 'OK',
+
   // Refinement Errors
   'refinement.error.emptyMessage': '메시지를 입력하세요',
   'refinement.error.messageTooLong': '메시지가 너무 깁니다 (최대 {max}자)',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -442,6 +442,12 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Success Messages
   'refinement.success.defaultMessage': '已编辑工作流。',
 
+  // Refinement Session Status
+  'refinement.session.warningDialog.title': 'AI编辑会话已重新连接',
+  'refinement.session.warningDialog.message':
+    '由于加载他人共享的工作流或会话过期等原因，无法继续AI对话会话，已开始新的对话会话。\n\n之前对话会话中AI记住的额外上下文（文件内容、工具执行结果等）可能已丢失。\n\n如有需要，请在消息中重新分享相关信息。',
+  'refinement.session.warningDialog.ok': 'OK',
+
   // Refinement Errors
   'refinement.error.emptyMessage': '请输入消息',
   'refinement.error.messageTooLong': '消息太长（最多{max}个字符）',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -442,6 +442,12 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Success Messages
   'refinement.success.defaultMessage': '已編輯工作流程。',
 
+  // Refinement Session Status
+  'refinement.session.warningDialog.title': 'AI編輯會話已重新連接',
+  'refinement.session.warningDialog.message':
+    '由於載入他人共享的工作流程或會話過期等原因，無法繼續AI對話會話，已開始新的對話會話。\n\n之前對話會話中AI記住的額外上下文（檔案內容、工具執行結果等）可能已遺失。\n\n如有需要，請在訊息中重新分享相關資訊。',
+  'refinement.session.warningDialog.ok': 'OK',
+
   // Refinement Errors
   'refinement.error.emptyMessage': '請輸入訊息',
   'refinement.error.messageTooLong': '訊息太長（最多{max}個字元）',

--- a/src/webview/src/types/refinement-chat-state.ts
+++ b/src/webview/src/types/refinement-chat-state.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ConversationHistory, ConversationMessage } from '@shared/types/workflow-definition';
+import type { SessionStatus } from '../stores/refinement-store';
 
 /** Error codes for refinement failures */
 export type RefinementErrorCode =
@@ -26,6 +27,7 @@ export interface RefinementChatState {
   // State
   conversationHistory: ConversationHistory | null;
   isProcessing: boolean;
+  sessionStatus: SessionStatus;
   currentInput: string;
   currentRequestId: string | null;
 
@@ -45,7 +47,7 @@ export interface RefinementChatState {
   removeMessage: (messageId: string) => void;
   clearHistory: () => void;
   startProcessing: (requestId: string) => void;
-  finishProcessing: (sessionId?: string) => void;
+  finishProcessing: (sessionId?: string, sessionReconnected?: boolean) => void;
   handleRefinementSuccess: (
     aiMessage: ConversationMessage,
     updatedHistory: ConversationHistory


### PR DESCRIPTION
## Problem

When users load a workflow shared by others or when the Claude Code CLI session expires, the AI editing session cannot be continued. However, users were not informed about this situation, leading to confusion about why AI might not remember previous context.

### Current Behavior
1. User loads a shared workflow or session expires
2. ❌ AI silently starts a new session without notification
3. ❌ User doesn't understand why AI lost context

### Expected Behavior
1. User loads a shared workflow or session expires
2. ✅ Warning dialog explains the situation clearly
3. ✅ User understands AI can only reference conversation history

## Solution

Add session reconnection detection and warning dialog to inform users when a new conversation session is started.

### Changes

**Session Reconnection Detection**
- Added error pattern matching in `refinement-service.ts` for:
  - `'no conversation found with session id'`
  - `'not a valid uuid'`

**Warning Dialog (AlertDialog Component)**
- New `AlertDialog.tsx` component for simple OK-only dialogs
- Shows warning when session status changes to 'reconnected'
- Clear explanation of what happened and what context may be lost

**i18n Support**
- Added translations for 5 languages (en, ja, ko, zh-CN, zh-TW)
- Warning dialog title: "AI Editing Session Reconnected"
- Message explains reasons (shared workflow, session expiration) and impact

**Removed SessionStatusBadge UI**
- Replaced persistent badge with one-time warning dialog
- Cleaner UX - users only see notification when relevant

## Impact

- Improved UX for session reconnection scenarios
- No breaking changes
- Users are now informed when AI context may be lost

## Testing

- [x] Manual E2E testing completed
- [x] Build verification passed
- [x] Code quality checks passed (format, lint, check)