### PR TITLE
improvement: Add context configuration option to SubAgent and SubAgentFlow nodes

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -61,10 +61,27 @@
           "enum": ["red", "blue", "green", "yellow", "purple", "orange", "pink", "cyan"],
           "description": "Visual indicator color for this sub-agent (optional)"
         },
+        "context": {
+          "type": "string",
+          "required": false,
+          "enum": ["fork"],
+          "description": "Context mode for sub-agent execution. 'fork' runs in an isolated sub-agent context (Claude Code v2.1.0+)"
+        },
         "outputPorts": { "type": "number", "required": true, "value": 1 }
       },
       "inputPorts": 1,
-      "outputPorts": 1
+      "outputPorts": 1,
+      "aiGenerationGuidance": {
+        "context": {
+          "description": "Use 'context: fork' when the sub-agent should run in an isolated context",
+          "useCases": [
+            "Handling sensitive/confidential data that should not leak to subsequent agents",
+            "Resetting conversation history to reduce token consumption",
+            "Ensuring isolated execution without inheriting parent context"
+          ],
+          "default": "Omit context field for default behavior (shared context with parent)"
+        }
+      }
     },
     "askUserQuestion": {
       "description": "Present a question with multiple-choice options",
@@ -302,6 +319,30 @@
           "required": false,
           "maxLength": 200,
           "description": "Optional description of what this sub-agent flow does"
+        },
+        "model": {
+          "type": "string",
+          "required": false,
+          "enum": ["sonnet", "opus", "haiku", "inherit"],
+          "default": "sonnet",
+          "description": "Model to use for this sub-agent flow execution"
+        },
+        "tools": {
+          "type": "string",
+          "required": false,
+          "description": "Comma-separated list of allowed tools"
+        },
+        "color": {
+          "type": "string",
+          "required": false,
+          "enum": ["red", "blue", "green", "yellow", "purple", "orange", "pink", "cyan"],
+          "description": "Visual indicator color for this sub-agent flow (optional)"
+        },
+        "context": {
+          "type": "string",
+          "required": false,
+          "enum": ["fork"],
+          "description": "Context mode for sub-agent flow execution. 'fork' runs in an isolated sub-agent context (Claude Code v2.1.0+)"
         },
         "outputPorts": {
           "type": "number",

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -61,12 +61,22 @@ nodeTypes:
         required: false
         enum[8]: red,blue,green,yellow,purple,orange,pink,cyan
         description: Visual indicator color for this sub-agent (optional)
+      context:
+        type: string
+        required: false
+        enum[1]: fork
+        description: Context mode for sub-agent execution. 'fork' runs in an isolated sub-agent context (Claude Code v2.1.0+)
       outputPorts:
         type: number
         required: true
         value: 1
     inputPorts: 1
     outputPorts: 1
+    aiGenerationGuidance:
+      context:
+        description: "Use 'context: fork' when the sub-agent should run in an isolated context"
+        useCases[3]: Handling sensitive/confidential data that should not leak to subsequent agents,Resetting conversation history to reduce token consumption,Ensuring isolated execution without inheriting parent context
+        default: Omit context field for default behavior (shared context with parent)
   askUserQuestion:
     description: Present a question with multiple-choice options
     fields:
@@ -305,6 +315,26 @@ nodeTypes:
         required: false
         maxLength: 200
         description: Optional description of what this sub-agent flow does
+      model:
+        type: string
+        required: false
+        enum[4]: sonnet,opus,haiku,inherit
+        default: sonnet
+        description: Model to use for this sub-agent flow execution
+      tools:
+        type: string
+        required: false
+        description: Comma-separated list of allowed tools
+      color:
+        type: string
+        required: false
+        enum[8]: red,blue,green,yellow,purple,orange,pink,cyan
+        description: Visual indicator color for this sub-agent flow (optional)
+      context:
+        type: string
+        required: false
+        enum[1]: fork
+        description: Context mode for sub-agent flow execution. 'fork' runs in an isolated sub-agent context (Claude Code v2.1.0+)
       outputPorts:
         type: number
         required: true

--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -240,6 +240,10 @@ function generateSubAgentFile(node: SubAgentNode): string {
     frontmatter.push(`color: ${data.color}`);
   }
 
+  if (data.context) {
+    frontmatter.push(`context: ${data.context}`);
+  }
+
   frontmatter.push('---');
   frontmatter.push('');
 
@@ -268,10 +272,11 @@ function generateSubAgentFlowAgentFile(
 ): string {
   const agentName = agentFileName;
 
-  // Get model/tools/color from referencing node, or use defaults
+  // Get model/tools/color/context from referencing node, or use defaults
   const model = referencingNode?.data.model || 'sonnet';
   const tools = referencingNode?.data.tools;
   const color = referencingNode?.data.color;
+  const context = referencingNode?.data.context;
 
   // YAML frontmatter (same structure as SubAgent)
   const frontmatter = [
@@ -289,6 +294,10 @@ function generateSubAgentFlowAgentFile(
 
   if (color) {
     frontmatter.push(`color: ${color}`);
+  }
+
+  if (context) {
+    frontmatter.push(`context: ${context}`);
   }
 
   frontmatter.push('---');

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -47,6 +47,8 @@ export interface SubAgentData {
   tools?: string;
   model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
   color?: 'red' | 'blue' | 'green' | 'yellow' | 'purple' | 'orange' | 'pink' | 'cyan';
+  /** Context mode for sub-agent execution. 'fork' runs in an isolated sub-agent context (Claude Code v2.1.0+). */
+  context?: 'fork';
   outputPorts: number;
 }
 
@@ -215,6 +217,8 @@ export interface SubAgentFlowNodeData {
   tools?: string;
   /** Visual color for the node */
   color?: keyof typeof SUB_AGENT_COLORS;
+  /** Context mode for sub-agent flow execution. 'fork' runs in an isolated sub-agent context (Claude Code v2.1.0+). */
+  context?: 'fork';
 }
 
 export interface McpNodeData {

--- a/src/webview/src/components/PropertyOverlay.tsx
+++ b/src/webview/src/components/PropertyOverlay.tsx
@@ -510,6 +510,53 @@ const SubAgentProperties: React.FC<{
 
       {/* Color */}
       <ColorPicker value={data.color} onChange={(color) => updateNodeData(node.id, { color })} />
+
+      {/* Context */}
+      <div>
+        <label
+          htmlFor="context-select"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('properties.subAgent.context')}
+        </label>
+        <select
+          id="context-select"
+          value={data.context || ''}
+          onChange={(e) =>
+            updateNodeData(node.id, {
+              context: e.target.value === 'fork' ? 'fork' : undefined,
+            })
+          }
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        >
+          <option value="">{t('properties.subAgent.contextDefault')}</option>
+          <option value="fork">{t('properties.subAgent.contextFork')}</option>
+        </select>
+        <div
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+            marginTop: '4px',
+          }}
+        >
+          {t('properties.subAgent.contextHelp')}
+        </div>
+      </div>
     </div>
   );
 };
@@ -2582,6 +2629,53 @@ const SubAgentFlowProperties: React.FC<{
 
       {/* Color */}
       <ColorPicker value={data.color} onChange={(color) => updateNodeData(node.id, { color })} />
+
+      {/* Context */}
+      <div>
+        <label
+          htmlFor="subagentflow-context-select"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('properties.subAgent.context')}
+        </label>
+        <select
+          id="subagentflow-context-select"
+          value={data.context || ''}
+          onChange={(e) =>
+            updateNodeData(node.id, {
+              context: e.target.value === 'fork' ? 'fork' : undefined,
+            })
+          }
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        >
+          <option value="">{t('properties.subAgent.contextDefault')}</option>
+          <option value="fork">{t('properties.subAgent.contextFork')}</option>
+        </select>
+        <div
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+            marginTop: '4px',
+          }}
+        >
+          {t('properties.subAgent.contextHelp')}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/webview/src/components/nodes/SubAgentFlowNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentFlowNode.tsx
@@ -144,6 +144,23 @@ export const SubAgentFlowNodeComponent: React.FC<NodeProps<SubAgentFlowNodeData>
               {data.color}
             </div>
           )}
