### PR TITLE
chore: update GitHub Copilot Export note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All operations run locally within VSCode. **Note:** MCP Tool nodes may require n
 
 💬 **Slack Workflow Sharing (β)** - Share workflows directly to Slack channels with preview cards and one-click import links for seamless team collaboration
 
-🤖 **GitHub Copilot Export (β)** - Export workflows to GitHub Copilot format with two execution modes: **VSCode Copilot** (`.github/prompts/*.prompt.md` for Copilot Chat) and **Copilot CLI** (`.github/skills/{name}/SKILL.md` for terminal execution). Select your preferred mode from the dropdown menu. **Note:** This is an experimental feature with limited support. Some features (e.g., Skill nodes) are not yet supported in Copilot export
+🤖 **GitHub Copilot Export (β)** - Export workflows to GitHub Copilot format with two execution modes: **VSCode Copilot** (`.github/prompts/*.prompt.md` for Copilot Chat) and **Copilot CLI** (`.github/skills/{name}/SKILL.md` for terminal execution). Select your preferred mode from the dropdown menu. **Note:** This is an experimental feature. Some workflows may not work as expected
 
 🧩 **Rich Node Types** - Build complex workflows with diverse node types: Prompt (templates), Sub-Agent (AI tasks), Skill (Claude Code Skills), MCP (external tools), IfElse/Switch (conditional branching), and AskUserQuestion (user decisions)
 


### PR DESCRIPTION
## Summary

Update the GitHub Copilot Export feature note in README.md to reflect current status.

## Changes

- Removed specific mention of "Skill nodes" as unsupported (now supported via `.claude/skills/` directory)
- Simplified to a general experimental feature warning: "Some workflows may not work as expected"

## Before
> **Note:** This is an experimental feature with limited support. Some features (e.g., Skill nodes) are not yet supported in Copilot export

## After
> **Note:** This is an experimental feature. Some workflows may not work as expected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)