### PR TITLE
improvement: add executionMode to Skill nodes (load/execute)

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -173,6 +173,19 @@
           "required": true,
           "default": "valid"
         },
+        "executionMode": {
+          "type": "string",
+          "enum": ["load", "execute"],
+          "required": false,
+          "default": "execute",
+          "description": "Execution mode: 'execute' runs the Skill (default), 'load' loads the Skill as knowledge context without executing it"
+        },
+        "executionPrompt": {
+          "type": "string",
+          "required": false,
+          "maxLength": 2000,
+          "description": "Custom execution instructions when executionMode is 'execute'. Ignored when executionMode is 'load'."
+        },
         "outputPorts": {
           "type": "number",
           "required": true,

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -202,6 +202,17 @@ nodeTypes:
         enum[3]: valid,missing,invalid
         required: true
         default: valid
+      executionMode:
+        type: string
+        enum[2]: load,execute
+        required: false
+        default: execute
+        description: "Execution mode: 'execute' runs the Skill (default), 'load' loads the Skill as knowledge context without executing it"
+      executionPrompt:
+        type: string
+        required: false
+        maxLength: 2000
+        description: Custom execution instructions when executionMode is 'execute'. Ignored when executionMode is 'load'.
       outputPorts:
         type: number
         required: true

--- a/src/extension/services/workflow-prompt-generator.ts
+++ b/src/extension/services/workflow-prompt-generator.ts
@@ -440,6 +440,8 @@ export function generateExecutionInstructions(
     sections.push('');
     for (const node of skillNodes) {
       const nodeId = sanitizeNodeId(node.id);
+      const executionMode = node.data.executionMode || 'execute';
+
       sections.push(`#### ${nodeId}(${node.data.name})`);
       sections.push('');
       sections.push(`**Description**: ${node.data.description}`);
@@ -454,9 +456,26 @@ export function generateExecutionInstructions(
       }
       sections.push(`**Skill Path**: \`${node.data.skillPath}\``);
       sections.push('');
-      sections.push(
-        'This node executes a Claude Code Skill. The Skill definition is stored in the SKILL.md file at the path shown above.'
-      );
+      sections.push(`**Execution Mode**: ${executionMode}`);
+      sections.push('');
+
+      if (executionMode === 'load') {
+        sections.push(
+          'Load the Skill knowledge from the SKILL.md file at the path shown above. Read and internalize the content as context for subsequent steps, but do NOT execute the Skill itself.'
+        );
+      } else {
+        sections.push(
+          'This node executes a Claude Code Skill. The Skill definition is stored in the SKILL.md file at the path shown above.'
+        );
+        if (node.data.executionPrompt) {
+          sections.push('');
+          sections.push('**Execution Instructions**:');
+          sections.push('');
+          sections.push('```');
+          sections.push(node.data.executionPrompt);
+          sections.push('```');
+        }
+      }
       sections.push('');
     }
   }

--- a/src/extension/utils/migrate-workflow.ts
+++ b/src/extension/utils/migrate-workflow.ts
@@ -142,6 +142,40 @@ export function migrateSkillScopes(workflow: Workflow): Workflow {
 }
 
 /**
+ * Migrate Skill nodes to include explicit executionMode
+ *
+ * For existing workflows without executionMode:
+ * - Sets executionMode to 'execute' (preserving existing behavior)
+ *
+ * @param workflow - The workflow to migrate
+ * @returns Migrated workflow with updated Skill nodes
+ */
+export function migrateSkillExecutionMode(workflow: Workflow): Workflow {
+  const migratedNodes = workflow.nodes.map((node) => {
+    if (node.type !== 'skill') return node;
+
+    const data = node.data as SkillNodeData;
+
+    if (data.executionMode === undefined) {
+      return {
+        ...node,
+        data: {
+          ...data,
+          executionMode: 'execute' as const,
+        },
+      } as WorkflowNode;
+    }
+
+    return node;
+  });
+
+  return {
+    ...workflow,
+    nodes: migratedNodes,
+  };
+}
+
+/**
  * Apply all workflow migrations
  *
  * Runs all migration functions in sequence.
@@ -159,6 +193,9 @@ export function migrateWorkflow(workflow: Workflow): Workflow {
 
   // Migration 2: Update Skill node scope terminology ('personal' → 'user')
   migrated = migrateSkillScopes(migrated);
+
+  // Migration 3: Set explicit executionMode on Skill nodes
+  migrated = migrateSkillExecutionMode(migrated);
 
   // Add future migrations here...
 

--- a/src/extension/utils/validate-workflow.ts
+++ b/src/extension/utils/validate-workflow.ts
@@ -524,6 +524,29 @@ function validateSkillNode(node: WorkflowNode): ValidationError[] {
     });
   }
 
+  // Execution mode validation
+  if (skillData.executionMode !== undefined) {
+    const validModes = ['load', 'execute'];
+    if (!validModes.includes(skillData.executionMode)) {
+      errors.push({
+        code: 'SKILL_INVALID_EXECUTION_MODE',
+        message: `Skill executionMode must be one of: ${validModes.join(', ')}`,
+        field: `nodes[${node.id}].data.executionMode`,
+      });
+    }
+  }
+
+  // Execution prompt length validation
+  if (skillData.executionPrompt) {
+    if (skillData.executionPrompt.length > VALIDATION_RULES.SKILL.EXECUTION_PROMPT_MAX_LENGTH) {
+      errors.push({
+        code: 'SKILL_EXECUTION_PROMPT_TOO_LONG',
+        message: `Skill executionPrompt exceeds ${VALIDATION_RULES.SKILL.EXECUTION_PROMPT_MAX_LENGTH} characters`,
+        field: `nodes[${node.id}].data.executionPrompt`,
+      });
+    }
+  }
+
   return errors;
 }
 

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -210,6 +210,19 @@ export interface SkillNodeData {
    * - undefined: for user/local scope or legacy data
    */
   source?: 'claude' | 'copilot';
+  /**
+   * Execution mode for this Skill node
+   * - 'execute': Execute the Skill (default behavior)
+   * - 'load': Load the Skill as knowledge context without executing it
+   * - undefined: treated as 'execute' for backward compatibility
+   */
+  executionMode?: 'load' | 'execute';
+  /**
+   * Custom execution prompt for 'execute' mode
+   * Provides additional instructions when executing the Skill.
+   * Only used when executionMode is 'execute' (or undefined).
+   */
+  executionPrompt?: string;
 }
 
 /**
@@ -619,6 +632,7 @@ export const VALIDATION_RULES = {
     DESCRIPTION_MIN_LENGTH: 1,
     DESCRIPTION_MAX_LENGTH: 1024,
     OUTPUT_PORTS: 1, // Fixed: 1 output port
+    EXECUTION_PROMPT_MAX_LENGTH: 2000,
   },
   MCP: {
     NAME_MIN_LENGTH: 1,

--- a/src/webview/src/components/PropertyOverlay.tsx
+++ b/src/webview/src/components/PropertyOverlay.tsx
@@ -32,6 +32,7 @@ import { ColorPicker } from './common/ColorPicker';
 import { EditInEditorButton } from './common/EditInEditorButton';
 import { ResizeHandle } from './common/ResizeHandle';
 import { McpNodeEditDialog } from './dialogs/McpNodeEditDialog';
+import { SkillNodeEditDialog } from './dialogs/SkillNodeEditDialog';
 
 /**
  * PropertyOverlay Props
@@ -1836,6 +1837,8 @@ const SkillProperties: React.FC<{
 }> = ({ node }) => {
   const { t } = useTranslation();
   const data = node.data;
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const executionMode = data.executionMode || 'execute';
 
   // Get validation status icon and color
   const getValidationIcon = (status: 'valid' | 'missing' | 'invalid'): string => {
@@ -2041,6 +2044,104 @@ const SkillProperties: React.FC<{
         </div>
       )}
 
+      {/* Execution Mode (Read-only display) */}
+      <div>
+        <label
+          htmlFor="skill-execution-mode"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('property.skill.executionMode')}
+        </label>
+        <div
+          id="skill-execution-mode"
+          style={{
+            fontSize: '12px',
+            color: 'var(--vscode-descriptionForeground)',
+            backgroundColor:
+              executionMode === 'load'
+                ? 'var(--vscode-terminal-ansiYellow)'
+                : 'var(--vscode-badge-background)',
+            padding: '4px 8px',
+            borderRadius: '3px',
+            display: 'inline-block',
+            fontWeight: 600,
+          }}
+        >
+          {executionMode === 'load'
+            ? t('property.skill.executionMode.load')
+            : t('property.skill.executionMode.execute')}
+        </div>
+      </div>
+
+      {/* Execution Prompt (Read-only display, only for execute mode) */}
+      {executionMode === 'execute' && data.executionPrompt && (
+        <div>
+          <label
+            htmlFor="skill-execution-prompt"
+            style={{
+              display: 'block',
+              fontSize: '12px',
+              fontWeight: 600,
+              color: 'var(--vscode-foreground)',
+              marginBottom: '6px',
+            }}
+          >
+            {t('property.skill.executionPrompt')}
+          </label>
+          <div
+            id="skill-execution-prompt"
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              backgroundColor: 'var(--vscode-input-background)',
+              color: 'var(--vscode-descriptionForeground)',
+              border: '1px solid var(--vscode-input-border)',
+              borderRadius: '2px',
+              fontSize: '12px',
+              lineHeight: '1.4',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              maxHeight: '100px',
+              overflow: 'auto',
+            }}
+          >
+            {data.executionPrompt}
+          </div>
+        </div>
+      )}
+
+      {/* Edit Settings Button */}
+      <div>
+        <button
+          type="button"
+          onClick={() => setIsEditDialogOpen(true)}
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '10px 16px',
+            fontSize: '13px',
+            fontWeight: 600,
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '8px',
+          }}
+        >
+          <span>{t('skill.editDialog.title')}</span>
+        </button>
+      </div>
+
       {/* Info Note */}
       <div
         style={{
@@ -2056,6 +2157,13 @@ const SkillProperties: React.FC<{
         💡 Skill properties are read-only and loaded from SKILL.md file. To modify, edit the source
         file directly.
       </div>
+
+      {/* Skill Node Edit Dialog */}
+      <SkillNodeEditDialog
+        isOpen={isEditDialogOpen}
+        nodeId={node.id}
+        onClose={() => setIsEditDialogOpen(false)}
+      />
     </div>
   );
 };

--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -9,7 +9,7 @@
 
 import * as Dialog from '@radix-ui/react-dialog';
 import type { SkillReference } from '@shared/types/messages';
-import { NodeType } from '@shared/types/workflow-definition';
+import { NodeType, VALIDATION_RULES } from '@shared/types/workflow-definition';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 import { browseSkills, createSkill } from '../../services/skill-browser-service';
@@ -68,6 +68,11 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
   const [activeTab, setActiveTab] = useState<TabType>('user');
   const [isSkillCreationOpen, setIsSkillCreationOpen] = useState(false);
   const [filterText, setFilterText] = useState('');
+
+  // Settings step state
+  const [showSettingsStep, setShowSettingsStep] = useState(false);
+  const [pendingExecutionMode, setPendingExecutionMode] = useState<'load' | 'execute'>('execute');
+  const [pendingExecutionPrompt, setPendingExecutionPrompt] = useState('');
 
   const { addNode, nodes } = useWorkflowStore();
 
@@ -167,18 +172,25 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
     }
   };
 
