### PR TITLE
improvement: clarify Copilot uses VSCode Language Model API

### DIFF
--- a/src/webview/src/components/chat/MessageList.tsx
+++ b/src/webview/src/components/chat/MessageList.tsx
@@ -9,9 +9,11 @@
  */
 
 import type { ConversationHistory } from '@shared/types/workflow-definition';
+import { ExternalLink } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useResponsiveFonts } from '../../contexts/ResponsiveFontContext';
 import { useTranslation } from '../../i18n/i18n-context';
+import { openExternalUrl } from '../../services/vscode-bridge';
 import { useRefinementStore } from '../../stores/refinement-store';
 import { MessageBubble } from './MessageBubble';
 
@@ -72,10 +74,41 @@ export function MessageList({
             textAlign: 'center',
           }}
         >
-          {t('refinement.initialMessage.note', {
-            providerName: selectedProvider === 'copilot' ? 'GitHub Copilot' : 'Claude Code',
-          })}
+          {selectedProvider === 'copilot'
+            ? t('refinement.initialMessage.noteCopilot')
+            : t('refinement.initialMessage.note', { providerName: 'Claude Code' })}
         </div>
+        {selectedProvider === 'copilot' && (
+          <button
+            type="button"
+            onClick={() =>
+              openExternalUrl(
+                'https://code.visualstudio.com/api/extension-guides/ai/language-model'
+              )
+            }
+            style={{
+              marginTop: '8px',
+              color: 'var(--vscode-textLink-foreground)',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              fontSize: `${fontSizes.small}px`,
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.textDecoration = 'underline';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.textDecoration = 'none';
+            }}
+          >
+            <ExternalLink size={12} />
+            <span>Learn more</span>
+          </button>
+        )}
         {selectedProvider !== 'copilot' && (
           <div
             style={{

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -480,6 +480,8 @@ export interface WebviewTranslationKeys {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': string;
   'refinement.initialMessage.note': string;
+  // Copilot-specific note with link
+  'refinement.initialMessage.noteCopilot': string;
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -535,6 +535,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'refinement.initialMessage.description':
     'Describe the workflow you want to achieve in natural language.',
   'refinement.initialMessage.note': '※ This feature uses {{providerName}}.',
+  // Copilot-specific note with link
+  'refinement.initialMessage.noteCopilot':
+    '※ This feature requests your GitHub Copilot through the VSCode Language Model API.',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -534,6 +534,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '実現したいワークフローを自然言語で説明してください。',
   'refinement.initialMessage.note': '※ この機能は{{providerName}}を使用します。',
+  // Copilot-specific note with link
+  'refinement.initialMessage.noteCopilot':
+    '※ この機能はVSCode Language Model APIを通じて、あなたのGitHub Copilotにリクエストします。',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -533,6 +533,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '실현하려는 워크플로를 자연어로 설명해주세요.',
   'refinement.initialMessage.note': '※ 이 기능은 {{providerName}}을(를) 사용합니다.',
+  // Copilot-specific note with link
+  'refinement.initialMessage.noteCopilot':
+    '※ 이 기능은 VSCode Language Model API를 통해 GitHub Copilot에 요청합니다.',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -512,6 +512,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '用自然语言描述您要实现的工作流。',
   'refinement.initialMessage.note': '※ 此功能使用{{providerName}}。',
+  // Copilot-specific note with link
+  'refinement.initialMessage.noteCopilot':
+    '※ 此功能通过 VSCode Language Model API 向您的 GitHub Copilot 发送请求。',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -512,6 +512,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '用自然語言描述您要實現的工作流。',
   'refinement.initialMessage.note': '※ 此功能使用{{providerName}}。',
+  // Copilot-specific note with link
+  'refinement.initialMessage.noteCopilot':
+    '※ 此功能透過 VSCode Language Model API 向您的 GitHub Copilot 發送請求。',
 
   // MCP Node (Feature: 001-mcp-node)
   'node.mcp.title': 'MCP Tool',


### PR DESCRIPTION
## Problem

When using GitHub Copilot as the AI provider in Edit with AI, users see a generic message:
- ❌ "※ This feature uses GitHub Copilot."

This doesn't explain that the feature uses the VSCode Language Model API, which consumes the user's Copilot quota/premium requests.

## Solution

Provide a clearer, more informative message for Copilot users:
- ✅ "※ This feature requests your GitHub Copilot through the VSCode Language Model API."
- ✅ Added "Learn more" link to VSCode LM API documentation

## Changes

### Files Modified

- `src/webview/src/components/chat/MessageList.tsx` - Added Copilot-specific note with external link
- `src/webview/src/i18n/translation-keys.ts` - Added new translation key
- `src/webview/src/i18n/translations/*.ts` - Added translations for all 5 languages

### UI Changes

**Copilot selected:**
```
※ This feature requests your GitHub Copilot through the VSCode Language Model API.
🔗 Learn more
```

**Claude Code selected (unchanged):**
```
※ This feature uses Claude Code.
```

## Impact

- Improved transparency for Copilot users
- No breaking changes
- No changes to Claude Code flow

## Testing

- [x] Build passes (`npm run build`)
- [x] Lint/format checks pass
- [x] Manual E2E testing in VSCode Extension Development Host

🤖 Generated with [Claude Code](https://claude.com/claude-code)