### PR TITLE
chore: refactor announcement banner to use centralized config

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -19,6 +19,7 @@ import ReactFlow, {
   type NodeTypes,
   Panel,
 } from 'reactflow';
+import { CURRENT_ANNOUNCEMENT, cleanupDismissedAnnouncements } from '../constants/announcements';
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
@@ -100,6 +101,11 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
 
   // Auto-focus on newly added nodes
   useAutoFocusNode();
+
+  // Cleanup dismissed announcements on mount
+  useEffect(() => {
+    cleanupDismissedAnnouncements();
+  }, []);
 
   // Get state and handlers from Zustand store
   const {
@@ -205,12 +211,16 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
 
   return (
     <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* Feature Announcement Banner - placed above the canvas */}
-      <FeatureAnnouncementBanner
-        featureId="codex-cli-v3.17"
-        title={t('announcement.codexCli.title')}
-        description={t('announcement.codexCli.description')}
-      />
+      {/* Feature Announcement Banner - displayed when CURRENT_ANNOUNCEMENT is set */}
+      {CURRENT_ANNOUNCEMENT && (
+        <FeatureAnnouncementBanner
+          featureId={CURRENT_ANNOUNCEMENT.featureId}
+          title={t(CURRENT_ANNOUNCEMENT.titleKey)}
+          description={
+            CURRENT_ANNOUNCEMENT.descriptionKey ? t(CURRENT_ANNOUNCEMENT.descriptionKey) : undefined
+          }
+        />
+      )}
 
       {/* Canvas area */}
       <div style={{ flex: 1, position: 'relative' }}>

--- a/src/webview/src/constants/announcements.ts
+++ b/src/webview/src/constants/announcements.ts
@@ -1,0 +1,70 @@
+/**
+ * Feature Announcement Configuration
+ *
+ * Set CURRENT_ANNOUNCEMENT to display a banner at the top of the canvas.
+ * Set to null when there is no active announcement.
+ *
+ * Usage:
+ * 1. Add translation keys to all translation files (ja.ts, en.ts, etc.)
+ * 2. Add featureId to VALID_FEATURE_IDS
+ * 3. Set the announcement config in CURRENT_ANNOUNCEMENT
+ * 4. When done, set CURRENT_ANNOUNCEMENT = null
+ * 5. To cleanup localStorage, remove featureId from VALID_FEATURE_IDS
+ */
+
+import type { WebviewTranslationKeys } from '../i18n/translation-keys';
+
+const DISMISSED_KEY_PREFIX = 'cc-wf-studio:feature-dismissed:';
+
+export interface AnnouncementConfig {
+  /** Unique identifier for localStorage persistence */
+  featureId: string;
+  /** Translation key for the title */
+  titleKey: keyof WebviewTranslationKeys;
+  /** Translation key for the description (optional) */
+  descriptionKey?: keyof WebviewTranslationKeys;
+}
+
+/**
+ * Valid feature IDs that should be retained in localStorage.
+ * Remove featureId from this list to cleanup dismissed state on next app launch.
+ */
+export const VALID_FEATURE_IDS: string[] = [];
+
+/**
+ * Current active announcement.
+ * Set to null when there is no announcement to display.
+ *
+ * Example:
+ * export const CURRENT_ANNOUNCEMENT: AnnouncementConfig | null = {
+ *   featureId: 'codex-cli-v3.17',
+ *   titleKey: 'announcement.codexCli.title',
+ *   descriptionKey: 'announcement.codexCli.description',
+ * };
+ */
+export const CURRENT_ANNOUNCEMENT: AnnouncementConfig | null = null;
+
+/**
+ * Cleanup dismissed announcement entries from localStorage.
+ * Removes entries for featureIds not in VALID_FEATURE_IDS.
+ * Call this on app startup to prevent localStorage bloat.
+ */
+export function cleanupDismissedAnnouncements(): void {
+  try {
+    // Collect keys first to avoid issues with modifying localStorage during iteration
+    const keysToRemove = Object.keys(localStorage)
+      .filter((key) => key.startsWith(DISMISSED_KEY_PREFIX))
+      .filter((key) => {
+        const featureId = key.slice(DISMISSED_KEY_PREFIX.length);
+        return !VALID_FEATURE_IDS.includes(featureId);
+      });
+
+    for (const key of keysToRemove) {
+      const featureId = key.slice(DISMISSED_KEY_PREFIX.length);
+      localStorage.removeItem(key);
+      console.log(`[Announcement] Cleaned up dismissed entry: ${featureId}`);
+    }
+  } catch {
+    // localStorage may not be available in some contexts
+  }
+}

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -819,8 +819,4 @@ export interface WebviewTranslationKeys {
   'description.panel.title': string;
   'description.panel.show': string;
   'description.panel.hide': string;
-
-  // Feature Announcement Banner
-  'announcement.codexCli.title': string;
-  'announcement.codexCli.description': string;
 }

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -906,8 +906,4 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': 'Description',
   'description.panel.show': 'Show description panel',
   'description.panel.hide': 'Hide description panel',
-
-  // Feature Announcement Banner
-  'announcement.codexCli.title': 'New: OpenAI Codex CLI Export & Run support is now available!',
-  'announcement.codexCli.description': 'Enable in More menu → Codex',
 };

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -898,8 +898,4 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '説明',
   'description.panel.show': '説明パネルを表示',
   'description.panel.hide': '説明パネルを非表示',
