### PR TITLE
fix: enforce lowercase-only workflow and SubAgentFlow names

### DIFF
--- a/src/extension/commands/save-workflow.ts
+++ b/src/extension/commands/save-workflow.ts
@@ -111,11 +111,11 @@ function validateWorkflow(workflow: Workflow): void {
     throw new Error('Workflow name is required');
   }
 
-  // Validate name format (alphanumeric, hyphen, underscore only)
-  const namePattern = /^[a-zA-Z0-9_-]+$/;
+  // Validate name format (lowercase, numbers, hyphen, underscore only)
+  const namePattern = /^[a-z0-9_-]+$/;
   if (!namePattern.test(workflow.name)) {
     throw new Error(
-      'Workflow name must contain only alphanumeric characters, hyphens, and underscores'
+      'Workflow name must contain only lowercase letters, numbers, hyphens, and underscores'
     );
   }
 

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -448,6 +448,7 @@ export const VALIDATION_RULES = {
     MAX_NODES: 50,
     NAME_MIN_LENGTH: 1,
     NAME_MAX_LENGTH: 100,
+    NAME_PATTERN: /^[a-z0-9_-]+$/, // Lowercase only (for cross-platform file system compatibility)
     VERSION_PATTERN: /^\d+\.\d+\.\d+$/,
   },
   NODE: {
@@ -518,7 +519,7 @@ export const VALIDATION_RULES = {
   SUB_AGENT_FLOW: {
     NAME_MIN_LENGTH: 1,
     NAME_MAX_LENGTH: 50,
-    NAME_PATTERN: /^[a-zA-Z0-9_-]+$/, // Alphanumeric, hyphens, underscores only
+    NAME_PATTERN: /^[a-z0-9_-]+$/, // Lowercase only (for cross-platform file system compatibility)
     DESCRIPTION_MAX_LENGTH: 200,
     MAX_NODES: 30, // Smaller than main workflow
     // Node-specific validation (for SubAgentFlow reference nodes)

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -77,7 +77,24 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   const [isLoadingFile, setIsLoadingFile] = useState(false);
   const [isGeneratingName, setIsGeneratingName] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [workflowNameError, setWorkflowNameError] = useState<string | null>(null);
   const generationNameRequestIdRef = useRef<string | null>(null);
+
+  // Workflow name validation pattern (lowercase, numbers, hyphens, underscores only)
+  const WORKFLOW_NAME_PATTERN = /^[a-z0-9_-]*$/;
+
+  // Handle workflow name change with validation
+  const handleWorkflowNameChange = useCallback(
+    (value: string) => {
+      setWorkflowName(value);
+      if (value && !WORKFLOW_NAME_PATTERN.test(value)) {
+        setWorkflowNameError(t('toolbar.error.workflowNameInvalid'));
+      } else {
+        setWorkflowNameError(null);
+      }
+    },
+    [setWorkflowName, t]
+  );
 
   // Handle reset workflow
   const handleResetWorkflow = useCallback(() => {
@@ -91,6 +108,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       onError({
         code: 'VALIDATION_ERROR',
         message: t('toolbar.error.workflowNameRequired'),
+      });
+      return;
+    }
+
+    // Validate workflow name pattern (lowercase only)
+    if (!WORKFLOW_NAME_PATTERN.test(workflowName)) {
+      onError({
+        code: 'VALIDATION_ERROR',
+        message: t('toolbar.error.workflowNameInvalid'),
       });
       return;
     }
@@ -198,6 +224,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       return;
     }
 
+    // Validate workflow name pattern (lowercase only)
+    if (!WORKFLOW_NAME_PATTERN.test(workflowName)) {
+      onError({
+        code: 'VALIDATION_ERROR',
+        message: t('toolbar.error.workflowNameInvalid'),
+      });
+      return;
+    }
+
     setIsExporting(true);
     try {
       // Issue #89: Get subAgentFlows from store for export
@@ -246,6 +281,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       onError({
         code: 'VALIDATION_ERROR',
         message: t('toolbar.error.workflowNameRequiredForExport'),
+      });
+      return;
+    }
+
+    // Validate workflow name pattern (lowercase only)
+    if (!WORKFLOW_NAME_PATTERN.test(workflowName)) {
+      onError({
+        code: 'VALIDATION_ERROR',
+        message: t('toolbar.error.workflowNameInvalid'),
       });
       return;
     }
@@ -457,9 +501,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             <div style={{ flex: 1, minWidth: 0 }}>
               <EditableNameField
                 value={workflowName}
-                onChange={setWorkflowName}
+                onChange={handleWorkflowNameChange}
                 placeholder={t('toolbar.workflowNamePlaceholder')}
                 disabled={isGeneratingName}
+                error={workflowNameError}
                 dataTour="workflow-name-input"
                 aiGeneration={{
                   isGenerating: isGeneratingName,

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -242,8 +242,8 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
   const [isGeneratingName, setIsGeneratingName] = useState(false);
   const generationNameRequestIdRef = useRef<string | null>(null);
 
-  // Sub-Agent Flow name pattern validation
-  const SUBAGENTFLOW_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+  // Sub-Agent Flow name pattern validation (lowercase only for cross-platform compatibility)
+  const SUBAGENTFLOW_NAME_PATTERN = /^[a-z0-9_-]+$/;
 
   // Handle name change with validation (local state only, saved on submit)
   const handleNameChange = useCallback(

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -46,6 +46,7 @@ export interface WebviewTranslationKeys {
 
   // Toolbar errors
   'toolbar.error.workflowNameRequired': string;
+  'toolbar.error.workflowNameInvalid': string;
   'toolbar.error.workflowNameRequiredForExport': string;
   'toolbar.error.selectWorkflowToLoad': string;
   'toolbar.error.validationFailed': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -48,6 +48,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar errors
   'toolbar.error.workflowNameRequired': 'Workflow name is required',
+  'toolbar.error.workflowNameInvalid':
+    'Use only lowercase letters (a-z), numbers, hyphens, and underscores',
   'toolbar.error.workflowNameRequiredForExport': 'Workflow name is required for export',
   'toolbar.error.selectWorkflowToLoad': 'Please select a workflow to load',
   'toolbar.error.validationFailed': 'Workflow validation failed',
@@ -125,7 +127,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'error.subAgentFlow.nameRequired': 'Name is required',
   'error.subAgentFlow.nameTooLong': 'Name must be 50 characters or less',
   'error.subAgentFlow.invalidName':
-    'Name must contain only letters, numbers, hyphens, and underscores',
+    'Name must contain only lowercase letters (a-z), numbers, hyphens, and underscores',
 
   // Quick start instructions
   'palette.nestedNotAllowed': 'Not available in Sub-Agent Flow (nesting not supported)',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -48,6 +48,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar errors
   'toolbar.error.workflowNameRequired': 'ワークフロー名は必須です',
+  'toolbar.error.workflowNameInvalid':
+    '半角英小文字(a-z)、数字、ハイフン、アンダースコアのみ使用可能です',
   'toolbar.error.workflowNameRequiredForExport': 'エクスポートにはワークフロー名が必要です',
   'toolbar.error.selectWorkflowToLoad': '読み込むワークフローを選択してください',
   'toolbar.error.validationFailed': 'ワークフローの検証に失敗しました',
@@ -124,7 +126,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '名前は必須です',
   'error.subAgentFlow.nameTooLong': '名前は50文字以内で入力してください',
-  'error.subAgentFlow.invalidName': '名前は英数字、ハイフン、アンダースコアのみ使用できます',
+  'error.subAgentFlow.invalidName':
+    '名前は半角英小文字(a-z)、数字、ハイフン、アンダースコアのみ使用できます',
 
   // Quick start instructions
   'palette.nestedNotAllowed': 'サブエージェントフロー内では使用できません（ネスト非対応）',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -48,6 +48,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar errors
   'toolbar.error.workflowNameRequired': '워크플로 이름이 필요합니다',
+  'toolbar.error.workflowNameInvalid': '영문 소문자(a-z), 숫자, 하이픈, 밑줄만 사용할 수 있습니다',
   'toolbar.error.workflowNameRequiredForExport': '내보내기에는 워크플로 이름이 필요합니다',
   'toolbar.error.selectWorkflowToLoad': '불러올 워크플로를 선택하세요',
   'toolbar.error.validationFailed': '워크플로 검증에 실패했습니다',
@@ -125,7 +126,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '이름은 필수입니다',
   'error.subAgentFlow.nameTooLong': '이름은 50자 이하여야 합니다',
-  'error.subAgentFlow.invalidName': '이름은 영문자, 숫자, 하이픈, 밑줄만 사용할 수 있습니다',
+  'error.subAgentFlow.invalidName':
+    '이름은 영문 소문자(a-z), 숫자, 하이픈, 밑줄만 사용할 수 있습니다',
 
   // Quick start instructions
   'palette.nestedNotAllowed': '서브 에이전트 플로우에서 사용할 수 없습니다 (중첩 미지원)',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -48,6 +48,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar errors
   'toolbar.error.workflowNameRequired': '工作流名称必填',
+  'toolbar.error.workflowNameInvalid': '只能使用英文小写字母(a-z)、数字、连字符和下划线',
   'toolbar.error.workflowNameRequiredForExport': '导出需要工作流名称',
   'toolbar.error.selectWorkflowToLoad': '请选择要加载的工作流',
   'toolbar.error.validationFailed': '工作流验证失败',
@@ -122,7 +123,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '名称为必填项',
   'error.subAgentFlow.nameTooLong': '名称不能超过50个字符',
-  'error.subAgentFlow.invalidName': '名称只能包含字母、数字、连字符和下划线',
+  'error.subAgentFlow.invalidName': '名称只能包含英文小写字母(a-z)、数字、连字符和下划线',
 
   // Quick start instructions
   'palette.nestedNotAllowed': '在子代理流程中不可用（不支持嵌套）',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -48,6 +48,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar errors
   'toolbar.error.workflowNameRequired': '工作流名稱為必填',
+  'toolbar.error.workflowNameInvalid': '只能使用英文小寫字母(a-z)、數字、連字號和底線',
   'toolbar.error.workflowNameRequiredForExport': '匯出需要工作流名稱',
   'toolbar.error.selectWorkflowToLoad': '請選擇要載入的工作流',
   'toolbar.error.validationFailed': '工作流驗證失敗',
@@ -122,7 +123,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // SubAgentFlow validation errors
   'error.subAgentFlow.nameRequired': '名稱為必填項',
   'error.subAgentFlow.nameTooLong': '名稱不能超過50個字元',
-  'error.subAgentFlow.invalidName': '名稱只能包含字母、數字、連字符和底線',
+  'error.subAgentFlow.invalidName': '名稱只能包含英文小寫字母(a-z)、數字、連字號和底線',
 
   // Quick start instructions
   'palette.nestedNotAllowed': '在子代理流程中不可用（不支援巢狀）',


### PR DESCRIPTION
## Problem

When a workflow is exported as a command file (`.claude/commands/*.md`), the filename is derived from the workflow name. Due to case-insensitivity differences between operating systems, uppercase letters in workflow names cause issues:

### Current Behavior
1. User creates a workflow named `General-worldflow-JP`
2. Export generates `.claude/commands/general-worldflow-jp.md` (lowercase)
3. User tries to run `/General-worldflow-JP`
4. ❌ Claude Code returns: `Unknown skill: General-worldflow-JP`

Additionally, on case-insensitive file systems (macOS/Windows), renaming from `Test.md` to `test.md` doesn't change the actual filename, causing Git synchronization issues across platforms.

### Expected Behavior
1. Workflow names only allow lowercase letters, numbers, hyphens, and underscores
2. Validation error is shown when uppercase letters are entered
3. ✅ Consistent behavior across all platforms

Fixes #415

## Solution

Enforce lowercase-only validation for workflow and SubAgentFlow names at multiple levels:

### Changes

**Validation Rules** (`src/shared/types/workflow-definition.ts`)
- Added `WORKFLOW.NAME_PATTERN: /^[a-z0-9_-]+$/`
- Updated `SUB_AGENT_FLOW.NAME_PATTERN` to lowercase only

**Extension Host** (`src/extension/commands/save-workflow.ts`)
- Updated validation regex to enforce lowercase

**UI Validation** (`src/webview/src/components/Toolbar.tsx`)
- Added real-time validation with error display
- Validation on Save, Export, and Run handlers

**SubAgentFlow Dialog** (`src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`)
- Updated pattern to lowercase only

**i18n** (5 languages)
- Added error messages for invalid workflow names

## Impact

- **Breaking Change**: Existing workflows with uppercase names will need to be renamed
- Users notified in #333 about this upcoming change
- Cross-platform Git compatibility improved

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)