### PR TITLE
feat: add model option to Slash Command export settings

### DIFF
--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -499,6 +499,11 @@ function generateSlashCommandFile(workflow: Workflow): string {
     'allowed-tools: Task,AskUserQuestion',
   ];
 
+  // Add model if specified and not 'default'
+  if (workflow.slashCommandOptions?.model && workflow.slashCommandOptions.model !== 'default') {
+    frontmatterLines.push(`model: ${workflow.slashCommandOptions.model}`);
+  }
+
   // Add context: fork if enabled (Claude Code v2.1.0+ feature)
   if (workflow.slashCommandOptions?.contextFork) {
     frontmatterLines.push('context: fork');

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -42,9 +42,14 @@ export interface WorkflowMetadata {
  *
  * Options that affect how the workflow is exported as a Slash Command (.md file)
  */
+/** Model options for Slash Command execution */
+export type SlashCommandModel = 'default' | 'sonnet' | 'opus' | 'haiku' | 'inherit';
+
 export interface SlashCommandOptions {
   /** If true, exports with context: fork for isolated sub-agent execution (Claude Code v2.1.0+) */
   contextFork?: boolean;
+  /** Model to use for Slash Command execution. 'default' means no model line in output */
+  model?: SlashCommandModel;
 }
 
 // ============================================================================

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -64,6 +64,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     toggleFocusMode,
     contextFork,
     setContextFork,
+    slashCommandModel,
+    setSlashCommandModel,
   } = useWorkflowStore();
   const {
     isProcessing,
@@ -127,7 +129,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsSaving(true);
     try {
       // Issue #89: Get subAgentFlows from store
-      const { subAgentFlows, workflowDescription, contextFork } = useWorkflowStore.getState();
+      const { subAgentFlows, workflowDescription, contextFork, slashCommandModel } =
+        useWorkflowStore.getState();
 
       // Phase 5 (T024): Serialize workflow with conversation history and subAgentFlows
       const workflow = serializeWorkflow(
@@ -137,7 +140,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         activeWorkflow?.conversationHistory,
         subAgentFlows,
-        contextFork
+        contextFork,
+        slashCommandModel
       );
 
       // Validate workflow before saving
@@ -185,6 +189,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           setWorkflowDescription(workflow.description || '');
           // Load contextFork from slashCommandOptions (default to false if not present)
           setContextFork(workflow.slashCommandOptions?.contextFork ?? false);
+          // Load model from slashCommandOptions (default to 'default' if not present)
+          setSlashCommandModel(workflow.slashCommandOptions?.model ?? 'default');
           // Set as active workflow to preserve conversation history
           setActiveWorkflow(workflow);
         }
@@ -218,6 +224,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setWorkflowName,
     setWorkflowDescription,
     setContextFork,
+    setSlashCommandModel,
   ]);
 
   const handleLoadWorkflow = () => {
@@ -249,7 +256,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsExporting(true);
     try {
       // Issue #89: Get subAgentFlows from store for export
-      const { subAgentFlows, workflowDescription, contextFork } = useWorkflowStore.getState();
+      const { subAgentFlows, workflowDescription, contextFork, slashCommandModel } =
+        useWorkflowStore.getState();
 
       // Serialize workflow with subAgentFlows and contextFork
       const workflow = serializeWorkflow(
@@ -259,7 +267,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         undefined, // conversationHistory not needed for export
         subAgentFlows,
-        contextFork
+        contextFork,
+        slashCommandModel
       );
 
       // Validate workflow before export
@@ -311,7 +320,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsRunning(true);
     try {
       // Issue #89: Get subAgentFlows from store for run
-      const { subAgentFlows, workflowDescription, contextFork } = useWorkflowStore.getState();
+      const { subAgentFlows, workflowDescription, contextFork, slashCommandModel } =
+        useWorkflowStore.getState();
 
       // Serialize workflow with subAgentFlows and contextFork
       const workflow = serializeWorkflow(
@@ -321,7 +331,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         undefined, // conversationHistory not needed for run
         subAgentFlows,
-        contextFork
+        contextFork,
+        slashCommandModel
       );
 
       // Validate workflow before run
@@ -440,7 +451,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       workflowName || 'Untitled',
       workflowDescription || undefined,
       activeWorkflow?.conversationHistory,
-      subAgentFlows
+      subAgentFlows,
+      contextFork,
+      slashCommandModel
     );
     setActiveWorkflow(currentWorkflow);
 
@@ -462,6 +475,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     workflowDescription,
     activeWorkflow?.conversationHistory,
     subAgentFlows,
+    contextFork,
+    slashCommandModel,
     setActiveWorkflow,
     loadConversationHistory,
     initConversation,
@@ -693,6 +708,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             <SlashCommandOptionsDropdown
               contextFork={contextFork}
               onToggleContextFork={() => setContextFork(!contextFork)}
+              model={slashCommandModel}
+              onModelChange={setSlashCommandModel}
             />
           </div>
         </div>

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -2,11 +2,13 @@
  * Slash Command Options Dropdown Component
  *
  * Provides options for Slash Command export (Export/Run):
+ * - model: Specify the model to use for execution (inherit/sonnet/opus/haiku)
  * - context: fork - Exports with `context: fork` for isolated sub-agent execution (Claude Code v2.1.0+)
  */
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Check, ChevronDown, GitFork } from 'lucide-react';
+import type { SlashCommandModel } from '@shared/types/workflow-definition';
+import { Check, ChevronDown, ChevronLeft, Cpu, GitFork } from 'lucide-react';
 import { useTranslation } from '../../i18n/i18n-context';
 
 // Fixed font sizes for dropdown menu (not responsive)
@@ -14,23 +16,36 @@ const FONT_SIZES = {
   small: 11,
 } as const;
 
+const MODEL_PRESETS: { value: SlashCommandModel; label: string }[] = [
+  { value: 'default', label: 'default' },
+  { value: 'inherit', label: 'inherit' },
+  { value: 'haiku', label: 'haiku' },
+  { value: 'sonnet', label: 'sonnet' },
+  { value: 'opus', label: 'opus' },
+];
+
 interface SlashCommandOptionsDropdownProps {
   contextFork: boolean;
   onToggleContextFork: () => void;
+  model: SlashCommandModel;
+  onModelChange: (model: SlashCommandModel) => void;
 }
 
 export function SlashCommandOptionsDropdown({
   contextFork,
   onToggleContextFork,
+  model,
+  onModelChange,
 }: SlashCommandOptionsDropdownProps) {
   const { t } = useTranslation();
+
+  const currentModelLabel = MODEL_PRESETS.find((p) => p.value === model)?.label || 'default';
 
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          title={t('toolbar.slashCommandOptions')}
           style={{
             padding: '4px 6px',
             backgroundColor: 'var(--vscode-button-secondaryBackground)',
@@ -62,40 +77,237 @@ export function SlashCommandOptionsDropdown({
             padding: '4px',
           }}
         >
-          {/* Fork Context Toggle */}
-          <DropdownMenu.Item
-            onSelect={(e) => {
-              e.preventDefault(); // Prevent menu from closing
-              onToggleContextFork();
-            }}
-            style={{
-              padding: '8px 12px',
-              fontSize: `${FONT_SIZES.small}px`,
-              color: 'var(--vscode-foreground)',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              outline: 'none',
-              borderRadius: '2px',
-            }}
-          >
-            <GitFork size={14} />
-            <span style={{ flex: 1 }}>context: fork</span>
-            {contextFork && <Check size={14} />}
-          </DropdownMenu.Item>
+          {/* Model Sub-menu */}
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger
+              style={{
+                padding: '8px 12px',
+                fontSize: `${FONT_SIZES.small}px`,
+                color: 'var(--vscode-foreground)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '8px',
+                outline: 'none',
+                borderRadius: '2px',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <ChevronLeft size={14} />
+                <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                  {currentModelLabel}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <Cpu size={14} />
+                <span>Model</span>
+              </div>
+            </DropdownMenu.SubTrigger>
 
-          {/* Description text */}
-          <div
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                sideOffset={4}
+                style={{
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+                  zIndex: 10000,
+                  minWidth: '100px',
+                  padding: '4px',
+                }}
+              >
+                <DropdownMenu.RadioGroup value={model}>
+                  {MODEL_PRESETS.map((preset) => (
+                    <DropdownMenu.RadioItem
+                      key={preset.value}
+                      value={preset.value}
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        onModelChange(preset.value);
+                      }}
+                      style={{
+                        padding: '6px 12px',
+                        fontSize: `${FONT_SIZES.small}px`,
+                        color: 'var(--vscode-foreground)',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        outline: 'none',
+                        borderRadius: '2px',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: '12px',
+                          height: '12px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <DropdownMenu.ItemIndicator>
+                          <Check size={12} />
+                        </DropdownMenu.ItemIndicator>
+                      </div>
+                      <span>{preset.label}</span>
+                    </DropdownMenu.RadioItem>
+                  ))}
+                </DropdownMenu.RadioGroup>
+
+                {/* Model Description */}
+                <div
+                  style={{
+                    padding: '6px 12px',
+                    fontSize: '10px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    lineHeight: '1.4',
+                    borderTop: '1px solid var(--vscode-dropdown-border)',
+                    marginTop: '4px',
+                  }}
+                >
+                  {t('toolbar.model.tooltip')}
+                </div>
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
+
+          <DropdownMenu.Separator
             style={{
-              padding: '4px 12px 8px',
-              fontSize: '10px',
-              color: 'var(--vscode-descriptionForeground)',
-              lineHeight: '1.4',
+              height: '1px',
+              backgroundColor: 'var(--vscode-dropdown-border)',
+              margin: '4px 0',
             }}
-          >
-            {t('toolbar.contextFork.tooltip')}
-          </div>
+          />
+
+          {/* Context Fork Sub-menu */}
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger
+              style={{
+                padding: '8px 12px',
+                fontSize: `${FONT_SIZES.small}px`,
+                color: 'var(--vscode-foreground)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '8px',
+                outline: 'none',
+                borderRadius: '2px',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <ChevronLeft size={14} />
+                <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                  {contextFork ? 'fork' : 'default'}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <GitFork size={14} />
+                <span>Context</span>
+              </div>
+            </DropdownMenu.SubTrigger>
+
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                sideOffset={4}
+                style={{
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+                  zIndex: 10000,
+                  minWidth: '100px',
+                  padding: '4px',
+                }}
+              >
+                <DropdownMenu.RadioGroup value={contextFork ? 'fork' : 'default'}>
+                  <DropdownMenu.RadioItem
+                    value="default"
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      if (contextFork) onToggleContextFork();
+                    }}
+                    style={{
+                      padding: '6px 12px',
+                      fontSize: `${FONT_SIZES.small}px`,
+                      color: 'var(--vscode-foreground)',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      outline: 'none',
+                      borderRadius: '2px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: '12px',
+                        height: '12px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <DropdownMenu.ItemIndicator>
+                        <Check size={12} />
+                      </DropdownMenu.ItemIndicator>
+                    </div>
+                    <span>default</span>
+                  </DropdownMenu.RadioItem>
+                  <DropdownMenu.RadioItem
+                    value="fork"
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      if (!contextFork) onToggleContextFork();
+                    }}
+                    style={{
+                      padding: '6px 12px',
+                      fontSize: `${FONT_SIZES.small}px`,
+                      color: 'var(--vscode-foreground)',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      outline: 'none',
+                      borderRadius: '2px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: '12px',
+                        height: '12px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <DropdownMenu.ItemIndicator>
+                        <Check size={12} />
+                      </DropdownMenu.ItemIndicator>
+                    </div>
+                    <span>fork</span>
+                  </DropdownMenu.RadioItem>
+                </DropdownMenu.RadioGroup>
+
+                {/* Context Fork Description */}
+                <div
+                  style={{
+                    padding: '6px 12px',
+                    fontSize: '10px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    lineHeight: '1.4',
+                    borderTop: '1px solid var(--vscode-dropdown-border)',
+                    marginTop: '4px',
+                  }}
+                >
+                  {t('toolbar.contextFork.tooltip')}
+                </div>
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -61,7 +61,7 @@ export interface WebviewTranslationKeys {
   'toolbar.running': string;
 
   // Toolbar slash command options dropdown
-  'toolbar.slashCommandOptions': string;
+  'toolbar.model.tooltip': string;
   'toolbar.contextFork.tooltip': string;
 
   // Toolbar more actions dropdown

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -66,7 +66,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': 'Running...',
 
   // Toolbar slash command options dropdown
-  'toolbar.slashCommandOptions': 'Slash Command Options',
+  'toolbar.model.tooltip': 'Specify the model to use for execution',
   'toolbar.contextFork.tooltip': 'Run in isolated sub-agent context (Claude Code v2.1.0+)',
 
   // Toolbar more actions dropdown

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -66,7 +66,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '実行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.slashCommandOptions': 'Slash Commandオプション',
+  'toolbar.model.tooltip': '実行に使用するモデルを指定',
   'toolbar.contextFork.tooltip':
     '分離されたサブエージェントコンテキストで実行 (Claude Code v2.1.0+)',
 

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -65,7 +65,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '실행 중...',
 
   // Toolbar slash command options dropdown
-  'toolbar.slashCommandOptions': 'Slash Command 옵션',
+  'toolbar.model.tooltip': '실행에 사용할 모델 지정',
   'toolbar.contextFork.tooltip': '분리된 서브 에이전트 컨텍스트에서 실행 (Claude Code v2.1.0+)',
 
   // Toolbar more actions dropdown

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -63,7 +63,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '执行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.slashCommandOptions': 'Slash Command 选项',
+  'toolbar.model.tooltip': '指定执行时使用的模型',
   'toolbar.contextFork.tooltip': '在隔离的子代理上下文中运行 (Claude Code v2.1.0+)',
 
   // Toolbar more actions dropdown

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -63,7 +63,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '執行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.slashCommandOptions': 'Slash Command 選項',
+  'toolbar.model.tooltip': '指定執行時使用的模型',
   'toolbar.contextFork.tooltip': '在隔離的子代理上下文中運行 (Claude Code v2.1.0+)',
 
   // Toolbar more actions dropdown

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -8,6 +8,7 @@
 import type {
   Connection,
   ConversationHistory,
+  SlashCommandModel,
   SubAgentFlow,
   Workflow,
   WorkflowNode,
@@ -24,6 +25,7 @@ import type { Edge, Node } from 'reactflow';
  * @param conversationHistory - Optional conversation history to preserve
  * @param subAgentFlows - Optional sub-agent flows to include
  * @param contextFork - Optional flag to export with context: fork for isolated execution
+ * @param model - Optional model to use for Slash Command execution
  * @returns Workflow definition
  */
 export function serializeWorkflow(
@@ -33,7 +35,8 @@ export function serializeWorkflow(
   workflowDescription?: string,
   conversationHistory?: ConversationHistory,
   subAgentFlows?: SubAgentFlow[],
-  contextFork?: boolean
+  contextFork?: boolean,
+  model?: SlashCommandModel
 ): Workflow {
   // Convert React Flow nodes to WorkflowNodes
   const workflowNodes: WorkflowNode[] = nodes.map((node) => ({
@@ -68,8 +71,14 @@ export function serializeWorkflow(
     conversationHistory,
     // Issue #89: Include subAgentFlows if provided
     subAgentFlows,
-    // Include slashCommandOptions if contextFork is enabled
-    slashCommandOptions: contextFork ? { contextFork: true } : undefined,
+    // Include slashCommandOptions if any option is set
+    slashCommandOptions:
+      contextFork || (model && model !== 'default')
+        ? {
+            ...(contextFork && { contextFork: true }),
+            ...(model && model !== 'default' && { model }),
+          }
+        : undefined,
   };
 
   return workflow;

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -8,7 +8,11 @@
 import type { McpNodeData } from '@shared/types/mcp-node';
 import { normalizeMcpNodeData } from '@shared/types/mcp-node';
 import type { Workflow } from '@shared/types/messages';
-import type { SubAgentFlow, WorkflowNode } from '@shared/types/workflow-definition';
+import type {
+  SlashCommandModel,
+  SubAgentFlow,
+  WorkflowNode,
+} from '@shared/types/workflow-definition';
 import { NodeType } from '@shared/types/workflow-definition';
 import type { Edge, Node, OnConnect, OnEdgesChange, OnNodesChange } from 'reactflow';
 import { addEdge, applyEdgeChanges, applyNodeChanges } from 'reactflow';
@@ -52,6 +56,8 @@ interface WorkflowStore {
   isFocusMode: boolean;
   /** If true, exports Slash Command with context: fork for isolated execution */
   contextFork: boolean;
+  /** Model to use for Slash Command execution */
+  slashCommandModel: SlashCommandModel;
   lastAddedNodeId: string | null;
 
   // Sub-Agent Flow State (Feature: 089-subworkflow)
@@ -78,6 +84,7 @@ interface WorkflowStore {
   toggleDescriptionPanelVisibility: () => void;
   toggleFocusMode: () => void;
   setContextFork: (value: boolean) => void;
+  setSlashCommandModel: (value: SlashCommandModel) => void;
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
@@ -252,6 +259,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     return saved !== null ? saved === 'true' : false; // Default: off
   })(),
   contextFork: false,
+  slashCommandModel: 'default',
   lastAddedNodeId: null,
 
   // Sub-Agent Flow Initial State (Feature: 089-subworkflow)
@@ -358,6 +366,8 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
 
   setContextFork: (contextFork: boolean) => set({ contextFork }),
 
+  setSlashCommandModel: (slashCommandModel: SlashCommandModel) => set({ slashCommandModel }),
+
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => {
     set({
@@ -446,6 +456,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       selectedNodeId: null,
       workflowDescription: '', // Reset description
       contextFork: false, // Reset context fork setting
+      slashCommandModel: 'default', // Reset model setting
       // Sub-Agent Flow関連の状態をクリア
       subAgentFlows: [],
       activeSubAgentFlowId: null,


### PR DESCRIPTION
## Summary

Add model selection option to Slash Command export settings, allowing users to specify which model to use for execution.

## Changes

- Add model selection dropdown with options: default, inherit, haiku, sonnet, opus
- `default`: No `model:` line in YAML frontmatter
- `inherit/haiku/sonnet/opus`: Outputs `model: <value>` in YAML frontmatter
- Update UI with SubMenu pattern matching AI settings dropdown style
- Add tooltip translations for model option (5 languages: en, ja, ko, zh-CN, zh-TW)

### Files Changed

| File | Change |
|------|--------|
| `src/shared/types/workflow-definition.ts` | Add `SlashCommandModel` type with 'default' option |
| `src/webview/src/stores/workflow-store.ts` | Add `slashCommandModel` state |
| `src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx` | Implement SubMenu UI for model/context selection |
| `src/webview/src/components/Toolbar.tsx` | Integrate model state |
| `src/webview/src/services/workflow-service.ts` | Add model to serialization |
| `src/extension/services/export-service.ts` | Add model to YAML frontmatter output |
| Translation files (5 languages) | Add `toolbar.model.tooltip` |

## Testing

- [x] Build passes (`npm run build`)
- [x] Lint/check passes (`npm run check`)
- [x] Manual E2E testing in VSCode Extension Development Host

🤖 Generated with [Claude Code](https://claude.com/claude-code)