### PR TITLE
fix: show AI provider badge for user scope skills

### DIFF
--- a/src/webview/src/components/nodes/SkillNode.tsx
+++ b/src/webview/src/components/nodes/SkillNode.tsx
@@ -159,8 +159,8 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
           >
             {data.scope}
           </div>
-          {/* Source Badge for project skills */}
-          {data.scope === 'project' && data.source && (
+          {/* Source Badge for project and user skills */}
+          {(data.scope === 'project' || data.scope === 'user') && data.source && (
             <AIProviderBadge provider={data.source as AIProviderType} size="small" />
           )}
         </div>


### PR DESCRIPTION
## Problem

AI provider badges (Claude Code, Copilot, Codex) were only displayed for project-scoped Skill nodes on the canvas.

### Current Behavior
1. Add a user-scoped Skill node to the canvas
2. ❌ No AI provider badge shown even when source is set

### Expected Behavior
1. Add a user-scoped Skill node to the canvas
2. ✅ AI provider badge displayed for Claude Code, Copilot, or Codex sources

## Solution

Extended the source badge visibility condition to include both project and user scopes.

### Changes

**File**: `src/webview/src/components/nodes/SkillNode.tsx`

- Changed condition from `data.scope === 'project'` to `(data.scope === 'project' || data.scope === 'user')`
- Updated comment to reflect the change

## Impact

- User-scoped Skills from Claude Code, Copilot, and Codex now display their source badge
- No breaking changes
- Local-scoped Skills remain unaffected (no source badge)

## Testing

- [x] Manual E2E testing
- [x] Build verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)