### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://snyk.io/test/github/breaking-brake/cc-wf-studio"><img src="https://snyk.io/test/github/breaking-brake/cc-wf-studio/badge.svg" alt="Known Vulnerabilities" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
+  <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Add DeepWiki documentation badge to README badges section.

## Changes

- Added DeepWiki badge linking to https://deepwiki.com/breaking-brake/cc-wf-studio
- Uses official DeepWiki badge SVG

## Screenshot

The new badge appears alongside existing badges:
`[Stars] [Vulnerabilities] [VS Marketplace] [OpenVSX] [DeepWiki]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)