### PR TITLE
improvement: show "Slash Command / Skill" label when Copilot/Codex enabled

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -886,7 +886,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                 whiteSpace: 'nowrap',
               }}
             >
-              Slash Command
+              Slash Command / Skill
             </span>
 
             {/* Two-column layout with divider */}


### PR DESCRIPTION
## Summary

Update toolbar section label to conditionally show "Slash Command / Skill" based on Copilot/Codex integration status.

## Changes

| State | Label |
|-------|-------|
| Copilot or Codex enabled | Slash Command / Skill |
| Both disabled | Slash Command (unchanged) |

**File**: `src/webview/src/components/Toolbar.tsx`

- Line 889: Changed label from `Slash Command` to `Slash Command / Skill` in the Copilot/Codex enabled section
- Line 1203: Remains `Slash Command` for the disabled state (no change)

## Impact

- UI text change only
- No functional changes
- No breaking changes

## Testing

- [x] Build passes (`npm run build`)
- [x] Manual verification of conditional display logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)