### PR TITLE
feat: add context: fork option for Slash Command export

### DIFF
--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -493,13 +493,19 @@ function escapeLabel(label: string): string {
  */
 function generateSlashCommandFile(workflow: Workflow): string {
   // YAML frontmatter
-  const frontmatter = [
+  const frontmatterLines = [
     '---',
     `description: ${workflow.description || workflow.name}`,
     'allowed-tools: Task,AskUserQuestion',
-    '---',
-    '',
-  ].join('\n');
+  ];
+
+  // Add context: fork if enabled (Claude Code v2.1.0+ feature)
+  if (workflow.slashCommandOptions?.contextFork) {
+    frontmatterLines.push('context: fork');
+  }
+
+  frontmatterLines.push('---', '');
+  const frontmatter = frontmatterLines.join('\n');
 
   // Mermaid flowchart
   const mermaidFlowchart = generateMermaidFlowchart(workflow);

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -37,6 +37,16 @@ export interface WorkflowMetadata {
   [key: string]: unknown;
 }
 
+/**
+ * Slash Command export options
+ *
+ * Options that affect how the workflow is exported as a Slash Command (.md file)
+ */
+export interface SlashCommandOptions {
+  /** If true, exports with context: fork for isolated sub-agent execution (Claude Code v2.1.0+) */
+  contextFork?: boolean;
+}
+
 // ============================================================================
 // Node Data Types
 // ============================================================================
@@ -437,6 +447,8 @@ export interface Workflow {
   conversationHistory?: ConversationHistory;
   /** Optional sub-agent flows defined within this workflow */
   subAgentFlows?: SubAgentFlow[];
+  /** Optional Slash Command export options */
+  slashCommandOptions?: SlashCommandOptions;
 }
 
 // ============================================================================

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -1,0 +1,103 @@
+/**
+ * Slash Command Options Dropdown Component
+ *
+ * Provides options for Slash Command export (Export/Run):
+ * - context: fork - Exports with `context: fork` for isolated sub-agent execution (Claude Code v2.1.0+)
+ */
+
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { Check, ChevronDown, GitFork } from 'lucide-react';
+import { useTranslation } from '../../i18n/i18n-context';
+
+// Fixed font sizes for dropdown menu (not responsive)
+const FONT_SIZES = {
+  small: 11,
+} as const;
+
+interface SlashCommandOptionsDropdownProps {
+  contextFork: boolean;
+  onToggleContextFork: () => void;
+}
+
+export function SlashCommandOptionsDropdown({
+  contextFork,
+  onToggleContextFork,
+}: SlashCommandOptionsDropdownProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          title={t('toolbar.slashCommandOptions')}
+          style={{
+            padding: '4px 6px',
+            backgroundColor: 'var(--vscode-button-secondaryBackground)',
+            color: 'var(--vscode-button-secondaryForeground)',
+            border: 'none',
+            borderRadius: '2px',
+            cursor: 'pointer',
+            fontSize: '13px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <ChevronDown size={14} />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          sideOffset={4}
+          align="end"
+          style={{
+            backgroundColor: 'var(--vscode-dropdown-background)',
+            border: '1px solid var(--vscode-dropdown-border)',
+            borderRadius: '4px',
+            boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+            zIndex: 9999,
+            minWidth: '200px',
+            padding: '4px',
+          }}
+        >
+          {/* Fork Context Toggle */}
+          <DropdownMenu.Item
+            onSelect={(e) => {
+              e.preventDefault(); // Prevent menu from closing
+              onToggleContextFork();
+            }}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <GitFork size={14} />
+            <span style={{ flex: 1 }}>context: fork</span>
+            {contextFork && <Check size={14} />}
+          </DropdownMenu.Item>
+
+          {/* Description text */}
+          <div
+            style={{
+              padding: '4px 12px 8px',
+              fontSize: '10px',
+              color: 'var(--vscode-descriptionForeground)',
+              lineHeight: '1.4',
+            }}
+          >
+            {t('toolbar.contextFork.tooltip')}
+          </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -60,6 +60,10 @@ export interface WebviewTranslationKeys {
   'toolbar.run': string;
   'toolbar.running': string;
 
+  // Toolbar slash command options dropdown
+  'toolbar.slashCommandOptions': string;
+  'toolbar.contextFork.tooltip': string;
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': string;
   'toolbar.help': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -65,6 +65,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.run': 'Run',
   'toolbar.running': 'Running...',
 
+  // Toolbar slash command options dropdown
+  'toolbar.slashCommandOptions': 'Slash Command Options',
+  'toolbar.contextFork.tooltip': 'Run in isolated sub-agent context (Claude Code v2.1.0+)',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'More',
   'toolbar.help': 'Help',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -65,6 +65,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.run': '実行',
   'toolbar.running': '実行中...',
 
+  // Toolbar slash command options dropdown
+  'toolbar.slashCommandOptions': 'Slash Commandオプション',
+  'toolbar.contextFork.tooltip':
+    '分離されたサブエージェントコンテキストで実行 (Claude Code v2.1.0+)',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'その他',
   'toolbar.help': 'ヘルプ',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -64,6 +64,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.run': '실행',
   'toolbar.running': '실행 중...',
 
+  // Toolbar slash command options dropdown
+  'toolbar.slashCommandOptions': 'Slash Command 옵션',
+  'toolbar.contextFork.tooltip': '분리된 서브 에이전트 컨텍스트에서 실행 (Claude Code v2.1.0+)',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '더보기',
   'toolbar.help': '도움말',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -62,6 +62,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.run': '执行',
   'toolbar.running': '执行中...',
 
+  // Toolbar slash command options dropdown
+  'toolbar.slashCommandOptions': 'Slash Command 选项',
+  'toolbar.contextFork.tooltip': '在隔离的子代理上下文中运行 (Claude Code v2.1.0+)',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '帮助',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -62,6 +62,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.run': '執行',
   'toolbar.running': '執行中...',
 
+  // Toolbar slash command options dropdown
+  'toolbar.slashCommandOptions': 'Slash Command 選項',
+  'toolbar.contextFork.tooltip': '在隔離的子代理上下文中運行 (Claude Code v2.1.0+)',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '說明',

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -23,6 +23,7 @@ import type { Edge, Node } from 'reactflow';
  * @param workflowDescription - Workflow description
  * @param conversationHistory - Optional conversation history to preserve
  * @param subAgentFlows - Optional sub-agent flows to include
+ * @param contextFork - Optional flag to export with context: fork for isolated execution
  * @returns Workflow definition
  */
 export function serializeWorkflow(
@@ -31,7 +32,8 @@ export function serializeWorkflow(
   workflowName: string,
   workflowDescription?: string,
   conversationHistory?: ConversationHistory,
-  subAgentFlows?: SubAgentFlow[]
+  subAgentFlows?: SubAgentFlow[],
+  contextFork?: boolean
 ): Workflow {
   // Convert React Flow nodes to WorkflowNodes
   const workflowNodes: WorkflowNode[] = nodes.map((node) => ({
@@ -66,6 +68,8 @@ export function serializeWorkflow(
     conversationHistory,
     // Issue #89: Include subAgentFlows if provided
     subAgentFlows,
+    // Include slashCommandOptions if contextFork is enabled
+    slashCommandOptions: contextFork ? { contextFork: true } : undefined,
   };
 
   return workflow;

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -50,6 +50,8 @@ interface WorkflowStore {
   isMinimapVisible: boolean;
   isDescriptionPanelVisible: boolean;
   isFocusMode: boolean;
+  /** If true, exports Slash Command with context: fork for isolated execution */
+  contextFork: boolean;
   lastAddedNodeId: string | null;
 
   // Sub-Agent Flow State (Feature: 089-subworkflow)
@@ -75,6 +77,7 @@ interface WorkflowStore {
   toggleMinimapVisibility: () => void;
   toggleDescriptionPanelVisibility: () => void;
   toggleFocusMode: () => void;
+  setContextFork: (value: boolean) => void;
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
@@ -248,6 +251,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     const saved = localStorage.getItem('cc-wf-studio.focusMode');
     return saved !== null ? saved === 'true' : false; // Default: off
   })(),
+  contextFork: false,
   lastAddedNodeId: null,
 
   // Sub-Agent Flow Initial State (Feature: 089-subworkflow)
@@ -352,6 +356,8 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     set({ isFocusMode: newValue });
   },
 
+  setContextFork: (contextFork: boolean) => set({ contextFork }),
+
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => {
     set({
@@ -439,6 +445,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       edges: [],
       selectedNodeId: null,
       workflowDescription: '', // Reset description
+      contextFork: false, // Reset context fork setting
       // Sub-Agent Flow関連の状態をクリア
       subAgentFlows: [],
       activeSubAgentFlowId: null,


### PR DESCRIPTION
## Summary

Add `context: fork` option for Slash Command export, enabling isolated sub-agent execution (Claude Code v2.1.0+ feature).

## Changes

### New Component
- **SlashCommandOptionsDropdown**: Dropdown menu for Slash Command export options (Export/Run)

### Type Definition
- Add `SlashCommandOptions` interface with `contextFork` field
- Add `slashCommandOptions` to `Workflow` interface

### Toolbar UI
- Group Export and Run buttons together
- Add ▼ dropdown button for options
- Show `context: fork` toggle in dropdown menu

### Export Service
- Output `context: fork` in YAML frontmatter when enabled

### i18n
- Add translations for 5 languages (en, ja, ko, zh-CN, zh-TW)

## UI Preview

```
┌────────┬─────┐ ┌──┐
│ Export │ Run │ │▼│
└────────┴─────┘ └──┘
```

## Output Example

When `context: fork` is enabled:
```yaml
---
description: My workflow
allowed-tools: Task,AskUserQuestion
context: fork
---
```

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)