### PR TITLE
fix: replace DeepWiki SVG badge with shields.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://snyk.io/test/github/breaking-brake/cc-wf-studio"><img src="https://snyk.io/test/github/breaking-brake/cc-wf-studio/badge.svg" alt="Known Vulnerabilities" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
-  <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+  <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Replace DeepWiki SVG badge (`deepwiki.com/badge.svg`) with shields.io static badge
- `vsce package` rejects SVGs from untrusted domains; shields.io is in the trusted list
- Fixes release workflow failure in #536

## Context

Release v3.19.2 failed at `vsce package` step due to:
```
SVGs are restricted in README.md; please use other file image formats, such as PNG: https://deepwiki.com/badge.svg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)