### PR TITLE
improvement: add argument-hint configuration to SlashCommandOptions

### DIFF
--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -538,6 +538,11 @@ function generateSlashCommandFile(workflow: Workflow): string {
     frontmatterLines.push('disable-model-invocation: true');
   }
 
+  // Issue #425: Add argument-hint if configured
+  if (workflow.slashCommandOptions?.argumentHint) {
+    frontmatterLines.push(`argument-hint: ${workflow.slashCommandOptions.argumentHint}`);
+  }
+
   // Issue #413: Add hooks if configured (Claude Code Docs compliant format)
   // See: https://code.claude.com/docs/en/hooks
   const hooks = workflow.slashCommandOptions?.hooks;

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -60,6 +60,8 @@ export interface SlashCommandOptions {
   allowedTools?: string;
   /** Disable model invocation. When true, prevents the Skill tool from invoking this command. */
   disableModelInvocation?: boolean;
+  /** Argument hint for Slash Command auto-completion. Format: "[arg1] [arg2] | [alt1] | [alt2]" */
+  argumentHint?: string;
 }
 
 // ============================================================================

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -68,6 +68,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setSlashCommandModel,
     setSlashCommandAllowedTools,
     setSlashCommandDisableModelInvocation,
+    setSlashCommandArgumentHint,
     addHookEntry,
     removeHookEntry,
     updateHookEntry,
@@ -730,6 +731,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               onAllowedToolsChange={setSlashCommandAllowedTools}
               disableModelInvocation={slashCommandOptions.disableModelInvocation ?? false}
               onDisableModelInvocationChange={setSlashCommandDisableModelInvocation}
+              argumentHint={slashCommandOptions.argumentHint ?? ''}
+              onArgumentHintChange={setSlashCommandArgumentHint}
             />
           </div>
         </div>

