### PR TITLE
improvement: add MCP config auto-sync for Copilot export

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All operations run locally within VSCode. **Note:** MCP Tool nodes may require n
 
 💬 **Slack Workflow Sharing (β)** - Share workflows directly to Slack channels with preview cards and one-click import links for seamless team collaboration
 
-🤖 **GitHub Copilot Export (β)** - Export workflows to GitHub Copilot Prompts format (`.github/prompts/*.prompt.md`) and run them directly in Copilot Chat. Enable from **More** menu in the toolbar. **Note:** This is an experimental feature with limited support. Some features (e.g., Skill nodes, MCP nodes) are not yet supported in Copilot export
+🤖 **GitHub Copilot Export (β)** - Export workflows to GitHub Copilot Prompts format (`.github/prompts/*.prompt.md`) and run them directly in Copilot Chat. Enable from **More** menu in the toolbar. **Note:** This is an experimental feature with limited support. Some features (e.g., Skill nodes) are not yet supported in Copilot export
 
 🧩 **Rich Node Types** - Build complex workflows with diverse node types: Prompt (templates), Sub-Agent (AI tasks), Skill (Claude Code Skills), MCP (external tools), IfElse/Switch (conditional branching), and AskUserQuestion (user decisions)
 

--- a/src/extension/services/copilot-export-service.ts
+++ b/src/extension/services/copilot-export-service.ts
@@ -8,9 +8,11 @@
  */
 
 import * as path from 'node:path';
+import type { McpNodeData } from '../../shared/types/mcp-node';
 import type { Workflow } from '../../shared/types/workflow-definition';
 import { nodeNameToFileName } from './export-service';
 import type { FileService } from './file-service';
+import { getMcpServerConfig } from './mcp-config-reader';
 
 /**
  * Copilot agent mode options
@@ -40,6 +42,8 @@ export interface CopilotExportOptions {
   model?: CopilotModel;
   /** Tools to enable (optional) */
   tools?: string[];
