### PR TITLE
chore: add .claude/ and .vscode/workflows/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ npm-debug.log*
 .env
 .env.local
 
+# Claude Code settings (contains private configuration)
+.claude/
+.vscode/workflows/
+
 # Temporary files
 *.tmp
 *.swp


### PR DESCRIPTION
## Summary

Add `.claude/` and `.vscode/workflows/` directories to `.gitignore` to prevent tracking of private configuration files.

## Changes

- Added `.claude/` to ignore private Claude Code settings
- Added `.vscode/workflows/` to ignore workflow files containing sensitive data

## Impact

- No breaking changes
- Prevents accidental commit of sensitive configuration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)