### PR TITLE
improvement: add hooks configuration UI for Slash Command export

### DIFF
--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -53,6 +53,45 @@ export interface SlashCommandOptions {
   context?: SlashCommandContext;
   /** Model to use for Slash Command execution. 'default' means no model line in output */
   model?: SlashCommandModel;
+  /** Hooks configuration for workflow execution */
+  hooks?: WorkflowHooks;
+}
+
+// ============================================================================
+// Hooks Configuration Types (Claude Code Docs compliant)
+// https://code.claude.com/docs/en/hooks
+// ============================================================================
+
+/** Supported hook types for workflow execution (frontmatter-compatible only) */
+export type HookType = 'PreToolUse' | 'PostToolUse' | 'Stop';
+
+/** Single hook action definition */
+export interface HookAction {
+  /** Hook type: 'command' for shell commands, 'prompt' for LLM-based (Stop only) */
+  type: 'command' | 'prompt';
+  /** Shell command to execute (required for type: 'command') */
+  command: string;
+  /** Run hook only once per session (optional) */
+  once?: boolean;
+}
+
+/** Hook entry with matcher and actions */
+export interface HookEntry {
+  /** Tool name pattern to match (e.g., "Bash", "Edit|Write", "*")
+   *  Required for PreToolUse/PostToolUse, optional for Stop */
+  matcher?: string;
+  /** Array of hook actions to execute */
+  hooks: HookAction[];
+}
+
+/** Hooks configuration for workflow execution */
+export interface WorkflowHooks {
+  /** Hooks to execute before a tool is used */
+  PreToolUse?: HookEntry[];
+  /** Hooks to execute after a tool is used */
+  PostToolUse?: HookEntry[];
+  /** Hooks to execute when the agent stops */
+  Stop?: HookEntry[];
 }
 
 // ============================================================================
@@ -455,7 +494,7 @@ export interface Workflow {
   conversationHistory?: ConversationHistory;
   /** Optional sub-agent flows defined within this workflow */
   subAgentFlows?: SubAgentFlow[];
-  /** Optional Slash Command export options */
+  /** Optional Slash Command export options (includes hooks) */
   slashCommandOptions?: SlashCommandOptions;
 }
 
@@ -546,5 +585,12 @@ export const VALIDATION_RULES = {
     LABEL_MIN_LENGTH: 1,
     LABEL_MAX_LENGTH: 50,
     OUTPUT_PORTS: 1, // Fixed: 1 output port
+  },
+  HOOKS: {
+    COMMAND_MIN_LENGTH: 1,
+    COMMAND_MAX_LENGTH: 2000,
+    MATCHER_MAX_LENGTH: 200,
+    MAX_ENTRIES_PER_HOOK: 10,
+    MAX_ACTIONS_PER_ENTRY: 5,
   },
 } as const;

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-toggle-group": "^1.1.11",
@@ -64,6 +65,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1009,30 +1011,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -1202,14 +1180,27 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1242,6 +1233,30 @@
         "@radix-ui/react-use-rect": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1",
         "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1379,30 +1394,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1522,30 +1513,6 @@
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-visually-hidden": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2654,6 +2621,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2664,6 +2632,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2792,6 +2761,7 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -2874,6 +2844,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2996,6 +2967,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3362,6 +3334,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3403,6 +3376,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3412,6 +3386,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3783,6 +3758,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3858,6 +3834,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/src/webview/package.json
+++ b/src/webview/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-toggle-group": "^1.1.11",

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -62,10 +62,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     subAgentFlows,
     isFocusMode,
     toggleFocusMode,
-    slashCommandContext,
+    slashCommandOptions,
+    setSlashCommandOptions,
     setSlashCommandContext,
-    slashCommandModel,
     setSlashCommandModel,