--- a/src/webview/src/components/common/ArgumentHintTagInput.tsx
+++ b/src/webview/src/components/common/ArgumentHintTagInput.tsx
@@ -1,0 +1,117 @@
+/**
+ * ArgumentHintInput Component
+ *
+ * A simple text input for configuring Slash Command argument hints.
+ * Includes an example with explanation to help users understand the syntax.
+ *
+ * Example syntax: add [tagId] | remove [tagId] | list
+ */
+
+import { memo } from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
+
+/**
+ * Stop arrow key propagation to prevent Radix UI menu navigation
+ */
+const stopArrowKeyPropagation = (e: React.KeyboardEvent) => {
+  if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+    e.stopPropagation();
+  }
+};
+
+interface ArgumentHintInputProps {
+  /** Current argument hint value */
+  value: string;
+  /** Callback when value changes */
+  onChange: (value: string) => void;
+  /** Disable the input */
+  disabled?: boolean;
+}
+
+export const ArgumentHintTagInput = memo(function ArgumentHintInput({
+  value,
+  onChange,
+  disabled = false,
+}: ArgumentHintInputProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '8px',
+        backgroundColor: 'var(--vscode-editor-background)',
+        borderRadius: '4px',
+        minWidth: '320px',
+      }}
+    >
+      {/* Text Input */}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={stopArrowKeyPropagation}
+        placeholder="add [tagId] | remove [tagId] | list"
+        disabled={disabled}
+        style={{
+          padding: '6px 8px',
+          backgroundColor: 'var(--vscode-input-background)',
+          color: 'var(--vscode-input-foreground)',
+          border: '1px solid var(--vscode-input-border)',
+          borderRadius: '2px',
+          fontSize: '12px',
+          fontFamily: 'monospace',
+          outline: 'none',
+          opacity: disabled ? 0.5 : 1,
+        }}
+      />
+
+      {/* Example Hint */}
+      <div
+        style={{
+          fontSize: '11px',
+        }}
+      >
+        <div
+          style={{
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('argumentHint.example')}
+        </div>
+        <span
+          style={{
+            display: 'block',
+            fontFamily: 'monospace',
+            color: 'var(--vscode-foreground)',
+            marginBottom: '8px',
+          }}
+        >
+          add [tagId] | remove [tagId] | list
+        </span>
+        <div
+          style={{
+            color: 'var(--vscode-descriptionForeground)',
+            lineHeight: '1.5',
+          }}
+        >
+          <div>
+            → <span style={{ fontFamily: 'monospace' }}>/command add myTag123</span> ...{' '}
+            {t('argumentHint.exampleAdd')}
+          </div>
+          <div>
+            → <span style={{ fontFamily: 'monospace' }}>/command remove myTag123</span> ...{' '}
+            {t('argumentHint.exampleRemove')}
+          </div>
+          <div>
+            → <span style={{ fontFamily: 'monospace' }}>/command list</span> ...{' '}
+            {t('argumentHint.exampleList')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -22,6 +22,7 @@ import {
   ChevronLeft,
   Cpu,
   ExternalLink,
+  FileQuestion,
   GitFork,
   Plus,
   RotateCcw,
@@ -35,6 +36,7 @@ import { useTranslation } from '../../i18n/i18n-context';
 import type { WebviewTranslationKeys } from '../../i18n/translation-keys';
 import { openExternalUrl } from '../../services/slack-integration-service';
 import { AVAILABLE_TOOLS } from '../../stores/refinement-store';
+import { ArgumentHintTagInput } from '../common/ArgumentHintTagInput';
 import { ToolSelectTagInput } from '../common/ToolSelectTagInput';
 
 // Fixed font sizes for dropdown menu (not responsive)
@@ -121,6 +123,8 @@ interface SlashCommandOptionsDropdownProps {
   onAllowedToolsChange: (tools: string) => void;
   disableModelInvocation: boolean;
   onDisableModelInvocationChange: (value: boolean) => void;
+  argumentHint: string;
+  onArgumentHintChange: (hint: string) => void;
 }
 
 interface NewEntryState {
@@ -142,6 +146,8 @@ export function SlashCommandOptionsDropdown({
   onAllowedToolsChange,
   disableModelInvocation,
   onDisableModelInvocationChange,
+  argumentHint,
+  onArgumentHintChange,
 }: SlashCommandOptionsDropdownProps) {
   const { t } = useTranslation();
   const [newEntry, setNewEntry] = useState<Record<HookType, NewEntryState>>({
@@ -398,7 +404,7 @@ export function SlashCommandOptionsDropdown({
             }}
           />
 
-          {/* Model Sub-menu */}
+          {/* Argument Hint Sub-menu */}
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger
               style={{
@@ -414,15 +420,23 @@ export function SlashCommandOptionsDropdown({
                 borderRadius: '2px',
               }}
             >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                <ChevronLeft size={14} />
-                <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
-                  {currentModelLabel}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0 }}>
+                <ChevronLeft size={14} style={{ flexShrink: 0 }} />
+                <span
+                  style={{
+                    color: 'var(--vscode-descriptionForeground)',
+                    maxWidth: '120px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {argumentHint || 'none'}
                 </span>
               </div>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <Cpu size={14} />
-                <span>Model</span>
+                <FileQuestion size={14} />
+                <span>Argument Hint</span>
               </div>
             </DropdownMenu.SubTrigger>
 
@@ -436,48 +450,11 @@ export function SlashCommandOptionsDropdown({
                   borderRadius: '4px',
                   boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
                   zIndex: 10000,
-                  minWidth: '180px',
+                  minWidth: '320px',
                   padding: '4px',
                 }}
               >
-                <DropdownMenu.RadioGroup value={model}>
-                  {MODEL_PRESETS.map((preset) => (
-                    <DropdownMenu.RadioItem
-                      key={preset.value}
-                      value={preset.value}
-                      onSelect={(event) => {
-                        event.preventDefault();
-                        onModelChange(preset.value);
-                      }}
-                      style={{
-                        padding: '6px 12px',
-                        fontSize: `${FONT_SIZES.small}px`,
-                        color: 'var(--vscode-foreground)',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                        outline: 'none',
-                        borderRadius: '2px',
-                      }}
-                    >
-                      <div
-                        style={{
-                          width: '12px',
-                          height: '12px',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                        }}
-                      >
-                        <DropdownMenu.ItemIndicator>
-                          <Check size={12} />
-                        </DropdownMenu.ItemIndicator>
-                      </div>
-                      <span>{preset.label}</span>
-                    </DropdownMenu.RadioItem>
-                  ))}
-                </DropdownMenu.RadioGroup>
+                <ArgumentHintTagInput value={argumentHint} onChange={onArgumentHintChange} />
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
@@ -540,6 +517,98 @@ export function SlashCommandOptionsDropdown({
                       onSelect={(event) => {
                         event.preventDefault();
                         onContextChange(preset.value);
+                      }}
+                      style={{
+                        padding: '6px 12px',
+                        fontSize: `${FONT_SIZES.small}px`,
+                        color: 'var(--vscode-foreground)',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        outline: 'none',
+                        borderRadius: '2px',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: '12px',
+                          height: '12px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <DropdownMenu.ItemIndicator>
+                          <Check size={12} />
+                        </DropdownMenu.ItemIndicator>
+                      </div>
+                      <span>{preset.label}</span>
+                    </DropdownMenu.RadioItem>
+                  ))}
+                </DropdownMenu.RadioGroup>
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
+
+          <DropdownMenu.Separator
+            style={{
+              height: '1px',
+              backgroundColor: 'var(--vscode-dropdown-border)',
+              margin: '4px 0',
+            }}
+          />
+
+          {/* Model Sub-menu */}
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger
+              style={{
+                padding: '8px 12px',
+                fontSize: `${FONT_SIZES.small}px`,
+                color: 'var(--vscode-foreground)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '8px',
+                outline: 'none',
+                borderRadius: '2px',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                <ChevronLeft size={14} />
+                <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                  {currentModelLabel}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <Cpu size={14} />
+                <span>Model</span>
+              </div>
+            </DropdownMenu.SubTrigger>
+
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                sideOffset={4}
+                collisionPadding={{ right: 300 }}
+                style={{
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+                  zIndex: 10000,
+                  minWidth: '180px',
+                  padding: '4px',
+                }}
+              >
+                <DropdownMenu.RadioGroup value={model}>
+                  {MODEL_PRESETS.map((preset) => (
+                    <DropdownMenu.RadioItem
+                      key={preset.value}
+                      value={preset.value}
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        onModelChange(preset.value);
                       }}
                       style={{
                         padding: '6px 12px',

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -76,6 +76,12 @@ export interface WebviewTranslationKeys {
   'hooks.validation.commandTooLong': string;
   'hooks.validation.matcherRequired': string;
 
+  // Argument Hint configuration
+  'argumentHint.example': string;
+  'argumentHint.exampleAdd': string;
+  'argumentHint.exampleRemove': string;
+  'argumentHint.exampleList': string;
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': string;
   'toolbar.help': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -82,6 +82,12 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'hooks.validation.commandTooLong': 'command exceeds maximum length',
   'hooks.validation.matcherRequired': 'matcher is required for this hook type',
 
+  // Argument Hint configuration
+  'argumentHint.example': 'Example:',
+  'argumentHint.exampleAdd': 'add tag',
+  'argumentHint.exampleRemove': 'remove tag',
+  'argumentHint.exampleList': 'list all',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'More',
   'toolbar.help': 'Help',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -82,6 +82,12 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'hooks.validation.commandTooLong': 'command が最大長を超えています',
   'hooks.validation.matcherRequired': 'このフックタイプには matcher が必須です',
 
+  // Argument Hint configuration
+  'argumentHint.example': '例:',
+  'argumentHint.exampleAdd': 'タグを追加',
+  'argumentHint.exampleRemove': 'タグを削除',
+  'argumentHint.exampleList': '一覧を表示',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'その他',
   'toolbar.help': 'ヘルプ',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -81,6 +81,12 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'hooks.validation.commandTooLong': 'command가 최대 길이를 초과했습니다',
   'hooks.validation.matcherRequired': '이 훅 유형에는 matcher가 필수입니다',
 
+  // Argument Hint configuration
+  'argumentHint.example': '예:',
+  'argumentHint.exampleAdd': '태그 추가',
+  'argumentHint.exampleRemove': '태그 삭제',
+  'argumentHint.exampleList': '목록 표시',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '더보기',
   'toolbar.help': '도움말',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -79,6 +79,12 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'hooks.validation.commandTooLong': 'command 超过最大长度',
   'hooks.validation.matcherRequired': '此钩子类型需要 matcher',
 
+  // Argument Hint configuration
+  'argumentHint.example': '示例:',
+  'argumentHint.exampleAdd': '添加标签',
+  'argumentHint.exampleRemove': '删除标签',
+  'argumentHint.exampleList': '显示列表',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '帮助',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -79,6 +79,12 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'hooks.validation.commandTooLong': 'command 超過最大長度',
   'hooks.validation.matcherRequired': '此鉤子類型需要 matcher',
 
+  // Argument Hint configuration
+  'argumentHint.example': '範例:',
+  'argumentHint.exampleAdd': '新增標籤',
+  'argumentHint.exampleRemove': '刪除標籤',
+  'argumentHint.exampleList': '顯示列表',
+
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '說明',

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -61,12 +61,14 @@ export function serializeWorkflow(
   const hooks = slashCommandOptions?.hooks;
   const allowedTools = slashCommandOptions?.allowedTools;
   const disableModelInvocation = slashCommandOptions?.disableModelInvocation;
+  const argumentHint = slashCommandOptions?.argumentHint;
   const hasNonDefaultOptions =
     (context && context !== 'default') ||
     (model && model !== 'default') ||
     (hooks && Object.keys(hooks).length > 0) ||
     (allowedTools && allowedTools.length > 0) ||
-    disableModelInvocation;
+    disableModelInvocation ||
+    (argumentHint && argumentHint.length > 0);
 
   // Create workflow object
   const workflow: Workflow = {
@@ -84,6 +86,7 @@ export function serializeWorkflow(
     subAgentFlows,
     // Issue #413: Include slashCommandOptions if any non-default option is set
     // Issue #424: Include allowedTools
+    // Issue #425: Include argumentHint
     // Issue #426: Include disableModelInvocation
     slashCommandOptions: hasNonDefaultOptions
       ? {
@@ -92,6 +95,7 @@ export function serializeWorkflow(
           ...(hooks && Object.keys(hooks).length > 0 && { hooks }),
           ...(allowedTools && allowedTools.length > 0 && { allowedTools }),
           ...(disableModelInvocation && { disableModelInvocation }),
+          ...(argumentHint && argumentHint.length > 0 && { argumentHint }),
         }
       : undefined,
   };

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -91,6 +91,7 @@ interface WorkflowStore {
   setSlashCommandModel: (value: SlashCommandModel) => void;
   setSlashCommandAllowedTools: (allowedTools: string) => void;
   setSlashCommandDisableModelInvocation: (disableModelInvocation: boolean) => void;
+  setSlashCommandArgumentHint: (argumentHint: string) => void;
   setHooks: (hooks: WorkflowHooks) => void;
   addHookEntry: (hookType: HookType, matcher: string, command: string, once?: boolean) => void;
   removeHookEntry: (hookType: HookType, entryIndex: number) => void;
@@ -397,6 +398,14 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   setSlashCommandDisableModelInvocation: (disableModelInvocation: boolean) =>
     set((state) => ({
       slashCommandOptions: { ...state.slashCommandOptions, disableModelInvocation },
+    })),
+
+  setSlashCommandArgumentHint: (argumentHint: string) =>
+    set((state) => ({
+      slashCommandOptions: {
+        ...state.slashCommandOptions,
+        argumentHint: argumentHint || undefined,
+      },
     })),
 
   setHooks: (hooks: WorkflowHooks) =>


### PR DESCRIPTION
## Summary

Add `argument-hint` configuration option to SlashCommandOptions, allowing users to define argument hints shown during auto-completion for slash commands.

Closes #425

**Output example:**
```yaml
---
argument-hint: add [tagId] | remove [tagId] | list
---
```

## Changes

- Added `argumentHint` property to `SlashCommandOptions` type
- Created `ArgumentHintTagInput` component with simple text input and example usage hints
- Added Argument Hint submenu to `SlashCommandOptionsDropdown`
- Export `argument-hint` to slash command frontmatter in `export-service.ts`
- Added store action `setSlashCommandArgumentHint`
- Added i18n support for example hints (5 languages: en, ja, ko, zh-CN, zh-TW)
- Reordered submenu: Allowed Tools > Argument Hint > Context > Model

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)