### PR TITLE
improvement: add Codex CLI feature announcement banner

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -21,7 +21,9 @@ import ReactFlow, {
 } from 'reactflow';
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
+import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
+import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
 import { DescriptionPanel } from './DescriptionPanel';
 // Custom edge with delete button
 import { DeletableEdge } from './edges/DeletableEdge';
@@ -91,6 +93,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   isNodePaletteCollapsed = false,
   onExpandNodePalette,
 }) => {
+  const { t } = useTranslation();
   const isCompact = useIsCompactMode();
 
   // Auto-focus on newly added nodes
@@ -199,109 +202,119 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const selectionOnDrag = effectiveMode === 'selection';
 
   return (
-    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={handleNodesChange}
-        onEdgesChange={handleEdgesChange}
-        onConnect={handleConnect}
-        onNodeClick={handleNodeClick}
-        onPaneClick={handlePaneClick}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        defaultEdgeOptions={defaultEdgeOptions}
-        isValidConnection={isValidConnection}
-        snapToGrid={true}
-        snapGrid={snapGrid}
-        panOnDrag={panOnDrag}
-        selectionOnDrag={selectionOnDrag}
-        fitView
-        attributionPosition="bottom-left"
-      >
-        {/* Background grid */}
-        <Background color="var(--vscode-panel-border)" gap={15} size={1} />
+    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* Feature Announcement Banner - placed above the canvas */}
+      <FeatureAnnouncementBanner
+        featureId="codex-cli-v3.17"
+        title={t('announcement.codexCli.title')}
+        description={t('announcement.codexCli.description')}
+      />
 
-        {/* Controls (zoom, fit view, etc.) */}
-        <Controls />
+      {/* Canvas area */}
+      <div style={{ flex: 1, position: 'relative' }}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={handleNodesChange}
+          onEdgesChange={handleEdgesChange}
+          onConnect={handleConnect}
+          onNodeClick={handleNodeClick}
+          onPaneClick={handlePaneClick}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          defaultEdgeOptions={defaultEdgeOptions}
+          isValidConnection={isValidConnection}
+          snapToGrid={true}
+          snapGrid={snapGrid}
+          panOnDrag={panOnDrag}
+          selectionOnDrag={selectionOnDrag}
+          fitView
+          attributionPosition="bottom-left"
+        >
+          {/* Background grid */}
+          <Background color="var(--vscode-panel-border)" gap={15} size={1} />
 
-        {/* Mini map with container */}
-        <Panel position="bottom-right">
-          <MinimapContainer>
-            <MiniMap
-              nodeColor={(node) => {
-                switch (node.type) {
-                  case 'subAgent':
-                    return 'var(--vscode-charts-blue)';
-                  case 'askUserQuestion':
-                    return 'var(--vscode-charts-orange)';
-                  case 'branch': // Legacy
-                    return 'var(--vscode-charts-yellow)';
-                  case 'ifElse':
-                    return 'var(--vscode-charts-yellow)';
-                  case 'switch':
-                    return 'var(--vscode-charts-yellow)';
-                  case 'start':
-                    return 'var(--vscode-charts-green)';
-                  case 'end':
-                    return 'var(--vscode-charts-red)';
-                  case 'prompt':
-                    return 'var(--vscode-charts-purple)';
-                  case 'skill':
-                    return 'var(--vscode-charts-cyan)';
-                  case 'subAgentFlow':
-                    return 'var(--vscode-charts-purple)';
-                  default:
-                    return 'var(--vscode-foreground)';
-                }
-              }}
-              maskColor="rgba(0, 0, 0, 0.5)"
-              style={{
-                position: 'relative',
-                backgroundColor: 'var(--vscode-editor-background)',
-                width: isCompact ? 120 : 200,
-                height: isCompact ? 80 : 150,
-                margin: '4px 16px',
-              }}
-            />
-          </MinimapContainer>
-        </Panel>
+          {/* Controls (zoom, fit view, etc.) */}
+          <Controls />
 
-        {/* Interaction Mode Toggle */}
-        <Panel position="top-left">
-          <InteractionModeToggle />
-        </Panel>
-
-        {/* Description Panel for workflow description */}
-        <Panel position="top-right">
-          <DescriptionPanel />
-        </Panel>
-
-        {/* Expand Node Palette Button (when collapsed) */}
-        {isNodePaletteCollapsed && onExpandNodePalette && (
-          <Panel position="top-left" style={{ marginTop: '48px' }}>
-            <button
-              type="button"
-              onClick={onExpandNodePalette}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: '32px',
-                height: '32px',
-                backgroundColor: 'var(--vscode-editor-background)',
-                border: '1px solid var(--vscode-panel-border)',
-                borderRadius: '6px',
-                cursor: 'pointer',
-                color: 'var(--vscode-foreground)',
-                opacity: 0.85,
-              }}
-            >
-              <PanelLeftOpen size={16} aria-hidden="true" />
-            </button>
+          {/* Mini map with container */}
+          <Panel position="bottom-right">
+            <MinimapContainer>
+              <MiniMap
+                nodeColor={(node) => {
+                  switch (node.type) {
+                    case 'subAgent':
+                      return 'var(--vscode-charts-blue)';
+                    case 'askUserQuestion':
+                      return 'var(--vscode-charts-orange)';
+                    case 'branch': // Legacy
+                      return 'var(--vscode-charts-yellow)';
+                    case 'ifElse':
+                      return 'var(--vscode-charts-yellow)';
+                    case 'switch':
+                      return 'var(--vscode-charts-yellow)';
+                    case 'start':
+                      return 'var(--vscode-charts-green)';
+                    case 'end':
+                      return 'var(--vscode-charts-red)';
+                    case 'prompt':
+                      return 'var(--vscode-charts-purple)';
+                    case 'skill':
+                      return 'var(--vscode-charts-cyan)';
+                    case 'subAgentFlow':
+                      return 'var(--vscode-charts-purple)';
+                    default:
+                      return 'var(--vscode-foreground)';
+                  }
+                }}
+                maskColor="rgba(0, 0, 0, 0.5)"
+                style={{
+                  position: 'relative',
+                  backgroundColor: 'var(--vscode-editor-background)',
+                  width: isCompact ? 120 : 200,
+                  height: isCompact ? 80 : 150,
+                  margin: '4px 16px',
+                }}
+              />
+            </MinimapContainer>
           </Panel>
-        )}
-      </ReactFlow>
+
+          {/* Interaction Mode Toggle */}
+          <Panel position="top-left">
+            <InteractionModeToggle />
+          </Panel>
+
+          {/* Description Panel for workflow description */}
+          <Panel position="top-right">
+            <DescriptionPanel />
+          </Panel>
+
+          {/* Expand Node Palette Button (when collapsed) */}
+          {isNodePaletteCollapsed && onExpandNodePalette && (
+            <Panel position="top-left" style={{ marginTop: '48px' }}>
+              <button
+                type="button"
+                onClick={onExpandNodePalette}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '32px',
+                  height: '32px',
+                  backgroundColor: 'var(--vscode-editor-background)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  color: 'var(--vscode-foreground)',
+                  opacity: 0.85,
+                }}
+              >
+                <PanelLeftOpen size={16} aria-hidden="true" />
+              </button>
+            </Panel>
+          )}
+        </ReactFlow>
+      </div>
     </div>
   );
 };

