### PR TITLE
fix: allow Codex node in Sub-Agent Flow

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -462,7 +462,7 @@
   "subAgentFlowConstraints": {
     "description": "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed.",
     "maxNodes": 30,
-    "supportedNodeTypes": ["start", "end", "prompt", "ifElse", "switch", "skill", "mcp"],
+    "supportedNodeTypes": ["start", "end", "prompt", "ifElse", "switch", "skill", "mcp", "codex"],
     "prohibitedNodeTypes": ["subAgent", "subAgentFlow", "askUserQuestion"],
     "rules": [
       "Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution)",

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -423,7 +423,7 @@ validationRules:
 subAgentFlowConstraints:
   description: "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed."
   maxNodes: 30
-  supportedNodeTypes[7]: start,end,prompt,ifElse,switch,skill,mcp
+  supportedNodeTypes[8]: start,end,prompt,ifElse,switch,skill,mcp,codex
   prohibitedNodeTypes[3]: subAgent,subAgentFlow,askUserQuestion
   rules[5]: Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution),Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP),Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context),Sub-Agent Flows must have exactly one Start node and at least one End node,Maximum 30 nodes per Sub-Agent Flow
 workflowStructure:

--- a/src/extension/services/refinement-service.ts
+++ b/src/extension/services/refinement-service.ts
@@ -1090,7 +1090,7 @@ Sub-Agent Flows have strict constraints that MUST be followed:
    - subAgent (Claude Code constraint for sequential execution)
    - subAgentFlow (no nesting allowed)
    - askUserQuestion (user interaction not supported in sub-agent context)
-2. **Allowed Node Types**: start, end, prompt, ifElse, switch, skill, mcp
+2. **Allowed Node Types**: start, end, prompt, ifElse, switch, skill, mcp, codex
 3. **Maximum Nodes**: ${SUBAGENTFLOW_MAX_NODES} nodes maximum
 4. **Must have exactly one Start node and at least one End node**
 


### PR DESCRIPTION
## Problem

Sub-Agent Flow AI editing rejected Codex Agent node creation with the error "Sub-Agent Flows prohibit 'codex' node type".

### Current Behavior
1. Open Sub-Agent Flow dialog and request AI to create a Codex Agent flow
2. ❌ AI returns error: "Cannot add Codex Agent node to Sub-Agent Flow. Allowed node types are: start, end, prompt, ifElse, switch, skill, mcp"

### Expected Behavior
1. Open Sub-Agent Flow dialog and request AI to create a Codex Agent flow
2. ✅ AI successfully creates a workflow containing Codex nodes

## Solution

Added `codex` to the supported node types for Sub-Agent Flow in all relevant locations.

### Changes

**File**: `resources/workflow-schema.json`
- Added `codex` to `subAgentFlowConstraints.supportedNodeTypes`

**File**: `resources/workflow-schema.toon`
- Updated `supportedNodeTypes[7]` to `supportedNodeTypes[8]` with `codex` included

**File**: `src/extension/services/refinement-service.ts`
- Added `codex` to hardcoded "Allowed Node Types" in SubAgentFlow refinement prompt

## Impact

- Codex Agent nodes can now be used in Sub-Agent Flows
- AI editing for Sub-Agent Flows will correctly recognize Codex as a valid node type

## Testing

- [x] Manual testing completed
- [x] Build verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)