-
-  // Feature Announcement Banner
-  'announcement.codexCli.title': '新機能: OpenAI Codex CLI での変換・実行に対応しました！',
-  'announcement.codexCli.description': 'その他メニュー → Codex で有効化',
 };

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -898,9 +898,4 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '설명',
   'description.panel.show': '설명 패널 표시',
   'description.panel.hide': '설명 패널 숨기기',
-
-  // Feature Announcement Banner
-  'announcement.codexCli.title':
-    '새 기능: OpenAI Codex CLI 내보내기 및 실행 지원이 추가되었습니다!',
-  'announcement.codexCli.description': '더보기 메뉴 → Codex에서 활성화',
 };

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -866,8 +866,4 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '描述',
   'description.panel.show': '显示描述面板',
   'description.panel.hide': '隐藏描述面板',
-
-  // Feature Announcement Banner
-  'announcement.codexCli.title': '新功能: 现已支持 OpenAI Codex CLI 导出和运行！',
-  'announcement.codexCli.description': '在 更多 菜单 → Codex 中启用',
 };

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -867,8 +867,4 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'description.panel.title': '描述',
   'description.panel.show': '顯示描述面板',
   'description.panel.hide': '隱藏描述面板',
-
-  // Feature Announcement Banner
-  'announcement.codexCli.title': '新功能: 現已支援 OpenAI Codex CLI 匯出和執行！',
-  'announcement.codexCli.description': '在 更多 選單 → Codex 中啟用',
 };


### PR DESCRIPTION
## Summary

Refactored the feature announcement banner to use centralized configuration instead of hardcoding values in the component. Also removed the Codex CLI announcement as it is no longer needed.

## What Changed

### Before
- Announcement content was hardcoded in `WorkflowEditor.tsx`
- Adding/removing announcements required editing the component file
- Dismissed state remained in localStorage forever

### After
- Announcement configuration is centralized in `announcements.ts`
- Set `CURRENT_ANNOUNCEMENT = null` to disable banner (no component changes needed)
- Type-safe translation key references
- localStorage cleanup on startup for removed announcements

## Changes

- `src/webview/src/constants/announcements.ts` - New centralized config with cleanup function
- `src/webview/src/components/WorkflowEditor.tsx` - Conditional banner rendering from config
- `src/webview/src/i18n/translation-keys.ts` - Removed Codex CLI keys
- `src/webview/src/i18n/translations/*.ts` - Removed Codex CLI translations (5 files)

## Testing

- [x] Manual E2E testing completed
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)