### PR TITLE
fix: ensure consistent left-side submenu positioning

### DIFF
--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -299,6 +299,7 @@ export function SlashCommandOptionsDropdown({
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
                 sideOffset={4}
+                collisionPadding={{ right: 300 }}
                 style={{
                   backgroundColor: 'var(--vscode-dropdown-background)',
                   border: '1px solid var(--vscode-dropdown-border)',
@@ -425,6 +426,7 @@ export function SlashCommandOptionsDropdown({
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
                 sideOffset={4}
+                collisionPadding={{ right: 300 }}
                 style={{
                   backgroundColor: 'var(--vscode-dropdown-background)',
                   border: '1px solid var(--vscode-dropdown-border)',
@@ -516,6 +518,7 @@ export function SlashCommandOptionsDropdown({
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
                 sideOffset={4}
+                collisionPadding={{ right: 300 }}
                 style={{
                   backgroundColor: 'var(--vscode-dropdown-background)',
                   border: '1px solid var(--vscode-dropdown-border)',
@@ -611,6 +614,7 @@ export function SlashCommandOptionsDropdown({
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
                 sideOffset={4}
+                collisionPadding={{ right: 300 }}
                 style={{
                   backgroundColor: 'var(--vscode-dropdown-background)',
                   border: '1px solid var(--vscode-dropdown-border)',
@@ -746,6 +750,7 @@ const HookTypeSubMenu = memo(function HookTypeSubMenu({
       <DropdownMenu.Portal>
         <DropdownMenu.SubContent
           sideOffset={4}
+          collisionPadding={{ right: 300 }}
           style={{
             backgroundColor: 'var(--vscode-dropdown-background)',
             border: '1px solid var(--vscode-dropdown-border)',


### PR DESCRIPTION
## Problem

In non-Focus Mode, the SlashCommandOptions dropdown submenus display inconsistently - some open on the right side, others on the left side.

### Current Behavior
| Submenu | Position |
|---------|----------|
| Allowed Tools | ❌ Right |
| Model | ❌ Right |
| Hooks | ✅ Left |
| Context | ✅ Left |

### Expected Behavior
All submenus should open on the same side (left) for consistency.

## Solution

Add `collisionPadding={{ right: 300 }}` to all `DropdownMenu.SubContent` components.

This forces Radix UI's collision detection to determine there's insufficient space on the right, causing all submenus to consistently open on the left side.

### Technical Details

- Radix UI intentionally omits `side` prop from `SubContent` (confirmed via TypeScript types)
- Available positioning props: `sideOffset`, `collisionPadding`, `collisionBoundary`, `avoidCollisions`
- Using `collisionPadding` is the recommended approach to influence positioning behavior

## Changes

**File**: `src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx`

Added `collisionPadding={{ right: 300 }}` to 5 SubContent components:
- Allowed Tools (L302)
- Model (L429)
- Hooks (L521)
- Context (L617)
- HookTypeSubMenu (L753)

## Testing

- [x] Manual E2E testing in non-Focus Mode
- [x] Manual E2E testing in Focus Mode
- [x] All submenus open consistently on the left side

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)