### PR TITLE
feat: add GitHub Copilot export integration (Beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ All operations run locally within VSCode. **Note:** MCP Tool nodes may require n
 
 💬 **Slack Workflow Sharing (β)** - Share workflows directly to Slack channels with preview cards and one-click import links for seamless team collaboration
 
+🤖 **GitHub Copilot Export (β)** - Export workflows to GitHub Copilot Prompts format (`.github/prompts/*.prompt.md`) and run them directly in Copilot Chat. Enable from **More** menu in the toolbar. **Note:** This is an experimental feature with limited support. Some features (e.g., Skill nodes, MCP nodes) are not yet supported in Copilot export
+
 🧩 **Rich Node Types** - Build complex workflows with diverse node types: Prompt (templates), Sub-Agent (AI tasks), Skill (Claude Code Skills), MCP (external tools), IfElse/Switch (conditional branching), and AskUserQuestion (user decisions)
 
 ## AI-Assisted Workflow Refinement

--- a/src/extension/commands/copilot-handlers.ts
+++ b/src/extension/commands/copilot-handlers.ts
@@ -1,0 +1,220 @@
+/**
+ * Claude Code Workflow Studio - Copilot Integration Handlers
+ *
+ * Handles Export/Run for GitHub Copilot integration
+ *
+ * @beta This is a PoC feature for GitHub Copilot integration
+ */
+
+import * as vscode from 'vscode';
+import type {
+  CopilotOperationFailedPayload,
+  ExportForCopilotPayload,
+  ExportForCopilotSuccessPayload,
+  RunForCopilotPayload,
+  RunForCopilotSuccessPayload,
+} from '../../shared/types/messages';
+import {
+  type CopilotExportOptions,
+  checkExistingCopilotFiles,
+  exportWorkflowForCopilot,
+} from '../services/copilot-export-service';
+import { nodeNameToFileName } from '../services/export-service';
+import type { FileService } from '../services/file-service';
+
+/**
+ * Handle Export for Copilot request
+ *
+ * @param fileService - File service instance
+ * @param webview - Webview for sending responses
+ * @param payload - Export payload
+ * @param requestId - Optional request ID for response correlation
+ */
+export async function handleExportForCopilot(
+  fileService: FileService,
+  webview: vscode.Webview,
+  payload: ExportForCopilotPayload,
+  requestId?: string
+): Promise<void> {
+  try {
+    const { workflow } = payload;
+
+    // Check for existing files and ask for confirmation
+    const existingFiles = await checkExistingCopilotFiles(workflow, fileService);
+
+    if (existingFiles.length > 0) {
+      const result = await vscode.window.showWarningMessage(
+        `The following files already exist:\n${existingFiles.join('\n')}\n\nOverwrite?`,
+        { modal: true },
+        'Overwrite',
+        'Cancel'
+      );
+
+      if (result !== 'Overwrite') {
+        webview.postMessage({
+          type: 'EXPORT_FOR_COPILOT_CANCELLED',
+          requestId,
+        });
+        return;
+      }
+    }
+
+    // Export to Copilot format (all options are fixed defaults)
+    const copilotOptions: CopilotExportOptions = {
+      destination: 'copilot',
+      agent: 'agent',
+    };
+
+    const copilotResult = await exportWorkflowForCopilot(workflow, fileService, copilotOptions);
+
+    if (!copilotResult.success) {
+      const failedPayload: CopilotOperationFailedPayload = {
+        errorCode: 'EXPORT_FAILED',
+        errorMessage: copilotResult.errors?.join(', ') || 'Unknown error',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'EXPORT_FOR_COPILOT_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Send success response
+    const successPayload: ExportForCopilotSuccessPayload = {
+      exportedFiles: copilotResult.exportedFiles,
+      timestamp: new Date().toISOString(),
+    };
+
+    webview.postMessage({
+      type: 'EXPORT_FOR_COPILOT_SUCCESS',
+      requestId,
+      payload: successPayload,
+    });
+
+    // Show notification
+    vscode.window.showInformationMessage(
+      `Exported workflow for Copilot (${copilotResult.exportedFiles.length} files)`
+    );
+  } catch (error) {
+    const failedPayload: CopilotOperationFailedPayload = {
+      errorCode: 'UNKNOWN_ERROR',
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
+    webview.postMessage({
+      type: 'EXPORT_FOR_COPILOT_FAILED',
+      requestId,
+      payload: failedPayload,
+    });
+  }
+}
+
+/**
+ * Handle Run for Copilot request
+ *
+ * Exports workflow to Copilot format and opens Copilot Chat with the prompt
+ *
+ * @param fileService - File service instance
+ * @param webview - Webview for sending responses
+ * @param payload - Run payload
+ * @param requestId - Optional request ID for response correlation
+ */
+export async function handleRunForCopilot(
+  fileService: FileService,
+  webview: vscode.Webview,
+  payload: RunForCopilotPayload,
+  requestId?: string
+): Promise<void> {
+  try {
+    const { workflow } = payload;
+
+    // First, export the workflow to Copilot format (all options are fixed defaults)
+    const copilotOptions: CopilotExportOptions = {
+      destination: 'copilot',
+      agent: 'agent',
+    };
+
+    const exportResult = await exportWorkflowForCopilot(workflow, fileService, copilotOptions);
+
+    if (!exportResult.success) {
+      const failedPayload: CopilotOperationFailedPayload = {
+        errorCode: 'EXPORT_FAILED',
+        errorMessage: exportResult.errors?.join(', ') || 'Failed to export workflow',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'RUN_FOR_COPILOT_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Try to open Copilot Chat with the prompt
+    const workflowName = nodeNameToFileName(workflow.name);
+    let copilotChatOpened = false;
+
+    try {
+      // Use workbench.action.chat.open to open Copilot Chat
+      await vscode.commands.executeCommand('workbench.action.chat.open', {
+        query: `/${workflowName}`,
+        isPartialQuery: false, // Auto-send
+      });
+      copilotChatOpened = true;
+    } catch (chatError) {
+      // Copilot Chat might not be installed or command failed
+      // We still exported the file, so it's a partial success
+      console.warn('Failed to open Copilot Chat:', chatError);
+
+      // Try alternative approach: just open the chat panel
+      try {
+        await vscode.commands.executeCommand('workbench.action.chat.open');
+        copilotChatOpened = true;
+        // Show message that user needs to type the command manually
+        vscode.window.showInformationMessage(
+          `Workflow exported. Type "/${workflowName}" in Copilot Chat to run.`
+        );
+      } catch {
+        // Copilot is likely not installed
+        const failedPayload: CopilotOperationFailedPayload = {
+          errorCode: 'COPILOT_NOT_INSTALLED',
+          errorMessage:
+            'GitHub Copilot Chat is not installed or not available. The workflow was exported but could not be run.',
+          timestamp: new Date().toISOString(),
+        };
+        webview.postMessage({
+          type: 'RUN_FOR_COPILOT_FAILED',
+          requestId,
+          payload: failedPayload,
+        });
+        return;
+      }
+    }
+
+    // Send success response
+    const successPayload: RunForCopilotSuccessPayload = {
+      workflowName: workflow.name,
+      copilotChatOpened,
+      timestamp: new Date().toISOString(),
+    };
+
+    webview.postMessage({
+      type: 'RUN_FOR_COPILOT_SUCCESS',
+      requestId,
+      payload: successPayload,
+    });
+  } catch (error) {
+    const failedPayload: CopilotOperationFailedPayload = {
+      errorCode: 'UNKNOWN_ERROR',
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
+    webview.postMessage({
+      type: 'RUN_FOR_COPILOT_FAILED',
+      requestId,
+      payload: failedPayload,
+    });
+  }
+}

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -16,6 +16,7 @@ import { migrateWorkflow } from '../utils/migrate-workflow';
 import { SlackTokenManager } from '../utils/slack-token-manager';
 import { validateWorkflowFile } from '../utils/workflow-validator';
 import { getWebviewContent } from '../webview-content';
+import { handleExportForCopilot, handleRunForCopilot } from './copilot-handlers';
 import { handleExportWorkflow, handleExportWorkflowForExecution } from './export-workflow';
 import { loadWorkflow } from './load-workflow';
 import { loadWorkflowList } from './load-workflow-list';
@@ -296,6 +297,45 @@ export function registerOpenEditorCommand(
                   payload: {
                     code: 'VALIDATION_ERROR',
                     message: 'Workflow is required',
+                  },
+                });
+              }
+              break;
+
+            case 'EXPORT_FOR_COPILOT':
+              // Export workflow for Copilot (Beta)
+              if (message.payload?.workflow) {
+                await handleExportForCopilot(
+                  fileService,
+                  webview,
+                  message.payload,
+                  message.requestId
+                );
+              } else {
+                webview.postMessage({
+                  type: 'EXPORT_FOR_COPILOT_FAILED',
+                  requestId: message.requestId,
+                  payload: {
+                    errorCode: 'UNKNOWN_ERROR',
+                    errorMessage: 'Workflow is required',
+                    timestamp: new Date().toISOString(),
+                  },
+                });
+              }
+              break;
+
+            case 'RUN_FOR_COPILOT':
+              // Run workflow for Copilot (Beta)
+              if (message.payload?.workflow) {
+                await handleRunForCopilot(fileService, webview, message.payload, message.requestId);
+              } else {
+                webview.postMessage({
+                  type: 'RUN_FOR_COPILOT_FAILED',
+                  requestId: message.requestId,
+                  payload: {
+                    errorCode: 'UNKNOWN_ERROR',
+                    errorMessage: 'Workflow is required',
+                    timestamp: new Date().toISOString(),
                   },
                 });
               }

--- a/src/extension/services/copilot-export-service.ts
+++ b/src/extension/services/copilot-export-service.ts
@@ -1,0 +1,399 @@
+/**
+ * Claude Code Workflow Studio - Copilot Export Service
+ *
+ * Handles workflow export to GitHub Copilot Prompts format (.github/prompts/*.prompt.md)
+ * Based on: /docs/Copilot-Prompts-Guide.md
+ *
+ * @beta This is a PoC feature for GitHub Copilot integration
+ */
+
+import * as path from 'node:path';
+import type { Workflow } from '../../shared/types/workflow-definition';
+import { nodeNameToFileName } from './export-service';
+import type { FileService } from './file-service';
+
+/**
+ * Copilot agent mode options
+ */
+export type CopilotAgentMode = 'ask' | 'edit' | 'agent';
+
+/**
+ * Copilot model options
+ */
+export type CopilotModel =
+  | 'gpt-4o'
+  | 'gpt-4o-mini'
+  | 'o1-preview'
+  | 'o1-mini'
+  | 'claude-3.5-sonnet'
+  | 'claude-3-opus';
+
+/**
+ * Copilot export options
+ */
+export interface CopilotExportOptions {
+  /** Export destination: copilot only, claude only, or both */
+  destination: 'copilot' | 'claude' | 'both';
+  /** Copilot agent mode */
+  agent: CopilotAgentMode;
+  /** Copilot model (optional - omit to use default) */
+  model?: CopilotModel;
+  /** Tools to enable (optional) */
+  tools?: string[];
+}
+
+/**
+ * Export result
+ */
+export interface CopilotExportResult {
+  success: boolean;
+  exportedFiles: string[];
+  errors?: string[];
+}
+
+/**
+ * Check if any Copilot export files already exist
+ *
+ * @param workflow - Workflow to export
+ * @param fileService - File service instance
+ * @returns Array of existing file paths (empty if no conflicts)
+ */
+export async function checkExistingCopilotFiles(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<string[]> {
+  const existingFiles: string[] = [];
+  const workspacePath = fileService.getWorkspacePath();
+
+  const promptsDir = path.join(workspacePath, '.github', 'prompts');
+  const workflowBaseName = nodeNameToFileName(workflow.name);
+  const filePath = path.join(promptsDir, `${workflowBaseName}.prompt.md`);
+
+  if (await fileService.fileExists(filePath)) {
+    existingFiles.push(filePath);
+  }
+
+  return existingFiles;
+}
+
+/**
+ * Export workflow to Copilot Prompts format
+ *
+ * @param workflow - Workflow to export
+ * @param fileService - File service instance
+ * @param options - Copilot export options
+ * @returns Export result with file paths
+ */
+export async function exportWorkflowForCopilot(
+  workflow: Workflow,
+  fileService: FileService,
+  options: CopilotExportOptions
+): Promise<CopilotExportResult> {
+  const exportedFiles: string[] = [];
+  const errors: string[] = [];
+  const workspacePath = fileService.getWorkspacePath();
+
+  try {
+    // Create .github/prompts directory if it doesn't exist
+    const promptsDir = path.join(workspacePath, '.github', 'prompts');
+    await fileService.createDirectory(path.join(workspacePath, '.github'));
+    await fileService.createDirectory(promptsDir);
+
+    // Generate Copilot prompt file
+    const workflowBaseName = nodeNameToFileName(workflow.name);
+    const filePath = path.join(promptsDir, `${workflowBaseName}.prompt.md`);
+    const content = generateCopilotPromptFile(workflow, options);
+
+    await fileService.writeFile(filePath, content);
+    exportedFiles.push(filePath);
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+  }
+
+  return {
+    success: errors.length === 0,
+    exportedFiles,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+/**
+ * Generate Copilot Prompt file content
+ *
+ * @param workflow - Workflow definition
+ * @param options - Copilot export options
+ * @returns Markdown content with YAML frontmatter
+ */
+function generateCopilotPromptFile(workflow: Workflow, options: CopilotExportOptions): string {
+  const workflowName = nodeNameToFileName(workflow.name);
+
+  // YAML frontmatter
+  const frontmatterLines = ['---', `name: ${workflowName}`];
+
+  // Add description
+  if (workflow.description) {
+    frontmatterLines.push(`description: ${workflow.description}`);
+  } else {
+    frontmatterLines.push(`description: ${workflow.name}`);
+  }
+
+  // Add argument-hint if configured
+  if (workflow.slashCommandOptions?.argumentHint) {
+    frontmatterLines.push(`argument-hint: ${workflow.slashCommandOptions.argumentHint}`);
+  }
+
+  // Add agent mode
+  frontmatterLines.push(`agent: ${options.agent}`);
+
+  // Add model if specified
+  if (options.model) {
+    frontmatterLines.push(`model: ${options.model}`);
+  }
+
+  // Add tools if specified (array format)
+  if (options.tools && options.tools.length > 0) {
+    frontmatterLines.push('tools:');
+    for (const tool of options.tools) {
+      frontmatterLines.push(`  - ${tool}`);
+    }
+  } else if (workflow.slashCommandOptions?.allowedTools) {
+    // Convert comma-separated allowed-tools to array format
+    const tools = workflow.slashCommandOptions.allowedTools.split(',').map((t) => t.trim());
+    if (tools.length > 0) {
+      frontmatterLines.push('tools:');
+      for (const tool of tools) {
+        frontmatterLines.push(`  - ${tool}`);
+      }
+    }
+  }
+
+  frontmatterLines.push('---', '');
+  const frontmatter = frontmatterLines.join('\n');
+
+  // Generate Mermaid flowchart
+  const mermaidFlowchart = generateMermaidFlowchartForCopilot(workflow);
+
+  // Generate execution instructions
+  const executionInstructions = generateExecutionInstructionsForCopilot(workflow);
+
+  return `${frontmatter}${mermaidFlowchart}\n\n${executionInstructions}`;
+}
+
+/**
+ * Sanitize node ID for Mermaid (remove special characters)
+ *
+ * @param id - Node ID
+ * @returns Sanitized ID
+ */
+function sanitizeNodeId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+/**
+ * Escape special characters in Mermaid labels
+ *
+ * @param label - Label text
+ * @returns Escaped label
+ */
+function escapeLabel(label: string): string {
+  return label.replace(/"/g, '#quot;').replace(/\[/g, '#91;').replace(/\]/g, '#93;');
+}
+
+/**
+ * Generate Mermaid flowchart for Copilot
+ *
+ * @param workflow - Workflow definition
+ * @returns Mermaid flowchart markdown
+ */
+function generateMermaidFlowchartForCopilot(workflow: Workflow): string {
+  const { nodes, connections } = workflow;
+  const lines: string[] = [];
+
+  lines.push('```mermaid');
+  lines.push('flowchart TD');
+
+  // Generate node definitions
+  for (const node of nodes) {
+    const nodeId = sanitizeNodeId(node.id);
+    const nodeType = node.type as string;
+
+    if (nodeType === 'start') {
+      lines.push(`    ${nodeId}([Start])`);
+    } else if (nodeType === 'end') {
+      lines.push(`    ${nodeId}([End])`);
+    } else if (nodeType === 'subAgent') {
+      const agentName = node.name || 'Sub-Agent';
+      lines.push(`    ${nodeId}[${escapeLabel(agentName)}]`);
+    } else if (nodeType === 'askUserQuestion') {
+      const questionText =
+        'data' in node && node.data && 'questionText' in node.data
+          ? (node.data.questionText as string)
+          : 'Question';
+      lines.push(`    ${nodeId}{${escapeLabel(`Question: ${questionText}`)}}`);
+    } else if (nodeType === 'ifElse' || nodeType === 'branch') {
+      lines.push(`    ${nodeId}{${escapeLabel('Condition')}}`);
+    } else if (nodeType === 'switch') {
+      lines.push(`    ${nodeId}{${escapeLabel('Switch')}}`);
+    } else if (nodeType === 'prompt') {
+      const promptData = 'data' in node && node.data && 'prompt' in node.data ? node.data : null;
+      const promptText = promptData
+        ? String(promptData.prompt).split('\n')[0] || 'Prompt'
+        : 'Prompt';
+      const label = promptText.length > 30 ? `${promptText.substring(0, 27)}...` : promptText;
+      lines.push(`    ${nodeId}[${escapeLabel(label)}]`);
+    } else if (nodeType === 'skill') {
+      const skillData = 'data' in node && node.data && 'name' in node.data ? node.data : null;
+      const skillName = skillData ? String(skillData.name) : 'Skill';
+      lines.push(`    ${nodeId}[[${escapeLabel(`Skill: ${skillName}`)}]]`);
+    } else if (nodeType === 'mcp') {
+      const mcpData = 'data' in node && node.data && 'toolName' in node.data ? node.data : null;
+      const toolName = mcpData ? String(mcpData.toolName) : 'MCP Tool';
+      lines.push(`    ${nodeId}[[${escapeLabel(`MCP: ${toolName}`)}]]`);
+    } else if (nodeType === 'subAgentFlow') {
+      const label = node.name || 'Sub-Agent Flow';
+      lines.push(`    ${nodeId}[["${escapeLabel(label)}"]]`);
+    }
+  }
+
+  lines.push('');
+
+  // Generate connections
+  for (const conn of connections) {
+    const fromId = sanitizeNodeId(conn.from);
+    const toId = sanitizeNodeId(conn.to);
+    lines.push(`    ${fromId} --> ${toId}`);
+  }
+
+  lines.push('```');
+
+  return lines.join('\n');
+}
+
+/**
+ * Generate execution instructions for Copilot
+ *
+ * @param workflow - Workflow definition
+ * @returns Markdown execution instructions
+ */
+function generateExecutionInstructionsForCopilot(workflow: Workflow): string {
+  const sections: string[] = [];
+
+  sections.push('# Workflow Execution Instructions');
+  sections.push('');
+  sections.push(
+    'Follow the flowchart above to execute this workflow. Each node represents a step to perform.'
+  );
+  sections.push('');
+
+  // Add node-specific instructions
+  const { nodes } = workflow;
+
+  // Prompt nodes
+  const promptNodes = nodes.filter((n) => n.type === 'prompt');
+  if (promptNodes.length > 0) {
+    sections.push('## Prompts');
+    sections.push('');
+    for (const node of promptNodes) {
+      const promptData = 'data' in node && node.data && 'prompt' in node.data ? node.data : null;
+      if (promptData) {
+        sections.push(`### ${node.name || 'Prompt'}`);
+        sections.push('');
+        sections.push('```');
+        sections.push(String(promptData.prompt || ''));
+        sections.push('```');
+        sections.push('');
+      }
+    }
+  }
+
+  // SubAgent nodes
+  const subAgentNodes = nodes.filter((n) => n.type === 'subAgent');
+  if (subAgentNodes.length > 0) {
+    sections.push('## Sub-Agents');
+    sections.push('');
+    for (const node of subAgentNodes) {
+      const agentData =
+        'data' in node && node.data && 'description' in node.data ? node.data : null;
+      if (agentData) {
+        sections.push(`### ${node.name || 'Sub-Agent'}`);
+        sections.push('');
+        sections.push(`**Description**: ${agentData.description || 'No description'}`);
+        sections.push('');
+        if ('prompt' in agentData && agentData.prompt) {
+          sections.push('**Prompt**:');
+          sections.push('```');
+          sections.push(String(agentData.prompt));
+          sections.push('```');
+          sections.push('');
+        }
+      }
+    }
+  }
+
+  // AskUserQuestion nodes
+  const askNodes = nodes.filter((n) => n.type === 'askUserQuestion');
+  if (askNodes.length > 0) {
+    sections.push('## User Questions');
+    sections.push('');
+    for (const node of askNodes) {
+      const askData = 'data' in node && node.data && 'questionText' in node.data ? node.data : null;
+      if (askData) {
+        sections.push(`### ${node.name || 'Question'}`);
+        sections.push('');
+        sections.push(`**Question**: ${askData.questionText || 'No question text'}`);
+        sections.push('');
+        if ('options' in askData && Array.isArray(askData.options) && askData.options.length > 0) {
+          sections.push('**Options**:');
+          for (const opt of askData.options) {
+            if (opt && typeof opt === 'object' && 'label' in opt) {
+              sections.push(`- **${opt.label}**: ${opt.description || ''}`);
+            }
+          }
+          sections.push('');
+        }
+      }
+    }
+  }
+
+  // Skill nodes
+  const skillNodes = nodes.filter((n) => n.type === 'skill');
+  if (skillNodes.length > 0) {
+    sections.push('## Skills');
+    sections.push('');
+    for (const node of skillNodes) {
+      const skillData = 'data' in node && node.data && 'name' in node.data ? node.data : null;
+      if (skillData) {
+        sections.push(`### ${skillData.name || 'Skill'}`);
+        sections.push('');
+        sections.push(`**Description**: ${skillData.description || 'No description'}`);
+        sections.push('');
+        if ('skillPath' in skillData && skillData.skillPath) {
+          sections.push(`**Path**: \`${skillData.skillPath}\``);
+          sections.push('');
+        }
+      }
+    }
+  }
+
+  // MCP nodes
+  const mcpNodes = nodes.filter((n) => n.type === 'mcp');
+  if (mcpNodes.length > 0) {
+    sections.push('## MCP Tools');
+    sections.push('');
+    for (const node of mcpNodes) {
+      const mcpData = 'data' in node && node.data && 'toolName' in node.data ? node.data : null;
+      if (mcpData) {
+        sections.push(`### ${mcpData.toolName || 'MCP Tool'}`);
+        sections.push('');
+        sections.push(`**Server**: ${mcpData.serverId || 'Unknown'}`);
+        sections.push('');
+        if ('toolDescription' in mcpData && mcpData.toolDescription) {
+          sections.push(`**Description**: ${mcpData.toolDescription}`);
+          sections.push('');
+        }
+      }
+    }
+  }
+
+  return sections.join('\n');
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -696,7 +696,12 @@ export type ExtensionMessage =
   | Message<void, 'FILE_PICKER_CANCELLED'>
   | Message<RunAsSlashCommandSuccessPayload, 'RUN_AS_SLASH_COMMAND_SUCCESS'>
   | Message<void, 'RUN_AS_SLASH_COMMAND_CANCELLED'>
-  | Message<EditorContentUpdatedPayload, 'EDITOR_CONTENT_UPDATED'>;
+  | Message<EditorContentUpdatedPayload, 'EDITOR_CONTENT_UPDATED'>
+  | Message<ExportForCopilotSuccessPayload, 'EXPORT_FOR_COPILOT_SUCCESS'>
+  | Message<void, 'EXPORT_FOR_COPILOT_CANCELLED'>
+  | Message<CopilotOperationFailedPayload, 'EXPORT_FOR_COPILOT_FAILED'>
+  | Message<RunForCopilotSuccessPayload, 'RUN_FOR_COPILOT_SUCCESS'>
+  | Message<CopilotOperationFailedPayload, 'RUN_FOR_COPILOT_FAILED'>;
 
 // ============================================================================
 // AI Slack Description Generation Payloads
@@ -1089,6 +1094,60 @@ export interface ShareWorkflowFailedPayload {
 }
 
 // ============================================================================
+// Copilot Integration Payloads (Beta)
+// ============================================================================
+
+/**
+ * Export workflow for Copilot payload
+ */
+export interface ExportForCopilotPayload {
+  /** Workflow to export */
+  workflow: Workflow;
+}
+
+/**
+ * Export for Copilot success payload
+ */
+export interface ExportForCopilotSuccessPayload {
+  /** Exported file paths */
+  exportedFiles: string[];
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+/**
+ * Run workflow for Copilot payload
+ */
+export interface RunForCopilotPayload {
+  /** Workflow to run */
+  workflow: Workflow;
+}
+
+/**
+ * Run for Copilot success payload
+ */
+export interface RunForCopilotSuccessPayload {
+  /** Workflow name */
+  workflowName: string;
+  /** Whether Copilot Chat was opened */
+  copilotChatOpened: boolean;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+/**
+ * Export/Run for Copilot failed payload
+ */
+export interface CopilotOperationFailedPayload {
+  /** Error code */
+  errorCode: 'COPILOT_NOT_INSTALLED' | 'EXPORT_FAILED' | 'CHAT_OPEN_FAILED' | 'UNKNOWN_ERROR';
+  /** Error message */
+  errorMessage: string;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+// ============================================================================
 // Edit in VSCode Editor Payloads
 // ============================================================================
 
@@ -1190,7 +1249,9 @@ export type WebviewMessage =
   | Message<void, 'OPEN_FILE_PICKER'>
   | Message<RunAsSlashCommandPayload, 'RUN_AS_SLASH_COMMAND'>
   | Message<OpenInEditorPayload, 'OPEN_IN_EDITOR'>
-  | Message<void, 'WEBVIEW_READY'>;
+  | Message<void, 'WEBVIEW_READY'>
+  | Message<ExportForCopilotPayload, 'EXPORT_FOR_COPILOT'>
+  | Message<RunForCopilotPayload, 'RUN_FOR_COPILOT'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Check, Focus, HelpCircle, MoreHorizontal, Share2, Trash2 } from 'lucide-react';
+import { Bot, Check, Focus, HelpCircle, MoreHorizontal, Share2, Trash2 } from 'lucide-react';
 import { useIsCompactMode } from '../../hooks/useWindowWidth';
 import { useTranslation } from '../../i18n/i18n-context';
 
@@ -23,6 +23,8 @@ interface MoreActionsDropdownProps {
   onStartTour: () => void;
   isFocusMode: boolean;
   onToggleFocusMode: () => void;
+  isCopilotBetaEnabled: boolean;
+  onToggleCopilotBeta: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -33,6 +35,8 @@ export function MoreActionsDropdown({
   onStartTour,
   isFocusMode,
   onToggleFocusMode,
+  isCopilotBetaEnabled,
+  onToggleCopilotBeta,
   open,
   onOpenChange,
 }: MoreActionsDropdownProps) {
@@ -134,6 +138,40 @@ export function MoreActionsDropdown({
             <Focus size={14} />
             <span style={{ flex: 1 }}>{t('toolbar.focusMode')}</span>
             {isFocusMode && <Check size={14} />}
+          </DropdownMenu.Item>
+
+          {/* Copilot Beta Toggle */}
+          <DropdownMenu.Item
+            onSelect={onToggleCopilotBeta}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <Bot size={14} />
+            <span style={{ flex: 1 }}>
+              Copilot
+              <span
+                style={{
+                  fontSize: '9px',
+                  backgroundColor: 'var(--vscode-badge-background)',
+                  color: 'var(--vscode-badge-foreground)',
+                  padding: '1px 4px',
+                  borderRadius: '2px',
+                  marginLeft: '4px',
+                }}
+              >
+                Beta
+              </span>
+            </span>
+            {isCopilotBetaEnabled && <Check size={14} />}
           </DropdownMenu.Item>
 
           <DropdownMenu.Separator


### PR DESCRIPTION
## Summary

Add experimental GitHub Copilot integration that allows exporting and running workflows in Copilot Chat.

- Export workflows to `.github/prompts/*.prompt.md` format (Copilot Prompts)
- Run workflows directly in Copilot Chat via `workbench.action.chat.open` API
- Feature toggle in More menu (disabled by default, persisted in localStorage)
- Combined Slash Command section with Claude Code / Copilot columns when enabled

## Changes

### New Files
- `src/extension/commands/copilot-handlers.ts` - Handle Export/Run for Copilot requests
- `src/extension/services/copilot-export-service.ts` - Convert workflow to Copilot Prompts format

### Modified Files
- `Toolbar.tsx` - Add Copilot Beta toggle and combined layout
- `MoreActionsDropdown.tsx` - Add Copilot Beta toggle item
- `vscode-bridge.ts` - Add exportForCopilot/runForCopilot functions
- `messages.ts` - Add Copilot-related message types
- `open-editor.ts` - Route Copilot messages to handlers
- `README.md` - Document the Beta feature

## Limitations (Beta)

- Some features not yet supported in Copilot export:
  - Skill nodes
  - MCP nodes
  - Other Claude Code-specific features

## Test Plan

- [x] Enable Copilot Beta from More menu
- [x] Export workflow to `.github/prompts/`
- [x] Run workflow opens Copilot Chat
- [x] Toggle persists across sessions (localStorage)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)