### PR TITLE
fix: load argumentHint from JSON when opening workflow

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -202,6 +202,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             hooks: workflow.slashCommandOptions?.hooks,
             allowedTools: workflow.slashCommandOptions?.allowedTools,
             disableModelInvocation: workflow.slashCommandOptions?.disableModelInvocation,
+            argumentHint: workflow.slashCommandOptions?.argumentHint,
           });
           // Set as active workflow to preserve conversation history
           setActiveWorkflow(workflow);


### PR DESCRIPTION
## Problem

When opening a saved workflow JSON file, the `argumentHint` property was not being loaded into the UI, even though it was correctly saved to the JSON file.

### Current Behavior
1. Set argument-hint in SlashCommandOptions
2. Save workflow to JSON ✅ (argumentHint is saved)
3. Close and reopen the workflow
4. ❌ argument-hint field is empty

### Expected Behavior
1. Set argument-hint in SlashCommandOptions
2. Save workflow to JSON ✅
3. Close and reopen the workflow
4. ✅ argument-hint field shows the saved value

## Solution

Added `argumentHint` to the `setSlashCommandOptions` call in the workflow load handler in `Toolbar.tsx`.

## Changes

**File**: `src/webview/src/components/Toolbar.tsx`

```typescript
setSlashCommandOptions({
  context: workflow.slashCommandOptions?.context ?? 'default',
  model: workflow.slashCommandOptions?.model ?? 'default',
  hooks: workflow.slashCommandOptions?.hooks,
  allowedTools: workflow.slashCommandOptions?.allowedTools,
  disableModelInvocation: workflow.slashCommandOptions?.disableModelInvocation,
  argumentHint: workflow.slashCommandOptions?.argumentHint,  // Added
});
```

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)