### PR TITLE
fix: add CLI-aware skill normalization to skip native directories

### DIFF
--- a/src/extension/commands/codex-handlers.ts
+++ b/src/extension/commands/codex-handlers.ts
@@ -160,10 +160,11 @@ export async function handleRunForCodexCli(
       projectTrustAdded = await ensureProjectTrustedForCodexCli(workspacePath);
     }
 
-    // Step 0.5: Normalize skills (copy non-.claude/skills/ to .claude/skills/)
-    // This ensures skills from .github/skills/, .codex/skills/, etc. are available in .claude/skills/
-    if (hasNonStandardSkills(workflow)) {
-      const normalizeResult = await promptAndNormalizeSkills(workflow);
+    // Step 0.5: Normalize skills (copy non-standard skills to .claude/skills/)
+    // For Codex CLI, .codex/skills/ is considered "native" (no copy needed)
+    // Only skills from other directories (e.g., .github/skills/, .copilot/skills/) need to be copied
+    if (hasNonStandardSkills(workflow, 'codex')) {
+      const normalizeResult = await promptAndNormalizeSkills(workflow, 'codex');
 
       if (!normalizeResult.success) {
         if (normalizeResult.cancelled) {

--- a/src/extension/commands/copilot-handlers.ts
+++ b/src/extension/commands/copilot-handlers.ts
@@ -327,10 +327,11 @@ export async function handleRunForCopilotCli(
     const { workflow } = payload;
     const workspacePath = fileService.getWorkspacePath();
 
-    // Step 0.5: Normalize skills (copy non-.claude/skills/ to .claude/skills/)
-    // This ensures skills from .github/skills/, .codex/skills/, etc. are available in .claude/skills/
-    if (hasNonStandardSkills(workflow)) {
-      const normalizeResult = await promptAndNormalizeSkills(workflow);
+    // Step 0.5: Normalize skills (copy non-standard skills to .claude/skills/)
+    // For Copilot CLI, .github/skills/ and .copilot/skills/ are considered "native" (no copy needed)
+    // Only skills from other directories (e.g., .codex/skills/) need to be copied
+    if (hasNonStandardSkills(workflow, 'copilot')) {
+      const normalizeResult = await promptAndNormalizeSkills(workflow, 'copilot');
 
       if (!normalizeResult.success) {
         if (normalizeResult.cancelled) {

--- a/src/extension/commands/export-workflow.ts
+++ b/src/extension/commands/export-workflow.ts
@@ -47,9 +47,10 @@ export async function handleExportWorkflow(
     }
 
     // Check if workflow uses skills from non-standard directories (e.g., .github/skills/, .codex/skills/)
-    // For Claude Code execution, skills must be in .claude/skills/
-    if (hasNonStandardSkills(payload.workflow)) {
-      const normalizeResult = await promptAndNormalizeSkills(payload.workflow);
+    // For Claude Code execution (export), only .claude/skills/ is considered standard
+    // All other skill directories need to be copied to .claude/skills/
+    if (hasNonStandardSkills(payload.workflow, 'claude')) {
+      const normalizeResult = await promptAndNormalizeSkills(payload.workflow, 'claude');
 
       if (!normalizeResult.success) {
         if (normalizeResult.cancelled) {
@@ -191,9 +192,10 @@ export async function handleExportWorkflowForExecution(
     }
 
     // Check if workflow uses skills from non-standard directories (e.g., .github/skills/, .codex/skills/)
-    // For Claude Code execution, skills must be in .claude/skills/
-    if (hasNonStandardSkills(workflow)) {
-      const normalizeResult = await promptAndNormalizeSkills(workflow);
+    // For Claude Code execution, only .claude/skills/ is considered standard
+    // All other skill directories need to be copied to .claude/skills/
+    if (hasNonStandardSkills(workflow, 'claude')) {
+      const normalizeResult = await promptAndNormalizeSkills(workflow, 'claude');
 
       if (!normalizeResult.success) {
         if (normalizeResult.cancelled) {

--- a/src/extension/services/skill-normalization-service.ts
+++ b/src/extension/services/skill-normalization-service.ts
@@ -29,6 +29,7 @@ import { getProjectSkillsDir, getWorkspaceRoot } from '../utils/path-utils';
  */
 const NON_STANDARD_SKILL_PATTERNS = [
   '.github/skills/', // GitHub Copilot CLI
+  '.copilot/skills/', // GitHub Copilot CLI (alternative)
   '.codex/skills/', // OpenAI Codex CLI
   // Future: '.gemini/skills/', '.cursor/skills/', etc.
 ] as const;
@@ -36,7 +37,57 @@ const NON_STANDARD_SKILL_PATTERNS = [
 /**
  * Source type for skill directories
  */
-export type SkillSourceType = 'github' | 'codex' | 'other';
+export type SkillSourceType = 'github' | 'copilot' | 'codex' | 'other';
+
+/**
+ * Target CLI for workflow execution
+ *
+ * Each CLI has its own "native" skill directory that should be considered standard:
+ * - 'claude': Only .claude/skills/ is standard (default for export/Claude Code)
+ * - 'copilot': .claude/skills/, .github/skills/, AND .copilot/skills/ are standard
+ * - 'codex': .claude/skills/ AND .codex/skills/ are standard
+ */
+export type TargetCli = 'claude' | 'copilot' | 'codex';
+
+/**
+ * Get the list of skill directory patterns that are considered "standard" for a given CLI
+ *
+ * @param targetCli - Target CLI for execution
+ * @returns Array of directory patterns that are standard for this CLI
+ */
+function getStandardSkillPatterns(targetCli: TargetCli): string[] {
+  // .claude/skills/ is always standard for all CLIs
+  const patterns = ['.claude/skills/'];
+
+  switch (targetCli) {
+    case 'copilot':
+      // Copilot CLI considers .github/skills/ and .copilot/skills/ as native
+      patterns.push('.github/skills/', '.copilot/skills/');
+      break;
+    case 'codex':
+      // Codex CLI considers .codex/skills/ as native
+      patterns.push('.codex/skills/');
+      break;
+    // case 'claude' falls through to default
+    // Claude Code only uses .claude/skills/
+  }
+
+  return patterns;
+}
+
+/**
+ * Check if a skill path is from a standard directory for the given target CLI
+ *
+ * @param skillPath - Path to check (relative or absolute)
+ * @param targetCli - Target CLI for execution
+ * @returns True if the skill is from a standard directory for this CLI
+ */
+function isSkillFromStandardDir(skillPath: string, targetCli: TargetCli): boolean {
+  const normalizedPath = skillPath.replace(/\\/g, '/');
+  const standardPatterns = getStandardSkillPatterns(targetCli);
+
+  return standardPatterns.some((pattern) => normalizedPath.includes(pattern));
+}
 
 /**
  * Information about a skill that needs to be normalized (copied)
@@ -133,6 +184,9 @@ function getSourceType(skillPath: string): SkillSourceType {
   if (normalizedPath.includes('.github/skills/')) {
     return 'github';
   }
+  if (normalizedPath.includes('.copilot/skills/')) {
+    return 'copilot';
+  }
   if (normalizedPath.includes('.codex/skills/')) {
     return 'codex';
   }
@@ -154,6 +208,8 @@ function getSourceSkillsDir(sourceType: SkillSourceType): string | null {
   switch (sourceType) {
     case 'github':
       return path.join(workspaceRoot, '.github', 'skills');
+    case 'copilot':
+      return path.join(workspaceRoot, '.copilot', 'skills');
     case 'codex':
       return path.join(workspaceRoot, '.codex', 'skills');
     default:
@@ -174,13 +230,15 @@ function getSkillName(skillPath: string): string {
 }
 
 /**
- * Check which skills need to be normalized (copied from non-.claude/skills/ to .claude/skills/)
+ * Check which skills need to be normalized (copied from non-standard directories to .claude/skills/)
  *
  * @param workflow - Workflow to check
+ * @param targetCli - Target CLI for execution (default: 'claude')
  * @returns Check result with skills to normalize and overwrite information
  */
 export async function checkSkillsToNormalize(
-  workflow: Workflow
+  workflow: Workflow,
+  targetCli: TargetCli = 'claude'
 ): Promise<SkillNormalizationCheckResult> {
   const skillNodes = extractSkillNodes(workflow);
   const workspaceRoot = getWorkspaceRoot();
@@ -206,8 +264,8 @@ export async function checkSkillsToNormalize(
     }
     processedNames.add(skillName);
 
-    // Only process skills from non-standard directories
-    if (!isNonStandardSkillPath(skillPath)) {
+    // Skip skills from standard directories for the target CLI
+    if (isSkillFromStandardDir(skillPath, targetCli)) {
       skippedSkills.push(skillName);
       continue;
     }
@@ -309,12 +367,14 @@ function getSourceDescription(skills: SkillToNormalize[]): string {
  * If any skills would overwrite existing files, shows a warning.
  *
  * @param workflow - Workflow being processed
+ * @param targetCli - Target CLI for execution (default: 'claude')
  * @returns Normalization result
  */
 export async function promptAndNormalizeSkills(
-  workflow: Workflow
+  workflow: Workflow,
+  targetCli: TargetCli = 'claude'
 ): Promise<SkillNormalizationResult> {
-  const checkResult = await checkSkillsToNormalize(workflow);
+  const checkResult = await checkSkillsToNormalize(workflow, targetCli);
 
   const allSkillsToNormalize = [...checkResult.skillsToNormalize, ...checkResult.skillsToOverwrite];
 
@@ -350,19 +410,21 @@ export async function promptAndNormalizeSkills(
   }
 
   // Execute the normalization
-  return normalizeSkillsWithoutPrompt(workflow);
+  return normalizeSkillsWithoutPrompt(workflow, targetCli);
 }
 
 /**
  * Normalize skills without prompting (for programmatic use or after user confirmation)
  *
  * @param workflow - Workflow to normalize skills for
+ * @param targetCli - Target CLI for execution (default: 'claude')
  * @returns Normalization result
  */
 export async function normalizeSkillsWithoutPrompt(
-  workflow: Workflow
+  workflow: Workflow,
+  targetCli: TargetCli = 'claude'
 ): Promise<SkillNormalizationResult> {
-  const checkResult = await checkSkillsToNormalize(workflow);
+  const checkResult = await checkSkillsToNormalize(workflow, targetCli);
 
   const allSkillsToNormalize = [...checkResult.skillsToNormalize, ...checkResult.skillsToOverwrite];
 
@@ -401,14 +463,15 @@ export async function normalizeSkillsWithoutPrompt(
 }
 
 /**
- * Check if workflow has any skills from non-standard directories
+ * Check if workflow has any skills from non-standard directories for the target CLI
  *
  * @param workflow - Workflow to check
- * @returns True if workflow has skills from non-standard directories
+ * @param targetCli - Target CLI for execution (default: 'claude')
+ * @returns True if workflow has skills from non-standard directories for this CLI
  */
-export function hasNonStandardSkills(workflow: Workflow): boolean {
+export function hasNonStandardSkills(workflow: Workflow, targetCli: TargetCli = 'claude'): boolean {
   const skillNodes = extractSkillNodes(workflow);
-  return skillNodes.some((node) => isNonStandardSkillPath(node.data.skillPath));
+  return skillNodes.some((node) => !isSkillFromStandardDir(node.data.skillPath, targetCli));
 }
 
 // ============================================================================
@@ -418,24 +481,26 @@ export function hasNonStandardSkills(workflow: Workflow): boolean {
 /**
  * @deprecated Use hasNonStandardSkills() instead
  */
-export function hasGithubSkills(workflow: Workflow): boolean {
-  return hasNonStandardSkills(workflow);
+export function hasGithubSkills(workflow: Workflow, targetCli: TargetCli = 'claude'): boolean {
+  return hasNonStandardSkills(workflow, targetCli);
 }
 
 /**
  * @deprecated Use promptAndNormalizeSkills() instead
  */
 export async function promptAndCopyGithubSkills(
-  workflow: Workflow
+  workflow: Workflow,
+  targetCli: TargetCli = 'claude'
 ): Promise<SkillNormalizationResult> {
-  return promptAndNormalizeSkills(workflow);
+  return promptAndNormalizeSkills(workflow, targetCli);
 }
 
 /**
  * @deprecated Use checkSkillsToNormalize() instead
  */
 export async function checkSkillsToCopy(
-  workflow: Workflow
+  workflow: Workflow,
+  targetCli: TargetCli = 'claude'
 ): Promise<SkillNormalizationCheckResult> {
-  return checkSkillsToNormalize(workflow);
+  return checkSkillsToNormalize(workflow, targetCli);
 }


### PR DESCRIPTION
## Problem

When running a workflow with Copilot CLI, users are prompted to copy skills from `.github/skills/` to `.claude/skills/` even though `.github/skills/` is a native directory for Copilot CLI.

### Current Behavior
1. User creates a workflow using a skill from `.github/skills/`
2. User clicks "Run with Copilot CLI"
3. ❌ Copy dialog appears asking to copy the skill to `.claude/skills/`

### Expected Behavior
1. User creates a workflow using a skill from `.github/skills/`
2. User clicks "Run with Copilot CLI"
3. ✅ No copy dialog - `.github/skills/` is native for Copilot CLI

## Solution

Added `targetCli` parameter to skill normalization functions to dynamically determine which directories are "standard" for each CLI.

### Standard Directories per CLI

| CLI | Standard Directories |
|-----|---------------------|
| `claude` | `.claude/skills/` |
| `copilot` | `.claude/skills/`, `.github/skills/`, `.copilot/skills/` |
| `codex` | `.claude/skills/`, `.codex/skills/` |

### Changes

**File**: `src/extension/services/skill-normalization-service.ts`

- Added `.copilot/skills/` to `NON_STANDARD_SKILL_PATTERNS`
- Added `'copilot'` to `SkillSourceType`
- Added `getStandardSkillPatterns(targetCli)` helper function
- Added `isSkillFromStandardDir(skillPath, targetCli)` helper function
- Updated `getSourceType()` and `getSourceSkillsDir()` to handle `.copilot/skills/`
- Added `targetCli` parameter (default: `'claude'`) to:
  - `hasNonStandardSkills()`
  - `checkSkillsToNormalize()`
  - `promptAndNormalizeSkills()`
  - `normalizeSkillsWithoutPrompt()`

**File**: `src/extension/commands/copilot-handlers.ts`

- Pass `'copilot'` to skill normalization functions

**File**: `src/extension/commands/codex-handlers.ts`

- Pass `'codex'` to skill normalization functions

**File**: `src/extension/commands/export-workflow.ts`

- Explicitly pass `'claude'` to skill normalization functions

## Impact

- Copilot CLI users no longer see unnecessary copy dialogs for `.github/skills/` or `.copilot/skills/`
- Codex CLI users no longer see unnecessary copy dialogs for `.codex/skills/`
- Export/Claude Code behavior unchanged (only `.claude/skills/` is standard)
- Backward compatible (default is `'claude'`)

## Testing

- [x] Code quality checks passed (`npm run format && npm run lint && npm run check`)
- [x] Build successful (`npm run build`)
- [x] Manual E2E testing: Copilot CLI + .github/skills/ skill
- [x] Manual E2E testing: Copilot CLI + .copilot/skills/ skill
- [x] Manual E2E testing: Codex CLI + .codex/skills/ skill
- [x] Manual E2E testing: Export + non-standard skill (should still show dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)