### PR TITLE
fix: disable SubAgentFlow submit button when name validation fails

### DIFF
--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -554,6 +554,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                 <button
                   type="button"
                   onClick={handleSubmit}
+                  disabled={!!nameError}
                   title={t('subAgentFlow.dialog.submit')}
                   style={{
                     display: 'flex',
@@ -565,11 +566,15 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                     color: 'var(--vscode-button-foreground)',
                     border: 'none',
                     borderRadius: '4px',
-                    cursor: 'pointer',
-                    transition: 'background-color 0.2s',
+                    cursor: nameError ? 'not-allowed' : 'pointer',
+                    opacity: nameError ? 0.5 : 1,
+                    transition: 'background-color 0.2s, opacity 0.2s',
                   }}
                   onMouseEnter={(e) => {
-                    e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+                    if (!nameError) {
+                      e.currentTarget.style.backgroundColor =
+                        'var(--vscode-button-hoverBackground)';
+                    }
                   }}
                   onMouseLeave={(e) => {
                     e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';


### PR DESCRIPTION
## Problem

When editing a SubAgentFlow name, if the user enters an invalid name (e.g., containing uppercase letters), the validation error is shown but the dialog still closes when clicking "Done", silently failing to save the name.

### Current Behavior
1. Open SubAgentFlow dialog
2. Enter invalid name (e.g., `Test-Flow`)
3. Validation error is displayed
4. Click "Done" button
5. ❌ Dialog closes, name is **not saved**

### Expected Behavior
1. Open SubAgentFlow dialog
2. Enter invalid name
3. Validation error is displayed
4. ✅ "Done" button is disabled until error is fixed

Fixes #417

## Solution

Disable the submit button when `nameError` exists:
- Added `disabled={!!nameError}` prop
- Visual feedback: `opacity: 0.5`, `cursor: not-allowed`
- Hover effect disabled when button is disabled

## Changes

**File:** `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx`

```diff
<button
  type="button"
  onClick={handleSubmit}
+ disabled={!!nameError}
  style={{
-   cursor: 'pointer',
+   cursor: nameError ? 'not-allowed' : 'pointer',
+   opacity: nameError ? 0.5 : 1,
  }}
  onMouseEnter={(e) => {
+   if (!nameError) {
      e.currentTarget.style.backgroundColor = '...';
+   }
  }}
>
```

## Impact

- Users can no longer accidentally close the dialog with an invalid name
- Clear visual indication that the button is disabled

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)