### PR TITLE
fix: display dynamic provider name in refinement chat initial message

### DIFF
--- a/src/webview/src/components/chat/MessageList.tsx
+++ b/src/webview/src/components/chat/MessageList.tsx
@@ -26,7 +26,7 @@ export function MessageList({
   conversationHistory: propsConversationHistory,
 }: MessageListProps) {
   const { t } = useTranslation();
-  const { conversationHistory: storeConversationHistory } = useRefinementStore();
+  const { conversationHistory: storeConversationHistory, selectedProvider } = useRefinementStore();
 
   // Use props if provided (controlled mode), otherwise use store (uncontrolled mode)
   const conversationHistory = propsConversationHistory ?? storeConversationHistory;
@@ -72,7 +72,9 @@ export function MessageList({
             textAlign: 'center',
           }}
         >
-          {t('refinement.initialMessage.note')}
+          {t('refinement.initialMessage.note', {
+            providerName: selectedProvider === 'copilot' ? 'GitHub Copilot' : 'Claude Code',
+          })}
         </div>
         <div
           style={{

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -534,8 +534,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description':
     'Describe the workflow you want to achieve in natural language.',
-  'refinement.initialMessage.note':
-    '※ This feature uses Claude Code installed in your environment.',
+  'refinement.initialMessage.note': '※ This feature uses {{providerName}}.',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -533,8 +533,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '実現したいワークフローを自然言語で説明してください。',
-  'refinement.initialMessage.note':
-    '※ この機能はお使いの環境にインストールされたClaude Codeを使用します。',
+  'refinement.initialMessage.note': '※ この機能は{{providerName}}を使用します。',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -532,7 +532,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '실현하려는 워크플로를 자연어로 설명해주세요.',
-  'refinement.initialMessage.note': '※ 이 기능은 환경에 설치된 Claude Code를 사용합니다.',
+  'refinement.initialMessage.note': '※ 이 기능은 {{providerName}}을(를) 사용합니다.',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -511,7 +511,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '用自然语言描述您要实现的工作流。',
-  'refinement.initialMessage.note': '※ 此功能使用您环境中安装的Claude Code。',
+  'refinement.initialMessage.note': '※ 此功能使用{{providerName}}。',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -511,7 +511,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '用自然語言描述您要實現的工作流。',
-  'refinement.initialMessage.note': '※ 此功能使用您環境中安裝的Claude Code。',
+  'refinement.initialMessage.note': '※ 此功能使用{{providerName}}。',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',


### PR DESCRIPTION
## Problem

### Current Behavior
1. User opens refinement chat
2. ❌ Initial message always shows "Claude Code" regardless of selected AI provider

### Expected Behavior
1. User opens refinement chat
2. ✅ Initial message shows the correct provider name based on selection:
   - `claude-code` → "Claude Code"
   - `copilot` → "GitHub Copilot"

## Solution

Implemented parameter interpolation in translation files to dynamically display the provider name.

### Changes

**Translation files** (`en.ts`, `ja.ts`, `ko.ts`, `zh-CN.ts`, `zh-TW.ts`):
- Changed `refinement.initialMessage.note` to use `{{providerName}}` parameter

**MessageList.tsx**:
- Added `selectedProvider` from refinement store
- Pass provider name as parameter to translation function

## Impact

- UX improvement: Users now see the correct AI provider name in the initial message
- No breaking changes
- All 5 languages updated consistently

## Testing

- [x] Manual E2E testing completed
  - Claude Code selection shows "Claude Code"
  - Copilot selection shows "GitHub Copilot"
  - Provider switch updates message immediately
  - All 5 languages verified
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)