+
+          {/* Context Fork Badge */}
+          {data.context === 'fork' && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: '#ffffff',
+                backgroundColor: '#6366f1',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                fontWeight: 600,
+              }}
+            >
+              Fork
+            </div>
+          )}
         </div>
 
         {/* Not linked warning */}

--- a/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -110,6 +110,23 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
               {data.color}
             </div>
           )}
+
+          {/* Context Fork Badge */}
+          {data.context === 'fork' && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: '#ffffff',
+                backgroundColor: '#6366f1',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                fontWeight: 600,
+              }}
+            >
+              Fork
+            </div>
+          )}
         </div>
 
         {/* Input Handle */}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -159,6 +159,10 @@ export interface WebviewTranslationKeys {
   'properties.subAgent.colorPlaceholder': string;
   'properties.subAgent.colorNone': string;
   'properties.subAgent.colorHelp': string;
+  'properties.subAgent.context': string;
+  'properties.subAgent.contextDefault': string;
+  'properties.subAgent.contextFork': string;
+  'properties.subAgent.contextHelp': string;
 
   // Skill properties
   'property.skillPath': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -167,6 +167,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'properties.subAgent.colorPlaceholder': 'Select color...',
   'properties.subAgent.colorNone': 'None',
   'properties.subAgent.colorHelp': 'Visual indicator color for this sub-agent',
+  'properties.subAgent.context': 'Context',
+  'properties.subAgent.contextDefault': 'Default',
+  'properties.subAgent.contextFork': 'Fork',
+  'properties.subAgent.contextHelp':
+    'Fork runs in an isolated sub-agent context (Claude Code v2.1.0+)',
 
   // Skill properties
   'property.skillPath': 'Skill Path',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -167,6 +167,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'properties.subAgent.colorPlaceholder': '色を選択...',
   'properties.subAgent.colorNone': 'なし',
   'properties.subAgent.colorHelp': 'このサブエージェントの視覚的な識別色',
+  'properties.subAgent.context': 'コンテキスト',
+  'properties.subAgent.contextDefault': 'デフォルト',
+  'properties.subAgent.contextFork': 'フォーク',
+  'properties.subAgent.contextHelp':
+    'フォークは独立したサブエージェントコンテキストで実行されます（Claude Code v2.1.0以降）',
 
   // Skill properties
   'property.skillPath': 'Skillパス',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -167,6 +167,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'properties.subAgent.colorPlaceholder': '색상 선택...',
   'properties.subAgent.colorNone': '없음',
   'properties.subAgent.colorHelp': '이 서브 에이전트의 시각적 식별 색상',
+  'properties.subAgent.context': '컨텍스트',
+  'properties.subAgent.contextDefault': '기본',
+  'properties.subAgent.contextFork': '포크',
+  'properties.subAgent.contextHelp':
+    '포크는 독립된 서브 에이전트 컨텍스트에서 실행됩니다 (Claude Code v2.1.0+)',
 
   // Skill properties
   'property.skillPath': 'Skill 경로',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -161,6 +161,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'properties.subAgent.colorPlaceholder': '选择颜色...',
   'properties.subAgent.colorNone': '无',
   'properties.subAgent.colorHelp': '此子代理的视觉标识颜色',
+  'properties.subAgent.context': '上下文',
+  'properties.subAgent.contextDefault': '默认',
+  'properties.subAgent.contextFork': '分叉',
+  'properties.subAgent.contextHelp': '分叉在独立的子代理上下文中运行（Claude Code v2.1.0+）',
 
   // Skill properties
   'property.skillPath': 'Skill路径',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -161,6 +161,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'properties.subAgent.colorPlaceholder': '選擇顏色...',
   'properties.subAgent.colorNone': '無',
   'properties.subAgent.colorHelp': '此子代理的視覺識別顏色',
+  'properties.subAgent.context': '上下文',
+  'properties.subAgent.contextDefault': '預設',
+  'properties.subAgent.contextFork': '分叉',
+  'properties.subAgent.contextHelp': '分叉在獨立的子代理上下文中運行（Claude Code v2.1.0+）',
 
   // Skill properties
   'property.skillPath': 'Skill路徑',


### PR DESCRIPTION
## Summary

Add `context: fork` support to SubAgent and SubAgentFlow nodes, aligning with Claude Code v2.1.0's isolated sub-agent context feature.

## Changes

### Type Definitions
- Added `context?: 'fork'` to `SubAgentData` and `SubAgentFlowNodeData` interfaces

### UI
- Added Context dropdown (Default/Fork) to SubAgent and SubAgentFlow property panels
- Added "Fork" badge on canvas nodes when context is set to fork
- i18n keys added for all 5 supported languages (en, ja, ko, zh-CN, zh-TW)

### Export
- `context: fork` now included in YAML frontmatter when configured:

```yaml
---
name: my-agent
description: Process data
model: sonnet
context: fork
---
```

### Schema
- Updated `workflow-schema.json` with context field documentation for both node types
- Added AI generation guidance for when to use `context: fork`

## Impact

- No breaking changes
- Backward compatible (context field is optional)

## Testing

- [x] Manual E2E testing completed
  - Context dropdown appears in SubAgent properties
  - Context dropdown appears in SubAgentFlow properties
  - Fork badge displayed on canvas when context is set
  - Export includes `context: fork` in YAML frontmatter
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

## Related

- Closes #412
- Replaces #414 (closed due to validation regression issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)