### PR TITLE
chore: update Node.js version to 22 in security-scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install root dependencies


### PR DESCRIPTION
## Problem

The security-scan workflow was using Node.js 20, but semantic-release packages require Node.js ^22.14.0 or >= 24.10.0.

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'semantic-release@25.0.2',
npm warn EBADENGINE   required: { node: '^22.14.0 || >= 24.10.0' },
npm warn EBADENGINE   current: { node: 'v20.19.6', npm: '10.8.2' }
npm warn EBADENGINE }
```

## Solution

Updated `node-version` from `'20'` to `'22'` in `.github/workflows/security-scan.yml`.

This aligns with `release.yml` which already uses Node.js 22.

## Changes

**File**: `.github/workflows/security-scan.yml`
- Line 31: `node-version: '20'` → `node-version: '22'`

## Impact

- Resolves npm EBADENGINE warnings
- No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)