-  const handleAddSkill = () => {
+  const handleGoToSettings = () => {
     if (!selectedSkill) {
       setError(t('skill.error.noSelection'));
       return;
     }
+    setPendingExecutionMode('execute');
+    setPendingExecutionPrompt('');
+    setShowSettingsStep(true);
+  };
 
-    // Add Skill node to canvas
+  const handleBackToList = () => {
+    setShowSettingsStep(false);
+  };
+
+  const handleAddSkillWithSettings = () => {
+    if (!selectedSkill) return;
+
     const position = calculateNonOverlappingPosition(300, 250);
 
-    // For project Skills, skillPath is already relative from Extension
-    // For personal Skills, skillPath is absolute
-    // No conversion needed here - Extension already provides the correct format
     addNode({
       id: `skill-${Date.now()}`,
       type: NodeType.Skill,
@@ -192,6 +204,9 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
         allowedTools: selectedSkill.allowedTools,
         outputPorts: 1,
         source: selectedSkill.source,
+        executionMode: pendingExecutionMode,
+        executionPrompt:
+          pendingExecutionMode === 'execute' ? pendingExecutionPrompt || undefined : undefined,
       },
     });
 
@@ -203,6 +218,7 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
     setError(null);
     setLoading(false);
     setFilterText('');
+    setShowSettingsStep(false);
     onClose();
   };
 
@@ -311,454 +327,696 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
               {t('skill.browser.description')}
             </Dialog.Description>
 
