### PR TITLE
fix: hide CLAUDE.md tip in Edit with AI when using Copilot

### DIFF
--- a/src/webview/src/components/chat/MessageList.tsx
+++ b/src/webview/src/components/chat/MessageList.tsx
@@ -76,23 +76,25 @@ export function MessageList({
             providerName: selectedProvider === 'copilot' ? 'GitHub Copilot' : 'Claude Code',
           })}
         </div>
-        <div
-          style={{
-            marginTop: '16px',
-            padding: '8px 12px',
-            backgroundColor: 'var(--vscode-textBlockQuote-background)',
-            border: '1px solid var(--vscode-textBlockQuote-border)',
-            borderRadius: '4px',
-            fontSize: `${fontSizes.small}px`,
-            lineHeight: '1.6',
-            color: 'var(--vscode-foreground)',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            textAlign: 'left',
-          }}
-        >
-          {t('refinement.chat.claudeMdTip')}
-        </div>
+        {selectedProvider !== 'copilot' && (
+          <div
+            style={{
+              marginTop: '16px',
+              padding: '8px 12px',
+              backgroundColor: 'var(--vscode-textBlockQuote-background)',
+              border: '1px solid var(--vscode-textBlockQuote-border)',
+              borderRadius: '4px',
+              fontSize: `${fontSizes.small}px`,
+              lineHeight: '1.6',
+              color: 'var(--vscode-foreground)',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              textAlign: 'left',
+            }}
+          >
+            {t('refinement.chat.claudeMdTip')}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Problem

When using "Edit with AI" with Copilot as the AI provider, the tip message about CLAUDE.md is displayed:

> 💡 Tip: Add workflow-specific rules and constraints to CLAUDE.md for more accurate AI edits

However, Copilot cannot reference CLAUDE.md files, making this tip irrelevant and potentially confusing.

## Solution

Conditionally hide the CLAUDE.md tip when `selectedProvider === 'copilot'`.

### Changes

**File**: `src/webview/src/components/chat/MessageList.tsx`

- Wrapped the tip `<div>` with `{selectedProvider !== 'copilot' && ( ... )}`
- Tip now only appears for Claude Code provider

## Impact

- UX improvement: Users using Copilot won't see irrelevant tips
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build passed (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)