### PR TITLE
fix: resolve skill source path correctly for all scopes

### DIFF
--- a/src/extension/services/skill-normalization-service.ts
+++ b/src/extension/services/skill-normalization-service.ts
@@ -196,10 +196,14 @@ function getSourceType(skillPath: string): SkillSourceType {
 /**
  * Get the source directory path for a given source type
  *
+ * NOTE: Currently unused. Kept for potential future use.
+ * This function only supports project-scope paths, not user-scope paths (~/.copilot/skills/).
+ * For user-scope skills, use path.dirname(skillPath) directly.
+ *
  * @param sourceType - Source type
  * @returns Absolute path to the source skills directory, or null if no workspace
  */
-function getSourceSkillsDir(sourceType: SkillSourceType): string | null {
+function _getSourceSkillsDir(sourceType: SkillSourceType): string | null {
   const workspaceRoot = getWorkspaceRoot();
   if (!workspaceRoot) {
     return null;
@@ -270,17 +274,13 @@ export async function checkSkillsToNormalize(
       continue;
     }
 
-    // Determine source type and directory
+    // Determine source type for metadata
     const sourceType = getSourceType(skillPath);
-    const sourceSkillsDir = getSourceSkillsDir(sourceType);
 
-    if (!sourceSkillsDir) {
-      skippedSkills.push(skillName);
-      continue;
-    }
-
-    // Resolve source and destination paths
-    const sourcePath = path.join(sourceSkillsDir, skillName);
+    // Use the actual skill directory from skillPath
+    // path.resolve() handles both absolute paths (user-scope: ~/.copilot/skills/) and
+    // relative paths (project-scope: .github/skills/) by resolving against workspaceRoot
+    const sourcePath = path.resolve(workspaceRoot, path.dirname(skillPath));
     const destinationPath = path.join(projectSkillsDir, skillName);
 
     // Check if destination already exists


### PR DESCRIPTION
## Problem

When executing workflows with Codex CLI, skills from global/user-scope directories (e.g., `~/.copilot/skills/time-greeting`) fail to copy with ENOENT error.

### Current Behavior

1. Add a skill from `~/.copilot/skills/time-greeting` to workflow
2. Click "Execute with Codex CLI"
3. ❌ Error: `Failed to copy skill "time-greeting": ENOENT: no such file or directory, scandir '{project}/.copilot/skills/time-greeting'`

The `checkSkillsToNormalize()` function was reconstructing the source path using `getSourceSkillsDir()`, which always returns project-scope paths. This caused user-scope skill paths to be incorrectly resolved.

### Expected Behavior

1. Add a skill from any scope (user or project) to workflow
2. Click "Execute with Codex CLI"
3. ✅ Skill is correctly copied from its actual location to `.claude/skills/`

## Solution

Use `path.resolve(workspaceRoot, path.dirname(skillPath))` to derive the source directory directly from the skill's actual path.

### Changes

**File**: `src/extension/services/skill-normalization-service.ts`

- Replace `getSourceSkillsDir()` call with `path.resolve(workspaceRoot, path.dirname(skillPath))`
- `path.resolve()` correctly handles:
  - **Absolute paths** (user-scope): Returns path as-is
  - **Relative paths** (project-scope): Resolves against workspaceRoot
- Mark unused `_getSourceSkillsDir()` with underscore prefix for future use

## Impact

- Fixes skill normalization for user-scope skills (`~/.copilot/skills/`, `~/.codex/skills/`)
- Fixes skill normalization for project-scope relative paths (`.github/skills/`)
- No breaking changes
- Windows compatible (verified `path.resolve()` handles both separators)

## Testing

- [x] Manual E2E: Global skill (`~/.copilot/skills/`) → Codex CLI execution
- [x] Manual E2E: Project skill (`.github/skills/`) → Codex CLI execution
- [x] Build passes (`npm run check && npm run build`)
- [x] Windows compatibility verified (code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)