-            {/* Filter Input */}
-            <div style={{ marginBottom: '16px' }}>
-              <input
-                type="text"
-                placeholder={t('skill.browser.filterPlaceholder')}
-                value={filterText}
-                onChange={(e) => setFilterText(e.target.value)}
-                style={{
-                  width: '100%',
-                  padding: '8px 12px',
-                  fontSize: '13px',
-                  backgroundColor: 'var(--vscode-input-background)',
-                  color: 'var(--vscode-input-foreground)',
-                  border: '1px solid var(--vscode-input-border)',
-                  borderRadius: '4px',
-                  outline: 'none',
-                }}
-              />
-            </div>
-
-            {/* Tabs */}
-            <div
-              style={{
-                display: 'flex',
-                gap: '8px',
-                marginBottom: '16px',
-                borderBottom: '1px solid var(--vscode-panel-border)',
-              }}
-            >
-              <button
-                type="button"
-                onClick={() => setActiveTab('user')}
-                style={{
-                  padding: '8px 16px',
-                  fontSize: '13px',
-                  background: 'none',
-                  border: 'none',
-                  borderBottom:
-                    activeTab === 'user' ? '2px solid var(--vscode-focusBorder)' : 'none',
-                  color:
-                    activeTab === 'user'
-                      ? 'var(--vscode-foreground)'
-                      : 'var(--vscode-descriptionForeground)',
-                  cursor: 'pointer',
-                  fontWeight: activeTab === 'user' ? 600 : 400,
-                }}
-              >
-                {t('skill.browser.userTab')} ({filteredUserSkills.length})
-              </button>
-              <button
-                type="button"
-                onClick={() => setActiveTab('project')}
-                style={{
-                  padding: '8px 16px',
-                  fontSize: '13px',
-                  background: 'none',
-                  border: 'none',
-                  borderBottom:
-                    activeTab === 'project' ? '2px solid var(--vscode-focusBorder)' : 'none',
-                  color:
-                    activeTab === 'project'
-                      ? 'var(--vscode-foreground)'
-                      : 'var(--vscode-descriptionForeground)',
-                  cursor: 'pointer',
-                  fontWeight: activeTab === 'project' ? 600 : 400,
-                }}
-              >
-                {t('skill.browser.projectTab')} ({filteredProjectSkills.length})
-              </button>
-              <button
-                type="button"
-                onClick={() => setActiveTab('local')}
-                style={{
-                  padding: '8px 16px',
-                  fontSize: '13px',
-                  background: 'none',
-                  border: 'none',
-                  borderBottom:
-                    activeTab === 'local' ? '2px solid var(--vscode-focusBorder)' : 'none',
-                  color:
-                    activeTab === 'local'
-                      ? 'var(--vscode-foreground)'
-                      : 'var(--vscode-descriptionForeground)',
-                  cursor: 'pointer',
-                  fontWeight: activeTab === 'local' ? 600 : 400,
-                }}
-              >
-                {t('skill.browser.localTab')} ({filteredLocalSkills.length})
-              </button>
-            </div>
-
-            {/* Scope Description */}
-            <div
-              style={{
-                padding: '12px',
-                marginBottom: '16px',
-                backgroundColor: 'var(--vscode-textBlockQuote-background)',
-                borderLeft: '3px solid var(--vscode-textBlockQuote-border)',
-                borderRadius: '0 4px 4px 0',
-                fontSize: '12px',
-                color: 'var(--vscode-descriptionForeground)',
-                lineHeight: '1.5',
-              }}
-            >
-              {activeTab === 'user' && t('skill.browser.userDescription')}
-              {activeTab === 'project' && t('skill.browser.projectDescription')}
-              {activeTab === 'local' && t('skill.browser.localDescription')}
-            </div>
-
-            {/* Refresh Button */}
-            <button
-              type="button"
-              onClick={handleRefresh}
-              disabled={refreshing || loading}
-              style={{
-                width: '100%',
-                padding: '8px 12px',
-                marginBottom: '16px',
-                fontSize: '13px',
-                backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                color: 'var(--vscode-button-secondaryForeground)',
-                border: '1px solid var(--vscode-panel-border)',
-                borderRadius: '4px',
-                cursor: refreshing || loading ? 'wait' : 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: '6px',
-              }}
-            >
-              <span>{refreshing ? t('skill.refreshing') : t('skill.action.refresh')}</span>
-            </button>
-
-            {/* Loading State */}
-            {loading && (
-              <div
-                style={{
-                  textAlign: 'center',
-                  padding: '40px',
-                  color: 'var(--vscode-descriptionForeground)',
-                }}
-              >
-                {t('skill.browser.loading')}
-              </div>
-            )}
-
-            {/* Error State */}
-            {error && !loading && (
-              <div
-                style={{
-                  padding: '12px',
-                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
-                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
-                  borderRadius: '4px',
-                  marginBottom: '16px',
-                  fontSize: '13px',
-                  color: 'var(--vscode-inputValidation-errorForeground)',
-                }}
-              >
-                {error}
-              </div>
-            )}
-
-            {/* Jump Navigation */}
-            {!loading && !error && groupedSkills.length > 1 && (
-              <div
-                style={{
-                  display: 'flex',
-                  gap: '8px',
-                  marginBottom: '16px',
-                  flexWrap: 'wrap',
-                  alignItems: 'center',
-                }}
-              >
-                {groupedSkills.map((group) => (
-                  <button
-                    key={group.source}
-                    type="button"
-                    onClick={() => scrollToSection(group.source)}
+            {!showSettingsStep && (
+              <>
+                {/* Filter Input */}
+                <div style={{ marginBottom: '16px' }}>
+                  <input
+                    type="text"
+                    placeholder={t('skill.browser.filterPlaceholder')}
+                    value={filterText}
+                    onChange={(e) => setFilterText(e.target.value)}
                     style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '4px',
-                      padding: '4px 8px',
-                      fontSize: '11px',
-                      backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                      color: 'var(--vscode-button-secondaryForeground)',
-                      border: '1px solid var(--vscode-panel-border)',
+                      width: '100%',
+                      padding: '8px 12px',
+                      fontSize: '13px',
+                      backgroundColor: 'var(--vscode-input-background)',
+                      color: 'var(--vscode-input-foreground)',
+                      border: '1px solid var(--vscode-input-border)',
                       borderRadius: '4px',
+                      outline: 'none',
+                    }}
+                  />
+                </div>
+
+                {/* Tabs */}
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: '8px',
+                    marginBottom: '16px',
+                    borderBottom: '1px solid var(--vscode-panel-border)',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setActiveTab('user')}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      background: 'none',
+                      border: 'none',
+                      borderBottom:
+                        activeTab === 'user' ? '2px solid var(--vscode-focusBorder)' : 'none',
+                      color:
+                        activeTab === 'user'
+                          ? 'var(--vscode-foreground)'
+                          : 'var(--vscode-descriptionForeground)',
                       cursor: 'pointer',
+                      fontWeight: activeTab === 'user' ? 600 : 400,
                     }}
                   >
-                    <AIProviderBadge provider={group.source as AIProviderType} size="small" />
-                    <span>({group.skills.length})</span>
+                    {t('skill.browser.userTab')} ({filteredUserSkills.length})
                   </button>
-                ))}
-              </div>
-            )}
+                  <button
+                    type="button"
+                    onClick={() => setActiveTab('project')}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      background: 'none',
+                      border: 'none',
+                      borderBottom:
+                        activeTab === 'project' ? '2px solid var(--vscode-focusBorder)' : 'none',
+                      color:
+                        activeTab === 'project'
+                          ? 'var(--vscode-foreground)'
+                          : 'var(--vscode-descriptionForeground)',
+                      cursor: 'pointer',
+                      fontWeight: activeTab === 'project' ? 600 : 400,
+                    }}
+                  >
+                    {t('skill.browser.projectTab')} ({filteredProjectSkills.length})
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setActiveTab('local')}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      background: 'none',
+                      border: 'none',
+                      borderBottom:
+                        activeTab === 'local' ? '2px solid var(--vscode-focusBorder)' : 'none',
+                      color:
+                        activeTab === 'local'
+                          ? 'var(--vscode-foreground)'
+                          : 'var(--vscode-descriptionForeground)',
+                      cursor: 'pointer',
+                      fontWeight: activeTab === 'local' ? 600 : 400,
+                    }}
+                  >
+                    {t('skill.browser.localTab')} ({filteredLocalSkills.length})
+                  </button>
+                </div>
 
-            {/* Skills List */}
-            {!loading && !error && currentSkills.length === 0 && (
-              <div
-                style={{
-                  textAlign: 'center',
-                  padding: '40px',
-                  color: 'var(--vscode-descriptionForeground)',
-                }}
-              >
-                {t('skill.browser.noSkills')}
-              </div>
-            )}
+                {/* Scope Description */}
+                <div
+                  style={{
+                    padding: '12px',
+                    marginBottom: '16px',
+                    backgroundColor: 'var(--vscode-textBlockQuote-background)',
+                    borderLeft: '3px solid var(--vscode-textBlockQuote-border)',
+                    borderRadius: '0 4px 4px 0',
+                    fontSize: '12px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    lineHeight: '1.5',
+                  }}
+                >
+                  {activeTab === 'user' && t('skill.browser.userDescription')}
+                  {activeTab === 'project' && t('skill.browser.projectDescription')}
+                  {activeTab === 'local' && t('skill.browser.localDescription')}
+                </div>
 
