### PR TITLE
improvement: add confirmation dialog for Codex project trust setting

### DIFF
--- a/src/extension/services/codex-mcp-sync-service.ts
+++ b/src/extension/services/codex-mcp-sync-service.ts
@@ -214,6 +214,17 @@ export async function syncMcpConfigForCodexCli(
 }
 
 /**
+ * Check if project trust needs to be added to Codex config
+ *
+ * @param workspacePath - Workspace path to check
+ * @returns true if trust needs to be added, false if already trusted
+ */
+export async function needsProjectTrustForCodexCli(workspacePath: string): Promise<boolean> {
+  const config = await readCodexConfig();
+  return config.projects?.[workspacePath]?.trust_level !== 'trusted';
+}
+
+/**
  * Ensure the workspace is marked as trusted in Codex config
  *
  * This is required for Codex CLI to recognize project-level skills.


### PR DESCRIPTION
## Problem

When running a workflow with Skills via Codex CLI, the project trust setting was automatically added to `~/.codex/config.toml` without user confirmation.

### Current Behavior
1. User clicks "Run for Codex CLI"
2. ❌ Project trust is silently added to config.toml without any notification

### Expected Behavior
1. User clicks "Run for Codex CLI"
2. ✅ Confirmation dialog appears explaining why the setting is needed
3. User can choose to proceed or cancel

## Solution

Added a confirmation dialog that explains the purpose of the project trust setting before adding it to the config file.

### Changes

**File**: `src/extension/services/codex-mcp-sync-service.ts`
- Added `needsProjectTrustForCodexCli()` function to check if project trust needs to be added

**File**: `src/extension/commands/codex-handlers.ts`
- Modified Step 0 to show confirmation dialog before adding project trust
- Dialog message: "To allow Codex CLI to recognize skills in this project, a project trust setting needs to be added to ~/.codex/config.toml."
- User can cancel the workflow execution by selecting "No"

## Impact

- Improved UX: Users are now informed about config changes before they happen
- No breaking changes
- Workflow execution can be cancelled if user declines

## Testing

- [x] Manual E2E testing completed
- [x] Code quality checks passed (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)