--- a/src/webview/src/components/common/FeatureAnnouncementBanner.tsx
+++ b/src/webview/src/components/common/FeatureAnnouncementBanner.tsx
@@ -1,0 +1,145 @@
+/**
+ * Feature Announcement Banner Component
+ *
+ * A dismissable banner for announcing new features to users.
+ * Once dismissed, the banner state is persisted to localStorage.
+ */
+
+import { Terminal, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+const DISMISSED_KEY_PREFIX = 'cc-wf-studio:feature-dismissed:';
+
+interface FeatureAnnouncementBannerProps {
+  /** Unique identifier for this feature announcement (used for localStorage key) */
+  featureId: string;
+  /** Optional icon to display (default: robot emoji) */
+  icon?: React.ReactNode;
+  /** Banner title text */
+  title: string;
+  /** Optional description text */
+  description?: string;
+  /** Optional callback when banner is dismissed */
+  onDismiss?: () => void;
+}
+
+/**
+ * Check if a feature announcement has been dismissed
+ */
+function isDismissed(featureId: string): boolean {
+  try {
+    return localStorage.getItem(`${DISMISSED_KEY_PREFIX}${featureId}`) === 'true';
+  } catch {
+    // localStorage may not be available in some contexts
+    return false;
+  }
+}
+
+/**
+ * Mark a feature announcement as dismissed
+ */
+function setDismissed(featureId: string): void {
+  try {
+    localStorage.setItem(`${DISMISSED_KEY_PREFIX}${featureId}`, 'true');
+  } catch {
+    // localStorage may not be available in some contexts
+  }
+}
+
+export function FeatureAnnouncementBanner({
+  featureId,
+  icon,
+  title,
+  description,
+  onDismiss,
+}: FeatureAnnouncementBannerProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Check if already dismissed
+    setVisible(!isDismissed(featureId));
+  }, [featureId]);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(featureId);
+    setVisible(false);
+    onDismiss?.();
+  }, [featureId, onDismiss]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.content}>
+        <span style={styles.icon}>{icon ?? <Terminal size={16} />}</span>
+        <div style={styles.textContainer}>
+          <span style={styles.title}>{title}</span>
+          {description && <span style={styles.description}>{description}</span>}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        style={styles.closeButton}
+        aria-label="Dismiss announcement"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '8px 16px',
+    backgroundColor: 'rgba(0, 122, 204, 0.15)',
+    borderBottom: '1px solid rgba(0, 122, 204, 0.3)',
+    fontSize: '13px',
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+  content: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    flex: 1,
+    minWidth: 0,
+  },
+  icon: {
+    fontSize: '16px',
+    flexShrink: 0,
+  },
+  textContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    minWidth: 0,
+  },
+  title: {
+    color: 'var(--vscode-foreground)',
+    fontWeight: 500,
+  },
+  description: {
+    color: 'var(--vscode-descriptionForeground)',
+    fontSize: '12px',
+  },
+  closeButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '4px',
+    backgroundColor: 'transparent',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    color: 'var(--vscode-foreground)',
+    opacity: 0.7,
+    flexShrink: 0,
+    marginLeft: '8px',
+  },
+};

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -772,4 +772,8 @@ export interface WebviewTranslationKeys {
   'description.panel.title': string;
   'description.panel.show': string;
   'description.panel.hide': string;
+
+  // Feature Announcement Banner
+  'announcement.codexCli.title': string;
+  'announcement.codexCli.description': string;
 }

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -853,4 +853,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': 'Description',
   'description.panel.show': 'Show description panel',
   'description.panel.hide': 'Hide description panel',