-            {!loading && !error && currentSkills.length > 0 && (
-              <div
-                style={{
-                  border: '1px solid var(--vscode-panel-border)',
-                  borderRadius: '4px',
-                  maxHeight: '400px',
-                  overflow: 'auto',
-                }}
-              >
-                {groupedSkills.map((group) => (
-                  <div key={group.source} id={`skill-section-${group.source}`}>
-                    {/* Section Header */}
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                        padding: '12px',
-                        backgroundColor: 'var(--vscode-sideBarSectionHeader-background)',
-                        borderBottom: '1px solid var(--vscode-panel-border)',
-                        position: 'sticky',
-                        top: 0,
-                        zIndex: 1,
-                      }}
-                    >
-                      <AIProviderBadge provider={group.source as AIProviderType} size="medium" />
-                      <span
+                {/* Refresh Button */}
+                <button
+                  type="button"
+                  onClick={handleRefresh}
+                  disabled={refreshing || loading}
+                  style={{
+                    width: '100%',
+                    padding: '8px 12px',
+                    marginBottom: '16px',
+                    fontSize: '13px',
+                    backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                    color: 'var(--vscode-button-secondaryForeground)',
+                    border: '1px solid var(--vscode-panel-border)',
+                    borderRadius: '4px',
+                    cursor: refreshing || loading ? 'wait' : 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  <span>{refreshing ? t('skill.refreshing') : t('skill.action.refresh')}</span>
+                </button>
+
+                {/* Loading State */}
+                {loading && (
+                  <div
+                    style={{
+                      textAlign: 'center',
+                      padding: '40px',
+                      color: 'var(--vscode-descriptionForeground)',
+                    }}
+                  >
+                    {t('skill.browser.loading')}
+                  </div>
+                )}
+
+                {/* Error State */}
+                {error && !loading && (
+                  <div
+                    style={{
+                      padding: '12px',
+                      backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                      border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                      borderRadius: '4px',
+                      marginBottom: '16px',
+                      fontSize: '13px',
+                      color: 'var(--vscode-inputValidation-errorForeground)',
+                    }}
+                  >
+                    {error}
+                  </div>
+                )}
+
+                {/* Jump Navigation */}
+                {!loading && !error && groupedSkills.length > 1 && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      gap: '8px',
+                      marginBottom: '16px',
+                      flexWrap: 'wrap',
+                      alignItems: 'center',
+                    }}
+                  >
+                    {groupedSkills.map((group) => (
+                      <button
+                        key={group.source}
+                        type="button"
+                        onClick={() => scrollToSection(group.source)}
                         style={{
-                          fontSize: '12px',
-                          color: 'var(--vscode-descriptionForeground)',
-                        }}
-                      >
-                        ({group.skills.length})
-                      </span>
-                    </div>
-
-                    {/* Skills in this group */}
-                    {group.skills.map((skill) => (
-                      <div
-                        key={skill.skillPath}
-                        onClick={() => setSelectedSkill(skill)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            setSelectedSkill(skill);
-                          }
-                        }}
-                        role="button"
-                        tabIndex={0}
-                        style={{
-                          padding: '12px',
-                          borderBottom: '1px solid var(--vscode-panel-border)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
+                          padding: '4px 8px',
+                          fontSize: '11px',
+                          backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                          color: 'var(--vscode-button-secondaryForeground)',
+                          border: '1px solid var(--vscode-panel-border)',
+                          borderRadius: '4px',
                           cursor: 'pointer',
-                          backgroundColor:
-                            selectedSkill?.skillPath === skill.skillPath
-                              ? 'var(--vscode-list-activeSelectionBackground)'
-                              : 'transparent',
-                        }}
-                        onMouseEnter={(e) => {
-                          if (selectedSkill?.skillPath !== skill.skillPath) {
-                            e.currentTarget.style.backgroundColor =
-                              'var(--vscode-list-hoverBackground)';
-                          }
-                        }}
-                        onMouseLeave={(e) => {
-                          if (selectedSkill?.skillPath !== skill.skillPath) {
-                            e.currentTarget.style.backgroundColor = 'transparent';
-                          }
                         }}
                       >
+                        <AIProviderBadge provider={group.source as AIProviderType} size="small" />
+                        <span>({group.skills.length})</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* Skills List */}
+                {!loading && !error && currentSkills.length === 0 && (
+                  <div
+                    style={{
+                      textAlign: 'center',
+                      padding: '40px',
+                      color: 'var(--vscode-descriptionForeground)',
+                    }}
+                  >
+                    {t('skill.browser.noSkills')}
+                  </div>
+                )}
+
+                {!loading && !error && currentSkills.length > 0 && (
+                  <div
+                    style={{
+                      border: '1px solid var(--vscode-panel-border)',
+                      borderRadius: '4px',
+                      maxHeight: '400px',
+                      overflow: 'auto',
+                    }}
+                  >
+                    {groupedSkills.map((group) => (
+                      <div key={group.source} id={`skill-section-${group.source}`}>
+                        {/* Section Header */}
                         <div
                           style={{
                             display: 'flex',
                             alignItems: 'center',
-                            justifyContent: 'space-between',
-                            marginBottom: '4px',
+                            gap: '8px',
+                            padding: '12px',
+                            backgroundColor: 'var(--vscode-sideBarSectionHeader-background)',
+                            borderBottom: '1px solid var(--vscode-panel-border)',
+                            position: 'sticky',
+                            top: 0,
+                            zIndex: 1,
                           }}
                         >
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <span
-                              style={{
-                                fontSize: '14px',
-                                fontWeight: 600,
-                                color: 'var(--vscode-foreground)',
-                              }}
-                            >
-                              {skill.name}
-                            </span>
-                            <span
-                              style={{
-                                fontSize: '10px',
-                                padding: '2px 6px',
-                                borderRadius: '3px',
-                                backgroundColor:
-                                  skill.scope === 'user'
-                                    ? 'var(--vscode-badge-background)'
-                                    : skill.scope === 'local'
-                                      ? 'var(--vscode-terminal-ansiBlue)'
-                                      : 'var(--vscode-button-secondaryBackground)',
-                                color:
-                                  skill.scope === 'user'
-                                    ? 'var(--vscode-badge-foreground)'
-                                    : skill.scope === 'local'
-                                      ? 'var(--vscode-editor-background)'
-                                      : 'var(--vscode-button-secondaryForeground)',
-                                fontWeight: 500,
-                              }}
-                            >
-                              {skill.scope === 'user'
-                                ? t('skill.browser.userTab')
-                                : skill.scope === 'local'
-                                  ? t('skill.browser.localTab')
-                                  : t('skill.browser.projectTab')}
-                            </span>
-                          </div>
+                          <AIProviderBadge
+                            provider={group.source as AIProviderType}
+                            size="medium"
+                          />
                           <span
                             style={{
-                              fontSize: '11px',
-                              color:
-                                skill.validationStatus === 'valid'
-                                  ? 'var(--vscode-testing-iconPassed)'
-                                  : skill.validationStatus === 'missing'
-                                    ? 'var(--vscode-editorWarning-foreground)'
-                                    : 'var(--vscode-errorForeground)',
-                            }}
-                          >
-                            {skill.validationStatus === 'valid'
-                              ? '✓'
-                              : skill.validationStatus === 'missing'
-                                ? '⚠'
-                                : '✗'}
-                          </span>
-                        </div>
-                        <div
-                          style={{
-                            fontSize: '12px',
-                            color: 'var(--vscode-descriptionForeground)',
-                            marginBottom: '4px',
-                          }}
-                        >
-                          {skill.description}
-                        </div>
-                        {skill.allowedTools && (
-                          <div
-                            style={{
-                              fontSize: '11px',
+                              fontSize: '12px',
                               color: 'var(--vscode-descriptionForeground)',
                             }}
                           >
-                            {skill.allowedTools}
+                            ({group.skills.length})
+                          </span>
+                        </div>
+
+                        {/* Skills in this group */}
+                        {group.skills.map((skill) => (
+                          <div
+                            key={skill.skillPath}
+                            onClick={() => setSelectedSkill(skill)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                setSelectedSkill(skill);
+                              }
+                            }}
+                            role="button"
+                            tabIndex={0}
+                            style={{
+                              padding: '12px',
+                              borderBottom: '1px solid var(--vscode-panel-border)',
+                              cursor: 'pointer',
+                              backgroundColor:
+                                selectedSkill?.skillPath === skill.skillPath
+                                  ? 'var(--vscode-list-activeSelectionBackground)'
+                                  : 'transparent',
+                            }}
+                            onMouseEnter={(e) => {
+                              if (selectedSkill?.skillPath !== skill.skillPath) {
+                                e.currentTarget.style.backgroundColor =
+                                  'var(--vscode-list-hoverBackground)';
+                              }
+                            }}
+                            onMouseLeave={(e) => {
+                              if (selectedSkill?.skillPath !== skill.skillPath) {
+                                e.currentTarget.style.backgroundColor = 'transparent';
+                              }
+                            }}
+                          >
+                            <div
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                marginBottom: '4px',
+                              }}
+                            >
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                <span
+                                  style={{
+                                    fontSize: '14px',
+                                    fontWeight: 600,
+                                    color: 'var(--vscode-foreground)',
+                                  }}
+                                >
+                                  {skill.name}
+                                </span>
+                                <span
+                                  style={{
+                                    fontSize: '10px',
+                                    padding: '2px 6px',
+                                    borderRadius: '3px',
+                                    backgroundColor:
+                                      skill.scope === 'user'
+                                        ? 'var(--vscode-badge-background)'
+                                        : skill.scope === 'local'
+                                          ? 'var(--vscode-terminal-ansiBlue)'
+                                          : 'var(--vscode-button-secondaryBackground)',
+                                    color:
+                                      skill.scope === 'user'
+                                        ? 'var(--vscode-badge-foreground)'
+                                        : skill.scope === 'local'
+                                          ? 'var(--vscode-editor-background)'
+                                          : 'var(--vscode-button-secondaryForeground)',
+                                    fontWeight: 500,
+                                  }}
+                                >
+                                  {skill.scope === 'user'
+                                    ? t('skill.browser.userTab')
+                                    : skill.scope === 'local'
+                                      ? t('skill.browser.localTab')
+                                      : t('skill.browser.projectTab')}
+                                </span>
+                              </div>
+                              <span
+                                style={{
+                                  fontSize: '11px',
+                                  color:
+                                    skill.validationStatus === 'valid'
+                                      ? 'var(--vscode-testing-iconPassed)'
+                                      : skill.validationStatus === 'missing'
+                                        ? 'var(--vscode-editorWarning-foreground)'
+                                        : 'var(--vscode-errorForeground)',
+                                }}
+                              >
+                                {skill.validationStatus === 'valid'
+                                  ? '✓'
+                                  : skill.validationStatus === 'missing'
+                                    ? '⚠'
+                                    : '✗'}
+                              </span>
+                            </div>
+                            <div
+                              style={{
+                                fontSize: '12px',
+                                color: 'var(--vscode-descriptionForeground)',
+                                marginBottom: '4px',
+                              }}
+                            >
+                              {skill.description}
+                            </div>
+                            {skill.allowedTools && (
+                              <div
+                                style={{
+                                  fontSize: '11px',
+                                  color: 'var(--vscode-descriptionForeground)',
+                                }}
+                              >
+                                {skill.allowedTools}
+                              </div>
+                            )}
                           </div>
-                        )}
+                        ))}
                       </div>
                     ))}
                   </div>
-                ))}
-              </div>
+                )}
+
+                {/* Create New Skill Button */}
+                {!loading && (
+                  <button
+                    type="button"
+                    onClick={() => setIsSkillCreationOpen(true)}
+                    style={{
+                      width: '100%',
+                      padding: '12px',
+                      marginTop: '16px',
+                      fontSize: '13px',
+                      border: '1px solid var(--vscode-button-border)',
+                      borderRadius: '4px',
+                      backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                      color: 'var(--vscode-button-secondaryForeground)',
+                      cursor: 'pointer',
+                      textAlign: 'center',
+                      fontWeight: 500,
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.backgroundColor =
+                        'var(--vscode-button-secondaryHoverBackground)';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.backgroundColor =
+                        'var(--vscode-button-secondaryBackground)';
+                    }}
+                  >
+                    + Create New Skill
+                  </button>
+                )}
+
+                {/* Actions - Browse Step */}
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    gap: '8px',
+                    marginTop: '20px',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      border: '1px solid var(--vscode-button-border)',
+                      borderRadius: '4px',
+                      backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                      color: 'var(--vscode-button-secondaryForeground)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {t('skill.browser.cancelButton')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleGoToSettings}
+                    disabled={!selectedSkill || loading}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      border: 'none',
+                      borderRadius: '4px',
+                      backgroundColor: selectedSkill
+                        ? 'var(--vscode-button-background)'
+                        : 'var(--vscode-button-secondaryBackground)',
+                      color: selectedSkill
+                        ? 'var(--vscode-button-foreground)'
+                        : 'var(--vscode-descriptionForeground)',
+                      cursor: selectedSkill ? 'pointer' : 'not-allowed',
+                      opacity: selectedSkill ? 1 : 0.5,
+                    }}
+                  >
+                    {t('skill.browser.configureButton')}
+                  </button>
+                </div>
+              </>
             )}
 
