### PR TITLE
chore: update hono to 4.11.4 for security fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4417,9 +4417,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
## Summary

Update `hono` from 4.11.3 to 4.11.4 to fix high-severity security vulnerabilities.

## Security Fixes

| Alert | CVE | Description | Severity |
|-------|-----|-------------|----------|
| [#11](https://github.com/breaking-brake/cc-wf-studio/security/dependabot/11) | CVE-2026-22818 | JWK Auth Middleware algorithm confusion | High (8.2) |
| [#12](https://github.com/breaking-brake/cc-wf-studio/security/dependabot/12) | CVE-2026-22817 | JWT Middleware algorithm confusion | High (8.2) |

## Impact

- **Affected package**: `hono` (transitive dependency via `@modelcontextprotocol/sdk`)
- **Actual risk to this project**: Low (JWT/JWK middleware not directly used)
- **Change scope**: `package-lock.json` only

## Changes

- Updated `hono` from `4.11.3` to `4.11.4`

## Testing

- [x] `npm ls hono` confirms version 4.11.4
- [x] `npm audit` shows no hono vulnerabilities
- [x] `npx vsce package` builds successfully

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)