### PR TITLE
feat: add Copilot support for AI workflow editing (Beta)

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -12,6 +12,7 @@ import { cancelGeneration } from '../services/claude-code-service';
 import { FileService } from '../services/file-service';
 import { SlackApiService } from '../services/slack-api-service';
 import { executeSlashCommandInTerminal } from '../services/terminal-execution-service';
+import { listCopilotModels } from '../services/vscode-lm-service';
 import { migrateWorkflow } from '../utils/migrate-workflow';
 import { SlackTokenManager } from '../utils/slack-token-manager';
 import { validateWorkflowFile } from '../utils/workflow-validator';
@@ -325,6 +326,18 @@ export function registerOpenEditorCommand(
                     errorMessage: 'Workflow is required',
                     timestamp: new Date().toISOString(),
                   },
+                });
+              }
+              break;
+
+            case 'LIST_COPILOT_MODELS':
+              // List available Copilot models from VS Code LM API
+              {
+                const result = await listCopilotModels();
+                webview.postMessage({
+                  type: 'COPILOT_MODELS_LIST',
+                  requestId: message.requestId,
+                  payload: result,
                 });
               }
               break;

--- a/src/extension/services/ai-provider.ts
+++ b/src/extension/services/ai-provider.ts
@@ -1,0 +1,176 @@
+/**
+ * AI Provider Abstraction Layer
+ *
+ * Claude Code CLI と VS Code Language Model API を抽象化し、
+ * プロバイダー選択に基づいてルーティングする。
+ *
+ * 注意: Claude CodeとCopilotで別々のモデル設定を使用する（マッピングしない）
+ * - Claude Code: ClaudeModel ('sonnet' | 'opus' | 'haiku')
+ * - Copilot: CopilotModel ('gpt-4o' | 'gpt-4o-mini' | 'claude-3.5-sonnet')
+ */
+
+import type { AiCliProvider, ClaudeModel, CopilotModel } from '../../shared/types/messages';
+import { log } from '../extension';
+import {
+  type ClaudeCodeExecutionResult,
+  cancelRefinement,
+  executeClaudeCodeCLI,
+  executeClaudeCodeCLIStreaming,
+  type StreamingProgressCallback,
+} from './claude-code-service';
+import {
+  cancelLmRequest,
+  checkLmApiAvailability,
+  executeVsCodeLm,
+  executeVsCodeLmStreaming,
+} from './vscode-lm-service';
+
+/** プロバイダー利用可否チェック結果 */
+export interface ProviderAvailability {
+  available: boolean;
+  reason?: string;
+}
+
+/**
+ * プロバイダーが利用可能かチェック
+ *
+ * @param provider - チェックするプロバイダー
+ * @returns 利用可否とその理由
+ */
+export async function isProviderAvailable(provider: AiCliProvider): Promise<ProviderAvailability> {
+  if (provider === 'copilot') {
+    const availability = await checkLmApiAvailability();
+    if (!availability.available) {
+      const reasonMap: Record<string, string> = {
+        VS_CODE_VERSION: 'VS Code 1.89+ is required for Copilot provider',
+        COPILOT_NOT_INSTALLED: 'GitHub Copilot extension is not installed',
+        NO_MODELS_FOUND: 'No Copilot models available',
+      };
+      return {
+        available: false,
+        reason: availability.reason ? reasonMap[availability.reason] : 'Unknown error',
+      };
+    }
+    return { available: true };
+  }
+
+  // claude-code は常に利用可能（CLI が見つからない場合は実行時エラー）
+  return { available: true };
+}
+
+/**
+ * AI を実行（非ストリーミング）
+ *
+ * @param prompt - プロンプト文字列
+ * @param provider - 使用するプロバイダー ('claude-code' | 'copilot')
+ * @param timeoutMs - タイムアウト（ミリ秒）
+ * @param requestId - リクエストID（キャンセル用）
+ * @param workingDirectory - 作業ディレクトリ（claude-code用）
+ * @param model - Claude Code用モデル (provider='claude-code'時のみ使用)
+ * @param copilotModel - Copilot用モデル (provider='copilot'時のみ使用)
+ * @param allowedTools - 許可ツールリスト（claude-code用）
+ * @returns 実行結果
+ */
+export async function executeAi(
+  prompt: string,
+  provider: AiCliProvider,
+  timeoutMs?: number,
+  requestId?: string,
+  workingDirectory?: string,
+  model?: ClaudeModel,
+  copilotModel?: CopilotModel,
+  allowedTools?: string[]
+): Promise<ClaudeCodeExecutionResult> {
+  log('INFO', 'executeAi called', {
+    provider,
+    model,
+    copilotModel,
+    promptLength: prompt.length,
+    requestId,
+  });
+
+  if (provider === 'copilot') {
+    // Copilot用モデルを直接使用（マッピングなし）
+    return executeVsCodeLm(prompt, timeoutMs, requestId, copilotModel);
+  }
+
+  // Default: claude-code - Claude Code用モデルを使用
+  return executeClaudeCodeCLI(prompt, timeoutMs, requestId, workingDirectory, model, allowedTools);
+}
+
+/**
+ * AI を実行（ストリーミング）
+ *
+ * @param prompt - プロンプト文字列
+ * @param provider - 使用するプロバイダー ('claude-code' | 'copilot')
+ * @param onProgress - ストリーミング進捗コールバック
+ * @param timeoutMs - タイムアウト（ミリ秒）
+ * @param requestId - リクエストID（キャンセル用）
+ * @param workingDirectory - 作業ディレクトリ（claude-code用）
+ * @param model - Claude Code用モデル (provider='claude-code'時のみ使用)
+ * @param copilotModel - Copilot用モデル (provider='copilot'時のみ使用)
+ * @param allowedTools - 許可ツールリスト（claude-code用）
+ * @param resumeSessionId - セッション継続用ID（claude-code用、copilotでは無視）
+ * @returns 実行結果
+ */
+export async function executeAiStreaming(
+  prompt: string,
+  provider: AiCliProvider,
+  onProgress: StreamingProgressCallback,
+  timeoutMs?: number,
+  requestId?: string,
+  workingDirectory?: string,
+  model?: ClaudeModel,
+  copilotModel?: CopilotModel,
+  allowedTools?: string[],
+  resumeSessionId?: string
+): Promise<ClaudeCodeExecutionResult> {
+  log('INFO', 'executeAiStreaming called', {
+    provider,
+    model,
+    copilotModel,
+    promptLength: prompt.length,
+    requestId,
+    resumeSessionId: resumeSessionId ? '(present)' : undefined,
+  });
+
+  if (provider === 'copilot') {
+    // VS Code LM API はセッション継続をサポートしない
+    if (resumeSessionId) {
+      log('WARN', 'Session resume not supported with Copilot provider, ignoring sessionId');
+    }
+    // Copilot用モデルを直接使用（マッピングなし）
+    return executeVsCodeLmStreaming(prompt, onProgress, timeoutMs, requestId, copilotModel);
+  }
+
+  // Default: claude-code - Claude Code用モデルを使用
+  return executeClaudeCodeCLIStreaming(
+    prompt,
+    onProgress,
+    timeoutMs,
+    requestId,
+    workingDirectory,
+    model,
+    allowedTools,
+    resumeSessionId
+  );
+}
+
+/**
+ * AI リクエストをキャンセル
+ *
+ * @param provider - キャンセル対象のプロバイダー
+ * @param requestId - キャンセルするリクエストのID
+ * @returns キャンセル結果
+ */
+export async function cancelAiRequest(
+  provider: AiCliProvider,
+  requestId: string
+): Promise<{ cancelled: boolean; executionTimeMs?: number }> {
+  log('INFO', 'cancelAiRequest called', { provider, requestId });
+
+  if (provider === 'copilot') {
+    return cancelLmRequest(requestId);
+  }
+  return cancelRefinement(requestId);
+}