-            {/* Create New Skill Button */}
-            {!loading && (
-              <button
-                type="button"
-                onClick={() => setIsSkillCreationOpen(true)}
-                style={{
-                  width: '100%',
-                  padding: '12px',
-                  marginTop: '16px',
-                  fontSize: '13px',
-                  border: '1px solid var(--vscode-button-border)',
-                  borderRadius: '4px',
-                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                  color: 'var(--vscode-button-secondaryForeground)',
-                  cursor: 'pointer',
-                  textAlign: 'center',
-                  fontWeight: 500,
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor =
-                    'var(--vscode-button-secondaryHoverBackground)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor =
-                    'var(--vscode-button-secondaryBackground)';
-                }}
-              >
-                + Create New Skill
-              </button>
-            )}
+            {/* Settings Step */}
+            {showSettingsStep && selectedSkill && (
+              <>
+                {/* Selected Skill Info */}
+                <div
+                  style={{
+                    marginBottom: '20px',
+                    padding: '12px',
+                    backgroundColor: 'var(--vscode-list-inactiveSelectionBackground)',
+                    border: '1px solid var(--vscode-panel-border)',
+                    borderRadius: '4px',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '14px',
+                      fontWeight: 600,
+                      color: 'var(--vscode-foreground)',
+                      marginBottom: '4px',
+                    }}
+                  >
+                    {selectedSkill.name}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--vscode-descriptionForeground)',
+                    }}
+                  >
+                    {selectedSkill.description}
+                  </div>
+                </div>
 
