### PR TITLE
chore: update hono to 4.11.7 to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4277,9 +4277,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
## Summary

Update `hono` from 4.11.4 to 4.11.7 to address security vulnerabilities identified by Dependabot.

## Security Fixes

This PR resolves the following Dependabot alerts:

| Alert | Severity | Description |
|-------|----------|-------------|
| #19 | Medium | IPv4 address validation bypass in IP Restriction Middleware |
| #20 | Medium | Cache middleware ignores `Cache-Control: private` |
| #21 | Medium | Arbitrary Key Read in Serve static Middleware |
| #22 | Medium | XSS through ErrorBoundary component |

### Impact Assessment

> **Note:** This extension runs entirely locally on the user's machine. The `hono` package is a transitive dependency of `@modelcontextprotocol/sdk` used for local MCP server communication. Since there is no external network exposure, the practical risk of these vulnerabilities being exploited is negligible. This update is primarily for Dependabot compliance and defense-in-depth.

## Changes

- Updated `hono` version in `package-lock.json` from 4.11.4 to 4.11.7

## Dependency Chain

```
@modelcontextprotocol/sdk@1.25.3
  └── @hono/node-server@1.19.9
        └── hono@4.11.7 (was 4.11.4)
```

## Testing

- [x] `npm install` succeeds
- [x] `npm ls hono` shows 4.11.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)