+  /** Skip MCP server sync to .vscode/mcp.json (default: false) */
+  skipMcpSync?: boolean;
 }
 
 /**
@@ -49,6 +53,27 @@ export interface CopilotExportResult {
   success: boolean;
   exportedFiles: string[];
   errors?: string[];
+  /** MCP servers synced to .vscode/mcp.json */
+  syncedMcpServers?: string[];
+}
+
+/**
+ * VS Code MCP configuration format (.vscode/mcp.json)
+ */
+interface VscodeMcpConfig {
+  servers?: Record<string, McpServerConfigEntry>;
+  inputs?: unknown[];
+}
+
+/**
+ * MCP server configuration entry
+ */
+interface McpServerConfigEntry {
+  type?: 'stdio' | 'http' | 'sse';
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
 }
 
 /**
@@ -92,6 +117,7 @@ export async function exportWorkflowForCopilot(
   const exportedFiles: string[] = [];
   const errors: string[] = [];
   const workspacePath = fileService.getWorkspacePath();
+  let syncedMcpServers: string[] = [];
 
   try {
     // Create .github/prompts directory if it doesn't exist
@@ -106,6 +132,12 @@ export async function exportWorkflowForCopilot(
 
     await fileService.writeFile(filePath, content);
     exportedFiles.push(filePath);
+
+    // Sync MCP server configurations to .vscode/mcp.json (unless skipped)
+    if (!options.skipMcpSync) {
+      const mcpServerIds = extractMcpServerIdsFromWorkflow(workflow);
+      syncedMcpServers = await syncMcpConfigForCopilot(mcpServerIds, fileService);
+    }
   } catch (error) {
     errors.push(error instanceof Error ? error.message : String(error));
   }
@@ -114,7 +146,180 @@ export async function exportWorkflowForCopilot(
     success: errors.length === 0,
     exportedFiles,
     errors: errors.length > 0 ? errors : undefined,
+    syncedMcpServers: syncedMcpServers.length > 0 ? syncedMcpServers : undefined,
   };
+}
+
+/**
+ * Preview result for MCP server sync
+ */
+export interface McpSyncPreviewResult {
+  /** Server IDs that would be added to .vscode/mcp.json */
+  serversToAdd: string[];
+  /** Server IDs that already exist in .vscode/mcp.json */
+  existingServers: string[];
+  /** Server IDs not found in any Claude Code config */
+  missingServers: string[];
+}
+
+/**
+ * Preview which MCP servers would be synced to .vscode/mcp.json
+ *
+ * This function checks without actually writing, allowing for confirmation dialogs.
+ *
+ * @param workflow - Workflow definition
+ * @param fileService - File service instance
+ * @returns Preview of servers to add, existing, and missing
+ */
+export async function previewMcpSyncForCopilot(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<McpSyncPreviewResult> {
+  const serverIds = extractMcpServerIdsFromWorkflow(workflow);
+
+  if (serverIds.length === 0) {
+    return { serversToAdd: [], existingServers: [], missingServers: [] };
+  }
+
+  const workspacePath = fileService.getWorkspacePath();
+  const vscodeMcpPath = path.join(workspacePath, '.vscode', 'mcp.json');
+
+  // Read existing VS Code mcp.json
+  let existingVscodeServers: Record<string, unknown> = {};
+  try {
+    if (await fileService.fileExists(vscodeMcpPath)) {
+      const content = await fileService.readFile(vscodeMcpPath);
+      const vscodeConfig = JSON.parse(content) as VscodeMcpConfig;
+      existingVscodeServers = vscodeConfig.servers || {};
+    }
+  } catch {
+    // File doesn't exist or invalid JSON
+  }
+
+  const serversToAdd: string[] = [];
+  const existingServers: string[] = [];
+  const missingServers: string[] = [];
+
+  for (const serverId of serverIds) {
+    if (existingVscodeServers[serverId]) {
+      existingServers.push(serverId);
+    } else {
+      // Check if server config exists in Claude Code
+      const serverConfig = getMcpServerConfig(serverId, workspacePath);
+      if (serverConfig) {
+        serversToAdd.push(serverId);
+      } else {
+        missingServers.push(serverId);
+      }
+    }
+  }
+
+  return { serversToAdd, existingServers, missingServers };
+}
+
+/**
+ * Execute MCP server sync to .vscode/mcp.json
+ *
+ * Call this after user confirms the sync via previewMcpSyncForCopilot.
+ *
+ * @param workflow - Workflow definition
+ * @param fileService - File service instance
+ * @returns Array of synced server IDs
+ */
+export async function executeMcpSyncForCopilot(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<string[]> {
+  const serverIds = extractMcpServerIdsFromWorkflow(workflow);
+  return syncMcpConfigForCopilot(serverIds, fileService);
+}
+
+/**
+ * Extract unique MCP server IDs from workflow nodes
+ *
+ * @param workflow - Workflow definition
+ * @returns Array of unique server IDs
+ */
+function extractMcpServerIdsFromWorkflow(workflow: Workflow): string[] {
+  const serverIds = new Set<string>();
+
+  for (const node of workflow.nodes) {
+    if (node.type !== 'mcp') continue;
+    if (!('data' in node) || !node.data) continue;
+
+    const mcpData = node.data as McpNodeData;
+    if (mcpData.serverId?.trim()) {
+      serverIds.add(mcpData.serverId);
+    }
+  }
+
+  return Array.from(serverIds);
+}
+
+/**
+ * Sync MCP server configurations from Claude Code to VS Code (.vscode/mcp.json)
+ *
+ * Reads MCP server configs from all Claude Code scopes (project, local, user)
+ * and writes them to .vscode/mcp.json for GitHub Copilot.
+ * Only adds servers that don't already exist in .vscode/mcp.json.
+ *
+ * @param serverIds - Server IDs to sync
+ * @param fileService - File service instance
+ * @returns Array of synced server IDs
+ */
+async function syncMcpConfigForCopilot(
+  serverIds: string[],
+  fileService: FileService
+): Promise<string[]> {
+  if (serverIds.length === 0) {
+    return [];
+  }
+
+  const workspacePath = fileService.getWorkspacePath();
+  const vscodeMcpPath = path.join(workspacePath, '.vscode', 'mcp.json');
+
+  // Read existing VS Code mcp.json
+  let vscodeConfig: VscodeMcpConfig = { servers: {} };
+  try {
+    if (await fileService.fileExists(vscodeMcpPath)) {
+      const content = await fileService.readFile(vscodeMcpPath);
+      vscodeConfig = JSON.parse(content) as VscodeMcpConfig;
+    }
+  } catch {
+    // File doesn't exist or invalid JSON - create new
+    vscodeConfig = { servers: {} };
+  }
+
+  if (!vscodeConfig.servers) {
+    vscodeConfig.servers = {};
+  }
+
+  // Sync servers from all Claude Code scopes (project, local, user)
+  const syncedServers: string[] = [];
+  for (const serverId of serverIds) {
+    // Skip if already exists in VS Code config
+    if (vscodeConfig.servers[serverId]) {
+      continue;
+    }
+
+    // Get server config from Claude Code (searches all scopes)
+    const serverConfig = getMcpServerConfig(serverId, workspacePath);
+    if (!serverConfig) {
+      continue;
+    }
+
+    // Add to VS Code config
+    vscodeConfig.servers[serverId] = serverConfig;
+    syncedServers.push(serverId);
+  }
+
+  // Write updated VS Code config if any servers were added
+  if (syncedServers.length > 0) {
+    await fileService.createDirectory(path.join(workspacePath, '.vscode'));
+    await fileService.writeFile(vscodeMcpPath, JSON.stringify(vscodeConfig, null, 2));
+  }
+
+  return syncedServers;
 }
 
 /**
@@ -150,20 +355,32 @@ function generateCopilotPromptFile(workflow: Workflow, options: CopilotExportOpt
     frontmatterLines.push(`model: ${options.model}`);
   }
 
-  // Add tools if specified (array format)
+  // Collect all tools from multiple sources
+  const allTools: string[] = [];
+
+  // 1. Add explicitly specified tools from export options
   if (options.tools && options.tools.length > 0) {
+    allTools.push(...options.tools);
+  }
+
+  // 2. Add allowed tools from workflow slashCommandOptions
+  if (workflow.slashCommandOptions?.allowedTools) {
+    const allowedTools = workflow.slashCommandOptions.allowedTools
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    allTools.push(...allowedTools);
+  }
+
+  // Note: MCP tools are NOT added to tools: frontmatter.
+  // When tools: is omitted, Copilot allows all available tools including MCP servers.
+
+  // De-duplicate and add to frontmatter
+  const uniqueTools = [...new Set(allTools)];
+  if (uniqueTools.length > 0) {
     frontmatterLines.push('tools:');
-    for (const tool of options.tools) {
+    for (const tool of uniqueTools) {
       frontmatterLines.push(`  - ${tool}`);
-    }
-  } else if (workflow.slashCommandOptions?.allowedTools) {
-    // Convert comma-separated allowed-tools to array format
-    const tools = workflow.slashCommandOptions.allowedTools.split(',').map((t) => t.trim());
-    if (tools.length > 0) {
-      frontmatterLines.push('tools:');
-      for (const tool of tools) {
-        frontmatterLines.push(`  - ${tool}`);
-      }
     }
   }
 
@@ -246,9 +463,20 @@ function generateMermaidFlowchartForCopilot(workflow: Workflow): string {
       const skillName = skillData ? String(skillData.name) : 'Skill';
       lines.push(`    ${nodeId}[[${escapeLabel(`Skill: ${skillName}`)}]]`);
     } else if (nodeType === 'mcp') {
-      const mcpData = 'data' in node && node.data && 'toolName' in node.data ? node.data : null;
-      const toolName = mcpData ? String(mcpData.toolName) : 'MCP Tool';
-      lines.push(`    ${nodeId}[[${escapeLabel(`MCP: ${toolName}`)}]]`);
+      const mcpData = 'data' in node && node.data ? (node.data as McpNodeData) : null;
+      let mcpLabel = 'MCP Tool';
+      if (mcpData) {
+        if (mcpData.toolName) {
+          mcpLabel = `MCP: ${mcpData.toolName}`;
+        } else if (mcpData.aiToolSelectionConfig?.taskDescription) {
+          // aiToolSelection mode: show task description
+          const desc = mcpData.aiToolSelectionConfig.taskDescription;
+          mcpLabel = `MCP Task: ${desc.length > 25 ? `${desc.substring(0, 22)}...` : desc}`;
+        } else {
+          mcpLabel = `MCP: ${mcpData.serverId || 'Tool'}`;
+        }
+      }
+      lines.push(`    ${nodeId}[[${escapeLabel(mcpLabel)}]]`);
     } else if (nodeType === 'subAgentFlow') {
       const label = node.name || 'Sub-Agent Flow';
       lines.push(`    ${nodeId}[["${escapeLabel(label)}"]]`);
@@ -381,15 +609,39 @@ function generateExecutionInstructionsForCopilot(workflow: Workflow): string {
     sections.push('## MCP Tools');
     sections.push('');
     for (const node of mcpNodes) {
-      const mcpData = 'data' in node && node.data && 'toolName' in node.data ? node.data : null;
+      const mcpData = 'data' in node && node.data ? (node.data as McpNodeData) : null;
       if (mcpData) {
-        sections.push(`### ${mcpData.toolName || 'MCP Tool'}`);
-        sections.push('');
-        sections.push(`**Server**: ${mcpData.serverId || 'Unknown'}`);
-        sections.push('');
-        if ('toolDescription' in mcpData && mcpData.toolDescription) {
-          sections.push(`**Description**: ${mcpData.toolDescription}`);
+        const mode = mcpData.mode || 'manualParameterConfig';
+
+        if (mode === 'aiToolSelection') {
+          // AI Tool Selection mode: show task description
+          const taskDesc = mcpData.aiToolSelectionConfig?.taskDescription || 'No task description';
+          sections.push(`### MCP Task: ${mcpData.serverId || 'Unknown Server'}`);
           sections.push('');
+          sections.push(`**Server**: ${mcpData.serverId || 'Unknown'}`);
+          sections.push('');
+          sections.push(`**Mode**: AI Tool Selection`);
+          sections.push('');
+          sections.push(`**Task Description**: ${taskDesc}`);
+          sections.push('');
+          sections.push(
+            '> Use the MCP tools from this server to accomplish the task described above.'
+          );
+          sections.push('');
+        } else {
+          // Manual or AI Parameter Config mode: show tool details
+          sections.push(`### ${mcpData.toolName || 'MCP Tool'}`);
+          sections.push('');
+          sections.push(`**Server**: ${mcpData.serverId || 'Unknown'}`);
+          sections.push('');
+          if (mcpData.toolDescription) {
+            sections.push(`**Description**: ${mcpData.toolDescription}`);
+            sections.push('');
+          }
+          if (mode === 'aiParameterConfig' && mcpData.aiParameterConfig?.description) {
+            sections.push(`**Parameter Instructions**: ${mcpData.aiParameterConfig.description}`);
+            sections.push('');
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Add MCP server configuration auto-sync for GitHub Copilot export, allowing workflows with MCP nodes to work seamlessly in Copilot Chat.

Closes #456

## Problem

When exporting workflows with MCP nodes to GitHub Copilot format, the MCP tools didn't work because:
1. Copilot requires MCP server configs in `.vscode/mcp.json` (not Claude Code's config)
2. The format differs: Claude Code uses `mcpServers` key, VS Code uses `servers` key

## Solution

### 1. Auto-sync MCP server configurations

Automatically sync MCP configs from Claude Code to `.vscode/mcp.json` when exporting/running for Copilot:

- Read from all Claude Code scopes (project, local, user)
- Convert format: `mcpServers` → `servers`
- Only add servers that don't already exist

### 2. Confirmation dialog before sync

Show a modal confirmation dialog before writing to `.vscode/mcp.json`:

```
The following MCP servers will be added to .vscode/mcp.json for GitHub Copilot:

  • playwright
  • aws-knowledge-mcp

Proceed?

[Yes] [No]
```

### 3. Improved MCP node display

- Mermaid flowchart: Show task description for `aiToolSelection` mode
- MCP Tools section: Mode-specific details (tool name, task description, etc.)

## Changes

| File | Changes |
|------|---------|
| `README.md` | Remove MCP from unsupported features note |
| `copilot-export-service.ts` | Add MCP sync functions, improve MCP display |
| `copilot-handlers.ts` | Add confirmation dialog |

## Impact

- MCP nodes now work in Copilot export
- User has control over `.vscode/mcp.json` modifications via confirmation dialog
- No breaking changes

## Testing

- [x] Export workflow with MCP node (aiToolSelection mode)
- [x] Verify confirmation dialog appears
- [x] Verify `.vscode/mcp.json` uses correct `servers` key
- [x] Verify MCP tools work in Copilot
- [x] Code quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)