### PR TITLE
Release: v3.14.2

### DIFF
--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -187,9 +187,7 @@ export function validateClaudeFileFormat(
     if (!frontmatterContent.includes('description:')) {
       throw new Error('SlashCommand file missing required field: description');
     }
-    if (!frontmatterContent.includes('allowed-tools:')) {
-      throw new Error('SlashCommand file missing required field: allowed-tools');
-    }
+    // Issue #424: allowed-tools is optional (omit = use Claude Code default)
   }
 
   // Check that there's content after frontmatter (prompt body)
@@ -518,11 +516,12 @@ function escapeYamlString(value: string, alwaysQuote = false): string {
  */
 function generateSlashCommandFile(workflow: Workflow): string {
   // YAML frontmatter
-  const frontmatterLines = [
-    '---',
-    `description: ${workflow.description || workflow.name}`,
-    'allowed-tools: Task,AskUserQuestion',
-  ];
+  const frontmatterLines = ['---', `description: ${workflow.description || workflow.name}`];
+
+  // Issue #424: Add allowed-tools only if explicitly configured (omit = use Claude Code default)
+  if (workflow.slashCommandOptions?.allowedTools) {
+    frontmatterLines.push(`allowed-tools: ${workflow.slashCommandOptions.allowedTools}`);
+  }
 
   // Add model if specified and not 'default'
   if (workflow.slashCommandOptions?.model && workflow.slashCommandOptions.model !== 'default') {

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -55,6 +55,8 @@ export interface SlashCommandOptions {
   model?: SlashCommandModel;
   /** Hooks configuration for workflow execution */
   hooks?: WorkflowHooks;
+  /** Comma-separated list of allowed tools for Slash Command execution */
+  allowedTools?: string;
 }
 
 // ============================================================================

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -66,6 +66,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setSlashCommandOptions,
     setSlashCommandContext,
     setSlashCommandModel,
+    setSlashCommandAllowedTools,
     addHookEntry,
     removeHookEntry,
     updateHookEntry,
@@ -191,11 +192,12 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           setWorkflowName(workflow.name);
           // Load description from workflow (default to empty string if not present)
           setWorkflowDescription(workflow.description || '');
-          // Issue #413: Load slashCommandOptions (context, model, hooks) as unified object
+          // Issue #413: Load slashCommandOptions (context, model, hooks, allowedTools) as unified object
           setSlashCommandOptions({
             context: workflow.slashCommandOptions?.context ?? 'default',
             model: workflow.slashCommandOptions?.model ?? 'default',
             hooks: workflow.slashCommandOptions?.hooks,
+            allowedTools: workflow.slashCommandOptions?.allowedTools,
           });
           // Set as active workflow to preserve conversation history
           setActiveWorkflow(workflow);
@@ -710,6 +712,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
             {/* Options Dropdown (separate with small gap) */}
             {/* Issue #413: Hooks are now integrated into SlashCommandOptionsDropdown */}
+            {/* Issue #424: Allowed Tools configuration added */}
             <SlashCommandOptionsDropdown
               context={slashCommandOptions.context ?? 'default'}
               onContextChange={setSlashCommandContext}
@@ -719,6 +722,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               onAddHookEntry={addHookEntry}
               onRemoveHookEntry={removeHookEntry}
               onUpdateHookEntry={updateHookEntry}
+              allowedTools={slashCommandOptions.allowedTools ?? ''}
+              onAllowedToolsChange={setSlashCommandAllowedTools}
             />
           </div>
         </div>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -61,7 +61,6 @@ export interface WebviewTranslationKeys {
   'toolbar.running': string;
 
   // Toolbar slash command options dropdown
-  'toolbar.model.tooltip': string;
   'toolbar.contextFork.tooltip': string;
 
   // Toolbar hooks configuration dropdown
@@ -77,8 +76,6 @@ export interface WebviewTranslationKeys {
   'hooks.removeEntry': string;
   'hooks.matcher.description': string;
   'hooks.once.description': string;
-  'hooks.noEntries': string;
-  'hooks.entryCount': string;
   'hooks.validation.commandRequired': string;
   'hooks.validation.commandTooLong': string;
   'hooks.validation.matcherRequired': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -66,7 +66,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': 'Running...',
 
   // Toolbar slash command options dropdown
-  'toolbar.model.tooltip': 'Specify the model to use for execution',
   'toolbar.contextFork.tooltip': 'Run in isolated sub-agent context (Claude Code v2.1.0+)',
 
   // Toolbar hooks configuration dropdown
@@ -82,8 +81,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'hooks.removeEntry': 'Remove',
   'hooks.matcher.description': 'Tool name pattern to match',
   'hooks.once.description': 'Run only once per session',
-  'hooks.noEntries': 'No hooks configured',
-  'hooks.entryCount': '{count} hook(s)',
   'hooks.validation.commandRequired': 'command is required',
   'hooks.validation.commandTooLong': 'command exceeds maximum length',
   'hooks.validation.matcherRequired': 'matcher is required for this hook type',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -66,7 +66,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '実行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.model.tooltip': '実行に使用するモデルを指定',
   'toolbar.contextFork.tooltip':
     '分離されたサブエージェントコンテキストで実行 (Claude Code v2.1.0+)',
 
@@ -83,8 +82,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'hooks.removeEntry': '削除',
   'hooks.matcher.description': 'マッチするツール名パターン',
   'hooks.once.description': 'セッションごとに一度だけ実行',
-  'hooks.noEntries': 'フックが設定されていません',
-  'hooks.entryCount': '{count} 件のフック',
   'hooks.validation.commandRequired': 'command は必須です',
   'hooks.validation.commandTooLong': 'command が最大長を超えています',
   'hooks.validation.matcherRequired': 'このフックタイプには matcher が必須です',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -65,7 +65,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '실행 중...',
 
   // Toolbar slash command options dropdown
-  'toolbar.model.tooltip': '실행에 사용할 모델 지정',
   'toolbar.contextFork.tooltip': '분리된 서브 에이전트 컨텍스트에서 실행 (Claude Code v2.1.0+)',
 
   // Toolbar hooks configuration dropdown
@@ -81,8 +80,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'hooks.removeEntry': '삭제',
   'hooks.matcher.description': '일치할 도구 이름 패턴',
   'hooks.once.description': '세션당 한 번만 실행',
-  'hooks.noEntries': '구성된 훅 없음',
-  'hooks.entryCount': '{count}개의 훅',
   'hooks.validation.commandRequired': 'command는 필수입니다',
   'hooks.validation.commandTooLong': 'command가 최대 길이를 초과했습니다',
   'hooks.validation.matcherRequired': '이 훅 유형에는 matcher가 필수입니다',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -63,7 +63,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '执行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.model.tooltip': '指定执行时使用的模型',
   'toolbar.contextFork.tooltip': '在隔离的子代理上下文中运行 (Claude Code v2.1.0+)',
 
   // Toolbar hooks configuration dropdown
@@ -79,8 +78,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'hooks.removeEntry': '删除',
   'hooks.matcher.description': '要匹配的工具名称模式',
   'hooks.once.description': '每个会话只运行一次',
-  'hooks.noEntries': '未配置钩子',
-  'hooks.entryCount': '{count} 个钩子',
   'hooks.validation.commandRequired': 'command 是必填项',
   'hooks.validation.commandTooLong': 'command 超过最大长度',
   'hooks.validation.matcherRequired': '此钩子类型需要 matcher',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -63,7 +63,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '執行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.model.tooltip': '指定執行時使用的模型',
   'toolbar.contextFork.tooltip': '在隔離的子代理上下文中運行 (Claude Code v2.1.0+)',
 
   // Toolbar hooks configuration dropdown
@@ -79,8 +78,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'hooks.removeEntry': '刪除',
   'hooks.matcher.description': '要匹配的工具名稱模式',
   'hooks.once.description': '每個會話只運行一次',
-  'hooks.noEntries': '未配置鉤子',
-  'hooks.entryCount': '{count} 個鉤子',
   'hooks.validation.commandRequired': 'command 是必填項',
   'hooks.validation.commandTooLong': 'command 超過最大長度',
   'hooks.validation.matcherRequired': '此鉤子類型需要 matcher',

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -59,10 +59,12 @@ export function serializeWorkflow(
   const context = slashCommandOptions?.context;
   const model = slashCommandOptions?.model;
   const hooks = slashCommandOptions?.hooks;
+  const allowedTools = slashCommandOptions?.allowedTools;
   const hasNonDefaultOptions =
     (context && context !== 'default') ||
     (model && model !== 'default') ||
-    (hooks && Object.keys(hooks).length > 0);
+    (hooks && Object.keys(hooks).length > 0) ||
+    (allowedTools && allowedTools.length > 0);
 
   // Create workflow object
   const workflow: Workflow = {
@@ -79,11 +81,13 @@ export function serializeWorkflow(
     // Issue #89: Include subAgentFlows if provided
     subAgentFlows,
     // Issue #413: Include slashCommandOptions if any non-default option is set
+    // Issue #424: Include allowedTools
     slashCommandOptions: hasNonDefaultOptions
       ? {
           ...(context && context !== 'default' && { context }),
           ...(model && model !== 'default' && { model }),
           ...(hooks && Object.keys(hooks).length > 0 && { hooks }),
+          ...(allowedTools && allowedTools.length > 0 && { allowedTools }),
         }
       : undefined,
   };

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -89,6 +89,7 @@ interface WorkflowStore {
   setSlashCommandOptions: (options: SlashCommandOptions) => void;
   setSlashCommandContext: (value: SlashCommandContext) => void;
   setSlashCommandModel: (value: SlashCommandModel) => void;
+  setSlashCommandAllowedTools: (allowedTools: string) => void;
   setHooks: (hooks: WorkflowHooks) => void;
   addHookEntry: (hookType: HookType, matcher: string, command: string, once?: boolean) => void;
   removeHookEntry: (hookType: HookType, entryIndex: number) => void;
@@ -385,6 +386,11 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   setSlashCommandModel: (model: SlashCommandModel) =>
     set((state) => ({
       slashCommandOptions: { ...state.slashCommandOptions, model },
+    })),
+
+  setSlashCommandAllowedTools: (allowedTools: string) =>
+    set((state) => ({
+      slashCommandOptions: { ...state.slashCommandOptions, allowedTools },
     })),
 
   setHooks: (hooks: WorkflowHooks) =>


### PR DESCRIPTION
## Summary

Merge latest changes from `main` to `production` for automated release v3.14.2.

## Included Changes

### Improvements
- improvement: add allowed-tools configuration UI for Slash Command export (#431)
  - Add Allowed Tools submenu with checkbox selection for 18 tools
  - Reorder dropdown menu: Allowed Tools → Model → Hooks → Context
  - Use static English text for technical terms
  - Unify submenu minWidth for consistent left-side display
  - Remove unnecessary tooltips and unused translation keys

## Release Version Calculation

**v3.14.2** (patch bump)

Semantic Release will analyze commits since the last release (v3.14.1) and will bump the version based on:
- ✅ `improvement: add allowed-tools configuration UI...` (#431) → **patch bump**

Result: **3.14.1 + patch = 3.14.2**

## CHANGELOG.md Contents

The following improvements will be included:
- add allowed-tools configuration UI for Slash Command export (#431)

## Release Automation

This merge will trigger the automated release workflow which will:
1. Analyze commit messages to determine version bump (3.14.1 → 3.14.2)
2. Update version in package.json files
3. Generate CHANGELOG.md with improvements
4. Create GitHub release with release notes
5. Build and upload VSIX package
6. Sync version changes back to main branch

## Merge Strategy

**Use merge commit** (not squash) to preserve all individual commits and their history for proper Semantic Release analysis.