### PR TITLE
fix: change contextFork boolean to context string for extensibility

### DIFF
--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -504,9 +504,9 @@ function generateSlashCommandFile(workflow: Workflow): string {
     frontmatterLines.push(`model: ${workflow.slashCommandOptions.model}`);
   }
 
-  // Add context: fork if enabled (Claude Code v2.1.0+ feature)
-  if (workflow.slashCommandOptions?.contextFork) {
-    frontmatterLines.push('context: fork');
+  // Add context if specified and not 'default' (Claude Code v2.1.0+ feature)
+  if (workflow.slashCommandOptions?.context && workflow.slashCommandOptions.context !== 'default') {
+    frontmatterLines.push(`context: ${workflow.slashCommandOptions.context}`);
   }
 
   frontmatterLines.push('---', '');

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -42,12 +42,15 @@ export interface WorkflowMetadata {
  *
  * Options that affect how the workflow is exported as a Slash Command (.md file)
  */
+/** Context options for Slash Command execution */
+export type SlashCommandContext = 'default' | 'fork';
+
 /** Model options for Slash Command execution */
 export type SlashCommandModel = 'default' | 'sonnet' | 'opus' | 'haiku' | 'inherit';
 
 export interface SlashCommandOptions {
-  /** If true, exports with context: fork for isolated sub-agent execution (Claude Code v2.1.0+) */
-  contextFork?: boolean;
+  /** Context mode for execution. 'default' means no context line in output */
+  context?: SlashCommandContext;
   /** Model to use for Slash Command execution. 'default' means no model line in output */
   model?: SlashCommandModel;
 }

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -62,8 +62,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     subAgentFlows,
     isFocusMode,
     toggleFocusMode,
-    contextFork,
-    setContextFork,
+    slashCommandContext,
+    setSlashCommandContext,
     slashCommandModel,
     setSlashCommandModel,
   } = useWorkflowStore();
@@ -129,7 +129,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsSaving(true);
     try {
       // Issue #89: Get subAgentFlows from store
-      const { subAgentFlows, workflowDescription, contextFork, slashCommandModel } =
+      const { subAgentFlows, workflowDescription, slashCommandContext, slashCommandModel } =
         useWorkflowStore.getState();
 
       // Phase 5 (T024): Serialize workflow with conversation history and subAgentFlows
@@ -140,7 +140,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         activeWorkflow?.conversationHistory,
         subAgentFlows,
-        contextFork,
+        slashCommandContext,
         slashCommandModel
       );
 
@@ -187,8 +187,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           setWorkflowName(workflow.name);
           // Load description from workflow (default to empty string if not present)
           setWorkflowDescription(workflow.description || '');
-          // Load contextFork from slashCommandOptions (default to false if not present)
-          setContextFork(workflow.slashCommandOptions?.contextFork ?? false);
+          // Load context from slashCommandOptions (default to 'default' if not present)
+          setSlashCommandContext(workflow.slashCommandOptions?.context ?? 'default');
           // Load model from slashCommandOptions (default to 'default' if not present)
           setSlashCommandModel(workflow.slashCommandOptions?.model ?? 'default');
           // Set as active workflow to preserve conversation history
@@ -223,7 +223,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setActiveWorkflow,
     setWorkflowName,
     setWorkflowDescription,
-    setContextFork,
+    setSlashCommandContext,
     setSlashCommandModel,
   ]);
 