+
+  // Feature Announcement Banner
+  'announcement.codexCli.title': 'New: OpenAI Codex CLI Export & Run support is now available!',
+  'announcement.codexCli.description': 'Enable in More menu → Codex',
 };

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -847,4 +847,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '説明',
   'description.panel.show': '説明パネルを表示',
   'description.panel.hide': '説明パネルを非表示',
+
+  // Feature Announcement Banner
+  'announcement.codexCli.title': '新機能: OpenAI Codex CLI での変換・実行に対応しました！',
+  'announcement.codexCli.description': 'その他メニュー → Codex で有効化',
 };

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -847,4 +847,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '설명',
   'description.panel.show': '설명 패널 표시',
   'description.panel.hide': '설명 패널 숨기기',
+
+  // Feature Announcement Banner
+  'announcement.codexCli.title': '새 기능: OpenAI Codex CLI 내보내기 및 실행 지원이 추가되었습니다!',
+  'announcement.codexCli.description': '더보기 메뉴 → Codex에서 활성화',
 };

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -816,4 +816,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '描述',
   'description.panel.show': '显示描述面板',
   'description.panel.hide': '隐藏描述面板',
+
+  // Feature Announcement Banner
+  'announcement.codexCli.title': '新功能: 现已支持 OpenAI Codex CLI 导出和运行！',
+  'announcement.codexCli.description': '在 更多 菜单 → Codex 中启用',
 };

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -817,4 +817,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '描述',
   'description.panel.show': '顯示描述面板',
   'description.panel.hide': '隱藏描述面板',
+
+  // Feature Announcement Banner
+  'announcement.codexCli.title': '新功能: 現已支援 OpenAI Codex CLI 匯出和執行！',
+  'announcement.codexCli.description': '在 更多 選單 → Codex 中啟用',
 };


### PR DESCRIPTION
## Summary

Add a dismissable feature announcement banner to notify users about the new OpenAI Codex CLI Export & Run support.

## Changes

### New Component
- **FeatureAnnouncementBanner.tsx**: Reusable announcement banner component
  - Dismissable with × button
  - Persists dismiss state to localStorage
  - Uses Terminal icon (matching Codex menu item)
  - Supports custom icons and descriptions

### Integration
- Banner placed above canvas (outside ReactFlow)
- Does not overlap with other canvas UI elements

### i18n Support
| Language | Title |
|----------|-------|
| en | New: OpenAI Codex CLI Export & Run support is now available! |
| ja | 新機能: OpenAI Codex CLI での変換・実行に対応しました！ |
| ko | 새 기능: OpenAI Codex CLI 내보내기 및 실행 지원이 추가되었습니다! |
| zh-CN | 新功能: 现已支持 OpenAI Codex CLI 导出和运行！ |
| zh-TW | 新功能: 現已支援 OpenAI Codex CLI 匯出和執行！ |

## Impact

- Users will see a one-time notification about the Codex CLI feature
- Banner can be dismissed and won't appear again (stored in localStorage)
- No breaking changes

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)