+    addHookEntry,
+    removeHookEntry,
+    updateHookEntry,
   } = useWorkflowStore();
   const {
     isProcessing,
@@ -129,10 +132,12 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsSaving(true);
     try {
       // Issue #89: Get subAgentFlows from store
-      const { subAgentFlows, workflowDescription, slashCommandContext, slashCommandModel } =
+      // Issue #413: Get slashCommandOptions from store
+      const { subAgentFlows, workflowDescription, slashCommandOptions } =
         useWorkflowStore.getState();
 
       // Phase 5 (T024): Serialize workflow with conversation history and subAgentFlows
+      // Issue #413: Include slashCommandOptions (context, model, hooks)
       const workflow = serializeWorkflow(
         nodes,
         edges,
@@ -140,8 +145,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         activeWorkflow?.conversationHistory,
         subAgentFlows,
-        slashCommandContext,
-        slashCommandModel
+        slashCommandOptions
       );
 
       // Validate workflow before saving
@@ -187,10 +191,12 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           setWorkflowName(workflow.name);
           // Load description from workflow (default to empty string if not present)
           setWorkflowDescription(workflow.description || '');
-          // Load context from slashCommandOptions (default to 'default' if not present)
-          setSlashCommandContext(workflow.slashCommandOptions?.context ?? 'default');
-          // Load model from slashCommandOptions (default to 'default' if not present)
-          setSlashCommandModel(workflow.slashCommandOptions?.model ?? 'default');
+          // Issue #413: Load slashCommandOptions (context, model, hooks) as unified object
+          setSlashCommandOptions({
+            context: workflow.slashCommandOptions?.context ?? 'default',
+            model: workflow.slashCommandOptions?.model ?? 'default',
+            hooks: workflow.slashCommandOptions?.hooks,
+          });
           // Set as active workflow to preserve conversation history
           setActiveWorkflow(workflow);
         }
@@ -223,8 +229,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setActiveWorkflow,
     setWorkflowName,
     setWorkflowDescription,
-    setSlashCommandContext,
-    setSlashCommandModel,
+    setSlashCommandOptions,
   ]);
 
   const handleLoadWorkflow = () => {
@@ -256,10 +261,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsExporting(true);
     try {
       // Issue #89: Get subAgentFlows from store for export
-      const { subAgentFlows, workflowDescription, slashCommandContext, slashCommandModel } =
+      // Issue #413: Get slashCommandOptions from store for export
+      const { subAgentFlows, workflowDescription, slashCommandOptions } =
         useWorkflowStore.getState();
 
-      // Serialize workflow with subAgentFlows and context
+      // Serialize workflow with subAgentFlows and slashCommandOptions
       const workflow = serializeWorkflow(
         nodes,
         edges,
@@ -267,8 +273,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         undefined, // conversationHistory not needed for export
         subAgentFlows,
-        slashCommandContext,
-        slashCommandModel
+        slashCommandOptions
       );
 
       // Validate workflow before export
@@ -320,10 +325,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setIsRunning(true);
     try {
       // Issue #89: Get subAgentFlows from store for run
-      const { subAgentFlows, workflowDescription, slashCommandContext, slashCommandModel } =
+      // Issue #413: Get slashCommandOptions from store for run
+      const { subAgentFlows, workflowDescription, slashCommandOptions } =
         useWorkflowStore.getState();
 
-      // Serialize workflow with subAgentFlows and context
+      // Serialize workflow with subAgentFlows and slashCommandOptions
       const workflow = serializeWorkflow(
         nodes,
         edges,
@@ -331,8 +337,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         workflowDescription || undefined,
         undefined, // conversationHistory not needed for run
         subAgentFlows,
-        slashCommandContext,
-        slashCommandModel
+        slashCommandOptions
       );
 
       // Validate workflow before run
@@ -445,6 +450,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
     // Serialize current workflow state to set as active workflow
     // Include subAgentFlows to preserve SubAgentFlow references
+    // Issue #413: Include slashCommandOptions configuration
     const currentWorkflow = serializeWorkflow(
       nodes,
       edges,
@@ -452,8 +458,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       workflowDescription || undefined,
       activeWorkflow?.conversationHistory,
       subAgentFlows,
-      slashCommandContext,
-      slashCommandModel
+      slashCommandOptions
     );
     setActiveWorkflow(currentWorkflow);
 
@@ -475,8 +480,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     workflowDescription,
     activeWorkflow?.conversationHistory,
     subAgentFlows,
-    slashCommandContext,
-    slashCommandModel,
+    slashCommandOptions,
     setActiveWorkflow,
     loadConversationHistory,
     initConversation,
@@ -705,11 +709,16 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             </div>
 
             {/* Options Dropdown (separate with small gap) */}
+            {/* Issue #413: Hooks are now integrated into SlashCommandOptionsDropdown */}
             <SlashCommandOptionsDropdown
-              context={slashCommandContext}
+              context={slashCommandOptions.context ?? 'default'}
               onContextChange={setSlashCommandContext}
-              model={slashCommandModel}
+              model={slashCommandOptions.model ?? 'default'}
               onModelChange={setSlashCommandModel}
+              hooks={slashCommandOptions.hooks ?? {}}
+              onAddHookEntry={addHookEntry}
+              onRemoveHookEntry={removeHookEntry}
+              onUpdateHookEntry={updateHookEntry}
             />
           </div>
         </div>

--- a/src/webview/src/components/common/TagInput.tsx
+++ b/src/webview/src/components/common/TagInput.tsx
@@ -1,0 +1,182 @@
+/**
+ * TagInput Component
+ *
+ * A reusable tag input component for entering multiple values as tags.
+ * Enter to add a tag, × to remove, Backspace to remove the last tag when input is empty.
+ * Used for matcher patterns in Hooks configuration (e.g., "Bash", "Edit", "Write").
+ */
+
+import { X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+interface TagInputProps {
+  /** Current tags array */
+  tags: string[];
+  /** Callback when tags change */
+  onChange: (tags: string[]) => void;
+  /** Placeholder text for the input */
+  placeholder?: string;
+  /** Disable the input */
+  disabled?: boolean;
+  /** Add nodrag class for React Flow compatibility */
+  className?: string;
+}
+
+/**
+ * TagInput - A tag-based input component
+ *
+ * Features:
+ * - Enter to add a new tag
+ * - × button to remove individual tags
+ * - Backspace to remove last tag when input is empty
+ * - IME composition support (Japanese/Chinese/Korean input)
+ * - Duplicate prevention
+ * - Whitespace trimming
+ */
+export function TagInput({
+  tags,
+  onChange,
+  placeholder = 'Type and press Enter',
+  disabled = false,
+  className,
+}: TagInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleAddTag = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+
+    // Prevent duplicates
+    if (tags.includes(trimmed)) {
+      setInputValue('');
+      return;
+    }
+
+    onChange([...tags, trimmed]);
+    setInputValue('');
+  }, [inputValue, tags, onChange]);
+
+  const handleRemoveTag = useCallback(
+    (indexToRemove: number) => {
+      onChange(tags.filter((_, index) => index !== indexToRemove));
+    },
+    [tags, onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Stop arrow key propagation to prevent parent menu navigation
+      if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        e.stopPropagation();
+        return;
+      }
+
+      // Skip if IME is composing
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleAddTag();
+      } else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+        // Remove last tag when input is empty
+        handleRemoveTag(tags.length - 1);
+      }
+    },
+    [handleAddTag, handleRemoveTag, inputValue, tags.length]
+  );
+
+  return (
+    <div
+      className={className}
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: '4px',
+        padding: '2px 4px',
+        minHeight: '24px',
+        backgroundColor: 'var(--vscode-input-background)',
+        border: '1px solid var(--vscode-input-border)',
+        borderRadius: '2px',
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {/* Tags */}
+      {tags.map((tag, index) => (
+        <span
+          key={tag}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '2px',
+            padding: '1px 6px',
+            backgroundColor: 'var(--vscode-badge-background)',
+            color: 'var(--vscode-badge-foreground)',
+            borderRadius: '10px',
+            fontSize: '11px',
+            fontFamily: 'monospace',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {tag}
+          {!disabled && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                handleRemoveTag(index);
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '0',
+                marginLeft: '2px',
+                backgroundColor: 'transparent',
+                border: 'none',
+                borderRadius: '50%',
+                cursor: 'pointer',
+                color: 'var(--vscode-badge-foreground)',
+                opacity: 0.7,
+                transition: 'opacity 100ms',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = '1';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = '0.7';
+              }}
+              aria-label={`Remove ${tag}`}
+            >
+              <X size={12} />
+            </button>
+          )}
+        </span>
+      ))}
+
+      {/* Input field */}
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={tags.length === 0 ? placeholder : ''}
+        disabled={disabled}
+        style={{
+          flex: 1,
+          minWidth: '60px',
+          padding: '2px 4px',
+          backgroundColor: 'transparent',
+          color: 'var(--vscode-input-foreground)',
+          border: 'none',
+          outline: 'none',
+          fontSize: '11px',
+          fontFamily: 'monospace',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/webview/src/components/common/ToolSelectTagInput.tsx
+++ b/src/webview/src/components/common/ToolSelectTagInput.tsx
@@ -1,0 +1,307 @@
+/**
+ * ToolSelectTagInput Component
+ *
+ * A React-Select style tool selection component for Hooks configuration.
+ * Tags and input are in the same container, typing filters the dropdown.
+ * Used for matcher patterns in Hooks configuration (e.g., "Bash", "Edit", "Write").
+ */
+
+import * as Popover from '@radix-ui/react-popover';
+import { Check, X } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { HOOKS_MATCHER_TOOLS } from '../../stores/refinement-store';
+
+interface ToolSelectTagInputProps {
+  /** Selected tools array */
+  selectedTools: string[];
+  /** Callback when tools change */
+  onChange: (tools: string[]) => void;
+  /** Disable the input */
+  disabled?: boolean;
+  /** Additional className */
+  className?: string;
+}
+
+/**
+ * ToolSelectTagInput - React-Select style tool selector
+ *
+ * Features:
+ * - Tags and input in the same container
+ * - Click anywhere to focus input
+ * - Type to filter and open dropdown
+ * - Click outside or Esc to close
+ */
+export function ToolSelectTagInput({
+  selectedTools,
+  onChange,
+  disabled = false,
+  className,
+}: ToolSelectTagInputProps) {
+  const [inputValue, setInputValue] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filteredTools = HOOKS_MATCHER_TOOLS.filter(
+    (tool) => tool.toLowerCase().includes(inputValue.toLowerCase()) && !selectedTools.includes(tool)
+  );
+
+  const handleToggleTool = useCallback(
+    (tool: string) => {
+      if (selectedTools.includes(tool)) {
+        onChange(selectedTools.filter((t) => t !== tool));
+      } else {
+        onChange([...selectedTools, tool]);
+        setInputValue('');
+      }
+    },
+    [selectedTools, onChange]
+  );
+
+  const handleRemoveTag = useCallback(
+    (tool: string, e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onChange(selectedTools.filter((t) => t !== tool));
+    },
+    [selectedTools, onChange]
+  );
+
+  const handleContainerClick = useCallback(() => {
+    if (!disabled) {
+      inputRef.current?.focus();
+      setIsOpen(true);
+    }
+  }, [disabled]);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    setHighlightedIndex(0);
+    setIsOpen(true);
+  }, []);
+
+  const handleInputFocus = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Skip if IME is composing (e.g., Japanese/Chinese/Korean input)
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+
+      // Stop arrow key propagation to prevent parent menu navigation
+      if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Tab'].includes(e.key)) {
+        e.stopPropagation();
+      }
+
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+        setHighlightedIndex(0);
+        inputRef.current?.blur();
+      } else if (e.key === 'Backspace' && inputValue === '' && selectedTools.length > 0) {
+        // Remove last tag when backspace on empty input
+        onChange(selectedTools.slice(0, -1));
+      } else if (e.key === 'Tab' && filteredTools.length > 0) {
+        // Tab/Shift+Tab navigates through options
+        e.preventDefault();
+        setIsOpen(true);
+        if (e.shiftKey) {
+          setHighlightedIndex((prev) => (prev - 1 + filteredTools.length) % filteredTools.length);
+        } else {
+          setHighlightedIndex((prev) => (prev + 1) % filteredTools.length);
+        }
+      } else if (e.key === 'ArrowDown' && filteredTools.length > 0) {
+        e.preventDefault();
+        setIsOpen(true);
+        setHighlightedIndex((prev) => (prev + 1) % filteredTools.length);
+      } else if (e.key === 'ArrowUp' && filteredTools.length > 0) {
+        e.preventDefault();
+        setIsOpen(true);
+        setHighlightedIndex((prev) => (prev - 1 + filteredTools.length) % filteredTools.length);
+      } else if (e.key === 'Enter' && filteredTools.length > 0 && isOpen) {
+        // Enter confirms the highlighted option
+        e.preventDefault();
+        handleToggleTool(filteredTools[highlightedIndex]);
+        setHighlightedIndex(0);
+      }
+    },
+    [inputValue, selectedTools, onChange, filteredTools, handleToggleTool, isOpen, highlightedIndex]
+  );
+
+  return (
+    <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
+      <Popover.Anchor asChild>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: Input inside handles keyboard */}
+        <div
+          className={className}
+          onClick={handleContainerClick}
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            gap: '4px',
+            padding: '2px 4px',
+            minHeight: '24px',
+            backgroundColor: 'var(--vscode-input-background)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            cursor: disabled ? 'not-allowed' : 'text',
+            opacity: disabled ? 0.5 : 1,
+          }}
+        >
+          {/* Selected Tags */}
+          {selectedTools.map((tool) => (
+            <span
+              key={tool}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '2px',
+                padding: '1px 6px',
+                backgroundColor: 'var(--vscode-badge-background)',
+                color: 'var(--vscode-badge-foreground)',
+                borderRadius: '10px',
+                fontSize: '11px',
+                fontFamily: 'monospace',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {tool}
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={(e) => handleRemoveTag(tool, e)}
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: '0',
+                    marginLeft: '2px',
+                    backgroundColor: 'transparent',
+                    border: 'none',
+                    borderRadius: '50%',
+                    cursor: 'pointer',
+                    color: 'var(--vscode-badge-foreground)',
+                    opacity: 0.7,
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.opacity = '1';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.opacity = '0.7';
+                  }}
+                  aria-label={`Remove ${tool}`}
+                >
+                  <X size={12} />
+                </button>
+              )}
+            </span>
+          ))}
+
+          {/* Input Field */}
+          {!disabled && (
+            <input
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={handleInputChange}
+              onFocus={handleInputFocus}
+              onKeyDown={handleKeyDown}
+              placeholder={selectedTools.length === 0 ? 'Select tools...' : ''}
+              style={{
+                flex: 1,
+                minWidth: '60px',
+                padding: '2px 4px',
+                backgroundColor: 'transparent',
+                color: 'var(--vscode-input-foreground)',
+                border: 'none',
+                outline: 'none',
+                fontSize: '11px',
+                fontFamily: 'monospace',
+              }}
+            />
+          )}
+        </div>
+      </Popover.Anchor>
+
+      <Popover.Portal>
+        <Popover.Content
+          sideOffset={4}
+          align="start"
+          onOpenAutoFocus={(e: Event) => e.preventDefault()}
+          onPointerDownOutside={() => setIsOpen(false)}
+          onEscapeKeyDown={() => setIsOpen(false)}
+          style={{
+            backgroundColor: 'var(--vscode-dropdown-background)',
+            border: '1px solid var(--vscode-dropdown-border)',
+            borderRadius: '4px',
+            boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+            zIndex: 10002,
+            minWidth: '150px',
+            maxHeight: '200px',
+            overflowY: 'auto',
+            padding: '4px',
+          }}
+        >
+          {filteredTools.length > 0 ? (
+            filteredTools.map((tool, index) => (
+              // biome-ignore lint/a11y/useKeyWithClickEvents: Mouse-only dropdown item
+              <div
+                key={tool}
+                onClick={() => {
+                  handleToggleTool(tool);
+                  setHighlightedIndex(0);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                style={{
+                  padding: '6px 12px',
+                  fontSize: '11px',
+                  color: 'var(--vscode-foreground)',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  borderRadius: '2px',
+                  backgroundColor:
+                    index === highlightedIndex
+                      ? 'var(--vscode-list-activeSelectionBackground)'
+                      : 'transparent',
+                }}
+              >
+                <div
+                  style={{
+                    width: '12px',
+                    height: '12px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {selectedTools.includes(tool) && <Check size={12} />}
+                </div>
+                <span style={{ fontFamily: 'monospace' }}>{tool}</span>
+              </div>
+            ))
+          ) : (
+            <div
+              style={{
+                padding: '8px 12px',
+                fontSize: '11px',
+                color: 'var(--vscode-descriptionForeground)',
+                textAlign: 'center',
+              }}
+            >
+              {inputValue ? 'No matching tools' : 'All tools selected'}
+            </div>
+          )}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -4,12 +4,22 @@
  * Provides options for Slash Command export (Export/Run):
  * - model: Specify the model to use for execution (inherit/sonnet/opus/haiku)
  * - context: fork - Exports with `context: fork` for isolated sub-agent execution (Claude Code v2.1.0+)
+ * - hooks: Configure execution hooks (PreToolUse, PostToolUse, Stop)
  */
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import type { SlashCommandContext, SlashCommandModel } from '@shared/types/workflow-definition';
-import { Check, ChevronDown, ChevronLeft, Cpu, GitFork } from 'lucide-react';
+import type {
+  HookEntry,
+  HookType,
+  SlashCommandContext,
+  SlashCommandModel,
+  WorkflowHooks,
+} from '@shared/types/workflow-definition';
+import { Check, ChevronDown, ChevronLeft, Cpu, GitFork, Plus, Terminal, X } from 'lucide-react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
+import type { WebviewTranslationKeys } from '../../i18n/translation-keys';
+import { ToolSelectTagInput } from '../common/ToolSelectTagInput';
 
 // Fixed font sizes for dropdown menu (not responsive)
 const FONT_SIZES = {
@@ -29,11 +39,64 @@ const MODEL_PRESETS: { value: SlashCommandModel; label: string }[] = [
   { value: 'opus', label: 'opus' },
 ];
 
+const HOOK_TYPES: {
+  type: HookType;
+  labelKey: keyof WebviewTranslationKeys;
+  descKey: keyof WebviewTranslationKeys;
+  /** Whether to show matcher field (only applicable for tool-based hooks) */
+  showMatcher: boolean;
+}[] = [
+  {
+    type: 'PreToolUse',
+    labelKey: 'hooks.preToolUse',
+    descKey: 'hooks.preToolUse.description',
+    showMatcher: true, // Tool-based hook - matcher applies
+  },
+  {
+    type: 'PostToolUse',
+    labelKey: 'hooks.postToolUse',
+    descKey: 'hooks.postToolUse.description',
+    showMatcher: true, // Tool-based hook - matcher applies
+  },
+  {
+    type: 'Stop',
+    labelKey: 'hooks.stop',
+    descKey: 'hooks.stop.description',
+    showMatcher: false, // Lifecycle hook - matcher is ignored
+  },
+];
+
+// Helper functions for matcher ↔ tags conversion
+const matcherToTags = (matcher: string): string[] =>
+  matcher ? matcher.split('|').filter(Boolean) : [];
+
+const tagsToMatcher = (tags: string[]): string => tags.join('|');
+
+/**
+ * Stop arrow key propagation to prevent Radix UI submenu navigation
+ * from interfering with text input cursor movement
+ */
+const stopArrowKeyPropagation = (e: React.KeyboardEvent) => {
+  if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+    e.stopPropagation();
+  }
+};
+
 interface SlashCommandOptionsDropdownProps {
   context: SlashCommandContext;
   onContextChange: (context: SlashCommandContext) => void;
   model: SlashCommandModel;
   onModelChange: (model: SlashCommandModel) => void;
+  hooks: WorkflowHooks;
+  onAddHookEntry: (hookType: HookType, matcher: string, command: string, once?: boolean) => void;
+  onRemoveHookEntry: (hookType: HookType, entryIndex: number) => void;
+  onUpdateHookEntry: (hookType: HookType, entryIndex: number, entry: Partial<HookEntry>) => void;
+}
+
+interface NewEntryState {
+  matcher: string;
+  command: string;
+  once: boolean;
 }
 
 export function SlashCommandOptionsDropdown({
@@ -41,11 +104,83 @@ export function SlashCommandOptionsDropdown({
   onContextChange,
   model,
   onModelChange,
+  hooks,
+  onAddHookEntry,
+  onRemoveHookEntry,
+  onUpdateHookEntry,
 }: SlashCommandOptionsDropdownProps) {
   const { t } = useTranslation();
+  const [newEntry, setNewEntry] = useState<Record<HookType, NewEntryState>>({
+    PreToolUse: { matcher: '', command: '', once: false },
+    PostToolUse: { matcher: '', command: '', once: false },
+    Stop: { matcher: '', command: '', once: false },
+  });
+  const [validationError, setValidationError] = useState<Record<HookType, string | null>>({
+    PreToolUse: null,
+    PostToolUse: null,
+    Stop: null,
+  });
 
   const currentContextLabel = CONTEXT_PRESETS.find((p) => p.value === context)?.label || 'default';
   const currentModelLabel = MODEL_PRESETS.find((p) => p.value === model)?.label || 'default';
+  const totalHookEntries = Object.values(hooks).reduce(
+    (sum, entries) => sum + (entries?.length || 0),
+    0
+  );
+
+  const handleAddEntry = useCallback(
+    (hookType: HookType) => {
+      const entry = newEntry[hookType];
+      const command = entry.command.trim();
+      const matcher = entry.matcher.trim();
+
+      if (!command) {
+        setValidationError((prev) => ({
+          ...prev,
+          [hookType]: t('hooks.validation.commandRequired'),
+        }));
+        return;
+      }
+
+      // Clear error and add entry
+      setValidationError((prev) => ({ ...prev, [hookType]: null }));
+      onAddHookEntry(hookType, matcher, command, entry.once || undefined);
+      setNewEntry((prev) => ({
+        ...prev,
+        [hookType]: { matcher: '', command: '', once: false },
+      }));
+    },
+    [newEntry, onAddHookEntry, t]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, hookType: HookType) => {
+      // Skip if IME is composing (e.g., Japanese/Chinese/Korean input)
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleAddEntry(hookType);
+      }
+    },
+    [handleAddEntry]
+  );
+
+  // Stable callback for new entry changes to prevent focus loss
+  const handleNewEntryChange = useCallback(
+    (hookType: HookType, updates: Partial<NewEntryState>) => {
+      setNewEntry((prev) => ({
+        ...prev,
+        [hookType]: { ...prev[hookType], ...updates },
+      }));
+      // Clear validation error when user starts typing command
+      if (updates.command !== undefined) {
+        setValidationError((prev) => ({ ...prev, [hookType]: null }));
+      }
+    },
+    []
+  );
 
   return (
     <DropdownMenu.Root>
@@ -284,8 +419,492 @@ export function SlashCommandOptionsDropdown({
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
+
+          <DropdownMenu.Separator
+            style={{
+              height: '1px',
+              backgroundColor: 'var(--vscode-dropdown-border)',
+              margin: '4px 0',
+            }}
+          />
+
+          {/* Hooks Sub-menu */}
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger
+              style={{
+                padding: '8px 12px',
+                fontSize: `${FONT_SIZES.small}px`,
+                color: 'var(--vscode-foreground)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '8px',
+                outline: 'none',
+                borderRadius: '2px',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <ChevronLeft size={14} />
+                <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                  {totalHookEntries > 0
+                    ? t('hooks.entryCount', { count: totalHookEntries })
+                    : t('hooks.noEntries')}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <Terminal size={14} />
+                <span>{t('hooks.title')}</span>
+              </div>
+            </DropdownMenu.SubTrigger>
+
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                sideOffset={4}
+                style={{
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+                  zIndex: 10000,
+                  minWidth: '220px',
+                  padding: '4px',
+                }}
+              >
+                {/* Hooks Tooltip */}
+                <div
+                  style={{
+                    padding: '6px 12px',
+                    fontSize: '10px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    lineHeight: '1.4',
+                    borderBottom: '1px solid var(--vscode-dropdown-border)',
+                    marginBottom: '4px',
+                  }}
+                >
+                  {t('hooks.tooltip')}
+                </div>
+
+                {/* Hook Types */}
+                {HOOK_TYPES.map((hookConfig, index) => (
+                  <div key={hookConfig.type}>
+                    {index > 0 && (
+                      <DropdownMenu.Separator
+                        style={{
+                          height: '1px',
+                          backgroundColor: 'var(--vscode-dropdown-border)',
+                          margin: '4px 0',
+                        }}
+                      />
+                    )}
+                    <HookTypeSubMenu
+                      hookType={hookConfig.type}
+                      labelKey={hookConfig.labelKey}
+                      descKey={hookConfig.descKey}
+                      showMatcher={hookConfig.showMatcher}
+                      entries={hooks[hookConfig.type] || []}
+                      newEntry={newEntry[hookConfig.type]}
+                      validationError={validationError[hookConfig.type]}
+                      onNewEntryChange={(updates) => handleNewEntryChange(hookConfig.type, updates)}
+                      onAddEntry={() => handleAddEntry(hookConfig.type)}
+                      onRemoveEntry={(idx) => onRemoveHookEntry(hookConfig.type, idx)}
+                      onUpdateEntry={(idx, entry) => onUpdateHookEntry(hookConfig.type, idx, entry)}
+                      onKeyDown={(e) => handleKeyDown(e, hookConfig.type)}
+                    />
+                  </div>
+                ))}
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
   );
 }
+
+// Hook Type Sub-menu Component
+interface HookTypeSubMenuProps {
+  hookType: HookType;
+  labelKey: keyof WebviewTranslationKeys;
+  descKey: keyof WebviewTranslationKeys;
+  /** Whether to show matcher field (only for tool-based hooks) */
+  showMatcher: boolean;
+  entries: HookEntry[];
+  newEntry: NewEntryState;
+  validationError: string | null;
+  onNewEntryChange: (updates: Partial<NewEntryState>) => void;
+  onAddEntry: () => void;
+  onRemoveEntry: (index: number) => void;
+  onUpdateEntry: (index: number, entry: Partial<HookEntry>) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+const HookTypeSubMenu = memo(function HookTypeSubMenu({
+  hookType: _hookType,
+  labelKey,
+  descKey,
+  showMatcher,
+  entries,
+  newEntry,
+  validationError,
+  onNewEntryChange,
+  onAddEntry,
+  onRemoveEntry,
+  onUpdateEntry,
+  onKeyDown,
+}: HookTypeSubMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu.Sub>
+      <DropdownMenu.SubTrigger
+        style={{
+          padding: '8px 12px',
+          fontSize: `${FONT_SIZES.small}px`,
+          color: 'var(--vscode-foreground)',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '8px',
+          outline: 'none',
+          borderRadius: '2px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <ChevronLeft size={14} />
+          <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+            {entries.length > 0
+              ? t('hooks.entryCount', { count: entries.length })
+              : t('hooks.noEntries')}
+          </span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <Terminal size={14} />
+          <span>{t(labelKey)}</span>
+        </div>
+      </DropdownMenu.SubTrigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.SubContent
+          sideOffset={4}
+          style={{
+            backgroundColor: 'var(--vscode-dropdown-background)',
+            border: '1px solid var(--vscode-dropdown-border)',
+            borderRadius: '4px',
+            boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+            zIndex: 10001,
+            minWidth: '350px',
+            maxWidth: '450px',
+            padding: '8px',
+          }}
+        >
+          {/* Description */}
+          <div
+            style={{
+              padding: '4px 8px 8px',
+              fontSize: '10px',
+              color: 'var(--vscode-descriptionForeground)',
+              lineHeight: '1.4',
+              borderBottom: '1px solid var(--vscode-dropdown-border)',
+              marginBottom: '8px',
+            }}
+          >
+            {t(descKey)}
+          </div>
+
+          {/* Existing Entries */}
+          {entries.length > 0 && (
+            <div style={{ marginBottom: '8px' }}>
+              {entries.map((entry, index) => {
+                // Use index as key since HookEntry doesn't have a unique ID field
+                const stableKey = `hook-entry-${index}`;
+                return (
+                  <div
+                    key={stableKey}
+                    style={{
+                      position: 'relative',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '4px',
+                      marginBottom: '8px',
+                      padding: '6px',
+                      paddingRight: '24px',
+                      backgroundColor: 'var(--vscode-editor-background)',
+                      borderRadius: '4px',
+                      border: '1px solid var(--vscode-panel-border)',
+                    }}
+                  >
+                    {/* Delete button (top-right) */}
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onRemoveEntry(index);
+                      }}
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      title={t('hooks.removeEntry')}
+                      style={{
+                        position: 'absolute',
+                        top: '4px',
+                        right: '4px',
+                        padding: '2px',
+                        backgroundColor: 'transparent',
+                        color: 'var(--vscode-descriptionForeground)',
+                        border: 'none',
+                        borderRadius: '2px',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        opacity: 0.7,
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.opacity = '1';
+                        e.currentTarget.style.color = 'var(--vscode-errorForeground)';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.opacity = '0.7';
+                        e.currentTarget.style.color = 'var(--vscode-descriptionForeground)';
+                      }}
+                    >
+                      <X size={14} />
+                    </button>
+                    {/* Matcher row (only for tool-based hooks) */}
+                    {showMatcher && (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                        <span
+                          style={{
+                            fontSize: '10px',
+                            color: 'var(--vscode-descriptionForeground)',
+                            minWidth: '55px',
+                          }}
+                        >
+                          matcher:
+                        </span>
+                        <div style={{ flex: 1 }}>
+                          <ToolSelectTagInput
+                            selectedTools={matcherToTags(entry.matcher || '')}
+                            onChange={(tools) =>
+                              onUpdateEntry(index, { ...entry, matcher: tagsToMatcher(tools) })
+                            }
+                          />
+                        </div>
+                      </div>
+                    )}
+                    {/* Command row */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          color: 'var(--vscode-descriptionForeground)',
+                          minWidth: '55px',
+                        }}
+                      >
+                        command<span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>:
+                      </span>
+                      <input
+                        type="text"
+                        value={entry.hooks[0]?.command || ''}
+                        onChange={(e) =>
+                          onUpdateEntry(index, {
+                            ...entry,
+                            hooks: [{ ...entry.hooks[0], command: e.target.value }],
+                          })
+                        }
+                        onKeyDown={stopArrowKeyPropagation}
+                        style={{
+                          flex: 1,
+                          padding: '2px 6px',
+                          fontSize: '11px',
+                          backgroundColor: 'var(--vscode-input-background)',
+                          color: 'var(--vscode-input-foreground)',
+                          border: '1px solid var(--vscode-input-border)',
+                          borderRadius: '2px',
+                          fontFamily: 'monospace',
+                        }}
+                      />
+                    </div>
+                    {/* Once checkbox row */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          color: 'var(--vscode-descriptionForeground)',
+                          minWidth: '50px',
+                        }}
+                      >
+                        once:
+                      </span>
+                      <label
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
+                          fontSize: '10px',
+                          color: 'var(--vscode-descriptionForeground)',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={entry.hooks[0]?.once || false}
+                          onChange={(e) =>
+                            onUpdateEntry(index, {
+                              ...entry,
+                              hooks: [{ ...entry.hooks[0], once: e.target.checked || undefined }],
+                            })
+                          }
+                          style={{ cursor: 'pointer' }}
+                        />
+                        {t('hooks.once.description')}
+                      </label>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Add New Entry */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '4px',
+              padding: '6px',
+              backgroundColor: 'var(--vscode-editor-background)',
+              borderRadius: '4px',
+              border: '1px dashed var(--vscode-panel-border)',
+            }}
+          >
+            {/* Matcher row (only for tool-based hooks) */}
+            {showMatcher && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <span
+                  style={{
+                    fontSize: '10px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    minWidth: '55px',
+                  }}
+                >
+                  matcher:
+                </span>
+                <div style={{ flex: 1 }}>
+                  <ToolSelectTagInput
+                    selectedTools={matcherToTags(newEntry.matcher)}
+                    onChange={(tools) => onNewEntryChange({ matcher: tagsToMatcher(tools) })}
+                  />
+                </div>
+              </div>
+            )}
+            {/* Command row */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span
+                style={{
+                  fontSize: '10px',
+                  color: 'var(--vscode-descriptionForeground)',
+                  minWidth: '55px',
+                }}
+              >
+                command<span style={{ color: 'var(--vscode-errorForeground)' }}>*</span>:
+              </span>
+              <input
+                type="text"
+                value={newEntry.command}
+                onChange={(e) => onNewEntryChange({ command: e.target.value })}
+                onKeyDown={(e) => {
+                  stopArrowKeyPropagation(e);
+                  onKeyDown(e);
+                }}
+                placeholder="e.g., npm run lint"
+                style={{
+                  flex: 1,
+                  padding: '2px 6px',
+                  fontSize: '11px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '2px',
+                  fontFamily: 'monospace',
+                }}
+              />
+            </div>
+            {/* Once checkbox row */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <span
+                style={{
+                  fontSize: '10px',
+                  color: 'var(--vscode-descriptionForeground)',
+                  minWidth: '50px',
+                }}
+              >
+                once:
+              </span>
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  fontSize: '10px',
+                  color: 'var(--vscode-descriptionForeground)',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={newEntry.once}
+                  onChange={(e) => onNewEntryChange({ once: e.target.checked })}
+                  style={{ cursor: 'pointer' }}
+                />
+                {t('hooks.once.description')}
+              </label>
+            </div>
+            {/* Validation error */}
+            {validationError && (
+              <div
+                style={{
+                  fontSize: '10px',
+                  color: 'var(--vscode-errorForeground)',
+                  marginTop: '2px',
+                }}
+              >
+                {validationError}
+              </div>
+            )}
+            {/* Add button row */}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onAddEntry();
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '4px',
+                padding: '4px 8px',
+                marginTop: '4px',
+                backgroundColor: 'var(--vscode-button-background)',
+                color: 'var(--vscode-button-foreground)',
+                border: 'none',
+                borderRadius: '2px',
+                cursor: 'pointer',
+                fontSize: '11px',
+                width: '100%',
+              }}
+            >
+              <Plus size={14} />
+              {t('hooks.addEntry')}
+            </button>
+          </div>
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Sub>
+  );
+});

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -64,6 +64,25 @@ export interface WebviewTranslationKeys {
   'toolbar.model.tooltip': string;
   'toolbar.contextFork.tooltip': string;
 
+  // Toolbar hooks configuration dropdown
+  'hooks.title': string;
+  'hooks.tooltip': string;
+  'hooks.preToolUse': string;
+  'hooks.preToolUse.description': string;
+  'hooks.postToolUse': string;
+  'hooks.postToolUse.description': string;
+  'hooks.stop': string;
+  'hooks.stop.description': string;
+  'hooks.addEntry': string;
+  'hooks.removeEntry': string;
+  'hooks.matcher.description': string;
+  'hooks.once.description': string;
+  'hooks.noEntries': string;
+  'hooks.entryCount': string;
+  'hooks.validation.commandRequired': string;
+  'hooks.validation.commandTooLong': string;
+  'hooks.validation.matcherRequired': string;
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': string;
   'toolbar.help': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -69,6 +69,25 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.model.tooltip': 'Specify the model to use for execution',
   'toolbar.contextFork.tooltip': 'Run in isolated sub-agent context (Claude Code v2.1.0+)',
 
+  // Toolbar hooks configuration dropdown
+  'hooks.title': 'Hooks',
+  'hooks.tooltip': 'Configure commands to run at specific execution points',
+  'hooks.preToolUse': 'PreToolUse',
+  'hooks.preToolUse.description': 'Commands to run before a tool is executed',
+  'hooks.postToolUse': 'PostToolUse',
+  'hooks.postToolUse.description': 'Commands to run after a tool is executed',
+  'hooks.stop': 'Stop',
+  'hooks.stop.description': 'Commands to run when the agent stops',
+  'hooks.addEntry': 'Add',
+  'hooks.removeEntry': 'Remove',
+  'hooks.matcher.description': 'Tool name pattern to match',
+  'hooks.once.description': 'Run only once per session',
+  'hooks.noEntries': 'No hooks configured',
+  'hooks.entryCount': '{count} hook(s)',
+  'hooks.validation.commandRequired': 'command is required',
+  'hooks.validation.commandTooLong': 'command exceeds maximum length',
+  'hooks.validation.matcherRequired': 'matcher is required for this hook type',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'More',
   'toolbar.help': 'Help',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -70,6 +70,25 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.contextFork.tooltip':
     '分離されたサブエージェントコンテキストで実行 (Claude Code v2.1.0+)',
 
+  // Toolbar hooks configuration dropdown
+  'hooks.title': 'Hooks',
+  'hooks.tooltip': '特定の実行タイミングで実行するコマンドを設定',
+  'hooks.preToolUse': 'PreToolUse',
+  'hooks.preToolUse.description': 'ツールが実行される前に実行されるコマンド',
+  'hooks.postToolUse': 'PostToolUse',
+  'hooks.postToolUse.description': 'ツールが実行された後に実行されるコマンド',
+  'hooks.stop': 'Stop',
+  'hooks.stop.description': 'エージェントが停止したときに実行されるコマンド',
+  'hooks.addEntry': '追加',
+  'hooks.removeEntry': '削除',
+  'hooks.matcher.description': 'マッチするツール名パターン',
+  'hooks.once.description': 'セッションごとに一度だけ実行',
+  'hooks.noEntries': 'フックが設定されていません',
+  'hooks.entryCount': '{count} 件のフック',
+  'hooks.validation.commandRequired': 'command は必須です',
+  'hooks.validation.commandTooLong': 'command が最大長を超えています',
+  'hooks.validation.matcherRequired': 'このフックタイプには matcher が必須です',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'その他',
   'toolbar.help': 'ヘルプ',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -68,6 +68,25 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.model.tooltip': '실행에 사용할 모델 지정',
   'toolbar.contextFork.tooltip': '분리된 서브 에이전트 컨텍스트에서 실행 (Claude Code v2.1.0+)',
 
+  // Toolbar hooks configuration dropdown
+  'hooks.title': 'Hooks',
+  'hooks.tooltip': '특정 실행 시점에 실행할 명령 구성',
+  'hooks.preToolUse': 'PreToolUse',
+  'hooks.preToolUse.description': '도구가 실행되기 전에 실행되는 명령',
+  'hooks.postToolUse': 'PostToolUse',
+  'hooks.postToolUse.description': '도구가 실행된 후에 실행되는 명령',
+  'hooks.stop': 'Stop',
+  'hooks.stop.description': '에이전트가 중지될 때 실행되는 명령',
+  'hooks.addEntry': '추가',
+  'hooks.removeEntry': '삭제',
+  'hooks.matcher.description': '일치할 도구 이름 패턴',
+  'hooks.once.description': '세션당 한 번만 실행',
+  'hooks.noEntries': '구성된 훅 없음',
+  'hooks.entryCount': '{count}개의 훅',
+  'hooks.validation.commandRequired': 'command는 필수입니다',
+  'hooks.validation.commandTooLong': 'command가 최대 길이를 초과했습니다',
+  'hooks.validation.matcherRequired': '이 훅 유형에는 matcher가 필수입니다',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '더보기',
   'toolbar.help': '도움말',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -66,6 +66,25 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.model.tooltip': '指定执行时使用的模型',
   'toolbar.contextFork.tooltip': '在隔离的子代理上下文中运行 (Claude Code v2.1.0+)',
 
+  // Toolbar hooks configuration dropdown
+  'hooks.title': 'Hooks',
+  'hooks.tooltip': '配置在特定执行点运行的命令',
+  'hooks.preToolUse': 'PreToolUse',
+  'hooks.preToolUse.description': '在工具执行前运行的命令',
+  'hooks.postToolUse': 'PostToolUse',
+  'hooks.postToolUse.description': '在工具执行后运行的命令',
+  'hooks.stop': 'Stop',
+  'hooks.stop.description': '代理停止时运行的命令',
+  'hooks.addEntry': '添加',
+  'hooks.removeEntry': '删除',
+  'hooks.matcher.description': '要匹配的工具名称模式',
+  'hooks.once.description': '每个会话只运行一次',
+  'hooks.noEntries': '未配置钩子',
+  'hooks.entryCount': '{count} 个钩子',
+  'hooks.validation.commandRequired': 'command 是必填项',
+  'hooks.validation.commandTooLong': 'command 超过最大长度',
+  'hooks.validation.matcherRequired': '此钩子类型需要 matcher',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '帮助',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -66,6 +66,25 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.model.tooltip': '指定執行時使用的模型',
   'toolbar.contextFork.tooltip': '在隔離的子代理上下文中運行 (Claude Code v2.1.0+)',
 
+  // Toolbar hooks configuration dropdown
+  'hooks.title': 'Hooks',
+  'hooks.tooltip': '配置在特定執行點運行的命令',
+  'hooks.preToolUse': 'PreToolUse',
+  'hooks.preToolUse.description': '在工具執行前運行的命令',
+  'hooks.postToolUse': 'PostToolUse',
+  'hooks.postToolUse.description': '在工具執行後運行的命令',
+  'hooks.stop': 'Stop',
+  'hooks.stop.description': '代理停止時運行的命令',
+  'hooks.addEntry': '新增',
+  'hooks.removeEntry': '刪除',
+  'hooks.matcher.description': '要匹配的工具名稱模式',
+  'hooks.once.description': '每個會話只運行一次',
+  'hooks.noEntries': '未配置鉤子',
+  'hooks.entryCount': '{count} 個鉤子',
+  'hooks.validation.commandRequired': 'command 是必填項',
+  'hooks.validation.commandTooLong': 'command 超過最大長度',
+  'hooks.validation.matcherRequired': '此鉤子類型需要 matcher',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '說明',

--- a/src/webview/src/stores/refinement-store.ts
+++ b/src/webview/src/stores/refinement-store.ts
@@ -13,7 +13,7 @@ import { create } from 'zustand';
 const MODEL_STORAGE_KEY = 'cc-wf-studio.refinement.selectedModel';
 const ALLOWED_TOOLS_STORAGE_KEY = 'cc-wf-studio.refinement.allowedTools';
 
-// Available tools for Claude Code CLI
+// Available tools for Claude Code CLI (used in AI editing allowed tools)
 export const AVAILABLE_TOOLS = [
   'AskUserQuestion',
   'Bash',
@@ -27,6 +27,26 @@ export const AVAILABLE_TOOLS = [
   'NotebookEdit',
   'Read',
   'Skill',
+  'SlashCommand',
+  'Task',
+  'TodoWrite',
+  'WebFetch',
+  'WebSearch',
+  'Write',
+] as const;
+
+// Official Claude Code tools for hooks matcher (PreToolUse, PostToolUse)
+// Based on: https://code.claude.com/docs/en/hooks
+export const HOOKS_MATCHER_TOOLS = [
+  'Bash',
+  'BashOutput',
+  'Edit',
+  'ExitPlanMode',
+  'Glob',
+  'Grep',
+  'KillShell',
+  'NotebookEdit',
+  'Read',
   'SlashCommand',
   'Task',
   'TodoWrite',


### PR DESCRIPTION
## Summary

Add hooks configuration UI to Slash Command Options, allowing users to configure PreToolUse, PostToolUse, and Stop hooks with tool matchers and shell commands.

## Changes

### New Components
- **ToolSelectTagInput.tsx**: React-Select style tool selector with tag display
  - Dropdown with filter input
  - Tab/Shift+Tab keyboard navigation
  - Enter to confirm selection
  - IME composition support (Japanese/Chinese/Korean)

- **TagInput.tsx**: Reusable tag input component for free-form text entry

### Architecture Changes
- **Unified slashCommandOptions**: Consolidated `context`, `model`, and `hooks` into single `slashCommandOptions` object
- **HOOKS_MATCHER_TOOLS**: New constant with official 15 Claude Code tools (separate from AI editing tools)

### Files Modified
| File | Changes |
|------|---------|
| `workflow-definition.ts` | Added hooks types (`HookType`, `HookEntry`, `HookAction`, `WorkflowHooks`) |
| `workflow-store.ts` | Unified `slashCommandOptions` state management |
| `workflow-service.ts` | Updated `serializeWorkflow` to accept `SlashCommandOptions` |
| `export-service.ts` | Read hooks from `slashCommandOptions.hooks` |
| `SlashCommandOptionsDropdown.tsx` | Added hooks configuration UI in submenu |
| `Toolbar.tsx` | Updated to use unified `slashCommandOptions` |
| `refinement-store.ts` | Added `HOOKS_MATCHER_TOOLS` constant |
| `i18n/*` | Added translation keys for hooks UI |

## Features

- **Hook Types**: PreToolUse, PostToolUse, Stop
- **Matcher Patterns**: Tool name selection from official 15 tools
- **Command Configuration**: Shell command with optional `once` flag
- **Export Format**: Claude Code Docs compliant YAML frontmatter

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

## Related

Closes #413