--- a/src/extension/services/claude-code-service.ts
+++ b/src/extension/services/claude-code-service.ts
@@ -66,7 +66,7 @@ export interface ClaudeCodeExecutionResult {
   success: boolean;
   output?: string;
   error?: {
-    code: 'COMMAND_NOT_FOUND' | 'TIMEOUT' | 'PARSE_ERROR' | 'UNKNOWN_ERROR';
+    code: 'COMMAND_NOT_FOUND' | 'MODEL_NOT_SUPPORTED' | 'TIMEOUT' | 'PARSE_ERROR' | 'UNKNOWN_ERROR';
     message: string;
     details?: string;
   };

--- a/src/extension/services/vscode-lm-service.ts
+++ b/src/extension/services/vscode-lm-service.ts
@@ -1,0 +1,458 @@
+/**
+ * VS Code Language Model Service
+ *
+ * VS Code の Language Model API (vscode.lm) を使用した AI 実行サービス。
+ * VS Code 1.89+ と GitHub Copilot 拡張機能が必要。
+ *
+ * ランタイム検出により、API が利用可能な場合のみ機能する。
+ * engines.vscode は 1.80.0 のまま維持し、後方互換性を保つ。
+ */
+
+import * as vscode from 'vscode';
+import type { CopilotModel, CopilotModelInfo } from '../../shared/types/messages';
+import { log } from '../extension';
+import type { ClaudeCodeExecutionResult, StreamingProgressCallback } from './claude-code-service';
+
+/** LM API 利用可否チェック結果 */
+export interface LmApiAvailability {
+  available: boolean;
+  reason?: 'VS_CODE_VERSION' | 'COPILOT_NOT_INSTALLED' | 'NO_MODELS_FOUND';
+}
+
+// アクティブなリクエストのキャンセレーショントークン管理
+const activeRequests = new Map<string, vscode.CancellationTokenSource>();
+
+/**
+ * VS Code LM API が利用可能かチェック（ランタイム検出）
+ *
+ * @returns true if vscode.lm API is available
+ */
+export function isVsCodeLmApiAvailable(): boolean {
+  // Check if vscode.lm exists and has the selectChatModels method
+  // This provides runtime detection without requiring minimum VS Code version
+  return typeof vscode.lm !== 'undefined' && typeof vscode.lm.selectChatModels === 'function';
+}
+
+/**
+ * LM API の詳細な利用可否をチェック
+ *
+ * @returns Availability status with reason if unavailable
+ */
+export async function checkLmApiAvailability(): Promise<LmApiAvailability> {
+  if (!isVsCodeLmApiAvailable()) {
+    return { available: false, reason: 'VS_CODE_VERSION' };
+  }
+
+  try {
+    const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
+    if (!models || models.length === 0) {
+      return { available: false, reason: 'COPILOT_NOT_INSTALLED' };
+    }
+    return { available: true };
+  } catch (error) {
+    log('WARN', 'Failed to check LM API availability', { error });
+    return { available: false, reason: 'NO_MODELS_FOUND' };
+  }
+}
+
+/**
+ * List all available Copilot models via VS Code LM API
+ *
+ * @returns List of available CopilotModelInfo objects
+ */
+export async function listCopilotModels(): Promise<{
+  models: CopilotModelInfo[];
+  available: boolean;
+  unavailableReason?: string;
+}> {
+  if (!isVsCodeLmApiAvailable()) {
+    return {
+      models: [],
+      available: false,
+      unavailableReason: 'VS Code 1.89+ is required for Copilot provider',
+    };
+  }
+
+  try {
+    const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
+
+    if (!models || models.length === 0) {
+      return {
+        models: [],
+        available: false,
+        unavailableReason: 'GitHub Copilot extension is not installed or no models available',
+      };
+    }
+
+    // Deduplicate by family AND name (use first occurrence)
+    // Some models have different family but same display name (e.g., gpt-4o-mini and copilot-fast both show "GPT-4o mini")
+    const seenFamilies = new Set<string>();
+    const seenNames = new Set<string>();
+    const modelInfos: CopilotModelInfo[] = [];
+    for (const model of models) {
+      if (!seenFamilies.has(model.family) && !seenNames.has(model.name)) {
+        seenFamilies.add(model.family);
+        seenNames.add(model.name);
+        modelInfos.push({
+          id: model.id,
+          name: model.name,
+          family: model.family,
+          vendor: model.vendor,
+        });
+      }
+    }
+
+    log('DEBUG', 'Listed Copilot models (after deduplication)', {
+      count: modelInfos.length,
+      rawCount: models.length,
+      models: modelInfos.map((m) => ({ id: m.id, family: m.family })),
+    });
+
+    return {
+      models: modelInfos,
+      available: true,
+    };
+  } catch (error) {
+    log('ERROR', 'Failed to list Copilot models', { error });
+    return {
+      models: [],
+      available: false,
+      unavailableReason: 'Failed to retrieve Copilot models',
+    };
+  }
+}
+
+/**
+ * Map CopilotModel to VS Code LM API family selector
+ *
+ * @param model - CopilotModel selection (now dynamic string)
+ * @returns VS Code LM family string or undefined for default
+ */
+function getCopilotFamily(model?: CopilotModel): string | undefined {
+  // CopilotModel is now a dynamic string type, so pass through directly
+  // The model value should match the family name from vscode.lm.selectChatModels()
+  if (!model || model.trim() === '') return undefined;
+  return model;
+}
+
+/**
+ * Select a Copilot model from available models
+ *
+ * @param model - Optional CopilotModel to prefer
+ * @returns Selected LanguageModelChat or null if not available
+ */
+export async function selectCopilotModel(
+  model?: CopilotModel
+): Promise<vscode.LanguageModelChat | null> {
+  if (!isVsCodeLmApiAvailable()) {
+    log('WARN', 'VS Code LM API not available');
+    return null;
+  }
+
+  try {
+    const selector: vscode.LanguageModelChatSelector = { vendor: 'copilot' };
+    const family = getCopilotFamily(model);
+    if (family) {
+      selector.family = family;
+    }
+
+    log('DEBUG', 'Selecting Copilot model', { selector, model });
+    const models = await vscode.lm.selectChatModels(selector);
+
+    if (!models || models.length === 0) {
+      // If specific family not found, try without family filter
+      if (family) {
+        log('WARN', `Copilot model family '${family}' not found, falling back to default`);
+        const fallbackModels = await vscode.lm.selectChatModels({ vendor: 'copilot' });
+        return fallbackModels.length > 0 ? fallbackModels[0] : null;
+      }
+      return null;
+    }
+
+    log('DEBUG', 'Selected Copilot model', {
+      id: models[0].id,
+      name: models[0].name,
+      family: models[0].family,
+      vendor: models[0].vendor,
+    });
+
+    return models[0];
+  } catch (error) {
+    log('ERROR', 'Failed to select Copilot model', { error, model });
+    return null;
+  }
+}
+
+/**
+ * VS Code LM API でプロンプトを実行（ストリーミング）
+ *
+ * @param prompt - プロンプト文字列
+ * @param onProgress - ストリーミング進捗コールバック
+ * @param timeoutMs - タイムアウト（ミリ秒、デフォルト: 120000）
+ * @param requestId - リクエストID（キャンセル用）
+ * @param copilotModel - 使用するCopilotモデル
+ * @returns 実行結果
+ */
+export async function executeVsCodeLmStreaming(
+  prompt: string,
+  onProgress: StreamingProgressCallback,
+  timeoutMs = 120000,
+  requestId?: string,
+  copilotModel?: CopilotModel
+): Promise<ClaudeCodeExecutionResult> {
+  const startTime = Date.now();
+
+  log('INFO', 'Starting VS Code LM execution', {
+    promptLength: prompt.length,
+    timeoutMs,
+    requestId,
+    copilotModel,
+  });
+
+  // Create cancellation token source
+  const cts = new vscode.CancellationTokenSource();
+  if (requestId) {
+    activeRequests.set(requestId, cts);
+    log('DEBUG', `Registered active LM request for requestId: ${requestId}`);
+  }
+
+  // Set up timeout (only if timeoutMs > 0; 0 means "unlimited")
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  if (timeoutMs > 0) {
+    timeoutId = setTimeout(() => {
+      log('WARN', 'VS Code LM request timed out', { timeoutMs, requestId });
+      cts.cancel();
+    }, timeoutMs);
+  }
+
+  try {
+    const model = await selectCopilotModel(copilotModel);
+    if (!model) {
+      if (timeoutId) clearTimeout(timeoutId);
+      return {
+        success: false,
+        error: {
+          code: 'COMMAND_NOT_FOUND',
+          message:
+            'Copilot is not available. Please ensure GitHub Copilot extension is installed and VS Code is 1.89+.',
+        },
+        executionTimeMs: Date.now() - startTime,
+      };
+    }
+
+    // Build messages array with user prompt
+    const messages = [vscode.LanguageModelChatMessage.User(prompt)];
+
+    // Send request to model
+    log('DEBUG', 'Sending request to Copilot model', {
+      modelId: model.id,
+      messageCount: messages.length,
+    });
+
+    const response = await model.sendRequest(messages, {}, cts.token);
+
+    // Process streaming response
+    let accumulatedText = '';
+    for await (const fragment of response.text) {
+      if (cts.token.isCancellationRequested) {
+        log('INFO', 'VS Code LM request cancelled during streaming', { requestId });
+        break;
+      }
+
+      accumulatedText += fragment;
+      // Call progress callback with same text for both display and explanatory
+      // (VS Code LM API doesn't have tool_use concept like Claude CLI)
+      onProgress(fragment, accumulatedText, accumulatedText, 'text');
+    }
+
+    if (timeoutId) clearTimeout(timeoutId);
+
+    const executionTimeMs = Date.now() - startTime;
+
+    log('INFO', 'VS Code LM execution succeeded', {
+      executionTimeMs,
+      outputLength: accumulatedText.length,
+      requestId,
+    });
+
+    return {
+      success: true,
+      output: accumulatedText,
+      executionTimeMs,
+    };
+  } catch (error) {
+    if (timeoutId) clearTimeout(timeoutId);
+
+    const executionTimeMs = Date.now() - startTime;
+
+    // Handle cancellation
+    if (cts.token.isCancellationRequested) {
+      log('INFO', 'VS Code LM request was cancelled', { requestId, executionTimeMs });
+      return {
+        success: false,
+        error: {
+          code: 'TIMEOUT',
+          message: 'Request was cancelled or timed out.',
+        },
+        executionTimeMs,
+      };
+    }
+
+    // Log error details
+    log('ERROR', 'VS Code LM execution failed', {
+      error,
+      requestId,
+      executionTimeMs,
+      errorType: error?.constructor?.name,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+
+    // Parse error message for HTTP API errors (these come as regular Error, not LanguageModelError)
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const httpErrorInfo = parseHttpErrorMessage(errorMessage);
+
+    if (httpErrorInfo) {
+      log('INFO', 'Parsed HTTP error from LM API', httpErrorInfo);
+
+      if (
+        httpErrorInfo.code === 'model_not_supported' ||
+        httpErrorInfo.code === 'model_not_found'
+      ) {
+        // Model is not enabled/supported
+        return {
+          success: false,
+          error: {
+            code: 'MODEL_NOT_SUPPORTED',
+            message: `Model "${copilotModel}" is not supported or access is not enabled.`,
+            details: httpErrorInfo.message,
+          },
+          executionTimeMs,
+        };
+      }
+    }
+
+    // Handle LanguageModelError specifically
+    if (error instanceof vscode.LanguageModelError) {
+      // Map LanguageModelError codes to our error codes
+      // See: https://code.visualstudio.com/api/references/vscode-api#LanguageModelError
+      let errorCode: ClaudeCodeExecutionResult['error'] extends { code: infer C } ? C : never =
+        'UNKNOWN_ERROR';
+      let message = error.message;
+
+      // Check for common error scenarios
+      if (error.code === 'Blocked') {
+        message = 'AI access was blocked. Please check your Copilot subscription.';
+      } else if (error.code === 'NoPermissions') {
+        message =
+          'AI access denied. Please click "Allow" in the permission dialog that appeared, then try again.';
+      } else if (error.code === 'NotFound') {
+        errorCode = 'COMMAND_NOT_FOUND';
+        message = 'Copilot model not found. Please ensure GitHub Copilot is installed.';
+      }
+
+      return {
+        success: false,
+        error: {
+          code: errorCode,
+          message,
+          details: `LanguageModelError: ${error.code} - ${error.cause || ''}`,
+        },
+        executionTimeMs,
+      };
+    }
+
+    // Unknown error
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_ERROR',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred.',
+        details: error instanceof Error ? error.stack : String(error),
+      },
+      executionTimeMs,
+    };
+  } finally {
+    // Clean up
+    if (requestId) {
+      activeRequests.delete(requestId);
+      log('DEBUG', `Removed active LM request for requestId: ${requestId}`);
+    }
+    cts.dispose();
+  }
+}
+
+/**
+ * VS Code LM API でプロンプトを実行（非ストリーミング）
+ *
+ * @param prompt - プロンプト文字列
+ * @param timeoutMs - タイムアウト（ミリ秒、デフォルト: 120000）
+ * @param requestId - リクエストID（キャンセル用）
+ * @param copilotModel - 使用するCopilotモデル
+ * @returns 実行結果
+ */
+export async function executeVsCodeLm(
+  prompt: string,
+  timeoutMs = 120000,
+  requestId?: string,
+  copilotModel?: CopilotModel
+): Promise<ClaudeCodeExecutionResult> {
+  // Callback captures accumulated text but we don't need it since streaming version returns it
+  const onProgress: StreamingProgressCallback = () => {
+    // No-op: we use the return value from executeVsCodeLmStreaming instead
+  };
+  return executeVsCodeLmStreaming(prompt, onProgress, timeoutMs, requestId, copilotModel);
+}
+
+/**
+ * VS Code LM リクエストをキャンセル
+ *
+ * @param requestId - キャンセルするリクエストのID
+ * @returns キャンセル結果
+ */
+export async function cancelLmRequest(requestId: string): Promise<{
+  cancelled: boolean;
+  executionTimeMs?: number;
+}> {
+  const cts = activeRequests.get(requestId);
+  if (!cts) {
+    log('WARN', `No active LM request found for requestId: ${requestId}`);
+    return { cancelled: false };
+  }
+
+  log('INFO', `Cancelling LM request for requestId: ${requestId}`);
+  cts.cancel();
+  activeRequests.delete(requestId);
+
+  return { cancelled: true };
+}
+
+/**
+ * Parse HTTP error message from LM API response
+ *
+ * Error messages look like:
+ * "Request Failed: 400 {\"error\":{\"message\":\"The requested model is not supported.\",\"code\":\"model_not_supported\",...}}"
+ *
+ * @param errorMessage - The error message to parse
+ * @returns Parsed error info or null if not parseable
+ */
+function parseHttpErrorMessage(
+  errorMessage: string
+): { code: string; message: string; type?: string } | null {
+  try {
+    // Look for JSON in the error message
+    const jsonMatch = errorMessage.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+
+    const parsed = JSON.parse(jsonMatch[0]);
+    if (parsed.error && typeof parsed.error === 'object') {
+      return {
+        code: parsed.error.code || 'unknown',
+        message: parsed.error.message || errorMessage,
+        type: parsed.error.type,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -266,6 +266,46 @@ import type { ConversationHistory, ConversationMessage } from './workflow-defini
  */
 export type ClaudeModel = 'sonnet' | 'opus' | 'haiku';
 
+/**
+ * AI CLI provider selection
+ * - claude-code: Claude Code CLI (default)
+ * - copilot: VS Code Language Model API (Copilot)
+ */
+export type AiCliProvider = 'claude-code' | 'copilot';
+
+/**
+ * Copilot model selection (for VS Code Language Model API)
+ * This type represents model family strings returned by vscode.lm API.
+ * The list is dynamic and fetched at runtime from vscode.lm.selectChatModels().
+ */
+export type CopilotModel = string;
+
+/**
+ * Information about a Copilot model available via VS Code LM API
+ */
+export interface CopilotModelInfo {
+  /** Model ID (e.g., 'gpt-4o') */
+  id: string;
+  /** Display name (e.g., 'GPT-4o') */
+  name: string;
+  /** Model family (e.g., 'gpt-4o') - used for selection */
+  family: string;
+  /** Vendor (always 'copilot' for Copilot models) */
+  vendor: string;
+}
+
+/**
+ * Payload for listing available Copilot models
+ */
+export interface CopilotModelsListPayload {
+  /** List of available Copilot models */
+  models: CopilotModelInfo[];
+  /** Whether the LM API is available */
+  available: boolean;
+  /** Error reason if not available */
+  unavailableReason?: string;
+}
+
 export interface RefineWorkflowPayload {
   /** ID of the workflow being refined */
   workflowId: string;
@@ -293,6 +333,10 @@ export interface RefineWorkflowPayload {
     message: string;
     field?: string;
   }>;
+  /** AI CLI provider to use (default: 'claude-code') */
+  provider?: AiCliProvider;
+  /** Copilot model to use when provider is 'copilot' (default: 'gpt-4o') */
+  copilotModel?: CopilotModel;
 }
 
 export interface RefinementSuccessPayload {
@@ -685,6 +729,7 @@ export type ExtensionMessage =
   | Message<SearchSlackWorkflowsSuccessPayload, 'SEARCH_SLACK_WORKFLOWS_SUCCESS'>
   | Message<SlackErrorPayload, 'SEARCH_SLACK_WORKFLOWS_FAILED'>
   | Message<SlackOAuthInitiatedPayload, 'SLACK_OAUTH_INITIATED'>
+  | Message<CopilotModelsListPayload, 'COPILOT_MODELS_LIST'>
   | Message<SlackOAuthSuccessPayload, 'SLACK_OAUTH_SUCCESS'>
   | Message<SlackErrorPayload, 'SLACK_OAUTH_FAILED'>
   | Message<void, 'SLACK_OAUTH_CANCELLED'>
@@ -1306,6 +1351,7 @@ export type WebviewMessage =
   | Message<OpenInEditorPayload, 'OPEN_IN_EDITOR'>
   | Message<void, 'WEBVIEW_READY'>
   | Message<ExportForCopilotPayload, 'EXPORT_FOR_COPILOT'>
+  | Message<void, 'LIST_COPILOT_MODELS'>
   | Message<RunForCopilotPayload, 'RUN_FOR_COPILOT'>
   | Message<RunForCopilotCliPayload, 'RUN_FOR_COPILOT_CLI'>
   | Message<ExportForCopilotCliPayload, 'EXPORT_FOR_COPILOT_CLI'>;

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -92,6 +92,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     closeChat,
     initConversation,
     loadConversationHistory,
+    isCopilotEnabled,
+    toggleCopilotEnabled,
   } = useRefinementStore();
   const [isSaving, setIsSaving] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
@@ -103,11 +105,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   // Copilot integration (Beta)
   const [isCopilotExporting, setIsCopilotExporting] = useState(false);
   const [isCopilotRunning, setIsCopilotRunning] = useState(false);
-  // Copilot Beta feature toggle (persisted in localStorage)
-  const [isCopilotBetaEnabled, setIsCopilotBetaEnabled] = useState(() => {
-    const stored = localStorage.getItem('cc-wf-studio:copilot-beta-enabled');
-    return stored === 'true';
-  });
+  // Copilot Beta feature toggle is now managed by refinement-store
   // Copilot execution mode (persisted in localStorage, default: 'cli')
   const [copilotExecutionMode, setCopilotExecutionMode] = useState<CopilotExecutionMode>(() => {
     const stored = localStorage.getItem('cc-wf-studio.copilotExecutionMode');
@@ -138,14 +136,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     setShowResetConfirm(false);
   }, [clearWorkflow, clearHistory]);
 
-  // Handle toggle Copilot Beta feature
-  const handleToggleCopilotBeta = useCallback(() => {
-    setIsCopilotBetaEnabled((prev) => {
-      const newValue = !prev;
-      localStorage.setItem('cc-wf-studio:copilot-beta-enabled', String(newValue));
-      return newValue;
-    });
-  }, []);
+  // Handle toggle Copilot Beta feature - now uses refinement store
 
   // Handle Copilot execution mode change
   const handleCopilotExecutionModeChange = useCallback((mode: CopilotExecutionMode) => {
@@ -772,7 +763,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         />
 
         {/* Slash Command Section - Layout changes based on Copilot Beta enabled */}
-        {isCopilotBetaEnabled ? (
+        {isCopilotEnabled ? (
           /* Combined layout when Copilot Beta is enabled */
           <div
             style={{
@@ -1164,8 +1155,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               onStartTour={onStartTour}
               isFocusMode={isFocusMode}
               onToggleFocusMode={toggleFocusMode}
-              isCopilotBetaEnabled={isCopilotBetaEnabled}
-              onToggleCopilotBeta={handleToggleCopilotBeta}
+              isCopilotEnabled={isCopilotEnabled}
+              onToggleCopilotBeta={toggleCopilotEnabled}
               open={moreActionsOpen}
               onOpenChange={onMoreActionsOpenChange}
             />

--- a/src/webview/src/components/dialogs/RefinementChatPanel.tsx
+++ b/src/webview/src/components/dialogs/RefinementChatPanel.tsx
@@ -93,7 +93,14 @@ export function RefinementChatPanel({
   } = chatState;
 
   // Settings from refinement store (shared across all panels)
-  const { useSkills, timeoutSeconds, selectedModel, allowedTools } = useRefinementStore();
+  const {
+    useSkills,
+    timeoutSeconds,
+    selectedModel,
+    selectedCopilotModel,
+    allowedTools,
+    selectedProvider,
+  } = useRefinementStore();
 
   const { activeWorkflow, updateWorkflow, subAgentFlows, updateSubAgentFlow, setNodes, setEdges } =
     useWorkflowStore();
@@ -164,7 +171,9 @@ export function RefinementChatPanel({
           useSkills,
           timeoutSeconds * 1000,
           selectedModel,
-          allowedTools
+          allowedTools,
+          selectedProvider,
+          selectedCopilotModel
         );
 
         if (result.type === 'success') {
@@ -248,7 +257,10 @@ export function RefinementChatPanel({
           timeoutSeconds * 1000,
           onProgress,
           selectedModel,
-          allowedTools
+          allowedTools,
+          undefined, // previousValidationErrors
+          selectedProvider,
+          selectedCopilotModel
         );
 
         if (result.type === 'success') {
@@ -358,7 +370,9 @@ export function RefinementChatPanel({
           useSkills,
           timeoutSeconds * 1000,
           selectedModel,
-          allowedTools
+          allowedTools,
+          selectedProvider,
+          selectedCopilotModel
         );
 
         if (result.type === 'success') {
@@ -439,7 +453,9 @@ export function RefinementChatPanel({
           onProgress,
           selectedModel,
           allowedTools,
-          previousValidationErrors
+          previousValidationErrors,
+          selectedProvider,
+          selectedCopilotModel
         );
 
         if (result.type === 'success') {

--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -17,8 +17,8 @@ import {
   connectSlackOAuth,
   disconnectFromSlack,
   listSlackWorkspaces,
-  openExternalUrl,
 } from '../../services/slack-integration-service';
+import { openExternalUrl } from '../../services/vscode-bridge';
 import { ConfirmDialog } from './ConfirmDialog';
 
 interface SlackManualTokenDialogProps {

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -23,7 +23,7 @@ interface MoreActionsDropdownProps {
   onStartTour: () => void;
   isFocusMode: boolean;
   onToggleFocusMode: () => void;
-  isCopilotBetaEnabled: boolean;
+  isCopilotEnabled: boolean;
   onToggleCopilotBeta: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -35,7 +35,7 @@ export function MoreActionsDropdown({
   onStartTour,
   isFocusMode,
   onToggleFocusMode,
-  isCopilotBetaEnabled,
+  isCopilotEnabled,
   onToggleCopilotBeta,
   open,
   onOpenChange,
@@ -171,7 +171,7 @@ export function MoreActionsDropdown({
                 Beta
               </span>
             </span>
-            {isCopilotBetaEnabled && <Check size={14} />}
+            {isCopilotEnabled && <Check size={14} />}
           </DropdownMenu.Item>
 
           <DropdownMenu.Separator

--- a/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -34,7 +34,7 @@ import {
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 import type { WebviewTranslationKeys } from '../../i18n/translation-keys';
-import { openExternalUrl } from '../../services/slack-integration-service';
+import { openExternalUrl } from '../../services/vscode-bridge';
 import { AVAILABLE_TOOLS } from '../../stores/refinement-store';
 import { ArgumentHintTagInput } from '../common/ArgumentHintTagInput';
 import { ToolSelectTagInput } from '../common/ToolSelectTagInput';

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -425,6 +425,9 @@ export interface WebviewTranslationKeys {
   // Model selector
   'refinement.model.label': string;
 
+  // Provider selector
+  'refinement.provider.label': string;
+
   // Settings dropdown
   'refinement.settings.title': string;
 
@@ -453,6 +456,7 @@ export interface WebviewTranslationKeys {
   'refinement.error.emptyMessage': string;
   'refinement.error.messageTooLong': string;
   'refinement.error.commandNotFound': string;
+  'refinement.error.modelNotSupported': string;
   'refinement.error.timeout': string;
   'refinement.error.parseError': string;
   'refinement.error.validationError': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -467,6 +467,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Model selector
   'refinement.model.label': 'Model',
 
+  // Provider selector
+  'refinement.provider.label': 'AI Provider',
+
   // Settings dropdown
   'refinement.settings.title': 'Settings',
 
@@ -491,7 +494,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Session Status
   'refinement.session.warningDialog.title': 'AI Editing Session Reconnected',
   'refinement.session.warningDialog.message':
-    'The AI conversation session could not be continued due to reasons such as loading a workflow shared by others or session expiration, so a new conversation session was started.\n\nAdditional context that the AI remembered in the previous conversation session (file contents, tool execution results, etc.) may have been lost.\n\nPlease re-share any relevant information in your message if needed.',
+    'The AI conversation session could not be continued due to reasons such as switching AI providers, loading a workflow shared by others, or session expiration, so a new conversation session was started.\n\nAdditional context that the AI remembered in the previous conversation session (file contents, tool execution results, etc.) may have been lost.\n\nPlease re-share any relevant information in your message if needed.',
   'refinement.session.warningDialog.ok': 'OK',
 
   // Refinement Errors
@@ -499,6 +502,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'refinement.error.messageTooLong': 'Message is too long (max {max} characters)',
   'refinement.error.commandNotFound':
     'Claude Code CLI not found. Please install Claude Code to use AI refinement.',
+  'refinement.error.modelNotSupported':
+    'The selected model is not supported or access is not enabled. You can enable access by selecting and using the model in Copilot Chat once.',
   'refinement.error.timeout':
     'AI refinement timed out. Please adjust the timeout value and try again. Simplifying the request is also recommended.',
   'refinement.error.parseError':

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -467,6 +467,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Model selector
   'refinement.model.label': 'モデル',
 
+  // Provider selector
+  'refinement.provider.label': 'AIプロバイダー',
+
   // Settings dropdown
   'refinement.settings.title': '設定',
 
@@ -491,7 +494,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Session Status
   'refinement.session.warningDialog.title': 'AI編集のセッションが再接続されました',
   'refinement.session.warningDialog.message':
-    '他者から共有されたワークフローの読み込みや、セッションの有効期限切れなどの理由で、AI会話セッションを継続できなかったため、新しい会話セッションを開始しました。\n\n前の会話セッションでAIが記憶していた追加のコンテキスト（ファイルの内容、ツール実行結果など）は失われている可能性があります。\n\n必要に応じて、関連する情報を改めてメッセージで伝えてください。',
+    'AIプロバイダーの切り替え、他者から共有されたワークフローの読み込み、セッションの有効期限切れなどの理由で、AI会話セッションを継続できなかったため、新しい会話セッションを開始しました。\n\n前の会話セッションでAIが記憶していた追加のコンテキスト（ファイルの内容、ツール実行結果など）は失われている可能性があります。\n\n必要に応じて、関連する情報を改めてメッセージで伝えてください。',
   'refinement.session.warningDialog.ok': 'OK',
 
   // Refinement Errors
@@ -499,6 +502,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'refinement.error.messageTooLong': 'メッセージが長すぎます（最大{max}文字）',
   'refinement.error.commandNotFound':
     'Claude Code CLIが見つかりません。AI改善機能を使用するにはClaude Codeをインストールしてください。',
+  'refinement.error.modelNotSupported':
+    '選択されたモデルはサポートされていないか、アクセスが有効になっていません。Copilot Chatで該当モデルを一度選択して使用することで、アクセス許可を有効にできます。',
   'refinement.error.timeout':
     'AI改善がタイムアウトしました。タイムアウト設定値を調整してもう一度試してみてください。リクエスト内容の簡略化もご検討ください。',
   'refinement.error.parseError':

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -467,6 +467,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Model selector
   'refinement.model.label': '모델',
 
+  // Provider selector
+  'refinement.provider.label': 'AI 프로바이더',
+
   // Settings dropdown
   'refinement.settings.title': '설정',
 
@@ -491,7 +494,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Session Status
   'refinement.session.warningDialog.title': 'AI 편집 세션이 재연결되었습니다',
   'refinement.session.warningDialog.message':
-    '다른 사용자가 공유한 워크플로우를 불러오거나 세션 만료 등의 이유로 AI 대화 세션을 계속할 수 없어 새 대화 세션을 시작했습니다.\n\n이전 대화 세션에서 AI가 기억하고 있던 추가 컨텍스트(파일 내용, 도구 실행 결과 등)는 손실되었을 수 있습니다.\n\n필요한 경우 관련 정보를 메시지로 다시 전달해 주세요.',
+    'AI 프로바이더 전환, 다른 사용자가 공유한 워크플로우 불러오기, 세션 만료 등의 이유로 AI 대화 세션을 계속할 수 없어 새 대화 세션을 시작했습니다.\n\n이전 대화 세션에서 AI가 기억하고 있던 추가 컨텍스트(파일 내용, 도구 실행 결과 등)는 손실되었을 수 있습니다.\n\n필요한 경우 관련 정보를 메시지로 다시 전달해 주세요.',
   'refinement.session.warningDialog.ok': 'OK',
 
   // Refinement Errors
@@ -499,6 +502,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'refinement.error.messageTooLong': '메시지가 너무 깁니다 (최대 {max}자)',
   'refinement.error.commandNotFound':
     'Claude Code CLI를 찾을 수 없습니다. AI 개선 기능을 사용하려면 Claude Code를 설치하세요.',
+  'refinement.error.modelNotSupported':
+    '선택한 모델이 지원되지 않거나 액세스가 활성화되어 있지 않습니다. Copilot Chat에서 해당 모델을 선택하고 한 번 사용하면 액세스 권한을 활성화할 수 있습니다.',
   'refinement.error.timeout':
     'AI 개선 시간이 초과되었습니다. 타임아웃 설정값을 조정하고 다시 시도해 보세요. 요청 내용을 단순화하는 것도 권장됩니다.',
   'refinement.error.parseError':

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -451,6 +451,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Model selector
   'refinement.model.label': '模型',
 
+  // Provider selector
+  'refinement.provider.label': 'AI提供商',
+
   // Settings dropdown
   'refinement.settings.title': '设置',
 
@@ -474,13 +477,15 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Session Status
   'refinement.session.warningDialog.title': 'AI编辑会话已重新连接',
   'refinement.session.warningDialog.message':
-    '由于加载他人共享的工作流或会话过期等原因，无法继续AI对话会话，已开始新的对话会话。\n\n之前对话会话中AI记住的额外上下文（文件内容、工具执行结果等）可能已丢失。\n\n如有需要，请在消息中重新分享相关信息。',
+    '由于切换AI提供商、加载他人共享的工作流或会话过期等原因，无法继续AI对话会话，已开始新的对话会话。\n\n之前对话会话中AI记住的额外上下文（文件内容、工具执行结果等）可能已丢失。\n\n如有需要，请在消息中重新分享相关信息。',
   'refinement.session.warningDialog.ok': 'OK',
 
   // Refinement Errors
   'refinement.error.emptyMessage': '请输入消息',
   'refinement.error.messageTooLong': '消息太长（最多{max}个字符）',
   'refinement.error.commandNotFound': '未找到Claude Code CLI。请安装Claude Code以使用AI优化功能。',
+  'refinement.error.modelNotSupported':
+    '所选模型不受支持或访问未启用。您可以在Copilot Chat中选择并使用该模型一次来启用访问权限。',
   'refinement.error.timeout': 'AI优化超时。请调整超时设定值后重试。建议您也可以考虑简化请求内容。',
   'refinement.error.parseError': '无法解析AI响应。请重试或重新表述您的请求。',
   'refinement.error.validationError': '优化后的工作流验证失败。请尝试不同的请求。',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -451,6 +451,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Model selector
   'refinement.model.label': '模型',
 
+  // Provider selector
+  'refinement.provider.label': 'AI提供商',
+
   // Settings dropdown
   'refinement.settings.title': '設定',
 
@@ -474,13 +477,15 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Refinement Session Status
   'refinement.session.warningDialog.title': 'AI編輯會話已重新連接',
   'refinement.session.warningDialog.message':
-    '由於載入他人共享的工作流程或會話過期等原因，無法繼續AI對話會話，已開始新的對話會話。\n\n之前對話會話中AI記住的額外上下文（檔案內容、工具執行結果等）可能已遺失。\n\n如有需要，請在訊息中重新分享相關資訊。',
+    '由於切換AI提供者、載入他人共享的工作流程或會話過期等原因，無法繼續AI對話會話，已開始新的對話會話。\n\n之前對話會話中AI記住的額外上下文（檔案內容、工具執行結果等）可能已遺失。\n\n如有需要，請在訊息中重新分享相關資訊。',
   'refinement.session.warningDialog.ok': 'OK',
 
   // Refinement Errors
   'refinement.error.emptyMessage': '請輸入訊息',
   'refinement.error.messageTooLong': '訊息太長（最多{max}個字元）',
   'refinement.error.commandNotFound': '未找到Claude Code CLI。請安裝Claude Code以使用AI優化功能。',
+  'refinement.error.modelNotSupported':
+    '所選模型不受支援或存取未啟用。您可以在Copilot Chat中選擇並使用該模型一次來啟用存取權限。',
   'refinement.error.timeout': 'AI優化逾時。請調整逾時設定值後重試。建議您也可以考慮簡化請求內容。',
   'refinement.error.parseError': '無法解析AI回應。請重試或重新表述您的請求。',
   'refinement.error.validationError': '優化後的工作流程驗證失敗。請嘗試不同的請求。',

--- a/src/webview/src/services/slack-integration-service.ts
+++ b/src/webview/src/services/slack-integration-service.ts
@@ -679,18 +679,6 @@ export function getOAuthRedirectUri(): Promise<{ redirectUri: string }> {
 }
 
 /**
- * Open external URL in browser
- *
- * @param url - URL to open
- */
-export function openExternalUrl(url: string): void {
-  vscode.postMessage({
-    type: 'OPEN_EXTERNAL_URL',
-    payload: { url },
-  });
-}
-
-/**
  * Get last shared channel ID
  *
  * Retrieves the channel ID that was last used for sharing.

--- a/src/webview/src/services/vscode-bridge.ts
+++ b/src/webview/src/services/vscode-bridge.ts
@@ -466,3 +466,22 @@ export function runForCopilotCli(workflow: Workflow): Promise<RunForCopilotCliSu
     }, 30000);
   });
 }
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Open external URL in browser
+ *
+ * Sends a message to the extension host to open the URL in the user's default browser.
+ * This is necessary because webview content cannot directly open external URLs.
+ *
+ * @param url - URL to open
+ */
+export function openExternalUrl(url: string): void {
+  vscode.postMessage({
+    type: 'OPEN_EXTERNAL_URL',
+    payload: { url },
+  });
+}

--- a/src/webview/src/utils/error-messages.ts
+++ b/src/webview/src/utils/error-messages.ts
@@ -9,6 +9,7 @@ import type { WebviewTranslationKeys } from '../i18n/translation-keys';
 
 type ErrorCode =
   | 'COMMAND_NOT_FOUND'
+  | 'MODEL_NOT_SUPPORTED'
   | 'TIMEOUT'
   | 'PARSE_ERROR'
   | 'VALIDATION_ERROR'
@@ -31,6 +32,10 @@ interface ErrorMessageInfo {
 const ERROR_MESSAGE_MAP: Record<ErrorCode, ErrorMessageInfo> = {
   COMMAND_NOT_FOUND: {
     messageKey: 'refinement.error.commandNotFound',
+    isRetryable: false,
+  },
+  MODEL_NOT_SUPPORTED: {
+    messageKey: 'refinement.error.modelNotSupported',
     isRetryable: false,
   },
   TIMEOUT: {


### PR DESCRIPTION
## Summary

Add GitHub Copilot as an alternative AI provider for workflow refinement, using VS Code Language Model API (`vscode.lm`).

Users can now choose between Claude Code CLI and Copilot in the refinement settings dropdown.

## Changes

### New Files
- **src/extension/services/vscode-lm-service.ts** - VS Code LM API wrapper with streaming support
- **src/extension/services/ai-provider.ts** - Provider abstraction layer for routing between Claude Code and Copilot

### Modified Files (Key Changes)

**Extension Host:**
- `workflow-refinement.ts` - Extract provider and copilotModel from payload
- `refinement-service.ts` - Add provider switch session detection, route to ai-provider
- `claude-code-service.ts` - Add MODEL_NOT_SUPPORTED error code type

**Webview:**
- `SettingsDropdown.tsx` - Add Provider selection UI, Copilot model dropdown with premium request multiplier
- `refinement-store.ts` - Add selectedProvider and selectedCopilotModel state with localStorage persistence
- `error-messages.ts` - Add MODEL_NOT_SUPPORTED error handling

**i18n (5 languages):**
- Add session warning reason for AI provider switch
- Add MODEL_NOT_SUPPORTED error message

## Features

- ✅ Provider selection (Claude Code / Copilot) in settings dropdown
- ✅ Dynamic Copilot model list fetched from `vscode.lm.selectChatModels()`
- ✅ Streaming response support for Copilot
- ✅ Session discontinuation detection when switching from Claude Code to Copilot
- ✅ MODEL_NOT_SUPPORTED error with user-friendly message for disabled models
- ✅ Hide Allowed Tools when Copilot selected (not supported by LM API)
- ✅ Premium Request multiplier link for Copilot models
- ✅ Model deduplication (by family and name)

## Technical Notes

- **Backward Compatibility**: `engines.vscode` remains at `^1.80.0` with runtime detection
- **LM API Requirements**: VS Code 1.89+ with GitHub Copilot extension
- **Session Handling**: Copilot doesn't support session continuation; conversation history is rebuilt in prompt
- **Tool Support**: `--allowed-tools` not supported with Copilot provider

## Testing

- [x] Manual E2E testing completed
  - Provider switch from Claude Code to Copilot
  - Copilot streaming response
  - Model selection and persistence
  - Error handling for disabled models
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build verified (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)