### PR TITLE
docs: clarify Save/Load vs Export in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,30 @@
   - Requires [Codex CLI](https://github.com/openai/codex) to be installed
   - Experimental feature; some workflows may not work as expected
 
-## Getting Started
+## How to Use
+
+### Launch the Extension
 
 - Click the <img src="./resources/icon.png" alt="icon" height="16" style="vertical-align: middle"> icon in the top-right corner of the editor
-- Or open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) → **"CC Workflow Studio: Open Editor"**
+- Or: Command Palette (`Cmd+Shift+P`) → **"CC Workflow Studio: Open Editor"**
+
+### Create a Workflow
+
+- Add nodes from the palette and configure their settings, or use [Edit with AI](#edit-with-ai).
+
+### Save & Load
+
+- Click Save <img src="./resources/icon-save.svg" alt="save" height="16" style="vertical-align: middle"> button in the toolbar to store your workflow as `.vscode/workflows/*.json`
+- Click Load <img src="./resources/icon-file-down.svg" alt="load" height="16" style="vertical-align: middle"> button in the toolbar to open a saved `.json` workflow
+
+### Export & Run
+
+- Click Export <img src="./resources/icon-export.svg" alt="export" height="16" style="vertical-align: middle"> button in the toolbar to create a `.md` slash command or agent skill (use `/workflow-name` in AI coding agents)
+- Click Run <img src="./resources/icon-play.svg" alt="run" height="16" style="vertical-align: middle"> button in the toolbar to run your workflow directly in AI coding agents
+
+### Edit with AI
+
+- Click Edit with AI <img src="./resources/icon-sparkles.svg" alt="sparkles" height="16" style="vertical-align: middle"> button in the toolbar to generate or refine workflows with natural language
 
 ## Usage Examples
 

--- a/resources/icon-export.svg
+++ b/resources/icon-export.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#666666"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <line x1="9" x2="15" y1="15" y2="9" />
+</svg>

--- a/resources/icon-file-down.svg
+++ b/resources/icon-file-down.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#666666"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M12 18v-6" />
+  <path d="m9 15 3 3 3-3" />
+</svg>

--- a/resources/icon-play.svg
+++ b/resources/icon-play.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#666666"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z" />
+</svg>

--- a/resources/icon-save.svg
+++ b/resources/icon-save.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#666666"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+</svg>

--- a/resources/icon-sparkles.svg
+++ b/resources/icon-sparkles.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#666666"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" />
+  <path d="M20 2v4" />
+  <path d="M22 4h-4" />
+  <circle cx="4" cy="20" r="2" />
+</svg>

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -1046,7 +1046,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                         }}
                       >
                         {isCompact ? (
-                          <FileDown size={16} />
+                          <SquareSlash size={16} />
                         ) : isCopilotExporting ? (
                           t('toolbar.exporting')
                         ) : (
@@ -1142,7 +1142,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                         }}
                       >
                         {isCompact ? (
-                          <FileDown size={16} />
+                          <SquareSlash size={16} />
                         ) : isCodexExporting ? (
                           t('toolbar.exporting')
                         ) : (


### PR DESCRIPTION
## Problem

Users are confused about the difference between Import/Export and Save/Load operations (see #528).

### Current Behavior
1. User exports a workflow
2. ❌ Export generates `.md` file, but user expects to re-import it
3. ❌ Load only accepts `.json` files, causing confusion

### Expected Behavior
1. User reads README documentation
2. ✅ Clear understanding that Save/Load uses `.json` for editor re-editing
3. ✅ Clear understanding that Export creates `.md` for AI coding agents

## Solution

Restructure the "How to Use" section in README to clearly separate and explain the different workflows.

### Changes

**File**: `README.md`

- Restructure into clear subsections: Launch, Create, Save & Load, Export & Run, Edit with AI
- Save & Load section explicitly shows `.json` format
- Export & Run section explicitly shows `.md` format
- Add visual icons for toolbar buttons

**File**: `resources/icon-*.svg` (5 new files)

- Add SVG icons for Save, Load, Export, Run, Edit with AI buttons

**File**: `src/webview/src/components/Toolbar.tsx`

- Change Copilot/Codex export button icon from FileDown to SquareSlash for clarity

## Impact

- Users can understand the difference between Save/Load and Export from documentation structure
- Visual icons help identify toolbar buttons
- Closes #528

## Testing

- [x] Manual review of README rendering
- [x] Icons display correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)