### PR TITLE
fix: normalize CRLF line endings for Windows compatibility

### DIFF
--- a/scripts/generate-editing-flow.ts
+++ b/scripts/generate-editing-flow.ts
@@ -127,19 +127,26 @@ function extractTopLevelBulletList(content: string, heading: string): string[] {
  * Parse the markdown file and extract all data
  */
 function parseMarkdown(content: string): EditingFlowData {
+  // Normalize CRLF to LF for cross-platform compatibility (Windows support)
+  const normalizedContent = content.replace(/\r\n/g, '\n');
+
   return {
-    mermaidDiagram: extractMermaidDiagram(content),
-    steps: extractNumberedList(content, 'Process Steps'),
+    mermaidDiagram: extractMermaidDiagram(normalizedContent),
+    steps: extractNumberedList(normalizedContent, 'Process Steps'),
     requestTypeGuidelines: {
       questionOrUnderstanding: extractBulletList(
-        content,
+        normalizedContent,
         'Request Type Guidelines',
         'Question or Understanding Request'
       ),
-      editRequest: extractBulletList(content, 'Request Type Guidelines', 'Edit Request'),
-      unclearRequest: extractBulletList(content, 'Request Type Guidelines', 'Unclear Request'),
+      editRequest: extractBulletList(normalizedContent, 'Request Type Guidelines', 'Edit Request'),
+      unclearRequest: extractBulletList(
+        normalizedContent,
+        'Request Type Guidelines',
+        'Unclear Request'
+      ),
     },
-    clarificationTriggers: extractTopLevelBulletList(content, 'Clarification Triggers'),
+    clarificationTriggers: extractTopLevelBulletList(normalizedContent, 'Clarification Triggers'),
   };
 }
 

--- a/src/extension/services/claude-code-service.ts
+++ b/src/extension/services/claude-code-service.ts
@@ -525,8 +525,12 @@ export async function executeClaudeCodeCLIStreaming(
 
     // Process streaming output using AsyncIterable
     for await (const chunk of subprocess.stdout) {
+      // Normalize CRLF to LF for cross-platform compatibility (Windows support)
       // Split by newlines (JSON Lines format)
-      const lines = chunk.split('\n').filter((line: string) => line.trim());
+      const lines = chunk
+        .replace(/\r\n/g, '\n')
+        .split('\n')
+        .filter((line: string) => line.trim());
 
       for (const line of lines) {
         try {


### PR DESCRIPTION
## Problem

Build and CLI output processing fail on Windows due to CRLF (`\r\n`) line endings.

### Root Cause

- `split('\n')` leaves trailing `\r` at end of each line
- Regex `$` anchors and `JSON.parse()` fail due to trailing `\r`

## Solution

Normalize CRLF to LF immediately after file reading or stream processing.

### Changes

**File**: `scripts/generate-editing-flow.ts`
- Add CRLF normalization in `parseMarkdown()` function

**File**: `src/extension/services/claude-code-service.ts`
- Add CRLF normalization in streaming processing loop

## Impact

- Enables build (`npm run build`) on Windows
- Enables Claude Code CLI streaming output processing on Windows
- No impact on Unix/Mac environments (no CRLF to normalize)

## Testing

- [x] `npm run format && npm run lint && npm run check` passed
- [x] `npm run build` passed
- [x] Verified on Windows environment

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)