### PR TITLE
chore: improve VS Code Marketplace SEO for keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,12 @@
   "homepage": "https://breaking-brake.github.io/",
   "license": "AGPL-3.0-or-later",
   "keywords": [
-    "claude",
-    "claude code",
-    "workflow",
-    "visual-editor",
-    "automation",
     "ai",
-    "mcp",
-    "copilot",
-    "github copilot",
-    "codex"
+    "claude",
+    "claude-code",
+    "cli",
+    "codex",
+    "copilot"
   ],
   "engines": {
     "vscode": "^1.80.0"


### PR DESCRIPTION
## Summary
Optimize VS Code Marketplace keywords for better search ranking.

## Changes
- Reduce keywords from 10 to 6 (fewer keywords = better ranking)
- Use hyphenated format (`claude-code` instead of `claude code`)
- Keep only high-value keywords: `ai`, `claude`, `claude-code`, `cli`, `codex`, `copilot`

## Rationale
Based on VS Code Marketplace SEO research:
- Too many keywords negatively impact search ranking
- Hyphenated terms (e.g., `claude-code`) rank higher than space-separated terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)