### PR TITLE
improvement: add disable-model-invocation configuration UI for Slash Command export

### DIFF
--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -533,6 +533,11 @@ function generateSlashCommandFile(workflow: Workflow): string {
     frontmatterLines.push(`context: ${workflow.slashCommandOptions.context}`);
   }
 
+  // Issue #426: Add disable-model-invocation if enabled
+  if (workflow.slashCommandOptions?.disableModelInvocation) {
+    frontmatterLines.push('disable-model-invocation: true');
+  }
+
   // Issue #413: Add hooks if configured (Claude Code Docs compliant format)
   // See: https://code.claude.com/docs/en/hooks
   const hooks = workflow.slashCommandOptions?.hooks;

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -41,6 +41,7 @@ export interface WorkflowMetadata {
  * Slash Command export options
  *
  * Options that affect how the workflow is exported as a Slash Command (.md file)
+ * @see https://code.claude.com/docs/en/slash-commands#frontmatter
  */
 /** Context options for Slash Command execution */
 export type SlashCommandContext = 'default' | 'fork';
@@ -57,6 +58,8 @@ export interface SlashCommandOptions {
   hooks?: WorkflowHooks;
   /** Comma-separated list of allowed tools for Slash Command execution */
   allowedTools?: string;
+  /** Disable model invocation. When true, prevents the Skill tool from invoking this command. */
+  disableModelInvocation?: boolean;
 }
 
 // ============================================================================

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -67,6 +67,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setSlashCommandContext,
     setSlashCommandModel,
     setSlashCommandAllowedTools,
+    setSlashCommandDisableModelInvocation,
     addHookEntry,
     removeHookEntry,
     updateHookEntry,
@@ -193,11 +194,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           // Load description from workflow (default to empty string if not present)
           setWorkflowDescription(workflow.description || '');
           // Issue #413: Load slashCommandOptions (context, model, hooks, allowedTools) as unified object
+          // Issue #426: Load disableModelInvocation
           setSlashCommandOptions({
             context: workflow.slashCommandOptions?.context ?? 'default',
             model: workflow.slashCommandOptions?.model ?? 'default',
             hooks: workflow.slashCommandOptions?.hooks,
             allowedTools: workflow.slashCommandOptions?.allowedTools,
+            disableModelInvocation: workflow.slashCommandOptions?.disableModelInvocation,
           });
           // Set as active workflow to preserve conversation history
           setActiveWorkflow(workflow);
@@ -713,6 +716,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             {/* Options Dropdown (separate with small gap) */}
             {/* Issue #413: Hooks are now integrated into SlashCommandOptionsDropdown */}
             {/* Issue #424: Allowed Tools configuration added */}
+            {/* Issue #426: Added disableModelInvocation props */}
             <SlashCommandOptionsDropdown
               context={slashCommandOptions.context ?? 'default'}
               onContextChange={setSlashCommandContext}
@@ -724,6 +728,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               onUpdateHookEntry={updateHookEntry}
               allowedTools={slashCommandOptions.allowedTools ?? ''}
               onAllowedToolsChange={setSlashCommandAllowedTools}
+              disableModelInvocation={slashCommandOptions.disableModelInvocation ?? false}
+              onDisableModelInvocationChange={setSlashCommandDisableModelInvocation}
             />
           </div>
         </div>

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -24,6 +24,7 @@ import {
   GitFork,
   Plus,
   RotateCcw,
+  Shield,
   Terminal,
   Wrench,
   X,
@@ -120,6 +121,8 @@ interface SlashCommandOptionsDropdownProps {
   onUpdateHookEntry: (hookType: HookType, entryIndex: number, entry: Partial<HookEntry>) => void;
   allowedTools: string;
   onAllowedToolsChange: (tools: string) => void;
+  disableModelInvocation: boolean;
+  onDisableModelInvocationChange: (value: boolean) => void;
 }
 
 interface NewEntryState {
@@ -139,6 +142,8 @@ export function SlashCommandOptionsDropdown({
   onUpdateHookEntry,
   allowedTools,
   onAllowedToolsChange,
+  disableModelInvocation,
+  onDisableModelInvocationChange,
 }: SlashCommandOptionsDropdownProps) {
   const { t } = useTranslation();
   const [newEntry, setNewEntry] = useState<Record<HookType, NewEntryState>>({
@@ -676,6 +681,142 @@ export function SlashCommandOptionsDropdown({
                   }}
                 >
                   {t('toolbar.contextFork.tooltip')}
+                </div>
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
+
+          <DropdownMenu.Separator
+            style={{
+              height: '1px',
+              backgroundColor: 'var(--vscode-dropdown-border)',
+              margin: '4px 0',
+            }}
+          />
+
+          {/* Disable Model Invocation Sub-menu */}
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger
+              style={{
+                padding: '8px 12px',
+                fontSize: `${FONT_SIZES.small}px`,
+                color: 'var(--vscode-foreground)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '8px',
+                outline: 'none',
+                borderRadius: '2px',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <ChevronLeft size={14} />
+                <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                  {disableModelInvocation ? 'true' : 'default'}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <Shield size={14} />
+                <span>Disable Model Invocation</span>
+              </div>
+            </DropdownMenu.SubTrigger>
+
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                sideOffset={4}
+                collisionPadding={{ right: 300 }}
+                style={{
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+                  zIndex: 10000,
+                  minWidth: '180px',
+                  padding: '4px',
+                }}
+              >
+                <DropdownMenu.RadioGroup value={disableModelInvocation ? 'true' : 'default'}>
+                  <DropdownMenu.RadioItem
+                    value="default"
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      onDisableModelInvocationChange(false);
+                    }}
+                    style={{
+                      padding: '6px 12px',
+                      fontSize: `${FONT_SIZES.small}px`,
+                      color: 'var(--vscode-foreground)',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      outline: 'none',
+                      borderRadius: '2px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: '12px',
+                        height: '12px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <DropdownMenu.ItemIndicator>
+                        <Check size={12} />
+                      </DropdownMenu.ItemIndicator>
+                    </div>
+                    <span>default</span>
+                  </DropdownMenu.RadioItem>
+                  <DropdownMenu.RadioItem
+                    value="true"
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      onDisableModelInvocationChange(true);
+                    }}
+                    style={{
+                      padding: '6px 12px',
+                      fontSize: `${FONT_SIZES.small}px`,
+                      color: 'var(--vscode-foreground)',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      outline: 'none',
+                      borderRadius: '2px',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: '12px',
+                        height: '12px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <DropdownMenu.ItemIndicator>
+                        <Check size={12} />
+                      </DropdownMenu.ItemIndicator>
+                    </div>
+                    <span>true</span>
+                  </DropdownMenu.RadioItem>
+                </DropdownMenu.RadioGroup>
+
+                {/* Description */}
+                <div
+                  style={{
+                    padding: '6px 12px',
+                    fontSize: '10px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    lineHeight: '1.4',
+                    borderTop: '1px solid var(--vscode-dropdown-border)',
+                    marginTop: '4px',
+                  }}
+                >
+                  {t('toolbar.disableModelInvocation.tooltip')}
                 </div>
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -62,6 +62,7 @@ export interface WebviewTranslationKeys {
 
   // Toolbar slash command options dropdown
   'toolbar.contextFork.tooltip': string;
+  'toolbar.disableModelInvocation.tooltip': string;
 
   // Toolbar hooks configuration dropdown
   'hooks.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -67,6 +67,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar slash command options dropdown
   'toolbar.contextFork.tooltip': 'Run in isolated sub-agent context (Claude Code v2.1.0+)',
+  'toolbar.disableModelInvocation.tooltip':
+    'When true, prevents the Skill tool from invoking this command',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -68,6 +68,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar slash command options dropdown
   'toolbar.contextFork.tooltip':
     '分離されたサブエージェントコンテキストで実行 (Claude Code v2.1.0+)',
+  'toolbar.disableModelInvocation.tooltip':
+    'trueの場合、Skillツールからこのコマンドの呼び出しを防止します',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -66,6 +66,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar slash command options dropdown
   'toolbar.contextFork.tooltip': '분리된 서브 에이전트 컨텍스트에서 실행 (Claude Code v2.1.0+)',
+  'toolbar.disableModelInvocation.tooltip':
+    'true인 경우, Skill 도구가 이 명령을 호출하는 것을 방지합니다',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -64,6 +64,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar slash command options dropdown
   'toolbar.contextFork.tooltip': '在隔离的子代理上下文中运行 (Claude Code v2.1.0+)',
+  'toolbar.disableModelInvocation.tooltip': '设为 true 时，阻止 Skill 工具调用此命令',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -64,6 +64,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Toolbar slash command options dropdown
   'toolbar.contextFork.tooltip': '在隔離的子代理上下文中運行 (Claude Code v2.1.0+)',
+  'toolbar.disableModelInvocation.tooltip': '設為 true 時，阻止 Skill 工具調用此命令',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -60,11 +60,13 @@ export function serializeWorkflow(
   const model = slashCommandOptions?.model;
   const hooks = slashCommandOptions?.hooks;
   const allowedTools = slashCommandOptions?.allowedTools;
+  const disableModelInvocation = slashCommandOptions?.disableModelInvocation;
   const hasNonDefaultOptions =
     (context && context !== 'default') ||
     (model && model !== 'default') ||
     (hooks && Object.keys(hooks).length > 0) ||
-    (allowedTools && allowedTools.length > 0);
+    (allowedTools && allowedTools.length > 0) ||
+    disableModelInvocation;
 
   // Create workflow object
   const workflow: Workflow = {
@@ -82,12 +84,14 @@ export function serializeWorkflow(
     subAgentFlows,
     // Issue #413: Include slashCommandOptions if any non-default option is set
     // Issue #424: Include allowedTools
+    // Issue #426: Include disableModelInvocation
     slashCommandOptions: hasNonDefaultOptions
       ? {
           ...(context && context !== 'default' && { context }),
           ...(model && model !== 'default' && { model }),
           ...(hooks && Object.keys(hooks).length > 0 && { hooks }),
           ...(allowedTools && allowedTools.length > 0 && { allowedTools }),
+          ...(disableModelInvocation && { disableModelInvocation }),
         }
       : undefined,
   };

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -90,6 +90,7 @@ interface WorkflowStore {
   setSlashCommandContext: (value: SlashCommandContext) => void;
   setSlashCommandModel: (value: SlashCommandModel) => void;
   setSlashCommandAllowedTools: (allowedTools: string) => void;
+  setSlashCommandDisableModelInvocation: (disableModelInvocation: boolean) => void;
   setHooks: (hooks: WorkflowHooks) => void;
   addHookEntry: (hookType: HookType, matcher: string, command: string, once?: boolean) => void;
   removeHookEntry: (hookType: HookType, entryIndex: number) => void;
@@ -391,6 +392,11 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   setSlashCommandAllowedTools: (allowedTools: string) =>
     set((state) => ({
       slashCommandOptions: { ...state.slashCommandOptions, allowedTools },
+    })),
+
+  setSlashCommandDisableModelInvocation: (disableModelInvocation: boolean) =>
+    set((state) => ({
+      slashCommandOptions: { ...state.slashCommandOptions, disableModelInvocation },
     })),
 
   setHooks: (hooks: WorkflowHooks) =>


### PR DESCRIPTION
## Problem

Currently, there is no way to configure the `disable-model-invocation` option in the Slash Command export settings. This option prevents the Skill tool from invoking the command, which is useful for controlling automated command execution.

### Current Behavior
1. User creates a workflow and wants to prevent Skill tool invocation
2. ❌ No UI option available to set `disable-model-invocation`
3. ❌ The setting is not exported to the frontmatter

### Expected Behavior
1. User creates a workflow and wants to prevent Skill tool invocation
2. ✅ User can set `Disable Model Invocation` to `true` via submenu in SlashCommandOptions dropdown
3. ✅ The setting is exported as `disable-model-invocation: true` in frontmatter

## Solution

Added `disableModelInvocation` configuration option to SlashCommandOptions with full UI support, serialization, and export functionality.

### Changes

**File**: `src/shared/types/workflow-definition.ts`

- Added `@see` link to Claude Code docs in SlashCommandOptions interface JSDoc
- Added `disableModelInvocation?: boolean` property with documentation

**File**: `src/extension/services/export-service.ts`

- Added frontmatter output for `disable-model-invocation: true` when enabled

**File**: `src/webview/src/stores/workflow-store.ts`

- Added `setSlashCommandDisableModelInvocation` action

**File**: `src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx`

- Added submenu UI with `default` / `true` radio options
- Used Shield icon to represent protection/prevention concept
- Added translated tooltip description

**File**: `src/webview/src/components/Toolbar.tsx`

- Connected `disableModelInvocation` state to dropdown component
- Added loading support in LOAD_WORKFLOW handler

**File**: `src/webview/src/services/workflow-service.ts`

- Added `disableModelInvocation` to serialization logic
- Added to `hasNonDefaultOptions` check

**Files**: Translation files (en.ts, ja.ts, ko.ts, zh-CN.ts, zh-TW.ts)

- Added `toolbar.disableModelInvocation.tooltip` translations

## Impact

- UX: Users can now configure disable-model-invocation setting via submenu UI
- No breaking changes
- Follows existing UI patterns (similar to Context submenu)

## Testing

- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build succeeded (`npm run build`)
- [x] Manual E2E testing: Setting UI, export to MD file, save/load workflow

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)