### PR TITLE
fix: use provider-specific translation keys for AI edit messages

### DIFF
--- a/src/webview/src/components/chat/MessageList.tsx
+++ b/src/webview/src/components/chat/MessageList.tsx
@@ -74,9 +74,9 @@ export function MessageList({
             textAlign: 'center',
           }}
         >
-          {selectedProvider === 'copilot'
-            ? t('refinement.initialMessage.noteCopilot')
-            : t('refinement.initialMessage.note', { providerName: 'Claude Code' })}
+          {selectedProvider === 'copilot' && t('refinement.initialMessage.noteCopilot')}
+          {selectedProvider === 'claude-code' && t('refinement.initialMessage.noteClaudeCode')}
+          {selectedProvider === 'codex' && t('refinement.initialMessage.noteCodex')}
         </div>
         {selectedProvider === 'copilot' && (
           <button
@@ -109,7 +109,7 @@ export function MessageList({
             <span>Learn more</span>
           </button>
         )}
-        {selectedProvider !== 'copilot' && (
+        {selectedProvider === 'claude-code' && (
           <div
             style={{
               marginTop: '16px',

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -479,8 +479,9 @@ export interface WebviewTranslationKeys {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': string;
-  'refinement.initialMessage.note': string;
-  // Copilot-specific note with link
+  // Provider-specific notes
+  'refinement.initialMessage.noteClaudeCode': string;
+  'refinement.initialMessage.noteCodex': string;
   'refinement.initialMessage.noteCopilot': string;
 
   // MCP Node (Feature: 001-mcp-node)

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -534,7 +534,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description':
     'Describe the workflow you want to achieve in natural language.',
-  'refinement.initialMessage.note': '※ This feature uses {{providerName}}.',
+  // Provider-specific notes
+  'refinement.initialMessage.noteClaudeCode': '※ This feature uses Claude Code.',
+  'refinement.initialMessage.noteCodex': '※ This feature uses Codex CLI.',
   // Copilot-specific note with link
   'refinement.initialMessage.noteCopilot':
     '※ This feature requests your GitHub Copilot through the VSCode Language Model API.',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -533,7 +533,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '実現したいワークフローを自然言語で説明してください。',
-  'refinement.initialMessage.note': '※ この機能は{{providerName}}を使用します。',
+  // Provider-specific notes
+  'refinement.initialMessage.noteClaudeCode': '※ この機能はClaude Codeを使用します。',
+  'refinement.initialMessage.noteCodex': '※ この機能はCodex CLIを使用します。',
   // Copilot-specific note with link
   'refinement.initialMessage.noteCopilot':
     '※ この機能はVSCode Language Model APIを通じて、あなたのGitHub Copilotにリクエストします。',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -532,7 +532,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '실현하려는 워크플로를 자연어로 설명해주세요.',
-  'refinement.initialMessage.note': '※ 이 기능은 {{providerName}}을(를) 사용합니다.',
+  // Provider-specific notes
+  'refinement.initialMessage.noteClaudeCode': '※ 이 기능은 Claude Code를 사용합니다.',
+  'refinement.initialMessage.noteCodex': '※ 이 기능은 Codex CLI를 사용합니다.',
   // Copilot-specific note with link
   'refinement.initialMessage.noteCopilot':
     '※ 이 기능은 VSCode Language Model API를 통해 GitHub Copilot에 요청합니다.',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -511,7 +511,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '用自然语言描述您要实现的工作流。',
-  'refinement.initialMessage.note': '※ 此功能使用{{providerName}}。',
+  // Provider-specific notes
+  'refinement.initialMessage.noteClaudeCode': '※ 此功能使用Claude Code。',
+  'refinement.initialMessage.noteCodex': '※ 此功能使用Codex CLI。',
   // Copilot-specific note with link
   'refinement.initialMessage.noteCopilot':
     '※ 此功能通过 VSCode Language Model API 向您的 GitHub Copilot 发送请求。',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -511,7 +511,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Initial instructional message (Phase 3.12)
   'refinement.initialMessage.description': '用自然語言描述您要實現的工作流。',
-  'refinement.initialMessage.note': '※ 此功能使用{{providerName}}。',
+  // Provider-specific notes
+  'refinement.initialMessage.noteClaudeCode': '※ 此功能使用Claude Code。',
+  'refinement.initialMessage.noteCodex': '※ 此功能使用Codex CLI。',
   // Copilot-specific note with link
   'refinement.initialMessage.noteCopilot':
     '※ 此功能透過 VSCode Language Model API 向您的 GitHub Copilot 發送請求。',


### PR DESCRIPTION
## Problem

### Current Behavior
1. AI Edit panel uses placeholder-based translation key `refinement.initialMessage.note` with `{{providerName}}`
2. ❌ CLAUDE.md tip is shown for both Claude Code and Codex CLI providers (should only appear for Claude Code)

### Expected Behavior
1. Each AI provider has its own dedicated translation key
2. ✅ CLAUDE.md tip only appears when Claude Code provider is selected

## Solution

Use provider-specific translation keys instead of placeholder substitution for cleaner, more maintainable code.

### Changes

**File**: `src/webview/src/components/chat/MessageList.tsx`
- Changed note display from ternary with placeholder to provider-specific conditionals
- Changed CLAUDE.md tip visibility from `selectedProvider !== 'copilot'` to `selectedProvider === 'claude-code'`

**File**: `src/webview/src/i18n/translation-keys.ts`
- Removed `refinement.initialMessage.note` (placeholder version)
- Added `refinement.initialMessage.noteClaudeCode`
- Added `refinement.initialMessage.noteCodex`

**Files**: `translations/{ja,en,ko,zh-CN,zh-TW}.ts`
- Added provider-specific translations for all 5 languages

## Impact

- Provider-specific messages are now explicitly defined, improving maintainability
- CLAUDE.md tip correctly only shows for Claude Code (not relevant for Codex CLI)
- No breaking changes

## Testing

- [x] Manual E2E testing completed
  - Claude Code: Shows "Claude Code" message + CLAUDE.md tip
  - Codex CLI: Shows "Codex CLI" message, no CLAUDE.md tip
  - Copilot: Shows Copilot-specific message, no tip
- [x] Code quality checks passed (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)