### PR TITLE
fix: use VSCode default terminal to find Claude CLI on Windows

### DIFF
--- a/src/extension/services/claude-cli-path.ts
+++ b/src/extension/services/claude-cli-path.ts
@@ -2,17 +2,19 @@
  * Claude CLI Path Detection Service
  *
  * Shared module for detecting Claude CLI executable path.
- * Handles cases where VSCode Extension Host doesn't have the user's shell PATH settings
- * (e.g., when launched from GUI instead of terminal).
+ * Uses VSCode's default terminal setting to get the user's shell,
+ * then executes with login shell to get the full PATH environment.
+ *
+ * This handles GUI-launched VSCode scenarios where the Extension Host
+ * doesn't inherit the user's shell PATH settings.
  *
  * Issue #375: https://github.com/breaking-brake/cc-wf-studio/issues/375
  * PR #376: https://github.com/breaking-brake/cc-wf-studio/pull/376
  */
 
 import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import nanoSpawn from 'nano-spawn';
+import * as vscode from 'vscode';
 import { log } from '../extension';
 
 interface Result {
@@ -32,33 +34,175 @@ const spawn =
   ) => Promise<Result>);
 
 /**
- * Known Claude CLI installation paths
- * These are checked explicitly to handle cases where VSCode Extension Host
- * doesn't have the user's shell PATH settings (e.g., when launched from GUI)
+ * Terminal profile configuration from VSCode settings
  */
-const CLAUDE_KNOWN_PATHS = [
-  // Native install (macOS/Linux/WSL) - curl -fsSL https://claude.ai/install.sh | bash
-  path.join(os.homedir(), '.local', 'bin', 'claude'),
-  // Homebrew (Apple Silicon Mac)
-  '/opt/homebrew/bin/claude',
-  // Homebrew (Intel Mac) / npm global default
-  '/usr/local/bin/claude',
-  // npm custom prefix (common configuration)
-  path.join(os.homedir(), '.npm-global', 'bin', 'claude'),
-];
+interface TerminalProfile {
+  path?: string;
+  args?: string[];
+}
 
 /**
- * Find Claude CLI executable in known installation paths
+ * Get the default terminal shell configuration from VSCode settings.
  *
- * @returns Full path to claude executable if found, null otherwise
+ * @returns Shell path and args, or null if not configured
  */
