### PR TITLE
feat: add Codex Agent node (#518)

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -13,7 +13,8 @@
       "switch",
       "skill",
       "mcp",
-      "subAgentFlow"
+      "subAgentFlow",
+      "codex"
     ]
   },
   "nodeTypes": {
@@ -375,6 +376,64 @@
           }
         }
       }
+    },
+    "codex": {
+      "description": "Execute an OpenAI Codex CLI agent for code generation and analysis tasks. **Important: Phase 1 only supports UI/data model - CLI execution is not yet implemented.**",
+      "fields": {
+        "label": {
+          "type": "string",
+          "required": true,
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "Display label for the Codex agent"
+        },
+        "promptMode": {
+          "type": "string",
+          "required": true,
+          "enum": ["fixed", "ai-generated"],
+          "default": "fixed",
+          "description": "Prompt mode: 'fixed' uses the prompt field as-is, 'ai-generated' lets the orchestrating AI agent generate instructions dynamically based on context"
+        },
+        "prompt": {
+          "type": "string",
+          "required": false,
+          "maxLength": 10000,
+          "description": "Instructions for the Codex agent. Required for 'fixed' mode, optional guidance for 'ai-generated' mode"
+        },
+        "model": {
+          "type": "string",
+          "required": true,
+          "minLength": 1,
+          "default": "gpt-5.2-codex",
+          "description": "Model to use for Codex execution. Predefined options: gpt-5.2-codex, gpt-5.2, gpt-5.1-codex-max, gpt-5.1-codex-mini. Custom model names are also supported."
+        },
+        "reasoningEffort": {
+          "type": "string",
+          "required": true,
+          "enum": ["low", "medium", "high"],
+          "default": "medium",
+          "description": "Reasoning effort level for the agent"
+        },
+        "sandbox": {
+          "type": "string",
+          "required": false,
+          "enum": ["read-only", "workspace-write", "danger-full-access"],
+          "description": "Optional. Sandbox mode for file system access. When specified, 'read-only' is recommended."
+        },
+        "outputPorts": {
+          "type": "number",
+          "required": true,
+          "value": 1
+        },
+        "skipGitRepoCheck": {
+          "type": "boolean",
+          "required": false,
+          "default": true,
+          "description": "Skip Git repository trust check. When true, allows execution outside trusted Git repositories. Use with caution."
+        }
+      },
+      "inputPorts": 1,
+      "outputPorts": 1
     }
   },
   "connectionRules": {

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0
 metadata:
   description: Workflow schema for CC Workflow Studio
   maxNodes: 50
-  supportedNodeTypes[10]: start,end,prompt,subAgent,askUserQuestion,ifElse,switch,skill,mcp,subAgentFlow
+  supportedNodeTypes[11]: start,end,prompt,subAgent,askUserQuestion,ifElse,switch,skill,mcp,subAgentFlow,codex
 nodeTypes:
   start:
     description: Workflow entry point. Exactly one required per workflow.
@@ -360,6 +360,54 @@ nodeTypes:
                 label: End
           connections[1]{id,from,to,fromPort,toPort}:
             sf-conn-1,sf-start,sf-end,output,input
+  codex:
+    description: "Execute an OpenAI Codex CLI agent for code generation and analysis tasks. **Important: Phase 1 only supports UI/data model - CLI execution is not yet implemented.**"
+    fields:
+      label:
+        type: string
+        required: true
+        minLength: 1
+        maxLength: 64
+        description: Display label for the Codex agent
+      promptMode:
+        type: string
+        required: true
+        enum[2]: fixed,ai-generated
+        default: fixed
+        description: "Prompt mode: 'fixed' uses the prompt field as-is, 'ai-generated' lets the orchestrating AI agent generate instructions dynamically based on context"
+      prompt:
+        type: string
+        required: false
+        maxLength: 10000
+        description: "Instructions for the Codex agent. Required for 'fixed' mode, optional guidance for 'ai-generated' mode"
+      model:
+        type: string
+        required: true
+        minLength: 1
+        default: gpt-5.2-codex
+        description: "Model to use for Codex execution. Predefined options: gpt-5.2-codex, gpt-5.2, gpt-5.1-codex-max, gpt-5.1-codex-mini. Custom model names are also supported."
+      reasoningEffort:
+        type: string
+        required: true
+        enum[3]: low,medium,high
+        default: medium
+        description: Reasoning effort level for the agent
+      sandbox:
+        type: string
+        required: false
+        enum[3]: read-only,workspace-write,danger-full-access
+        description: "Optional. Sandbox mode for file system access. When specified, 'read-only' is recommended."
+      outputPorts:
+        type: number
+        required: true
+        value: 1
+      skipGitRepoCheck:
+        type: boolean
+        required: false
+        default: true
+        description: "Skip Git repository trust check. When true, allows execution outside trusted Git repositories. Use with caution."
+    inputPorts: 1
+    outputPorts: 1
 connectionRules:
   forbidden[5]: Start node cannot have input connections,End node cannot have output connections,No cycles allowed,No self-connections,One connection per output port
   required[4]: Exactly one Start node per workflow,At least one End node per workflow,All non-Start nodes must have input connection,All non-End nodes must have output connection

--- a/src/extension/commands/workflow-refinement.ts
+++ b/src/extension/commands/workflow-refinement.ts
@@ -59,6 +59,7 @@ export async function handleRefineWorkflow(
     copilotModel = 'gpt-4o',
     codexModel = '',
     codexReasoningEffort = 'low',
+    useCodex = false,
   } = payload;
   const startTime = Date.now();
 
@@ -72,6 +73,7 @@ export async function handleRefineWorkflow(
     currentIteration: conversationHistory.currentIteration,
     maxIterations: conversationHistory.maxIterations,
     useSkills,
+    useCodex,
     timeoutMs: effectiveTimeoutMs,
     targetType,
     subAgentFlowId,
@@ -153,7 +155,8 @@ export async function handleRefineWorkflow(
       provider,
       copilotModel,
       codexModel,
-      codexReasoningEffort
+      codexReasoningEffort,
+      useCodex
     );
 
     // Check if AI is asking for clarification
@@ -327,6 +330,7 @@ async function handleRefineSubAgentFlow(
     copilotModel = 'gpt-4o',
     codexModel = '',
     codexReasoningEffort = 'low',
+    useCodex = false,
   } = payload;
   const startTime = Date.now();
 
@@ -341,6 +345,7 @@ async function handleRefineSubAgentFlow(
     currentIteration: conversationHistory.currentIteration,
     maxIterations: conversationHistory.maxIterations,
     useSkills,
+    useCodex,
     timeoutMs: effectiveTimeoutMs,
     model,
     allowedTools,
@@ -426,7 +431,8 @@ async function handleRefineSubAgentFlow(
       provider,
       copilotModel,
       codexModel,
-      codexReasoningEffort
+      codexReasoningEffort,
+      useCodex
     );
 
     // Check if AI is asking for clarification

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -364,6 +364,8 @@ export interface RefineWorkflowPayload {
   codexModel?: CodexModel;
   /** Codex reasoning effort level (default: 'low') */
   codexReasoningEffort?: CodexReasoningEffort;
+  /** Whether to include Codex Agent node in AI prompt (default: false) */
+  useCodex?: boolean;
 }
 
 export interface RefinementSuccessPayload {

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -20,6 +20,7 @@ export enum NodeType {
   Skill = 'skill', // New: Claude Code Skill integration
   Mcp = 'mcp', // New: MCP (Model Context Protocol) tool integration
   SubAgentFlow = 'subAgentFlow', // New: Sub-Agent Flow reference node
+  Codex = 'codex', // New: OpenAI Codex CLI integration
 }
 
 // ============================================================================
@@ -327,6 +328,39 @@ export interface McpNodeData {
   };
 }
 
+/**
+ * Codex Agent node data
+ *
+ * Represents an OpenAI Codex CLI execution node for multi-agent workflows.
+ * Phase 1: UI/data model only (CLI execution is out of scope)
+ */
+export interface CodexNodeData {
+  /** Display label for the Codex agent node. Must match pattern /^[a-zA-Z0-9_-]+$/ */
+  label: string;
+  /**
+   * Prompt mode for Codex execution.
+   * - 'fixed': Use the prompt field as-is (default)
+   * - 'ai-generated': Let the orchestrating AI agent generate the prompt dynamically
+   */
+  promptMode: 'fixed' | 'ai-generated';
+  /** Prompt/instructions for the Codex agent (required for 'fixed', optional guidance for 'ai-generated') */
+  prompt: string;
+  /** Model to use for Codex execution. Predefined options or custom model name. */
+  model: string;
+  /** Reasoning effort level */
+  reasoningEffort: 'low' | 'medium' | 'high';
+  /** Sandbox mode for file system access. If undefined, Codex default is used (no -s option). */
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+  /** Number of output ports (fixed at 1) */
+  outputPorts: 1;
+  /**
+   * Skip Git repository trust check.
+   * When true, allows execution outside trusted Git repositories.
+   * Default: false (respects Codex's security model)
+   */
+  skipGitRepoCheck?: boolean;
+}
+
 // ============================================================================
 // Node Types
 // ============================================================================
@@ -393,6 +427,11 @@ export interface SubAgentFlowNode extends BaseNode {
   data: SubAgentFlowNodeData;
 }
 
+export interface CodexNode extends BaseNode {
+  type: NodeType.Codex;
+  data: CodexNodeData;
+}
+
 export type WorkflowNode =
   | SubAgentNode
   | AskUserQuestionNode
@@ -404,7 +443,8 @@ export type WorkflowNode =
   | PromptNode
   | SkillNode
   | McpNode
-  | SubAgentFlowNode;
+  | SubAgentFlowNode
+  | CodexNode;
 
 // ============================================================================
 // Connection Type
@@ -608,5 +648,12 @@ export const VALIDATION_RULES = {
     MATCHER_MAX_LENGTH: 200,
     MAX_ENTRIES_PER_HOOK: 10,
     MAX_ACTIONS_PER_ENTRY: 5,
+  },
+  CODEX: {
+    NAME_MIN_LENGTH: 1,
+    NAME_MAX_LENGTH: 64,
+    PROMPT_MIN_LENGTH: 1,
+    PROMPT_MAX_LENGTH: 10000,
+    OUTPUT_PORTS: 1, // Fixed: 1 output port
   },
 } as const;

--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -12,7 +12,10 @@ import type React from 'react';
 import { useState } from 'react';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
+import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
+import { BetaBadge } from './common/BetaBadge';
+import { CodexNodeDialog } from './dialogs/CodexNodeDialog';
 import { McpNodeDialog } from './dialogs/McpNodeDialog';
 import { SkillBrowserDialog } from './dialogs/SkillBrowserDialog';
 
@@ -44,8 +47,11 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
 
   // サブエージェントフロー編集中はネスト不可のノードを非活性にする
   const isEditingSubAgentFlow = activeSubAgentFlowId !== null;
+  // Codex Beta が有効かどうか
+  const isCodexEnabled = useRefinementStore((state) => state.isCodexEnabled);
   const [isSkillBrowserOpen, setIsSkillBrowserOpen] = useState(false);
   const [isMcpDialogOpen, setIsMcpDialogOpen] = useState(false);
+  const [isCodexDialogOpen, setIsCodexDialogOpen] = useState(false);
 
   /**
    * 既存のノードと重ならない位置を計算する
@@ -533,6 +539,78 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
         )}
       </button>
 
+      {/* Section: Special Nodes - only shown when Codex Beta is enabled */}
+      {isCodexEnabled && (
+        <>
+          <div
+            style={{
+              fontSize: isCompact ? '10px' : '11px',
+              fontWeight: 600,
+              color: 'var(--vscode-descriptionForeground)',
+              marginBottom: isCompact ? '4px' : '8px',
+              marginTop: isCompact ? '8px' : '16px',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+            }}
+          >
+            {t('palette.specialNodes')}
+          </div>
+
+          {/* Codex Agent Node Button (Feature: 518-codex-agent-node) */}
+          <button
+            type="button"
+            onClick={() => setIsCodexDialogOpen(true)}
+            data-tour="add-codex-button"
+            style={{
+              width: '100%',
+              padding: isCompact ? '8px' : '12px',
+              marginBottom: isCompact ? '8px' : '12px',
+              backgroundColor: 'var(--vscode-button-background)',
+              color: 'var(--vscode-button-foreground)',
+              border: '1px solid var(--vscode-button-border)',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: isCompact ? '11px' : '13px',
+              fontWeight: 500,
+              textAlign: 'left',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '4px',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '6px',
+                fontWeight: 600,
+              }}
+            >
+              {t('node.codex.title')}
+              <BetaBadge style={{ borderRadius: '3px' }} />
+            </div>
+            {!isCompact && (
+              <div
+                style={{
+                  fontSize: '11px',
+                  color: 'var(--vscode-button-foreground)',
+                  opacity: 0.8,
+                }}
+              >
+                {t('node.codex.description')}
+              </div>
+            )}
+          </button>
+        </>
+      )}
+
       {/* Section: Control Flow */}
       <div
         style={{
@@ -809,6 +887,9 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
 
       {/* MCP Node Dialog (Feature: 001-mcp-node) */}
       <McpNodeDialog isOpen={isMcpDialogOpen} onClose={() => setIsMcpDialogOpen(false)} />
+
+      {/* Codex Node Dialog (Feature: 518-codex-agent-node) */}
+      <CodexNodeDialog isOpen={isCodexDialogOpen} onClose={() => setIsCodexDialogOpen(false)} />
     </div>
   );
 };

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -31,9 +31,10 @@ import { InteractionModeToggle } from './InteractionModeToggle';
 import { MinimapContainer } from './MinimapContainer';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from './nodes/BranchNode';
+// 新規ノードタイプのインポート
+import { CodexNodeComponent } from './nodes/CodexNode';
 import { EndNode } from './nodes/EndNode';
 import { IfElseNodeComponent } from './nodes/IfElseNode';
-// 新規ノードタイプのインポート
 import { McpNodeComponent } from './nodes/McpNode/McpNode';
 import { PromptNode } from './nodes/PromptNode';
 import { SkillNodeComponent } from './nodes/SkillNode';
@@ -61,6 +62,7 @@ const nodeTypes: NodeTypes = {
   skill: SkillNodeComponent,
   mcp: McpNodeComponent, // Feature: 001-mcp-node
   subAgentFlow: SubAgentFlowNodeComponent, // Feature: 089-subworkflow
+  codex: CodexNodeComponent, // Feature: 518-codex-agent-node
 };
 
 /**
@@ -263,6 +265,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                       return 'var(--vscode-charts-cyan)';
                     case 'subAgentFlow':
                       return 'var(--vscode-charts-purple)';
+                    case 'codex':
+                      return 'var(--vscode-charts-orange)';
                     default:
                       return 'var(--vscode-foreground)';
                   }

--- a/src/webview/src/components/chat/SettingsDropdown.tsx
+++ b/src/webview/src/components/chat/SettingsDropdown.tsx
@@ -60,6 +60,8 @@ export function SettingsDropdown({ onClearHistoryClick, hasMessages }: SettingsD
   const {
     useSkills,
     toggleUseSkills,
+    useCodexNodes,
+    toggleUseCodexNodes,
     isProcessing,
     selectedModel,
     setSelectedModel,
@@ -222,6 +224,43 @@ export function SettingsDropdown({ onClearHistoryClick, hasMessages }: SettingsD
             <UserCog size={14} />
             <span>{t('refinement.chat.useSkillsCheckbox')}</span>
           </DropdownMenu.CheckboxItem>
+
+          {/* Use Codex Nodes Toggle Item - Only shown when Codex Beta is enabled */}
+          {isCodexEnabled && (
+            <DropdownMenu.CheckboxItem
+              checked={useCodexNodes}
+              onCheckedChange={toggleUseCodexNodes}
+              disabled={isProcessing}
+              style={{
+                padding: '8px 12px',
+                fontSize: `${FONT_SIZES.small}px`,
+                color: 'var(--vscode-foreground)',
+                cursor: isProcessing ? 'not-allowed' : 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                outline: 'none',
+                borderRadius: '2px',
+                opacity: isProcessing ? 0.5 : 1,
+              }}
+            >
+              <div
+                style={{
+                  width: '14px',
+                  height: '14px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <DropdownMenu.ItemIndicator>
+                  <Check size={14} />
+                </DropdownMenu.ItemIndicator>
+              </div>
+              <Bot size={14} />
+              <span>{t('refinement.chat.useCodexNodesCheckbox')}</span>
+            </DropdownMenu.CheckboxItem>
+          )}
 
           <DropdownMenu.Separator
             style={{

--- a/src/webview/src/components/common/BetaBadge.tsx
+++ b/src/webview/src/components/common/BetaBadge.tsx
@@ -1,0 +1,34 @@
+/**
+ * BetaBadge Component
+ *
+ * A reusable badge component for indicating beta features.
+ * Used in toolbar menus, node palette, and other UI elements.
+ */
+
+import type React from 'react';
+
+interface BetaBadgeProps {
+  /** Optional custom style overrides */
+  style?: React.CSSProperties;
+}
+
+/**
+ * BetaBadge displays a small "Beta" label badge.
+ * Uses VSCode theme colors for consistency.
+ */
+export const BetaBadge: React.FC<BetaBadgeProps> = ({ style }) => {
+  return (
+    <span
+      style={{
+        fontSize: '9px',
+        padding: '1px 4px',
+        backgroundColor: 'var(--vscode-badge-background)',
+        color: 'var(--vscode-badge-foreground)',
+        borderRadius: '2px',
+        ...style,
+      }}
+    >
+      Beta
+    </span>
+  );
+};

--- a/src/webview/src/components/dialogs/CodexNodeDialog.tsx
+++ b/src/webview/src/components/dialogs/CodexNodeDialog.tsx
@@ -1,0 +1,750 @@
+/**
+ * Codex Node Creation Dialog Component
+ *
+ * Feature: 518-codex-agent-node
+ * Purpose: Dialog for creating and configuring Codex agent nodes
+ *
+ * Phase 1: UI/data model only (CLI execution is out of scope)
+ */
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { NodeType, VALIDATION_RULES } from '@shared/types/workflow-definition';
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
+import { openExternalUrl } from '../../services/vscode-bridge';
+import { useWorkflowStore } from '../../stores/workflow-store';
+import { EditInEditorButton } from '../common/EditInEditorButton';
+
+// Codex CLI documentation URL
+const CODEX_CLI_REFERENCE_URL = 'https://developers.openai.com/codex/cli/reference/#codex-exec';
+
+interface CodexNodeDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type ReasoningEffort = 'low' | 'medium' | 'high';
+type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+// Predefined model options
+const PREDEFINED_MODELS = [
+  'gpt-5.2-codex',
+  'gpt-5.2',
+  'gpt-5.1-codex-max',
+  'gpt-5.1-codex-mini',
+] as const;
+
+type ModelSelectValue = (typeof PREDEFINED_MODELS)[number] | 'custom';
+
+export function CodexNodeDialog({ isOpen, onClose }: CodexNodeDialogProps) {
+  const { t } = useTranslation();
+  const { addNode, nodes } = useWorkflowStore();
+
+  // Form state
+  const [name, setName] = useState('');
+  const [promptMode, setPromptMode] = useState<'fixed' | 'ai-generated'>('fixed');
+  const [prompt, setPrompt] = useState('');
+  const [modelSelect, setModelSelect] = useState<ModelSelectValue>('gpt-5.2-codex');
+  const [customModel, setCustomModel] = useState('');
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('medium');
+  const [useSandbox, setUseSandbox] = useState(false);
+  const [sandbox, setSandbox] = useState<SandboxMode>('read-only');
+  const [skipGitRepoCheck, setSkipGitRepoCheck] = useState(true);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isEditingPrompt, setIsEditingPrompt] = useState(false);
+
+  // Get effective model value
+  const getEffectiveModel = (): string => {
+    if (modelSelect === 'custom') {
+      return customModel.trim();
+    }
+    return modelSelect;
+  };
+
+  /**
+   * Calculate non-overlapping position for new node
+   */
+  const calculateNonOverlappingPosition = (
+    defaultX: number,
+    defaultY: number
+  ): { x: number; y: number } => {
+    const OFFSET_X = 30;
+    const OFFSET_Y = 30;
+    const NODE_WIDTH = 250;
+    const NODE_HEIGHT = 100;
+
+    let newX = defaultX;
+    let newY = defaultY;
+
+    for (let i = 0; i < 100; i++) {
+      const hasOverlap = nodes.some((node) => {
+        const xOverlap =
+          Math.abs(node.position.x - newX) < NODE_WIDTH &&
+          Math.abs(node.position.y - newY) < NODE_HEIGHT;
+        return xOverlap;
+      });
+
+      if (!hasOverlap) {
+        return { x: newX, y: newY };
+      }
+
+      newX += OFFSET_X;
+      newY += OFFSET_Y;
+    }
+
+    return { x: newX, y: newY };
+  };
+
+  /**
+   * Validate form inputs
+   */
+  const validateForm = (): string | null => {
+    const trimmedName = name.trim();
+    const trimmedPrompt = prompt.trim();
+
+    if (trimmedName.length < VALIDATION_RULES.CODEX.NAME_MIN_LENGTH) {
+      return t('codex.error.nameRequired');
+    }
+
+    if (trimmedName.length > VALIDATION_RULES.CODEX.NAME_MAX_LENGTH) {
+      return t('codex.error.nameTooLong');
+    }
+
+    // Prompt is required only for 'fixed' mode
+    if (promptMode === 'fixed') {
+      if (trimmedPrompt.length < VALIDATION_RULES.CODEX.PROMPT_MIN_LENGTH) {
+        return t('codex.error.promptRequired');
+      }
+    }
+
+    if (trimmedPrompt.length > VALIDATION_RULES.CODEX.PROMPT_MAX_LENGTH) {
+      return t('codex.error.promptTooLong');
+    }
+
+    // Validate custom model
+    if (modelSelect === 'custom' && customModel.trim().length === 0) {
+      return t('codex.error.modelRequired');
+    }
+
+    return null;
+  };
+
+  /**
+   * Handle form submission
+   */
+  const handleCreate = () => {
+    const validationError = validateForm();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    const position = calculateNonOverlappingPosition(300, 250);
+    const nodeId = `codex-${Date.now()}`;
+
+    addNode({
+      id: nodeId,
+      type: NodeType.Codex,
+      position,
+      data: {
+        label: name.trim(),
+        promptMode,
+        prompt: prompt.trim(),
+        model: getEffectiveModel(),
+        reasoningEffort,
+        sandbox: useSandbox ? sandbox : undefined,
+        outputPorts: 1,
+        skipGitRepoCheck,
+      },
+    });
+
+    handleClose();
+  };
+
+  /**
+   * Handle dialog close
+   */
+  const handleClose = () => {
+    // Reset form state
+    setName('');
+    setPromptMode('fixed');
+    setPrompt('');
+    setModelSelect('gpt-5.2-codex');
+    setCustomModel('');
+    setReasoningEffort('medium');
+    setUseSandbox(false);
+    setSandbox('read-only');
+    setSkipGitRepoCheck(true);
+    setIsAdvancedOpen(false);
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
+          }}
+        >
+          <Dialog.Content
+            style={{
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '6px',
+              padding: '24px',
+              maxWidth: '500px',
+              width: '90%',
+              maxHeight: '90vh',
+              overflow: 'auto',
+            }}
+          >
+            {/* Dialog Header */}
+            <Dialog.Title
+              style={{
+                margin: '0 0 8px 0',
+                fontSize: '18px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+              }}
+            >
+              {t('codex.title')}
+            </Dialog.Title>
+
+            <Dialog.Description
+              style={{
+                marginBottom: '20px',
+                fontSize: '12px',
+                color: 'var(--vscode-descriptionForeground)',
+              }}
+            >
+              {t('codex.description')}
+            </Dialog.Description>
+
+            {/* Error Message */}
+            {error && (
+              <div
+                style={{
+                  marginBottom: '16px',
+                  padding: '12px',
+                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                  borderRadius: '4px',
+                  color: 'var(--vscode-errorForeground)',
+                }}
+              >
+                {error}
+              </div>
+            )}
+
+            {/* Name Field */}
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="codex-name-input"
+                style={{
+                  display: 'block',
+                  marginBottom: '4px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('codex.nameLabel')} *
+              </label>
+              <input
+                id="codex-name-input"
+                type="text"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setError(null);
+                }}
+                placeholder={t('codex.namePlaceholder')}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '4px',
+                  fontSize: '13px',
+                  boxSizing: 'border-box',
+                }}
+              />
+              <div
+                style={{
+                  marginTop: '4px',
+                  fontSize: '11px',
+                  color: 'var(--vscode-descriptionForeground)',
+                }}
+              >
+                {t('codex.nameHelp')}
+              </div>
+            </div>
+
+            {/* Prompt Mode Selection */}
+            <div style={{ marginBottom: '16px' }}>
+              <div
+                style={{
+                  display: 'block',
+                  marginBottom: '8px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('codex.promptModeLabel')}
+              </div>
+              <div style={{ display: 'flex', gap: '16px' }}>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    cursor: 'pointer',
+                    fontSize: '12px',
+                    color: 'var(--vscode-foreground)',
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="promptMode"
+                    value="fixed"
+                    checked={promptMode === 'fixed'}
+                    onChange={() => setPromptMode('fixed')}
+                    style={{ cursor: 'pointer' }}
+                  />
+                  {t('codex.promptMode.fixed')}
+                </label>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    cursor: 'pointer',
+                    fontSize: '12px',
+                    color: 'var(--vscode-foreground)',
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="promptMode"
+                    value="ai-generated"
+                    checked={promptMode === 'ai-generated'}
+                    onChange={() => setPromptMode('ai-generated')}
+                    style={{ cursor: 'pointer' }}
+                  />
+                  {t('codex.promptMode.aiGenerated')}
+                </label>
+              </div>
+              {promptMode === 'ai-generated' && (
+                <div
+                  style={{
+                    marginTop: '8px',
+                    fontSize: '11px',
+                    color: 'var(--vscode-descriptionForeground)',
+                  }}
+                >
+                  {t('codex.promptMode.aiGeneratedHelp')}
+                </div>
+              )}
+            </div>
+
+            {/* Prompt Field */}
+            <div style={{ marginBottom: '16px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '4px',
+                }}
+              >
+                <label
+                  htmlFor="codex-prompt-input"
+                  style={{
+                    fontSize: '12px',
+                    fontWeight: 600,
+                    color: 'var(--vscode-foreground)',
+                  }}
+                >
+                  {promptMode === 'fixed'
+                    ? `${t('codex.promptLabel')} *`
+                    : t('codex.promptGuidanceLabel')}
+                </label>
+                <EditInEditorButton
+                  content={prompt}
+                  onContentUpdated={(newContent) => {
+                    setPrompt(newContent);
+                    setError(null);
+                  }}
+                  label={
+                    promptMode === 'fixed' ? t('codex.promptLabel') : t('codex.promptGuidanceLabel')
+                  }
+                  language="markdown"
+                  onEditingStateChange={setIsEditingPrompt}
+                />
+              </div>
+              <textarea
+                id="codex-prompt-input"
+                value={prompt}
+                onChange={(e) => {
+                  setPrompt(e.target.value);
+                  setError(null);
+                }}
+                placeholder={
+                  promptMode === 'fixed'
+                    ? t('codex.promptPlaceholder')
+                    : t('codex.promptGuidancePlaceholder')
+                }
+                rows={4}
+                readOnly={isEditingPrompt}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  color: 'var(--vscode-input-foreground)',
+                  border: '1px solid var(--vscode-input-border)',
+                  borderRadius: '4px',
+                  fontSize: '13px',
+                  resize: 'vertical',
+                  boxSizing: 'border-box',
+                  opacity: isEditingPrompt ? 0.5 : 1,
+                }}
+              />
+            </div>
+
+            {/* Model Field */}
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="codex-model-select"
+                style={{
+                  display: 'block',
+                  marginBottom: '4px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('codex.modelLabel')}
+              </label>
+              <select
+                id="codex-model-select"
+                value={modelSelect}
+                onChange={(e) => setModelSelect(e.target.value as ModelSelectValue)}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  color: 'var(--vscode-dropdown-foreground)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  fontSize: '13px',
+                }}
+              >
+                <option value="gpt-5.2-codex">gpt-5.2-codex</option>
+                <option value="gpt-5.2">gpt-5.2</option>
+                <option value="gpt-5.1-codex-max">gpt-5.1-codex-max</option>
+                <option value="gpt-5.1-codex-mini">gpt-5.1-codex-mini</option>
+                <option value="custom">{t('codex.model.custom')}</option>
+              </select>
+              {/* Custom Model Input */}
+              {modelSelect === 'custom' && (
+                <input
+                  id="codex-custom-model-input"
+                  type="text"
+                  value={customModel}
+                  onChange={(e) => {
+                    setCustomModel(e.target.value);
+                    setError(null);
+                  }}
+                  placeholder={t('codex.customModelPlaceholder')}
+                  style={{
+                    width: '100%',
+                    padding: '8px',
+                    marginTop: '8px',
+                    backgroundColor: 'var(--vscode-input-background)',
+                    color: 'var(--vscode-input-foreground)',
+                    border: '1px solid var(--vscode-input-border)',
+                    borderRadius: '4px',
+                    fontSize: '13px',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              )}
+            </div>
+
+            {/* Reasoning Effort Field */}
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="codex-reasoning-effort-select"
+                style={{
+                  display: 'block',
+                  marginBottom: '4px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('codex.reasoningEffortLabel')}
+              </label>
+              <select
+                id="codex-reasoning-effort-select"
+                value={reasoningEffort}
+                onChange={(e) => setReasoningEffort(e.target.value as ReasoningEffort)}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  backgroundColor: 'var(--vscode-dropdown-background)',
+                  color: 'var(--vscode-dropdown-foreground)',
+                  border: '1px solid var(--vscode-dropdown-border)',
+                  borderRadius: '4px',
+                  fontSize: '13px',
+                }}
+              >
+                <option value="low">{t('codex.reasoningEffort.low')}</option>
+                <option value="medium">{t('codex.reasoningEffort.medium')}</option>
+                <option value="high">{t('codex.reasoningEffort.high')}</option>
+              </select>
+            </div>
+
+            {/* Skip Git Repo Check Field - always visible */}
+            <div style={{ marginBottom: '16px' }}>
+              <label
+                htmlFor="codex-skip-git-repo-check"
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '8px',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  id="codex-skip-git-repo-check"
+                  type="checkbox"
+                  checked={skipGitRepoCheck}
+                  onChange={(e) => setSkipGitRepoCheck(e.target.checked)}
+                  style={{
+                    marginTop: '2px',
+                    cursor: 'pointer',
+                  }}
+                />
+                <div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: '12px',
+                        fontWeight: 600,
+                        color: 'var(--vscode-foreground)',
+                        fontFamily: 'monospace',
+                      }}
+                    >
+                      --skip-git-repo-check
+                    </span>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        openExternalUrl(CODEX_CLI_REFERENCE_URL);
+                      }}
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        padding: '2px',
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: 'var(--vscode-textLink-foreground)',
+                      }}
+                      title="Open documentation"
+                    >
+                      <ExternalLink size={12} />
+                    </button>
+                  </div>
+                  <div
+                    style={{
+                      marginTop: '4px',
+                      fontSize: '11px',
+                      color: 'var(--vscode-errorForeground)',
+                    }}
+                  >
+                    ⚠️ {t('codex.skipGitRepoCheckWarning')}
+                  </div>
+                </div>
+              </label>
+            </div>
+
+            {/* Advanced Options - collapsible section */}
+            <div style={{ marginBottom: '20px' }}>
+              <button
+                type="button"
+                onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  padding: '8px 0',
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                  width: '100%',
+                }}
+              >
+                {isAdvancedOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                {t('codex.advancedOptions')}
+              </button>
+
+              {isAdvancedOpen && (
+                <div
+                  style={{
+                    marginTop: '12px',
+                    paddingLeft: '20px',
+                    borderLeft: '2px solid var(--vscode-panel-border)',
+                  }}
+                >
+                  {/* Sandbox Field - checkbox + select */}
+                  <div>
+                    <label
+                      htmlFor="codex-use-sandbox"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        marginBottom: '8px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <input
+                        id="codex-use-sandbox"
+                        type="checkbox"
+                        checked={useSandbox}
+                        onChange={(e) => setUseSandbox(e.target.checked)}
+                        style={{ cursor: 'pointer' }}
+                      />
+                      <span
+                        style={{
+                          fontSize: '12px',
+                          fontWeight: 600,
+                          color: 'var(--vscode-foreground)',
+                        }}
+                      >
+                        {t('codex.sandboxLabel')}
+                      </span>
+                    </label>
+                    {useSandbox && (
+                      <>
+                        <select
+                          id="codex-sandbox-select"
+                          value={sandbox}
+                          onChange={(e) => setSandbox(e.target.value as SandboxMode)}
+                          style={{
+                            width: '100%',
+                            padding: '8px',
+                            backgroundColor: 'var(--vscode-dropdown-background)',
+                            color: 'var(--vscode-dropdown-foreground)',
+                            border: '1px solid var(--vscode-dropdown-border)',
+                            borderRadius: '4px',
+                            fontSize: '13px',
+                          }}
+                        >
+                          <option value="read-only">{t('codex.sandbox.readOnly')}</option>
+                          <option value="workspace-write">
+                            {t('codex.sandbox.workspaceWrite')}
+                          </option>
+                          <option value="danger-full-access">
+                            {t('codex.sandbox.dangerFullAccess')}
+                          </option>
+                        </select>
+                        <div
+                          style={{
+                            marginTop: '4px',
+                            fontSize: '11px',
+                            color: 'var(--vscode-descriptionForeground)',
+                          }}
+                        >
+                          {t('codex.sandboxHelp')}
+                        </div>
+                      </>
+                    )}
+                    {!useSandbox && (
+                      <div
+                        style={{
+                          fontSize: '11px',
+                          color: 'var(--vscode-descriptionForeground)',
+                        }}
+                      >
+                        {t('codex.sandboxDefaultHelp')}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Dialog Actions */}
+            <div
+              style={{
+                display: 'flex',
+                gap: '12px',
+                justifyContent: 'flex-end',
+                paddingTop: '20px',
+                borderTop: '1px solid var(--vscode-panel-border)',
+              }}
+            >
+              <button
+                type="button"
+                onClick={handleClose}
+                style={{
+                  padding: '8px 16px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+              >
+                {t('codex.cancelButton')}
+              </button>
+
+              <button
+                type="button"
+                onClick={handleCreate}
+                style={{
+                  padding: '8px 16px',
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+              >
+                {t('codex.createButton')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/webview/src/components/dialogs/RefinementChatPanel.tsx
+++ b/src/webview/src/components/dialogs/RefinementChatPanel.tsx
@@ -95,6 +95,7 @@ export function RefinementChatPanel({
   // Settings from refinement store (shared across all panels)
   const {
     useSkills,
+    useCodexNodes,
     timeoutSeconds,
     selectedModel,
     selectedCopilotModel,
@@ -177,7 +178,8 @@ export function RefinementChatPanel({
           selectedProvider,
           selectedCopilotModel,
           selectedCodexModel,
-          selectedCodexReasoningEffort
+          selectedCodexReasoningEffort,
+          useCodexNodes
         );
 
         if (result.type === 'success') {
@@ -266,7 +268,8 @@ export function RefinementChatPanel({
           selectedProvider,
           selectedCopilotModel,
           selectedCodexModel,
-          selectedCodexReasoningEffort
+          selectedCodexReasoningEffort,
+          useCodexNodes
         );
 
         if (result.type === 'success') {
@@ -383,7 +386,8 @@ export function RefinementChatPanel({
           selectedProvider,
           selectedCopilotModel,
           selectedCodexModel,
-          selectedCodexReasoningEffort
+          selectedCodexReasoningEffort,
+          useCodexNodes
         );
 
         if (result.type === 'success') {
@@ -468,7 +472,8 @@ export function RefinementChatPanel({
           selectedProvider,
           selectedCopilotModel,
           selectedCodexModel,
-          selectedCodexReasoningEffort
+          selectedCodexReasoningEffort,
+          useCodexNodes
         );
 
         if (result.type === 'success') {

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -41,6 +41,7 @@ import { MinimapContainer } from '../MinimapContainer';
 import { NodePalette } from '../NodePalette';
 import { AskUserQuestionNodeComponent } from '../nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from '../nodes/BranchNode';
+import { CodexNodeComponent } from '../nodes/CodexNode';
 import { EndNode } from '../nodes/EndNode';
 import { IfElseNodeComponent } from '../nodes/IfElseNode';
 import { McpNodeComponent } from '../nodes/McpNode/McpNode';
@@ -67,6 +68,7 @@ const nodeTypes: NodeTypes = {
   prompt: PromptNode,
   skill: SkillNodeComponent,
   mcp: McpNodeComponent,
+  codex: CodexNodeComponent,
   subAgentFlow: SubAgentFlowNodeComponent,
 };
 
@@ -666,6 +668,10 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                               return 'var(--vscode-charts-purple)';
                             case 'skill':
                               return 'var(--vscode-charts-cyan)';
+                            case 'mcp':
+                              return 'var(--vscode-charts-green)';
+                            case 'codex':
+                              return 'var(--vscode-charts-orange)';
                             default:
                               return 'var(--vscode-foreground)';
                           }

--- a/src/webview/src/components/nodes/CodexNode.tsx
+++ b/src/webview/src/components/nodes/CodexNode.tsx
@@ -1,0 +1,259 @@
+/**
+ * Claude Code Workflow Studio - Codex Node Component
+ *
+ * Feature: 518-codex-agent-node
+ * Purpose: Display Codex agent nodes on the React Flow canvas
+ *
+ * Phase 1: UI/data model only (CLI execution is out of scope)
+ */
+
+import type { CodexNodeData } from '@shared/types/workflow-definition';
+import React from 'react';
+import { Handle, type NodeProps, Position } from 'reactflow';
+import { useTranslation } from '../../i18n/i18n-context';
+import { DeleteButton } from './DeleteButton';
+
+/**
+ * Truncate text with ellipsis
+ */
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.substring(0, maxLength)}...`;
+}
+
+/**
+ * Get badge color for model
+ */
+function getModelBadgeColor(model: string): string {
+  switch (model) {
+    case 'gpt-5.2-codex':
+      return 'var(--vscode-charts-blue)';
+    case 'gpt-5.2':
+      return 'var(--vscode-charts-purple)';
+    case 'gpt-5.1-codex-max':
+      return 'var(--vscode-charts-orange)';
+    case 'gpt-5.1-codex-mini':
+      return 'var(--vscode-charts-green)';
+    default:
+      return 'var(--vscode-foreground)';
+  }
+}
+
+/**
+ * Get badge color for reasoning effort
+ */
+function getReasoningEffortBadgeColor(effort: string): string {
+  switch (effort) {
+    case 'high':
+      return 'var(--vscode-charts-red)';
+    case 'medium':
+      return 'var(--vscode-charts-yellow)';
+    case 'low':
+      return 'var(--vscode-charts-green)';
+    default:
+      return 'var(--vscode-foreground)';
+  }
+}
+
+/**
+ * Get badge color for sandbox mode
+ */
+function getSandboxBadgeColor(sandbox: string): string {
+  switch (sandbox) {
+    case 'danger-full-access':
+      return 'var(--vscode-charts-red)';
+    case 'workspace-write':
+      return 'var(--vscode-charts-yellow)';
+    case 'read-only':
+      return 'var(--vscode-charts-green)';
+    default:
+      return 'var(--vscode-foreground)';
+  }
+}
+
+/**
+ * Get display label for sandbox mode
+ */
+function getSandboxLabel(sandbox: string): string {
+  switch (sandbox) {
+    case 'danger-full-access':
+      return 'Full Access';
+    case 'workspace-write':
+      return 'Workspace Write';
+    case 'read-only':
+      return 'Read Only';
+    default:
+      return sandbox;
+  }
+}
+
+/**
+ * CodexNode Component
+ */
+export const CodexNodeComponent: React.FC<NodeProps<CodexNodeData>> = React.memo(
+  ({ id, data, selected }) => {
+    const { t } = useTranslation();
+
+    return (
+      <div
+        className={`codex-node ${selected ? 'selected' : ''}`}
+        style={{
+          position: 'relative',
+          padding: '12px',
+          borderRadius: '8px',
+          border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
+          backgroundColor: 'var(--vscode-editor-background)',
+          minWidth: '200px',
+          maxWidth: '300px',
+        }}
+      >
+        {/* Input Handle */}
+        <Handle
+          type="target"
+          position={Position.Left}
+          style={{
+            width: '10px',
+            height: '10px',
+            background: 'var(--vscode-button-background)',
+            border: '2px solid var(--vscode-editor-background)',
+          }}
+        />
+
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
+
+        {/* Node Header */}
+        <div
+          style={{
+            fontSize: '11px',
+            fontWeight: 600,
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: '8px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {t('node.codex.title')}
+        </div>
+
+        {/* Node Name */}
+        <div
+          style={{
+            fontSize: '13px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '8px',
+          }}
+        >
+          {data.label || t('node.codex.untitled')}
+        </div>
+
+        {/* Badges Row */}
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4px',
+            marginBottom: '8px',
+          }}
+        >
+          {/* Prompt Mode Badge - only show for AI-generated */}
+          {data.promptMode === 'ai-generated' && (
+            <span
+              style={{
+                fontSize: '10px',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                border: '1px solid var(--vscode-charts-purple)',
+                backgroundColor: 'transparent',
+                color: 'var(--vscode-charts-purple)',
+                fontWeight: 600,
+              }}
+            >
+              {t('node.codex.aiGenerated')}
+            </span>
+          )}
+
+          {/* Model Badge - theme-aware (similar to Codex CLI) */}
+          <span
+            style={{
+              fontSize: '10px',
+              padding: '2px 6px',
+              borderRadius: '3px',
+              border: `1px solid ${getModelBadgeColor(data.model)}`,
+              backgroundColor: 'transparent',
+              color: getModelBadgeColor(data.model),
+              fontWeight: 600,
+            }}
+          >
+            {data.model}
+          </span>
+
+          {/* Reasoning Effort Badge - theme-aware */}
+          <span
+            style={{
+              fontSize: '10px',
+              padding: '2px 6px',
+              borderRadius: '3px',
+              border: `1px solid ${getReasoningEffortBadgeColor(data.reasoningEffort)}`,
+              backgroundColor: 'transparent',
+              color: getReasoningEffortBadgeColor(data.reasoningEffort),
+              fontWeight: 600,
+            }}
+          >
+            {data.reasoningEffort}
+          </span>
+
+          {/* Sandbox Badge - theme-aware (only show when sandbox is specified) */}
+          {data.sandbox && (
+            <span
+              style={{
+                fontSize: '10px',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                border: `1px solid ${getSandboxBadgeColor(data.sandbox)}`,
+                backgroundColor: 'transparent',
+                color: getSandboxBadgeColor(data.sandbox),
+                fontWeight: 600,
+              }}
+            >
+              {getSandboxLabel(data.sandbox)}
+            </span>
+          )}
+        </div>
+
+        {/* Prompt Preview (truncated, 2 lines) */}
+        {data.prompt && (
+          <div
+            style={{
+              fontSize: '11px',
+              color: 'var(--vscode-descriptionForeground)',
+              lineHeight: '1.4',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {truncateText(data.prompt, 100)}
+          </div>
+        )}
+
+        {/* Output Handle */}
+        <Handle
+          type="source"
+          position={Position.Right}
+          style={{
+            width: '10px',
+            height: '10px',
+            background: 'var(--vscode-button-background)',
+            border: '2px solid var(--vscode-editor-background)',
+          }}
+        />
+      </div>
+    );
+  }
+);
+
+CodexNodeComponent.displayName = 'CodexNode';

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import { useIsCompactMode } from '../../hooks/useWindowWidth';
 import { useTranslation } from '../../i18n/i18n-context';
+import { BetaBadge } from '../common/BetaBadge';
 
 // Fixed font sizes for dropdown menu (not responsive)
 const FONT_SIZES = {
@@ -171,18 +172,7 @@ export function MoreActionsDropdown({
             <Bot size={14} />
             <span style={{ flex: 1 }}>
               Copilot
-              <span
-                style={{
-                  fontSize: '9px',
-                  backgroundColor: 'var(--vscode-badge-background)',
-                  color: 'var(--vscode-badge-foreground)',
-                  padding: '1px 4px',
-                  borderRadius: '2px',
-                  marginLeft: '4px',
-                }}
-              >
-                Beta
-              </span>
+              <BetaBadge style={{ marginLeft: '4px' }} />
             </span>
             {isCopilotEnabled && <Check size={14} />}
           </DropdownMenu.Item>
@@ -205,18 +195,7 @@ export function MoreActionsDropdown({
             <Terminal size={14} />
             <span style={{ flex: 1 }}>
               Codex
-              <span
-                style={{
-                  fontSize: '9px',
-                  backgroundColor: 'var(--vscode-badge-background)',
-                  color: 'var(--vscode-badge-foreground)',
-                  padding: '1px 4px',
-                  borderRadius: '2px',
-                  marginLeft: '4px',
-                }}
-              >
-                Beta
-              </span>
+              <BetaBadge style={{ marginLeft: '4px' }} />
             </span>
             {isCodexEnabled && <Check size={14} />}
           </DropdownMenu.Item>

--- a/src/webview/src/constants/node-type-labels.ts
+++ b/src/webview/src/constants/node-type-labels.ts
@@ -17,6 +17,7 @@ export const NODE_TYPE_LABELS: Record<string, string> = {
   end: 'End',
   skill: 'Skill',
   mcp: 'MCP Tool',
+  codex: 'Codex Agent',
 } as const;
 
 export const NODE_TYPE_UNKNOWN = 'Unknown';

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -94,6 +94,7 @@ export interface WebviewTranslationKeys {
   // Node Palette
   'palette.title': string;
   'palette.basicNodes': string;
+  'palette.specialNodes': string;
   'palette.controlFlow': string;
   'palette.quickStart': string;
 
@@ -115,6 +116,50 @@ export interface WebviewTranslationKeys {
   'node.askUserQuestion.description': string;
   'node.skill.title': string;
   'node.skill.description': string;
+
+  // Codex Node (Feature: 518-codex-agent-node)
+  'node.codex.title': string;
+  'node.codex.description': string;
+  'node.codex.untitled': string;
+  'node.codex.aiGenerated': string;
+
+  // Codex Dialog (Feature: 518-codex-agent-node)
+  'codex.title': string;
+  'codex.description': string;
+  'codex.nameLabel': string;
+  'codex.namePlaceholder': string;
+  'codex.promptModeLabel': string;
+  'codex.promptMode.fixed': string;
+  'codex.promptMode.aiGenerated': string;
+  'codex.promptMode.aiGeneratedHelp': string;
+  'codex.promptLabel': string;
+  'codex.promptPlaceholder': string;
+  'codex.promptGuidanceLabel': string;
+  'codex.promptGuidancePlaceholder': string;
+  'codex.modelLabel': string;
+  'codex.model.custom': string;
+  'codex.customModelPlaceholder': string;
+  'codex.reasoningEffortLabel': string;
+  'codex.reasoningEffort.low': string;
+  'codex.reasoningEffort.medium': string;
+  'codex.reasoningEffort.high': string;
+  'codex.sandboxLabel': string;
+  'codex.sandbox.readOnly': string;
+  'codex.sandbox.workspaceWrite': string;
+  'codex.sandbox.dangerFullAccess': string;
+  'codex.sandboxHelp': string;
+  'codex.sandboxDefaultHelp': string;
+  'codex.advancedOptions': string;
+  'codex.skipGitRepoCheckWarning': string;
+  'codex.createButton': string;
+  'codex.cancelButton': string;
+  'codex.error.nameRequired': string;
+  'codex.error.nameTooLong': string;
+  'codex.error.nameInvalidPattern': string;
+  'codex.error.promptRequired': string;
+  'codex.error.promptTooLong': string;
+  'codex.error.modelRequired': string;
+  'codex.nameHelp': string;
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': string;
@@ -417,6 +462,7 @@ export interface WebviewTranslationKeys {
   'refinement.chat.clearButton': string;
   'refinement.chat.clearButton.tooltip': string;
   'refinement.chat.useSkillsCheckbox': string;
+  'refinement.chat.useCodexNodesCheckbox': string;
 
   // Timeout selector
   'refinement.timeout.label': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -100,6 +100,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Node Palette
   'palette.title': 'Node Palette',
   'palette.basicNodes': 'Basic Nodes',
+  'palette.specialNodes': 'Special Nodes',
   'palette.controlFlow': 'Control Flow',
   'palette.quickStart': '💡 Quick Start',
 
@@ -121,6 +122,53 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'node.askUserQuestion.description': 'Branch based on user choice',
   'node.skill.title': 'Skill',
   'node.skill.description': 'Execute a Claude Code Skill',
+
+  // Codex Node (Feature: 518-codex-agent-node)
+  'node.codex.title': 'Codex Agent',
+  'node.codex.description': 'Execute OpenAI Codex CLI',
+  'node.codex.untitled': 'Untitled Codex Agent',
+  'node.codex.aiGenerated': 'AI Generated',
+
+  // Codex Dialog (Feature: 518-codex-agent-node)
+  'codex.title': 'Create Codex Agent',
+  'codex.description': 'Configure an OpenAI Codex CLI agent for your workflow.',
+  'codex.nameLabel': 'Name',
+  'codex.namePlaceholder': 'e.g., code-reviewer',
+  'codex.promptModeLabel': 'Prompt Mode',
+  'codex.promptMode.fixed': 'Fixed',
+  'codex.promptMode.aiGenerated': 'AI Generated',
+  'codex.promptMode.aiGeneratedHelp':
+    'The orchestrating AI agent will generate instructions based on context.',
+  'codex.promptLabel': 'Prompt',
+  'codex.promptPlaceholder': 'Enter instructions for the Codex agent...',
+  'codex.promptGuidanceLabel': 'Guidance (Optional)',
+  'codex.promptGuidancePlaceholder': 'Optional hints for the AI when generating instructions...',
+  'codex.modelLabel': 'Model',
+  'codex.model.custom': 'Custom',
+  'codex.customModelPlaceholder': 'e.g., gpt-6.0-codex',
+  'codex.reasoningEffortLabel': 'Reasoning Effort',
+  'codex.reasoningEffort.low': 'Low',
+  'codex.reasoningEffort.medium': 'Medium',
+  'codex.reasoningEffort.high': 'High',
+  'codex.sandboxLabel': 'Sandbox Mode',
+  'codex.sandbox.readOnly': 'Read Only',
+  'codex.sandbox.workspaceWrite': 'Workspace Write',
+  'codex.sandbox.dangerFullAccess': 'Full Access (Dangerous)',
+  'codex.sandboxHelp': 'Controls file system access permissions for the Codex agent.',
+  'codex.sandboxDefaultHelp': 'Uses Codex default behavior (no -s option specified).',
+  'codex.advancedOptions': 'Advanced Options',
+  'codex.skipGitRepoCheckWarning':
+    'This option is usually required for workflow execution. Enables execution outside trusted Git repositories.',
+  'codex.createButton': 'Create',
+  'codex.cancelButton': 'Cancel',
+  'codex.error.nameRequired': 'Name is required',
+  'codex.error.nameTooLong': 'Name must be 64 characters or less',
+  'codex.error.nameInvalidPattern':
+    'Name must contain only alphanumeric characters, hyphens, and underscores',
+  'codex.error.promptRequired': 'Prompt is required',
+  'codex.error.promptTooLong': 'Prompt must be 10,000 characters or less',
+  'codex.error.modelRequired': 'Model name is required',
+  'codex.nameHelp': 'Alphanumeric characters, hyphens, and underscores only',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -212,6 +260,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.validationStatus.missing.tooltip': 'SKILL.md file not found at specified path',
   'property.validationStatus.invalid.tooltip': 'SKILL.md has invalid YAML frontmatter',
   'property.allowedTools': 'Allowed Tools',
+
+  // Codex Agent properties
 
   // AskUserQuestion properties
   'property.questionText': 'Question',
@@ -459,6 +509,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton': 'Clear Conversation',
   'refinement.chat.clearButton.tooltip': 'Clear conversation history and start fresh',
   'refinement.chat.useSkillsCheckbox': 'Include Skills',
+  'refinement.chat.useCodexNodesCheckbox': 'Include Codex Nodes',
 
   // Timeout selector
   'refinement.timeout.label': 'Timeout',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -100,6 +100,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Node Palette
   'palette.title': 'ノードパレット',
   'palette.basicNodes': '基本ノード',
+  'palette.specialNodes': '特殊ノード',
   'palette.controlFlow': '制御フロー',
   'palette.quickStart': '💡 クイックスタート',
 
@@ -121,6 +122,51 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'node.askUserQuestion.description': 'ユーザーの選択に基づいて分岐',
   'node.skill.title': 'Skill',
   'node.skill.description': 'Claude Code Skillを実行',
+
+  // Codex Node (Feature: 518-codex-agent-node)
+  'node.codex.title': 'Codex Agent',
+  'node.codex.description': 'OpenAI Codex CLIを実行',
+  'node.codex.untitled': '無題のCodex Agent',
+  'node.codex.aiGenerated': 'AI生成',
+
+  // Codex Dialog (Feature: 518-codex-agent-node)
+  'codex.title': 'Codex Agentを作成',
+  'codex.description': 'ワークフロー用のOpenAI Codex CLIエージェントを設定します。',
+  'codex.nameLabel': '名前',
+  'codex.namePlaceholder': '例: code-reviewer',
+  'codex.promptModeLabel': 'プロンプトモード',
+  'codex.promptMode.fixed': '固定',
+  'codex.promptMode.aiGenerated': 'AI生成',
+  'codex.promptMode.aiGeneratedHelp': 'オーケストレーターAIが文脈に応じて指示を生成します。',
+  'codex.promptLabel': 'プロンプト',
+  'codex.promptPlaceholder': 'Codexエージェントへの指示を入力...',
+  'codex.promptGuidanceLabel': 'ガイダンス（任意）',
+  'codex.promptGuidancePlaceholder': 'AI生成時のヒント（任意）...',
+  'codex.modelLabel': 'モデル',
+  'codex.model.custom': 'カスタム',
+  'codex.customModelPlaceholder': '例: gpt-6.0-codex',
+  'codex.reasoningEffortLabel': '推論レベル',
+  'codex.reasoningEffort.low': '低',
+  'codex.reasoningEffort.medium': '中',
+  'codex.reasoningEffort.high': '高',
+  'codex.sandboxLabel': 'サンドボックスモード',
+  'codex.sandbox.readOnly': '読み取り専用',
+  'codex.sandbox.workspaceWrite': 'ワークスペース書き込み',
+  'codex.sandbox.dangerFullAccess': 'フルアクセス（危険）',
+  'codex.sandboxHelp': 'Codexエージェントのファイルシステムアクセス権限を制御します。',
+  'codex.sandboxDefaultHelp': 'Codexのデフォルト動作を使用します（-sオプションなし）。',
+  'codex.advancedOptions': '詳細設定',
+  'codex.skipGitRepoCheckWarning':
+    'ワークフロー実行時は通常このオプションが必要です。信頼されたGitリポジトリ外での実行を許可します。',
+  'codex.createButton': '作成',
+  'codex.cancelButton': 'キャンセル',
+  'codex.error.nameRequired': '名前は必須です',
+  'codex.error.nameTooLong': '名前は64文字以内で入力してください',
+  'codex.error.nameInvalidPattern': '名前は英数字、ハイフン、アンダースコアのみ使用可能です',
+  'codex.error.promptRequired': 'プロンプトは必須です',
+  'codex.error.promptTooLong': 'プロンプトは10,000文字以内で入力してください',
+  'codex.error.modelRequired': 'モデル名は必須です',
+  'codex.nameHelp': '英数字、ハイフン、アンダースコアのみ使用可能',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -212,6 +258,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.validationStatus.missing.tooltip': '指定されたパスにSKILL.mdファイルが見つかりません',
   'property.validationStatus.invalid.tooltip': 'SKILL.mdのYAMLフロントマターが無効です',
   'property.allowedTools': '許可ツール',
+
+  // Codex Agent properties
 
   // AskUserQuestion properties
   'property.questionText': '質問',
@@ -459,6 +507,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton': '会話をクリア',
   'refinement.chat.clearButton.tooltip': '会話履歴をクリアして最初からやり直します',
   'refinement.chat.useSkillsCheckbox': 'Skillを含める',
+  'refinement.chat.useCodexNodesCheckbox': 'Codex Agentノードを含める',
 
   // Timeout selector
   'refinement.timeout.label': 'タイムアウト',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -99,6 +99,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Node Palette
   'palette.title': '노드 팔레트',
   'palette.basicNodes': '기본 노드',
+  'palette.specialNodes': '특수 노드',
   'palette.controlFlow': '제어 흐름',
   'palette.quickStart': '💡 빠른 시작',
 
@@ -121,6 +122,51 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'node.askUserQuestion.description': '사용자 선택에 따라 분기',
   'node.skill.title': 'Skill',
   'node.skill.description': 'Claude Code Skill 실행',
+
+  // Codex Node (Feature: 518-codex-agent-node)
+  'node.codex.title': 'Codex Agent',
+  'node.codex.description': 'OpenAI Codex CLI 실행',
+  'node.codex.untitled': '제목 없는 Codex Agent',
+  'node.codex.aiGenerated': 'AI 생성',
+
+  // Codex Dialog (Feature: 518-codex-agent-node)
+  'codex.title': 'Codex Agent 생성',
+  'codex.description': '워크플로용 OpenAI Codex CLI 에이전트를 구성합니다.',
+  'codex.nameLabel': '이름',
+  'codex.namePlaceholder': '예: code-reviewer',
+  'codex.promptModeLabel': '프롬프트 모드',
+  'codex.promptMode.fixed': '고정',
+  'codex.promptMode.aiGenerated': 'AI 생성',
+  'codex.promptMode.aiGeneratedHelp': '오케스트레이터 AI가 컨텍스트에 따라 지침을 생성합니다.',
+  'codex.promptLabel': '프롬프트',
+  'codex.promptPlaceholder': 'Codex 에이전트에 대한 지침을 입력하세요...',
+  'codex.promptGuidanceLabel': '가이던스 (선택사항)',
+  'codex.promptGuidancePlaceholder': 'AI 생성 시 힌트 (선택사항)...',
+  'codex.modelLabel': '모델',
+  'codex.model.custom': '사용자 정의',
+  'codex.customModelPlaceholder': '예: gpt-6.0-codex',
+  'codex.reasoningEffortLabel': '추론 수준',
+  'codex.reasoningEffort.low': '낮음',
+  'codex.reasoningEffort.medium': '중간',
+  'codex.reasoningEffort.high': '높음',
+  'codex.sandboxLabel': '샌드박스 모드',
+  'codex.sandbox.readOnly': '읽기 전용',
+  'codex.sandbox.workspaceWrite': '워크스페이스 쓰기',
+  'codex.sandbox.dangerFullAccess': '전체 액세스 (위험)',
+  'codex.sandboxHelp': 'Codex 에이전트의 파일 시스템 액세스 권한을 제어합니다.',
+  'codex.sandboxDefaultHelp': 'Codex 기본 동작을 사용합니다 (-s 옵션 없음).',
+  'codex.advancedOptions': '고급 옵션',
+  'codex.skipGitRepoCheckWarning':
+    '워크플로우 실행 시 일반적으로 이 옵션이 필요합니다. 신뢰할 수 있는 Git 리포지토리 외부에서 실행을 허용합니다.',
+  'codex.createButton': '생성',
+  'codex.cancelButton': '취소',
+  'codex.error.nameRequired': '이름이 필요합니다',
+  'codex.error.nameTooLong': '이름은 64자 이내로 입력하세요',
+  'codex.error.nameInvalidPattern': '이름은 영숫자, 하이픈, 밑줄만 사용할 수 있습니다',
+  'codex.error.promptRequired': '프롬프트가 필요합니다',
+  'codex.error.promptTooLong': '프롬프트는 10,000자 이내로 입력하세요',
+  'codex.error.modelRequired': '모델 이름이 필요합니다',
+  'codex.nameHelp': '영숫자, 하이픈, 밑줄만 사용 가능',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -213,6 +259,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.validationStatus.invalid.tooltip':
     'SKILL.md에 유효하지 않은 YAML frontmatter가 있습니다',
   'property.allowedTools': '허용된 도구',
+
+  // Codex Agent properties
 
   // AskUserQuestion properties
   'property.questionText': '질문',
@@ -459,6 +507,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton': '대화 지우기',
   'refinement.chat.clearButton.tooltip': '대화 기록을 지우고 처음부터 시작합니다',
   'refinement.chat.useSkillsCheckbox': 'Skill 포함',
+  'refinement.chat.useCodexNodesCheckbox': 'Codex Agent 노드 포함',
 
   // Timeout selector
   'refinement.timeout.label': '타임아웃',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -97,6 +97,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Node Palette
   'palette.title': '节点面板',
   'palette.basicNodes': '基本节点',
+  'palette.specialNodes': '特殊节点',
   'palette.controlFlow': '控制流程',
   'palette.quickStart': '💡 快速入门',
 
@@ -118,6 +119,50 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'node.askUserQuestion.description': '根据用户选择分支',
   'node.skill.title': 'Skill',
   'node.skill.description': '执行Claude Code Skill',
+
+  // Codex Node (Feature: 518-codex-agent-node)
+  'node.codex.title': 'Codex Agent',
+  'node.codex.description': '执行OpenAI Codex CLI',
+  'node.codex.untitled': '未命名Codex Agent',
+  'node.codex.aiGenerated': 'AI生成',
+
+  // Codex Dialog (Feature: 518-codex-agent-node)
+  'codex.title': '创建Codex Agent',
+  'codex.description': '为工作流配置OpenAI Codex CLI代理。',
+  'codex.nameLabel': '名称',
+  'codex.namePlaceholder': '例如: code-reviewer',
+  'codex.promptModeLabel': '提示模式',
+  'codex.promptMode.fixed': '固定',
+  'codex.promptMode.aiGenerated': 'AI生成',
+  'codex.promptMode.aiGeneratedHelp': '协调AI代理将根据上下文生成指令。',
+  'codex.promptLabel': '提示词',
+  'codex.promptPlaceholder': '输入Codex代理的指令...',
+  'codex.promptGuidanceLabel': '引导（可选）',
+  'codex.promptGuidancePlaceholder': 'AI生成时的提示（可选）...',
+  'codex.modelLabel': '模型',
+  'codex.model.custom': '自定义',
+  'codex.customModelPlaceholder': '例如: gpt-6.0-codex',
+  'codex.reasoningEffortLabel': '推理级别',
+  'codex.reasoningEffort.low': '低',
+  'codex.reasoningEffort.medium': '中',
+  'codex.reasoningEffort.high': '高',
+  'codex.sandboxLabel': '沙箱模式',
+  'codex.sandbox.readOnly': '只读',
+  'codex.sandbox.workspaceWrite': '工作区写入',
+  'codex.sandbox.dangerFullAccess': '完全访问（危险）',
+  'codex.sandboxHelp': '控制Codex代理的文件系统访问权限。',
+  'codex.sandboxDefaultHelp': '使用Codex默认行为（无-s选项）。',
+  'codex.advancedOptions': '高级选项',
+  'codex.skipGitRepoCheckWarning': '工作流执行通常需要此选项。允许在受信任的Git仓库外执行。',
+  'codex.createButton': '创建',
+  'codex.cancelButton': '取消',
+  'codex.error.nameRequired': '名称是必填项',
+  'codex.error.nameTooLong': '名称不能超过64个字符',
+  'codex.error.nameInvalidPattern': '名称只能包含字母、数字、连字符和下划线',
+  'codex.error.promptRequired': '提示词是必填项',
+  'codex.error.promptTooLong': '提示词不能超过10,000个字符',
+  'codex.error.modelRequired': '模型名称是必填项',
+  'codex.nameHelp': '只能使用字母、数字、连字符和下划线',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -206,6 +251,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.validationStatus.missing.tooltip': '在指定路径找不到SKILL.md文件',
   'property.validationStatus.invalid.tooltip': 'SKILL.md包含无效的YAML前置内容',
   'property.allowedTools': '允许的工具',
+
+  // Codex Agent properties
 
   // AskUserQuestion properties
   'property.questionText': '问题',
@@ -443,6 +490,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton': '清除对话',
   'refinement.chat.clearButton.tooltip': '清除对话历史记录并重新开始',
   'refinement.chat.useSkillsCheckbox': '包含Skill',
+  'refinement.chat.useCodexNodesCheckbox': '包含Codex Agent节点',
 
   // Timeout selector
   'refinement.timeout.label': '超时',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -97,6 +97,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Node Palette
   'palette.title': '節點面板',
   'palette.basicNodes': '基本節點',
+  'palette.specialNodes': '特殊節點',
   'palette.controlFlow': '控制流程',
   'palette.quickStart': '💡 快速入門',
 
@@ -118,6 +119,50 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'node.askUserQuestion.description': '根據使用者選擇分支',
   'node.skill.title': 'Skill',
   'node.skill.description': '執行Claude Code Skill',
+
+  // Codex Node (Feature: 518-codex-agent-node)
+  'node.codex.title': 'Codex Agent',
+  'node.codex.description': '執行OpenAI Codex CLI',
+  'node.codex.untitled': '未命名Codex Agent',
+  'node.codex.aiGenerated': 'AI生成',
+
+  // Codex Dialog (Feature: 518-codex-agent-node)
+  'codex.title': '建立Codex Agent',
+  'codex.description': '為工作流程配置OpenAI Codex CLI代理。',
+  'codex.nameLabel': '名稱',
+  'codex.namePlaceholder': '例如: code-reviewer',
+  'codex.promptModeLabel': '提示模式',
+  'codex.promptMode.fixed': '固定',
+  'codex.promptMode.aiGenerated': 'AI生成',
+  'codex.promptMode.aiGeneratedHelp': '協調AI代理將根據上下文生成指令。',
+  'codex.promptLabel': '提示詞',
+  'codex.promptPlaceholder': '輸入Codex代理的指令...',
+  'codex.promptGuidanceLabel': '引導（可選）',
+  'codex.promptGuidancePlaceholder': 'AI生成時的提示（可選）...',
+  'codex.modelLabel': '模型',
+  'codex.model.custom': '自訂',
+  'codex.customModelPlaceholder': '例如: gpt-6.0-codex',
+  'codex.reasoningEffortLabel': '推理等級',
+  'codex.reasoningEffort.low': '低',
+  'codex.reasoningEffort.medium': '中',
+  'codex.reasoningEffort.high': '高',
+  'codex.sandboxLabel': '沙箱模式',
+  'codex.sandbox.readOnly': '唯讀',
+  'codex.sandbox.workspaceWrite': '工作區寫入',
+  'codex.sandbox.dangerFullAccess': '完全存取（危險）',
+  'codex.sandboxHelp': '控制Codex代理的檔案系統存取權限。',
+  'codex.sandboxDefaultHelp': '使用Codex預設行為（無-s選項）。',
+  'codex.advancedOptions': '進階選項',
+  'codex.skipGitRepoCheckWarning': '工作流程執行通常需要此選項。允許在受信任的Git儲存庫外執行。',
+  'codex.createButton': '建立',
+  'codex.cancelButton': '取消',
+  'codex.error.nameRequired': '名稱為必填',
+  'codex.error.nameTooLong': '名稱不能超過64個字元',
+  'codex.error.nameInvalidPattern': '名稱只能包含字母、數字、連字符和底線',
+  'codex.error.promptRequired': '提示詞為必填',
+  'codex.error.promptTooLong': '提示詞不能超過10,000個字元',
+  'codex.error.modelRequired': '模型名稱為必填',
+  'codex.nameHelp': '只能使用字母、數字、連字符和底線',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -206,6 +251,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.validationStatus.missing.tooltip': '在指定路徑找不到SKILL.md檔案',
   'property.validationStatus.invalid.tooltip': 'SKILL.md包含無效的YAML前置內容',
   'property.allowedTools': '允許的工具',
+
+  // Codex Agent properties
 
   // AskUserQuestion properties
   'property.questionText': '問題',
@@ -443,6 +490,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'refinement.chat.clearButton': '清除對話',
   'refinement.chat.clearButton.tooltip': '清除對話歷史記錄並重新開始',
   'refinement.chat.useSkillsCheckbox': '包含Skill',
+  'refinement.chat.useCodexNodesCheckbox': '包含Codex Agent節點',
 
   // Timeout selector
   'refinement.timeout.label': '逾時',

--- a/src/webview/src/services/refinement-service.ts
+++ b/src/webview/src/services/refinement-service.ts
@@ -115,7 +115,8 @@ export function refineWorkflow(
   provider: AiCliProvider = 'claude-code',
   copilotModel: CopilotModel = 'gpt-4o',
   codexModel: CodexModel = '',
-  codexReasoningEffort: CodexReasoningEffort = 'low'
+  codexReasoningEffort: CodexReasoningEffort = 'low',
+  useCodex = false
 ): Promise<RefinementResult> {
   return new Promise((resolve, reject) => {
     // Register response handler
@@ -176,6 +177,7 @@ export function refineWorkflow(
       copilotModel,
       codexModel,
       codexReasoningEffort,
+      useCodex,
     };
 
     vscode.postMessage({
@@ -284,7 +286,8 @@ export function refineSubAgentFlow(
   provider: AiCliProvider = 'claude-code',
   copilotModel: CopilotModel = 'gpt-4o',
   codexModel: CodexModel = '',
-  codexReasoningEffort: CodexReasoningEffort = 'low'
+  codexReasoningEffort: CodexReasoningEffort = 'low',
+  useCodex = false
 ): Promise<SubAgentFlowRefinementResult> {
   return new Promise((resolve, reject) => {
     // Register response handler
@@ -339,6 +342,7 @@ export function refineSubAgentFlow(
       copilotModel,
       codexModel,
       codexReasoningEffort,
+      useCodex,
     };
 
     vscode.postMessage({

--- a/src/webview/src/stores/refinement-store.ts
+++ b/src/webview/src/stores/refinement-store.ts
@@ -336,6 +336,7 @@ interface RefinementStore {
   currentInput: string;
   currentRequestId: string | null;
   useSkills: boolean;
+  useCodexNodes: boolean;
   timeoutSeconds: number;
   selectedModel: ClaudeModel;
   selectedCopilotModel: CopilotModel;
@@ -363,6 +364,7 @@ interface RefinementStore {
   closeChat: () => void;
   toggleChat: () => void;
   toggleUseSkills: () => void;
+  toggleUseCodexNodes: () => void;
   setTimeoutSeconds: (seconds: number) => void;
   setSelectedModel: (model: ClaudeModel) => void;
   setSelectedCopilotModel: (model: CopilotModel) => void;
@@ -459,6 +461,7 @@ export const useRefinementStore = create<RefinementStore>((set, get) => ({
   currentInput: '',
   currentRequestId: null,
   useSkills: true,
+  useCodexNodes: false, // Default: disabled, only shown when Codex Beta is enabled
   timeoutSeconds: 0, // Default timeout: None (0 = use system guard)
   selectedModel: loadModelFromStorage(), // Load from localStorage, default: 'haiku'
   selectedCopilotModel: loadCopilotModelFromStorage(), // Load from localStorage, default: 'gpt-4o'
@@ -496,6 +499,10 @@ export const useRefinementStore = create<RefinementStore>((set, get) => ({
 
   toggleUseSkills: () => {
     set({ useSkills: !get().useSkills });
+  },
+
+  toggleUseCodexNodes: () => {
+    set({ useCodexNodes: !get().useCodexNodes });
   },
 
   setTimeoutSeconds: (seconds: number) => {


### PR DESCRIPTION
## Summary

Add Codex Agent node type for OpenAI Codex CLI integration within workflows.

Closes #518

## Motivation

Enable users to leverage Codex agents for advanced code generation and analysis tasks directly in their workflow designs.

For example, in a Claude Code orchestrated workflow, Codex CLI can be invoked as a sub-agent to handle complex implementation tasks that benefit from OpenAI's reasoning capabilities - combining the strengths of both AI systems.

## Changes

**New Files:**
- `src/webview/src/components/nodes/CodexNode.tsx` - Node component with model/reasoning badges
- `src/webview/src/components/dialogs/CodexNodeDialog.tsx` - Configuration dialog
- `src/webview/src/components/common/BetaBadge.tsx` - Shared Beta badge component

**Modified Files:**
- `src/shared/types/workflow-definition.ts` - Add CodexNodeData type and validation rules
- `resources/workflow-schema.json` - Add codex node schema for AI generation
- `src/webview/src/components/WorkflowEditor.tsx` - Register codex node type
- `src/webview/src/components/NodePalette.tsx` - Add Codex Agent button with Beta badge
- `src/webview/src/components/PropertyOverlay.tsx` - Add CodexProperties editor
- `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx` - Support Codex in sub-agent flows
- `src/webview/src/components/chat/SettingsDropdown.tsx` - Add Codex toggle for AI refinement
- `src/webview/src/constants/node-type-labels.ts` - Add "Codex Agent" label
- i18n translations (en, ja, ko, zh-CN, zh-TW) - Unified codex.* keys

## Testing

- [x] Manual E2E testing completed
- [x] Node creation via dialog
- [x] PropertyOverlay editing
- [x] SubAgentFlow support verified
- [x] Build passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)