### PR TITLE
improvement: reorganize SlashCommandOptions dropdown and add help link

### DIFF
--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -61,18 +61,13 @@ export interface WebviewTranslationKeys {
   'toolbar.running': string;
 
   // Toolbar slash command options dropdown
-  'toolbar.contextFork.tooltip': string;
-  'toolbar.disableModelInvocation.tooltip': string;
+  'toolbar.slashCommandOptions.frontmatterReferenceUrl': string;
 
   // Toolbar hooks configuration dropdown
   'hooks.title': string;
-  'hooks.tooltip': string;
   'hooks.preToolUse': string;
-  'hooks.preToolUse.description': string;
   'hooks.postToolUse': string;
-  'hooks.postToolUse.description': string;
   'hooks.stop': string;
-  'hooks.stop.description': string;
   'hooks.addEntry': string;
   'hooks.removeEntry': string;
   'hooks.matcher.description': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -66,19 +66,14 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': 'Running...',
 
   // Toolbar slash command options dropdown
-  'toolbar.contextFork.tooltip': 'Run in isolated sub-agent context (Claude Code v2.1.0+)',
-  'toolbar.disableModelInvocation.tooltip':
-    'When true, prevents the Skill tool from invoking this command',
+  'toolbar.slashCommandOptions.frontmatterReferenceUrl':
+    'https://code.claude.com/docs/en/slash-commands#frontmatter',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',
-  'hooks.tooltip': 'Configure commands to run at specific execution points',
   'hooks.preToolUse': 'PreToolUse',
-  'hooks.preToolUse.description': 'Commands to run before a tool is executed',
   'hooks.postToolUse': 'PostToolUse',
-  'hooks.postToolUse.description': 'Commands to run after a tool is executed',
   'hooks.stop': 'Stop',
-  'hooks.stop.description': 'Commands to run when the agent stops',
   'hooks.addEntry': 'Add',
   'hooks.removeEntry': 'Remove',
   'hooks.matcher.description': 'Tool name pattern to match',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -66,20 +66,14 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '実行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.contextFork.tooltip':
-    '分離されたサブエージェントコンテキストで実行 (Claude Code v2.1.0+)',
-  'toolbar.disableModelInvocation.tooltip':
-    'trueの場合、Skillツールからこのコマンドの呼び出しを防止します',
+  'toolbar.slashCommandOptions.frontmatterReferenceUrl':
+    'https://code.claude.com/docs/ja/slash-commands#フロントマター',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',
-  'hooks.tooltip': '特定の実行タイミングで実行するコマンドを設定',
   'hooks.preToolUse': 'PreToolUse',
-  'hooks.preToolUse.description': 'ツールが実行される前に実行されるコマンド',
   'hooks.postToolUse': 'PostToolUse',
-  'hooks.postToolUse.description': 'ツールが実行された後に実行されるコマンド',
   'hooks.stop': 'Stop',
-  'hooks.stop.description': 'エージェントが停止したときに実行されるコマンド',
   'hooks.addEntry': '追加',
   'hooks.removeEntry': '削除',
   'hooks.matcher.description': 'マッチするツール名パターン',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -65,19 +65,14 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '실행 중...',
 
   // Toolbar slash command options dropdown
-  'toolbar.contextFork.tooltip': '분리된 서브 에이전트 컨텍스트에서 실행 (Claude Code v2.1.0+)',
-  'toolbar.disableModelInvocation.tooltip':
-    'true인 경우, Skill 도구가 이 명령을 호출하는 것을 방지합니다',
+  'toolbar.slashCommandOptions.frontmatterReferenceUrl':
+    'https://code.claude.com/docs/ko/slash-commands#프론트매터',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',
-  'hooks.tooltip': '특정 실행 시점에 실행할 명령 구성',
   'hooks.preToolUse': 'PreToolUse',
-  'hooks.preToolUse.description': '도구가 실행되기 전에 실행되는 명령',
   'hooks.postToolUse': 'PostToolUse',
-  'hooks.postToolUse.description': '도구가 실행된 후에 실행되는 명령',
   'hooks.stop': 'Stop',
-  'hooks.stop.description': '에이전트가 중지될 때 실행되는 명령',
   'hooks.addEntry': '추가',
   'hooks.removeEntry': '삭제',
   'hooks.matcher.description': '일치할 도구 이름 패턴',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -63,18 +63,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '执行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.contextFork.tooltip': '在隔离的子代理上下文中运行 (Claude Code v2.1.0+)',
-  'toolbar.disableModelInvocation.tooltip': '设为 true 时，阻止 Skill 工具调用此命令',
+  'toolbar.slashCommandOptions.frontmatterReferenceUrl':
+    'https://code.claude.com/docs/zh-CN/slash-commands#前置事项',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',
-  'hooks.tooltip': '配置在特定执行点运行的命令',
   'hooks.preToolUse': 'PreToolUse',
-  'hooks.preToolUse.description': '在工具执行前运行的命令',
   'hooks.postToolUse': 'PostToolUse',
-  'hooks.postToolUse.description': '在工具执行后运行的命令',
   'hooks.stop': 'Stop',
-  'hooks.stop.description': '代理停止时运行的命令',
   'hooks.addEntry': '添加',
   'hooks.removeEntry': '删除',
   'hooks.matcher.description': '要匹配的工具名称模式',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -63,18 +63,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.running': '執行中...',
 
   // Toolbar slash command options dropdown
-  'toolbar.contextFork.tooltip': '在隔離的子代理上下文中運行 (Claude Code v2.1.0+)',
-  'toolbar.disableModelInvocation.tooltip': '設為 true 時，阻止 Skill 工具調用此命令',
+  'toolbar.slashCommandOptions.frontmatterReferenceUrl':
+    'https://code.claude.com/docs/zh-TW/slash-commands#前置資料',
 
   // Toolbar hooks configuration dropdown
   'hooks.title': 'Hooks',
-  'hooks.tooltip': '配置在特定執行點運行的命令',
   'hooks.preToolUse': 'PreToolUse',
-  'hooks.preToolUse.description': '在工具執行前運行的命令',
   'hooks.postToolUse': 'PostToolUse',
-  'hooks.postToolUse.description': '在工具執行後運行的命令',
   'hooks.stop': 'Stop',
-  'hooks.stop.description': '代理停止時運行的命令',
   'hooks.addEntry': '新增',
   'hooks.removeEntry': '刪除',
   'hooks.matcher.description': '要匹配的工具名稱模式',


### PR DESCRIPTION
## Problem

The SlashCommandOptions dropdown had several UX issues:

### Current Behavior
1. Submenu order didn't match the frontmatter export order in Claude Code docs
2. Individual tooltip descriptions were inconsistent (some submenus had them, others didn't)
3. No direct link to official documentation for users who need help

### Expected Behavior
1. ✅ Submenu order matches frontmatter export order
2. ✅ Consistent help experience via single documentation link
3. ✅ Easy access to official documentation

## Solution

Reorganize the dropdown structure and consolidate help resources:
- Reorder submenus to match Claude Code docs frontmatter order
- Add localized "Frontmatter Reference" link at dropdown bottom
- Remove individual tooltip descriptions from submenus
- Clean up unused translation keys

## Changes

### Submenu Order (matches export-service.ts frontmatter output)
1. Allowed Tools
2. Model
3. Context
4. Disable Model Invocation
5. Hooks

### File Changes

**File**: `src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx`
- Reordered submenu components
- Added ExternalLink icon and Frontmatter Reference link
- Removed tooltip descriptions from Context, Disable Model Invocation, Hooks submenus
- Removed `descKey` prop from HookTypeSubMenu component

**Files**: `src/webview/src/i18n/translation-keys.ts`, `translations/*.ts`
- Added `toolbar.slashCommandOptions.frontmatterReferenceUrl` with locale-specific URLs
- Removed unused keys: `toolbar.contextFork.tooltip`, `toolbar.disableModelInvocation.tooltip`, `hooks.tooltip`, `hooks.preToolUse.description`, `hooks.postToolUse.description`, `hooks.stop.description`

## Impact

- **UX**: Users get consistent help experience via official documentation link
- **Localization**: Help link opens documentation in user's language
- **Code cleanup**: -60 lines of code, fewer translation keys to maintain

## Testing

- [x] Manual E2E testing completed
  - Submenu order verified
  - Frontmatter Reference link opens correct localized URL
  - No tooltip descriptions appear in submenus
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)