-            {/* Actions */}
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                gap: '8px',
-                marginTop: '20px',
-              }}
-            >
-              <button
-                type="button"
-                onClick={handleClose}
-                style={{
-                  padding: '8px 16px',
-                  fontSize: '13px',
-                  border: '1px solid var(--vscode-button-border)',
-                  borderRadius: '4px',
-                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
-                  color: 'var(--vscode-button-secondaryForeground)',
-                  cursor: 'pointer',
-                }}
-              >
-                {t('skill.browser.cancelButton')}
-              </button>
-              <button
-                type="button"
-                onClick={handleAddSkill}
-                disabled={!selectedSkill || loading}
-                style={{
-                  padding: '8px 16px',
-                  fontSize: '13px',
-                  border: 'none',
-                  borderRadius: '4px',
-                  backgroundColor: selectedSkill
-                    ? 'var(--vscode-button-background)'
-                    : 'var(--vscode-button-secondaryBackground)',
-                  color: selectedSkill
-                    ? 'var(--vscode-button-foreground)'
-                    : 'var(--vscode-descriptionForeground)',
-                  cursor: selectedSkill ? 'pointer' : 'not-allowed',
-                  opacity: selectedSkill ? 1 : 0.5,
-                }}
-              >
-                {t('skill.browser.selectButton')}
-              </button>
-            </div>
+                {/* Execution Mode Selection */}
+                <div style={{ marginBottom: '20px' }}>
+                  <label
+                    htmlFor="browser-execution-mode-execute"
+                    style={{
+                      display: 'block',
+                      fontSize: '13px',
+                      fontWeight: 600,
+                      color: 'var(--vscode-foreground)',
+                      marginBottom: '12px',
+                    }}
+                  >
+                    {t('property.skill.executionMode')}
+                  </label>
+
+                  {/* Execute Option */}
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: '10px',
+                      padding: '12px',
+                      marginBottom: '8px',
+                      borderRadius: '4px',
+                      border: `1px solid ${pendingExecutionMode === 'execute' ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
+                      backgroundColor:
+                        pendingExecutionMode === 'execute'
+                          ? 'var(--vscode-list-activeSelectionBackground)'
+                          : 'transparent',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <input
+                      id="browser-execution-mode-execute"
+                      type="radio"
+                      name="browserExecutionMode"
+                      value="execute"
+                      checked={pendingExecutionMode === 'execute'}
+                      onChange={() => setPendingExecutionMode('execute')}
+                      style={{ marginTop: '2px' }}
+                    />
+                    <div>
+                      <div
+                        style={{
+                          fontSize: '13px',
+                          fontWeight: 600,
+                          color: 'var(--vscode-foreground)',
+                        }}
+                      >
+                        {t('property.skill.executionMode.execute')}
+                      </div>
+                      <div
+                        style={{
+                          fontSize: '12px',
+                          color: 'var(--vscode-descriptionForeground)',
+                          marginTop: '4px',
+                        }}
+                      >
+                        {t('property.skill.executionMode.execute.description')}
+                      </div>
+                    </div>
+                  </label>
+
+                  {/* Load Option */}
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: '10px',
+                      padding: '12px',
+                      borderRadius: '4px',
+                      border: `1px solid ${pendingExecutionMode === 'load' ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
+                      backgroundColor:
+                        pendingExecutionMode === 'load'
+                          ? 'var(--vscode-list-activeSelectionBackground)'
+                          : 'transparent',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <input
+                      type="radio"
+                      name="browserExecutionMode"
+                      value="load"
+                      checked={pendingExecutionMode === 'load'}
+                      onChange={() => setPendingExecutionMode('load')}
+                      style={{ marginTop: '2px' }}
+                    />
+                    <div>
+                      <div
+                        style={{
+                          fontSize: '13px',
+                          fontWeight: 600,
+                          color: 'var(--vscode-foreground)',
+                        }}
+                      >
+                        {t('property.skill.executionMode.load')}
+                      </div>
+                      <div
+                        style={{
+                          fontSize: '12px',
+                          color: 'var(--vscode-descriptionForeground)',
+                          marginTop: '4px',
+                        }}
+                      >
+                        {t('property.skill.executionMode.load.description')}
+                      </div>
+                    </div>
+                  </label>
+                </div>
+
+                {/* Execution Prompt (only for execute mode) */}
+                {pendingExecutionMode === 'execute' && (
+                  <div style={{ marginBottom: '20px' }}>
+                    <label
+                      htmlFor="browser-execution-prompt"
+                      style={{
+                        display: 'block',
+                        fontSize: '13px',
+                        fontWeight: 600,
+                        color: 'var(--vscode-foreground)',
+                        marginBottom: '8px',
+                      }}
+                    >
+                      {t('property.skill.executionPrompt')}
+                    </label>
+                    <textarea
+                      id="browser-execution-prompt"
+                      value={pendingExecutionPrompt}
+                      onChange={(e) => setPendingExecutionPrompt(e.target.value)}
+                      placeholder={t('property.skill.executionPrompt.placeholder')}
+                      maxLength={VALIDATION_RULES.SKILL.EXECUTION_PROMPT_MAX_LENGTH}
+                      style={{
+                        width: '100%',
+                        minHeight: '120px',
+                        padding: '8px 12px',
+                        fontSize: '13px',
+                        fontFamily: 'monospace',
+                        backgroundColor: 'var(--vscode-input-background)',
+                        color: 'var(--vscode-input-foreground)',
+                        border: '1px solid var(--vscode-input-border)',
+                        borderRadius: '4px',
+                        resize: 'vertical',
+                        outline: 'none',
+                      }}
+                    />
+                    <div
+                      style={{
+                        fontSize: '11px',
+                        color: 'var(--vscode-descriptionForeground)',
+                        marginTop: '4px',
+                        textAlign: 'right',
+                      }}
+                    >
+                      {pendingExecutionPrompt.length} /{' '}
+                      {VALIDATION_RULES.SKILL.EXECUTION_PROMPT_MAX_LENGTH}
+                    </div>
+                  </div>
+                )}
+
+                {/* Actions - Settings Step */}
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    gap: '8px',
+                    marginTop: '20px',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={handleBackToList}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      border: '1px solid var(--vscode-button-border)',
+                      borderRadius: '4px',
+                      backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                      color: 'var(--vscode-button-secondaryForeground)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {t('skill.browser.backToList')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleAddSkillWithSettings}
+                    style={{
+                      padding: '8px 16px',
+                      fontSize: '13px',
+                      border: 'none',
+                      borderRadius: '4px',
+                      backgroundColor: 'var(--vscode-button-background)',
+                      color: 'var(--vscode-button-foreground)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {t('skill.browser.addButton')}
+                  </button>
+                </div>
+              </>
+            )}
 
             {/* Skill Creation Dialog - nested dialog */}
             <SkillCreationDialog

--- a/src/webview/src/components/dialogs/SkillNodeEditDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillNodeEditDialog.tsx
@@ -1,0 +1,334 @@
+/**
+ * Skill Node Edit Dialog Component
+ *
+ * Feature: 001-skill-execution-mode
+ * Purpose: Edit Skill node execution mode and execution prompt
+ *
+ * Based on: McpNodeEditDialog pattern
+ */
+
+import * as Dialog from '@radix-ui/react-dialog';
+import type { SkillNodeData } from '@shared/types/workflow-definition';
+import { VALIDATION_RULES } from '@shared/types/workflow-definition';
+import { useState } from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
+import { useWorkflowStore } from '../../stores/workflow-store';
+
+interface SkillNodeEditDialogProps {
+  isOpen: boolean;
+  nodeId: string;
+  onClose: () => void;
+}
+
+export function SkillNodeEditDialog({ isOpen, nodeId, onClose }: SkillNodeEditDialogProps) {
+  const { t } = useTranslation();
+  const { nodes, updateNodeData } = useWorkflowStore();
+
+  const node = nodes.find((n) => n.id === nodeId);
+  const nodeData = node?.data as SkillNodeData | undefined;
+
+  const [executionMode, setExecutionMode] = useState<'load' | 'execute'>(
+    nodeData?.executionMode || 'execute'
+  );
+  const [executionPrompt, setExecutionPrompt] = useState(nodeData?.executionPrompt || '');
+
+  // Reset state when dialog opens with new data
+  const handleOpenChange = (open: boolean) => {
+    if (open && nodeData) {
+      setExecutionMode(nodeData.executionMode || 'execute');
+      setExecutionPrompt(nodeData.executionPrompt || '');
+    }
+    if (!open) {
+      onClose();
+    }
+  };
+
+  const handleSave = () => {
+    if (!node || !nodeData) return;
+
+    updateNodeData(nodeId, {
+      ...nodeData,
+      executionMode,
+      executionPrompt: executionMode === 'execute' ? executionPrompt : undefined,
+    });
+
+    onClose();
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
+          }}
+        >
+          <Dialog.Content
+            style={{
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '6px',
+              padding: '24px',
+              maxWidth: '600px',
+              width: '90%',
+              maxHeight: '80vh',
+              overflow: 'auto',
+            }}
+          >
+            {/* Dialog Header */}
+            <Dialog.Title
+              style={{
+                fontSize: '16px',
+                fontWeight: 'bold',
+                color: 'var(--vscode-foreground)',
+                marginBottom: '16px',
+              }}
+            >
+              {t('skill.editDialog.title')}
+            </Dialog.Title>
+
+            {/* Hidden description for accessibility */}
+            <Dialog.Description style={{ display: 'none' }}>
+              {t('skill.editDialog.title')}
+            </Dialog.Description>
+
+            {/* Skill Info */}
+            {nodeData && (
+              <div
+                style={{
+                  marginBottom: '16px',
+                  padding: '12px',
+                  backgroundColor: 'var(--vscode-list-inactiveSelectionBackground)',
+                  border: '1px solid var(--vscode-panel-border)',
+                  borderRadius: '4px',
+                }}
+              >
+                <div style={{ fontSize: '13px', color: 'var(--vscode-disabledForeground)' }}>
+                  <strong>Skill:</strong> {nodeData.name}
+                </div>
+                <div
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--vscode-disabledForeground)',
+                    marginTop: '4px',
+                  }}
+                >
+                  {nodeData.description}
+                </div>
+              </div>
+            )}
+
+            {/* Execution Mode Selection */}
+            <div style={{ marginBottom: '20px' }}>
+              <label
+                htmlFor="execution-mode-execute"
+                style={{
+                  display: 'block',
+                  fontSize: '13px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                  marginBottom: '12px',
+                }}
+              >
+                {t('property.skill.executionMode')}
+              </label>
+
+              {/* Execute Option */}
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '10px',
+                  padding: '12px',
+                  marginBottom: '8px',
+                  borderRadius: '4px',
+                  border: `1px solid ${executionMode === 'execute' ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
+                  backgroundColor:
+                    executionMode === 'execute'
+                      ? 'var(--vscode-list-activeSelectionBackground)'
+                      : 'transparent',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  id="execution-mode-execute"
+                  type="radio"
+                  name="executionMode"
+                  value="execute"
+                  checked={executionMode === 'execute'}
+                  onChange={() => setExecutionMode('execute')}
+                  style={{ marginTop: '2px' }}
+                />
+                <div>
+                  <div
+                    style={{
+                      fontSize: '13px',
+                      fontWeight: 600,
+                      color: 'var(--vscode-foreground)',
+                    }}
+                  >
+                    {t('property.skill.executionMode.execute')}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--vscode-descriptionForeground)',
+                      marginTop: '4px',
+                    }}
+                  >
+                    {t('property.skill.executionMode.execute.description')}
+                  </div>
+                </div>
+              </label>
+
+              {/* Load Option */}
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '10px',
+                  padding: '12px',
+                  borderRadius: '4px',
+                  border: `1px solid ${executionMode === 'load' ? 'var(--vscode-focusBorder)' : 'var(--vscode-panel-border)'}`,
+                  backgroundColor:
+                    executionMode === 'load'
+                      ? 'var(--vscode-list-activeSelectionBackground)'
+                      : 'transparent',
+                  cursor: 'pointer',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="executionMode"
+                  value="load"
+                  checked={executionMode === 'load'}
+                  onChange={() => setExecutionMode('load')}
+                  style={{ marginTop: '2px' }}
+                />
+                <div>
+                  <div
+                    style={{
+                      fontSize: '13px',
+                      fontWeight: 600,
+                      color: 'var(--vscode-foreground)',
+                    }}
+                  >
+                    {t('property.skill.executionMode.load')}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--vscode-descriptionForeground)',
+                      marginTop: '4px',
+                    }}
+                  >
+                    {t('property.skill.executionMode.load.description')}
+                  </div>
+                </div>
+              </label>
+            </div>
+
+            {/* Execution Prompt (only for execute mode) */}
+            {executionMode === 'execute' && (
+              <div style={{ marginBottom: '20px' }}>
+                <label
+                  htmlFor="execution-prompt"
+                  style={{
+                    display: 'block',
+                    fontSize: '13px',
+                    fontWeight: 600,
+                    color: 'var(--vscode-foreground)',
+                    marginBottom: '8px',
+                  }}
+                >
+                  {t('property.skill.executionPrompt')}
+                </label>
+                <textarea
+                  id="execution-prompt"
+                  value={executionPrompt}
+                  onChange={(e) => setExecutionPrompt(e.target.value)}
+                  placeholder={t('property.skill.executionPrompt.placeholder')}
+                  maxLength={VALIDATION_RULES.SKILL.EXECUTION_PROMPT_MAX_LENGTH}
+                  style={{
+                    width: '100%',
+                    minHeight: '120px',
+                    padding: '8px 12px',
+                    fontSize: '13px',
+                    fontFamily: 'monospace',
+                    backgroundColor: 'var(--vscode-input-background)',
+                    color: 'var(--vscode-input-foreground)',
+                    border: '1px solid var(--vscode-input-border)',
+                    borderRadius: '4px',
+                    resize: 'vertical',
+                    outline: 'none',
+                  }}
+                />
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    marginTop: '4px',
+                    textAlign: 'right',
+                  }}
+                >
+                  {executionPrompt.length} / {VALIDATION_RULES.SKILL.EXECUTION_PROMPT_MAX_LENGTH}
+                </div>
+              </div>
+            )}
+
+            {/* Dialog Actions */}
+            <div
+              style={{
+                marginTop: '24px',
+                display: 'flex',
+                gap: '12px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={handleClose}
+                style={{
+                  padding: '8px 16px',
+                  fontSize: '13px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                }}
+              >
+                {t('skill.editDialog.cancelButton')}
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                style={{
+                  padding: '8px 16px',
+                  fontSize: '13px',
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                }}
+              >
+                {t('skill.editDialog.saveButton')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/webview/src/components/nodes/SkillNode.tsx
+++ b/src/webview/src/components/nodes/SkillNode.tsx
@@ -117,8 +117,8 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
           {data.name || 'Untitled Skill'}
         </div>
 
-        {/* Description */}
-        {data.description && (
+        {/* Description or Execution Prompt */}
+        {(data.executionPrompt || data.description) && (
           <div
             style={{
               fontSize: '11px',
@@ -132,11 +132,11 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
               WebkitBoxOrient: 'vertical',
             }}
           >
-            {data.description}
+            {data.executionPrompt || data.description}
           </div>
         )}
 
-        {/* Scope and Source Badges */}
+        {/* Scope, Source, and Execution Mode Badges */}
         <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
           {/* Scope Badge */}
           <div
@@ -162,6 +162,24 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
           {/* Source Badge for project and user skills */}
           {(data.scope === 'project' || data.scope === 'user') && data.source && (
             <AIProviderBadge provider={data.source as AIProviderType} size="small" />
+          )}
+          {/* Execution Mode Badge (only show for 'load' mode) */}
+          {data.executionMode === 'load' && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: 'var(--vscode-badge-foreground)',
+                backgroundColor: 'var(--vscode-terminal-ansiYellow)',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                fontWeight: 600,
+                letterSpacing: '0.3px',
+              }}
+              title={t('property.skill.executionMode.load.description')}
+            >
+              LOAD ONLY
+            </div>
           )}
         </div>
 

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -395,6 +395,11 @@ export interface WebviewTranslationKeys {
   'skill.browser.skillPath': string;
   'skill.browser.validationStatus': string;
 
+  // Skill Browser Settings Step
+  'skill.browser.configureButton': string;
+  'skill.browser.addButton': string;
+  'skill.browser.backToList': string;
+
   // Skill Browser Actions
   'skill.action.refresh': string;
   'skill.refreshing': string;
@@ -426,6 +431,20 @@ export interface WebviewTranslationKeys {
   'skill.creation.createButton': string;
   'skill.creation.creatingButton': string;
   'skill.creation.error.unknown': string;
+
+  // Skill Execution Mode
+  'property.skill.executionMode': string;
+  'property.skill.executionMode.execute': string;
+  'property.skill.executionMode.load': string;
+  'property.skill.executionMode.execute.description': string;
+  'property.skill.executionMode.load.description': string;
+  'property.skill.executionPrompt': string;
+  'property.skill.executionPrompt.placeholder': string;
+
+  // Skill Edit Dialog
+  'skill.editDialog.title': string;
+  'skill.editDialog.saveButton': string;
+  'skill.editDialog.cancelButton': string;
 
   // Skill Validation Errors
   'skill.validation.nameRequired': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -433,6 +433,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': 'Path',
   'skill.browser.validationStatus': 'Status',
 
+  // Skill Browser Settings Step
+  'skill.browser.configureButton': 'Configure',
+  'skill.browser.addButton': 'Add to Workflow',
+  'skill.browser.backToList': 'Back',
+
   // Skill Browser Actions
   'skill.action.refresh': 'Refresh',
   'skill.refreshing': 'Refreshing...',
@@ -467,6 +472,23 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'skill.creation.createButton': 'Create Skill',
   'skill.creation.creatingButton': 'Creating...',
   'skill.creation.error.unknown': 'Failed to create Skill. Please try again.',
+
+  // Skill Execution Mode
+  'property.skill.executionMode': 'Execution Mode',
+  'property.skill.executionMode.execute': 'Execute',
+  'property.skill.executionMode.load': 'Load as Knowledge',
+  'property.skill.executionMode.execute.description':
+    'Execute the Skill as an action in the workflow',
+  'property.skill.executionMode.load.description':
+    'Load the Skill content as knowledge context without executing it',
+  'property.skill.executionPrompt': 'Prompt',
+  'property.skill.executionPrompt.placeholder':
+    'Enter additional instructions for executing this Skill...',
+
+  // Skill Edit Dialog
+  'skill.editDialog.title': 'Edit Skill Settings',
+  'skill.editDialog.saveButton': 'Save',
+  'skill.editDialog.cancelButton': 'Cancel',
 
   // Skill Validation Errors
   'skill.validation.nameRequired': 'Skill name is required',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -432,6 +432,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': 'パス',
   'skill.browser.validationStatus': 'ステータス',
 
+  // Skill Browser Settings Step
+  'skill.browser.configureButton': '設定へ',
+  'skill.browser.addButton': 'ワークフローに追加',
+  'skill.browser.backToList': '戻る',
+
   // Skill Browser Actions
   'skill.action.refresh': '再読み込み',
   'skill.refreshing': '再読み込み中...',
@@ -465,6 +470,23 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'skill.creation.createButton': 'Skillを作成',
   'skill.creation.creatingButton': '作成中...',
   'skill.creation.error.unknown': 'Skillの作成に失敗しました。もう一度お試しください。',
+
+  // Skill Execution Mode
+  'property.skill.executionMode': '実行モード',
+  'property.skill.executionMode.execute': '実行する',
+  'property.skill.executionMode.load': '知識として読み込む',
+  'property.skill.executionMode.execute.description':
+    'ワークフロー内でSkillをアクションとして実行します',
+  'property.skill.executionMode.load.description':
+    'Skillの内容を知識コンテキストとして読み込みます（実行はしません）',
+  'property.skill.executionPrompt': 'プロンプト',
+  'property.skill.executionPrompt.placeholder':
+    'このSkillを実行する際の追加指示を入力してください...',
+
+  // Skill Edit Dialog
+  'skill.editDialog.title': 'Skill設定の編集',
+  'skill.editDialog.saveButton': '保存',
+  'skill.editDialog.cancelButton': 'キャンセル',
 
   // Skill Validation Errors
   'skill.validation.nameRequired': 'Skill名は必須です',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -433,6 +433,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': '경로',
   'skill.browser.validationStatus': '상태',
 
+  // Skill Browser Settings Step
+  'skill.browser.configureButton': '설정으로',
+  'skill.browser.addButton': '워크플로우에 추가',
+  'skill.browser.backToList': '뒤로',
+
   // Skill Browser Actions
   'skill.action.refresh': '새로고침',
   'skill.refreshing': '새로고침 중...',
@@ -466,6 +471,21 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'skill.creation.createButton': '스킬 만들기',
   'skill.creation.creatingButton': '만드는 중...',
   'skill.creation.error.unknown': '스킬 생성에 실패했습니다. 다시 시도해 주세요.',
+
+  // Skill Execution Mode
+  'property.skill.executionMode': '실행 모드',
+  'property.skill.executionMode.execute': '실행',
+  'property.skill.executionMode.load': '지식으로 로드',
+  'property.skill.executionMode.execute.description': '워크플로우에서 스킬을 액션으로 실행합니다',
+  'property.skill.executionMode.load.description':
+    '스킬 내용을 지식 컨텍스트로 로드합니다 (실행하지 않음)',
+  'property.skill.executionPrompt': '프롬프트',
+  'property.skill.executionPrompt.placeholder': '이 스킬을 실행할 때의 추가 지침을 입력하세요...',
+
+  // Skill Edit Dialog
+  'skill.editDialog.title': '스킬 설정 편집',
+  'skill.editDialog.saveButton': '저장',
+  'skill.editDialog.cancelButton': '취소',
 
   // Skill Validation Errors
   'skill.validation.nameRequired': '스킬 이름은 필수입니다',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -417,6 +417,11 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': '路径',
   'skill.browser.validationStatus': '状态',
 
+  // Skill Browser Settings Step
+  'skill.browser.configureButton': '前往设置',
+  'skill.browser.addButton': '添加到工作流',
+  'skill.browser.backToList': '返回',
+
   // Skill Browser Actions
   'skill.action.refresh': '刷新',
   'skill.refreshing': '刷新中...',
@@ -450,6 +455,20 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'skill.creation.createButton': '创建技能',
   'skill.creation.creatingButton': '创建中...',
   'skill.creation.error.unknown': '创建技能失败。请重试。',
+
+  // Skill Execution Mode
+  'property.skill.executionMode': '执行模式',
+  'property.skill.executionMode.execute': '执行',
+  'property.skill.executionMode.load': '作为知识加载',
+  'property.skill.executionMode.execute.description': '在工作流中将技能作为操作执行',
+  'property.skill.executionMode.load.description': '将技能内容作为知识上下文加载（不执行）',
+  'property.skill.executionPrompt': '提示词',
+  'property.skill.executionPrompt.placeholder': '输入执行此技能时的附加指令...',
+
+  // Skill Edit Dialog
+  'skill.editDialog.title': '编辑技能设置',
+  'skill.editDialog.saveButton': '保存',
+  'skill.editDialog.cancelButton': '取消',
 
   // Skill Validation Errors
   'skill.validation.nameRequired': '技能名称是必需的',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -417,6 +417,11 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'skill.browser.skillPath': '路徑',
   'skill.browser.validationStatus': '狀態',
 
+  // Skill Browser Settings Step
+  'skill.browser.configureButton': '前往設定',
+  'skill.browser.addButton': '新增至工作流程',
+  'skill.browser.backToList': '返回',
+
   // Skill Browser Actions
   'skill.action.refresh': '重新整理',
   'skill.refreshing': '重新整理中...',
@@ -450,6 +455,20 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'skill.creation.createButton': '建立技能',
   'skill.creation.creatingButton': '建立中...',
   'skill.creation.error.unknown': '建立技能失敗。請重試。',
+
+  // Skill Execution Mode
+  'property.skill.executionMode': '執行模式',
+  'property.skill.executionMode.execute': '執行',
+  'property.skill.executionMode.load': '作為知識載入',
+  'property.skill.executionMode.execute.description': '在工作流程中將技能作為操作執行',
+  'property.skill.executionMode.load.description': '將技能內容作為知識上下文載入（不執行）',
+  'property.skill.executionPrompt': '提示詞',
+  'property.skill.executionPrompt.placeholder': '輸入執行此技能時的附加指令...',
+
+  // Skill Edit Dialog
+  'skill.editDialog.title': '編輯技能設定',
+  'skill.editDialog.saveButton': '儲存',
+  'skill.editDialog.cancelButton': '取消',
 
   // Skill Validation Errors
   'skill.validation.nameRequired': '技能名稱為必填',


### PR DESCRIPTION
## Summary

Add execution mode selection to Skill nodes, allowing users to choose between executing a Skill or loading it as knowledge context.

## What Changed

### Before
- Skill nodes always executed the Skill as an action
- No way to use a Skill purely as knowledge context

### After
- Users can select `execute` (default) or `load` mode for each Skill node
- `execute` mode: runs the Skill as before, with optional custom prompt
- `load` mode: loads Skill content as knowledge context without executing
- 2-step configuration flow in Skill Browser: select Skill → configure settings → add to workflow
- "LOAD ONLY" badge displayed on canvas for load mode nodes
- Execution prompt shown on canvas when set (instead of Skill description)
- Edit Settings dialog available from property panel for existing nodes

## Changes

- `src/shared/types/workflow-definition.ts` - Add executionMode and executionPrompt to SkillNodeData
- `src/extension/utils/migrate-workflow.ts` - Add migration for backward compatibility
- `src/extension/utils/validate-workflow.ts` - Add validation for new fields
- `resources/workflow-schema.json` - Add schema definitions
- `src/extension/services/workflow-prompt-generator.ts` - Branch prompt output by executionMode
- `src/webview/src/components/dialogs/SkillBrowserDialog.tsx` - Add 2-step config flow
- `src/webview/src/components/dialogs/SkillNodeEditDialog.tsx` - New edit dialog for existing nodes
- `src/webview/src/components/nodes/SkillNode.tsx` - Add LOAD ONLY badge, show executionPrompt
- `src/webview/src/components/PropertyOverlay.tsx` - Add settings display and edit button
- `src/webview/src/i18n/translation-keys.ts` - Add translation keys
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Add translations (5 languages)

## Testing

- [x] Manual E2E testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)