-function findClaudeCliInKnownPaths(): string | null {
-  for (const p of CLAUDE_KNOWN_PATHS) {
-    if (fs.existsSync(p)) {
-      log('DEBUG', 'Found Claude CLI at known path', { path: p });
-      return p;
+function getDefaultShellConfig(): { path: string; args: string[] } | null {
+  const config = vscode.workspace.getConfiguration('terminal.integrated');
+
+  let platformKey: 'windows' | 'linux' | 'osx';
+  if (process.platform === 'win32') {
+    platformKey = 'windows';
+  } else if (process.platform === 'darwin') {
+    platformKey = 'osx';
+  } else {
+    platformKey = 'linux';
+  }
+
+  const defaultProfileName = config.get<string>(`defaultProfile.${platformKey}`);
+  const profiles = config.get<Record<string, TerminalProfile>>(`profiles.${platformKey}`);
+
+  if (defaultProfileName && profiles?.[defaultProfileName]) {
+    const profile = profiles[defaultProfileName];
+    if (profile.path) {
+      log('INFO', 'Using VSCode default terminal profile', {
+        profile: defaultProfileName,
+        path: profile.path,
+        args: profile.args,
+      });
+      return {
+        path: profile.path,
+        args: profile.args || [],
+      };
     }
   }
+
+  log('INFO', 'No VSCode default terminal profile configured');
+  return null;
+}
+
+/**
+ * Check if the shell is PowerShell (pwsh or powershell)
+ */
+function isPowerShell(shellPath: string): boolean {
+  const lowerPath = shellPath.toLowerCase();
+  return lowerPath.includes('pwsh') || lowerPath.includes('powershell');
+}
+
+/**
+ * Find an executable using VSCode's default terminal shell.
+ * Falls back to platform-specific defaults if not configured.
+ *
+ * @param executable - The executable name to find (e.g., 'claude', 'npx')
+ * @returns Full path to executable if found, null otherwise
+ */
+async function findExecutableViaDefaultShell(executable: string): Promise<string | null> {
+  const shellConfig = getDefaultShellConfig();
+
+  if (shellConfig) {
+    // Use VSCode's configured default terminal
+    const result = await findExecutableWithShell(executable, shellConfig.path, shellConfig.args);
+    if (result) return result;
+  }
+
+  // Fallback to platform-specific defaults
+  if (process.platform === 'win32') {
+    return findExecutableViaWindowsFallback(executable);
+  }
+  return findExecutableViaUnixFallback(executable);
+}
+
+/**
+ * Find an executable using a specific shell.
+ *
+ * @param executable - The executable name to find
+ * @param shellPath - Path to the shell executable
+ * @param shellArgs - Additional shell arguments from profile
+ * @returns Full path to executable if found, null otherwise
+ */
+async function findExecutableWithShell(
+  executable: string,
+  shellPath: string,
+  shellArgs: string[]
+): Promise<string | null> {
+  log('INFO', `Searching for ${executable} via configured shell`, {
+    shell: shellPath,
+  });
+
+  try {
+    let args: string[];
+    let timeout = 15000;
+
+    if (isPowerShell(shellPath)) {
+      // PowerShell: use Get-Command with -CommandType Application
+      // to avoid .ps1 wrapper scripts
+      args = [
+        ...shellArgs,
+        '-NonInteractive',
+        '-Command',
+        `(Get-Command ${executable} -CommandType Application -ErrorAction SilentlyContinue).Source`,
+      ];
+    } else {
+      // Unix shells (bash, zsh, etc.): use login shell with which command
+      args = [...shellArgs, '-ilc', `which ${executable}`];
+      timeout = 10000;
+    }
+
+    const result = await spawn(shellPath, args, { timeout });
+
+    log('INFO', `Shell execution completed for ${executable}`, {
+      shell: shellPath,
+      stdout: result.stdout.trim().substring(0, 300),
+      stderr: result.stderr.substring(0, 100),
+    });
+
+    const foundPath = result.stdout.trim().split(/\r?\n/)[0];
+    if (foundPath && fs.existsSync(foundPath)) {
+      log('INFO', `Found ${executable} via configured shell`, {
+        shell: shellPath,
+        path: foundPath,
+      });
+      return foundPath;
+    }
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; exitCode?: number };
+    log('INFO', `${executable} not found via configured shell`, {
+      shell: shellPath,
+      error: error instanceof Error ? error.message : String(error),
+      stdout: err.stdout?.substring(0, 200),
+      stderr: err.stderr?.substring(0, 200),
+    });
+  }
+
+  return null;
+}
+
+/**
+ * Fallback for Windows when no VSCode terminal is configured.
+ * Tries PowerShell 7 (pwsh) first, then PowerShell 5 (powershell).
+ */
+async function findExecutableViaWindowsFallback(executable: string): Promise<string | null> {
+  const shells = ['pwsh', 'powershell'];
+
+  for (const shell of shells) {
+    const result = await findExecutableWithShell(executable, shell, []);
+    if (result) return result;
+  }
+
+  return null;
+}
+
+/**
+ * Fallback for Unix/macOS when no VSCode terminal is configured.
+ * Tries zsh first, then bash.
+ */
+async function findExecutableViaUnixFallback(executable: string): Promise<string | null> {
+  const shells = ['/bin/zsh', '/bin/bash', 'zsh', 'bash'];
+
+  for (const shell of shells) {
+    const result = await findExecutableWithShell(executable, shell, []);
+    if (result) return result;
+  }
+
   return null;
 }
 
@@ -72,9 +216,12 @@ let cachedClaudePath: string | null | undefined;
 
 /**
  * Get the path to Claude CLI executable
- * First checks known installation paths, then falls back to PATH lookup
+ * Detection order:
+ * 1. VSCode default terminal shell (handles version managers like mise, nvm)
+ * 2. Direct PATH lookup (fallback for terminal-launched VSCode)
+ * 3. npx fallback (handled in getClaudeSpawnCommand)
  *
- * @returns Path to claude executable ('claude' for PATH, full path for known locations, null for npx fallback)
+ * @returns Path to claude executable (full path or 'claude' for PATH), null for npx fallback
  */
 export async function getClaudeCliPath(): Promise<string | null> {
   // Return cached result if available
@@ -82,27 +229,26 @@ export async function getClaudeCliPath(): Promise<string | null> {
     return cachedClaudePath;
   }
 
-  // 1. Check known installation paths first (handles GUI-launched VSCode)
-  const knownPath = findClaudeCliInKnownPaths();
-  if (knownPath) {
+  // 1. Try VSCode default terminal (handles GUI-launched VSCode + version managers)
+  const shellPath = await findExecutableViaDefaultShell('claude');
+  if (shellPath) {
     try {
-      const result = await spawn(knownPath, ['--version'], { timeout: 5000 });
-      log('INFO', 'Claude CLI found at known path', {
-        path: knownPath,
+      const result = await spawn(shellPath, ['--version'], { timeout: 5000 });
+      log('INFO', 'Claude CLI found via default shell', {
+        path: shellPath,
         version: result.stdout.trim().substring(0, 50),
       });
-      cachedClaudePath = knownPath;
-      return knownPath;
+      cachedClaudePath = shellPath;
+      return shellPath;
     } catch (error) {
-      // Path exists but execution failed - log and continue to PATH check
-      log('WARN', 'Claude CLI found but not executable at known path', {
-        path: knownPath,
+      log('WARN', 'Claude CLI found but not executable', {
+        path: shellPath,
         error: error instanceof Error ? error.message : String(error),
       });
     }
   }
 
-  // 2. Fall back to PATH lookup (terminal-launched VSCode or other installations)
+  // 2. Fall back to direct PATH lookup (terminal-launched VSCode)
   try {
     const result = await spawn('claude', ['--version'], { timeout: 5000 });
     log('INFO', 'Claude CLI found in PATH', {
@@ -127,7 +273,10 @@ export function clearClaudeCliPathCache(): void {
 
 /**
  * Get the command and args for spawning Claude CLI
- * Uses claude directly if available (from known paths or PATH), otherwise falls back to 'npx claude'
+ * Uses claude directly if available, otherwise falls back to 'npx claude'
+ * npx detection order:
+ * 1. VSCode default terminal shell (handles version managers)
+ * 2. Direct PATH lookup
  *
  * @param args - CLI arguments (without 'claude' command itself)
  * @returns command and args for spawn
@@ -140,5 +289,17 @@ export async function getClaudeSpawnCommand(
   if (claudePath) {
     return { command: claudePath, args };
   }
+
+  // 1. Try VSCode default terminal for npx (handles version managers like mise, nvm)
+  const npxPath = await findExecutableViaDefaultShell('npx');
+  if (npxPath) {
+    log('INFO', 'Using npx from default shell for Claude CLI fallback', {
+      path: npxPath,
+    });
+    return { command: npxPath, args: ['claude', ...args] };
+  }
+
+  // 2. Final fallback to direct PATH lookup
+  log('INFO', 'Using npx from PATH for Claude CLI fallback');
   return { command: 'npx', args: ['claude', ...args] };
 }


### PR DESCRIPTION
## Problem

When running Claude Code CLI in Windows environment, `npx` is not recognized.

### Current Behavior
1. Launch VSCode from GUI
2. ❌ Extension Host doesn't inherit shell PATH environment variable
3. ❌ `claude` command not found, falls back to `npx claude`
4. ❌ `npx` is also not in PATH, execution fails

```
'npx' is not recognized as an internal or external command,
operable program or batch file.
```

### Expected Behavior
1. Launch VSCode from GUI
2. ✅ Get shell from VSCode's default terminal setting
3. ✅ Get PATH environment variable via login shell
4. ✅ Correctly detect and execute `claude` or `npx`

## Solution

Use VSCode's default terminal setting (`terminal.integrated.defaultProfile`) to respect user's shell configuration.

### Changes

**File**: `src/extension/services/claude-cli-path.ts`

- Read VSCode's `terminal.integrated.defaultProfile.{platform}` setting
- Spawn login shell with configured shell to execute `which` (Unix) or `Get-Command` (Windows)
- Fallback when VSCode setting is not configured:
  - Windows: pwsh → powershell
  - Unix: zsh → bash
- Support version managers (mise, nvm, fnm, volta)

## Impact

- Works on Windows/macOS/Linux
- Can detect CLI tools installed via version managers
- Respects VSCode terminal settings (behaves as user expects)

## Testing

- [x] Manual E2E testing on macOS completed
- [x] Manual E2E testing on Windows completed
- [x] AI workflow generation (Generate with AI)
- [x] AI workflow refinement (Refinement Chat Panel)
- [x] AI workflow name generation (Generate Name)
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

## Notes

- Fixes Issue #463
- Uses `-CommandType Application` in PowerShell to exclude `.ps1` wrapper scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)