@@ -256,10 +256,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsExporting(true);
     try {
       // Issue #89: Get subAgentFlows from store for export
-      const { subAgentFlows, workflowDescription, contextFork, slashCommandModel } =
+      const { subAgentFlows, workflowDescription, slashCommandContext, slashCommandModel } =
         useWorkflowStore.getState();
 
-      // Serialize workflow with subAgentFlows and contextFork
+      // Serialize workflow with subAgentFlows and context
       const workflow = serializeWorkflow(
         nodes,
         edges,
@@ -267,7 +267,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         undefined, // conversationHistory not needed for export
         subAgentFlows,
-        contextFork,
+        slashCommandContext,
         slashCommandModel
       );
 
@@ -320,10 +320,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsRunning(true);
     try {
       // Issue #89: Get subAgentFlows from store for run
-      const { subAgentFlows, workflowDescription, contextFork, slashCommandModel } =
+      const { subAgentFlows, workflowDescription, slashCommandContext, slashCommandModel } =
         useWorkflowStore.getState();
 
-      // Serialize workflow with subAgentFlows and contextFork
+      // Serialize workflow with subAgentFlows and context
       const workflow = serializeWorkflow(
         nodes,
         edges,
@@ -331,7 +331,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         undefined, // conversationHistory not needed for run
         subAgentFlows,
-        contextFork,
+        slashCommandContext,
         slashCommandModel
       );
 
@@ -452,7 +452,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       workflowDescription || undefined,
       activeWorkflow?.conversationHistory,
       subAgentFlows,
-      contextFork,
+      slashCommandContext,
       slashCommandModel
     );
     setActiveWorkflow(currentWorkflow);
@@ -475,7 +475,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     workflowDescription,
     activeWorkflow?.conversationHistory,
     subAgentFlows,
-    contextFork,
+    slashCommandContext,
     slashCommandModel,
     setActiveWorkflow,
     loadConversationHistory,
@@ -706,8 +706,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
             {/* Options Dropdown (separate with small gap) */}
             <SlashCommandOptionsDropdown
-              contextFork={contextFork}
-              onToggleContextFork={() => setContextFork(!contextFork)}
+              context={slashCommandContext}
+              onContextChange={setSlashCommandContext}
               model={slashCommandModel}
               onModelChange={setSlashCommandModel}
             />

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import type { SlashCommandModel } from '@shared/types/workflow-definition';
+import type { SlashCommandContext, SlashCommandModel } from '@shared/types/workflow-definition';
 import { Check, ChevronDown, ChevronLeft, Cpu, GitFork } from 'lucide-react';
 import { useTranslation } from '../../i18n/i18n-context';
 
@@ -15,6 +15,11 @@ import { useTranslation } from '../../i18n/i18n-context';
 const FONT_SIZES = {
   small: 11,
 } as const;
+
+const CONTEXT_PRESETS: { value: SlashCommandContext; label: string }[] = [
+  { value: 'default', label: 'default' },
+  { value: 'fork', label: 'fork' },
+];
 
 const MODEL_PRESETS: { value: SlashCommandModel; label: string }[] = [
   { value: 'default', label: 'default' },
@@ -25,20 +30,21 @@ const MODEL_PRESETS: { value: SlashCommandModel; label: string }[] = [
 ];
 
 interface SlashCommandOptionsDropdownProps {
-  contextFork: boolean;
-  onToggleContextFork: () => void;
+  context: SlashCommandContext;
+  onContextChange: (context: SlashCommandContext) => void;
   model: SlashCommandModel;
   onModelChange: (model: SlashCommandModel) => void;
 }
 
 export function SlashCommandOptionsDropdown({
-  contextFork,
-  onToggleContextFork,
+  context,
+  onContextChange,
   model,
   onModelChange,
 }: SlashCommandOptionsDropdownProps) {
   const { t } = useTranslation();
 
+  const currentContextLabel = CONTEXT_PRESETS.find((p) => p.value === context)?.label || 'default';
   const currentModelLabel = MODEL_PRESETS.find((p) => p.value === model)?.label || 'default';
 
   return (
@@ -182,7 +188,7 @@ export function SlashCommandOptionsDropdown({
             }}
           />
 
-          {/* Context Fork Sub-menu */}
+          {/* Context Sub-menu */}
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger
               style={{
@@ -201,7 +207,7 @@ export function SlashCommandOptionsDropdown({
               <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                 <ChevronLeft size={14} />
                 <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
-                  {contextFork ? 'fork' : 'default'}
+                  {currentContextLabel}
                 </span>
               </div>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -223,76 +229,46 @@ export function SlashCommandOptionsDropdown({
                   padding: '4px',
                 }}
               >
-                <DropdownMenu.RadioGroup value={contextFork ? 'fork' : 'default'}>
-                  <DropdownMenu.RadioItem
-                    value="default"
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      if (contextFork) onToggleContextFork();
-                    }}
-                    style={{
-                      padding: '6px 12px',
-                      fontSize: `${FONT_SIZES.small}px`,
-                      color: 'var(--vscode-foreground)',
-                      cursor: 'pointer',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '8px',
-                      outline: 'none',
-                      borderRadius: '2px',
-                    }}
-                  >
-                    <div
+                <DropdownMenu.RadioGroup value={context}>
+                  {CONTEXT_PRESETS.map((preset) => (
+                    <DropdownMenu.RadioItem
+                      key={preset.value}
+                      value={preset.value}
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        onContextChange(preset.value);
+                      }}
                       style={{
-                        width: '12px',
-                        height: '12px',
+                        padding: '6px 12px',
+                        fontSize: `${FONT_SIZES.small}px`,
+                        color: 'var(--vscode-foreground)',
+                        cursor: 'pointer',
                         display: 'flex',
                         alignItems: 'center',
-                        justifyContent: 'center',
+                        gap: '8px',
+                        outline: 'none',
+                        borderRadius: '2px',
                       }}
                     >
-                      <DropdownMenu.ItemIndicator>
-                        <Check size={12} />
-                      </DropdownMenu.ItemIndicator>
-                    </div>
-                    <span>default</span>
-                  </DropdownMenu.RadioItem>
-                  <DropdownMenu.RadioItem
-                    value="fork"
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      if (!contextFork) onToggleContextFork();
-                    }}
-                    style={{
-                      padding: '6px 12px',
-                      fontSize: `${FONT_SIZES.small}px`,
-                      color: 'var(--vscode-foreground)',
-                      cursor: 'pointer',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '8px',
-                      outline: 'none',
-                      borderRadius: '2px',
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: '12px',
-                        height: '12px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      <DropdownMenu.ItemIndicator>
-                        <Check size={12} />
-                      </DropdownMenu.ItemIndicator>
-                    </div>
-                    <span>fork</span>
-                  </DropdownMenu.RadioItem>
+                      <div
+                        style={{
+                          width: '12px',
+                          height: '12px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <DropdownMenu.ItemIndicator>
+                          <Check size={12} />
+                        </DropdownMenu.ItemIndicator>
+                      </div>
+                      <span>{preset.label}</span>
+                    </DropdownMenu.RadioItem>
+                  ))}
                 </DropdownMenu.RadioGroup>
 
-                {/* Context Fork Description */}
+                {/* Context Description */}
                 <div
                   style={{
                     padding: '6px 12px',

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -8,6 +8,7 @@
 import type {
   Connection,
   ConversationHistory,
+  SlashCommandContext,
   SlashCommandModel,
   SubAgentFlow,
   Workflow,
@@ -24,7 +25,7 @@ import type { Edge, Node } from 'reactflow';
  * @param workflowDescription - Workflow description
  * @param conversationHistory - Optional conversation history to preserve
  * @param subAgentFlows - Optional sub-agent flows to include
- * @param contextFork - Optional flag to export with context: fork for isolated execution
+ * @param context - Optional context mode for Slash Command execution
  * @param model - Optional model to use for Slash Command execution
  * @returns Workflow definition
  */
@@ -35,7 +36,7 @@ export function serializeWorkflow(
   workflowDescription?: string,
   conversationHistory?: ConversationHistory,
   subAgentFlows?: SubAgentFlow[],
-  contextFork?: boolean,
+  context?: SlashCommandContext,
   model?: SlashCommandModel
 ): Workflow {
   // Convert React Flow nodes to WorkflowNodes
@@ -73,9 +74,9 @@ export function serializeWorkflow(
     subAgentFlows,
     // Include slashCommandOptions if any option is set
     slashCommandOptions:
-      contextFork || (model && model !== 'default')
+      (context && context !== 'default') || (model && model !== 'default')
         ? {
-            ...(contextFork && { contextFork: true }),
+            ...(context && context !== 'default' && { context }),
             ...(model && model !== 'default' && { model }),
           }
         : undefined,

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -9,6 +9,7 @@ import type { McpNodeData } from '@shared/types/mcp-node';
 import { normalizeMcpNodeData } from '@shared/types/mcp-node';
 import type { Workflow } from '@shared/types/messages';
 import type {
+  SlashCommandContext,
   SlashCommandModel,
   SubAgentFlow,
   WorkflowNode,
@@ -54,8 +55,8 @@ interface WorkflowStore {
   isMinimapVisible: boolean;
   isDescriptionPanelVisible: boolean;
   isFocusMode: boolean;
-  /** If true, exports Slash Command with context: fork for isolated execution */
-  contextFork: boolean;
+  /** Context mode for Slash Command execution */
+  slashCommandContext: SlashCommandContext;
   /** Model to use for Slash Command execution */
   slashCommandModel: SlashCommandModel;
   lastAddedNodeId: string | null;
@@ -83,7 +84,7 @@ interface WorkflowStore {
   toggleMinimapVisibility: () => void;
   toggleDescriptionPanelVisibility: () => void;
   toggleFocusMode: () => void;
-  setContextFork: (value: boolean) => void;
+  setSlashCommandContext: (value: SlashCommandContext) => void;
   setSlashCommandModel: (value: SlashCommandModel) => void;
 
   // Custom Actions
@@ -258,7 +259,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     const saved = localStorage.getItem('cc-wf-studio.focusMode');
     return saved !== null ? saved === 'true' : false; // Default: off
   })(),
-  contextFork: false,
+  slashCommandContext: 'default',
   slashCommandModel: 'default',
   lastAddedNodeId: null,
 
@@ -364,7 +365,8 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     set({ isFocusMode: newValue });
   },
 
-  setContextFork: (contextFork: boolean) => set({ contextFork }),
+  setSlashCommandContext: (slashCommandContext: SlashCommandContext) =>
+    set({ slashCommandContext }),
 
   setSlashCommandModel: (slashCommandModel: SlashCommandModel) => set({ slashCommandModel }),
 
@@ -455,7 +457,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
       edges: [],
       selectedNodeId: null,
       workflowDescription: '', // Reset description
-      contextFork: false, // Reset context fork setting
+      slashCommandContext: 'default', // Reset context setting
       slashCommandModel: 'default', // Reset model setting
       // Sub-Agent Flow関連の状態をクリア
       subAgentFlows: [],


### PR DESCRIPTION
## Summary

Change `contextFork: boolean` to `context: SlashCommandContext` for future extensibility.

## Problem

The previous implementation used `contextFork: boolean` which only allowed true/false values. This limits future expansion when additional context options may be needed.

## Solution

Replace boolean with a string union type `SlashCommandContext = 'default' | 'fork'`, matching the pattern already used for `model`.

## Changes

| File | Change |
|------|--------|
| `src/shared/types/workflow-definition.ts` | Add `SlashCommandContext` type, replace `contextFork` with `context` |
| `src/webview/src/stores/workflow-store.ts` | `contextFork: boolean` → `slashCommandContext: SlashCommandContext` |
| `src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx` | Update props to use string type |
| `src/webview/src/components/Toolbar.tsx` | Update all references |
| `src/webview/src/services/workflow-service.ts` | Update serialization |
| `src/extension/services/export-service.ts` | Update YAML export |

## Behavior

| Selection | JSON Output | YAML Output |
|-----------|-------------|-------------|
| default | (none) | no `context:` line |
| fork | `"context": "fork"` | `context: fork` |

## Testing

- [x] Build passes (`npm run build`)
- [x] Lint/check passes (`npm run check`)
- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)