### PR TITLE
improvement: add persistent memory setting to SubAgent/SubAgentFlow nodes

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -62,6 +62,12 @@
           "enum": ["red", "blue", "green", "yellow", "purple", "orange", "pink", "cyan"],
           "description": "Visual indicator color for this sub-agent (optional)"
         },
+        "memory": {
+          "type": "string",
+          "required": false,
+          "enum": ["user", "project", "local"],
+          "description": "Persistent memory scope. 'user'=cross-project, 'project'=VCS-trackable, 'local'=local-only"
+        },
         "outputPorts": { "type": "number", "required": true, "value": 1 }
       },
       "inputPorts": 1,
@@ -316,6 +322,12 @@
           "required": false,
           "maxLength": 200,
           "description": "Optional description of what this sub-agent flow does"
+        },
+        "memory": {
+          "type": "string",
+          "required": false,
+          "enum": ["user", "project", "local"],
+          "description": "Persistent memory scope. 'user'=cross-project, 'project'=VCS-trackable, 'local'=local-only"
         },
         "outputPorts": {
           "type": "number",

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -61,6 +61,11 @@ nodeTypes:
         required: false
         enum[8]: red,blue,green,yellow,purple,orange,pink,cyan
         description: Visual indicator color for this sub-agent (optional)
+      memory:
+        type: string
+        required: false
+        enum[3]: user,project,local
+        description: "Persistent memory scope. 'user'=cross-project, 'project'=VCS-trackable, 'local'=local-only"
       outputPorts:
         type: number
         required: true
@@ -316,6 +321,11 @@ nodeTypes:
         required: false
         maxLength: 200
         description: Optional description of what this sub-agent flow does
+      memory:
+        type: string
+        required: false
+        enum[3]: user,project,local
+        description: "Persistent memory scope. 'user'=cross-project, 'project'=VCS-trackable, 'local'=local-only"
       outputPorts:
         type: number
         required: true

--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -234,6 +234,10 @@ function generateSubAgentFile(node: SubAgentNode): string {
     frontmatter.push(`color: ${data.color}`);
   }
 
+  if (data.memory) {
+    frontmatter.push(`memory: ${data.memory}`);
+  }
+
   frontmatter.push('---');
   frontmatter.push('');
 
@@ -262,10 +266,11 @@ function generateSubAgentFlowAgentFile(
 ): string {
   const agentName = agentFileName;
 
-  // Get model/tools/color from referencing node, or use defaults
+  // Get model/tools/color/memory from referencing node, or use defaults
   const model = referencingNode?.data.model || 'sonnet';
   const tools = referencingNode?.data.tools;
   const color = referencingNode?.data.color;
+  const memory = referencingNode?.data.memory;
 
   // YAML frontmatter (same structure as SubAgent)
   const frontmatter = [
@@ -283,6 +288,10 @@ function generateSubAgentFlowAgentFile(
 
   if (color) {
     frontmatter.push(`color: ${color}`);
+  }
+
+  if (memory) {
+    frontmatter.push(`memory: ${memory}`);
   }
 
   frontmatter.push('---');

--- a/src/extension/utils/validate-workflow.ts
+++ b/src/extension/utils/validate-workflow.ts
@@ -265,6 +265,21 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
       const subAgentFlowErrors = validateSubAgentFlowNode(node);
       errors.push(...subAgentFlowErrors);
     }
+
+    // Validate SubAgent memory enum (Feature: 540-persistent-memory)
+    if (node.type === NodeType.SubAgent) {
+      const subAgentData = node.data as { memory?: string };
+      if (subAgentData.memory !== undefined) {
+        const validMemoryScopes = ['user', 'project', 'local'];
+        if (!validMemoryScopes.includes(subAgentData.memory)) {
+          errors.push({
+            code: 'SUBAGENT_INVALID_MEMORY',
+            message: `SubAgent memory must be one of: ${validMemoryScopes.join(', ')}`,
+            field: `nodes[${node.id}].data.memory`,
+          });
+        }
+      }
+    }
   }
 
   return errors;
@@ -351,6 +366,18 @@ function validateSubAgentFlowNode(node: WorkflowNode): ValidationError[] {
       message: 'SubAgentFlow outputPorts must equal 1',
       field: `nodes[${node.id}].data.outputPorts`,
     });
+  }
+
+  // Memory enum validation
+  if (refData.memory !== undefined) {
+    const validMemoryScopes = ['user', 'project', 'local'];
+    if (!validMemoryScopes.includes(refData.memory)) {
+      errors.push({
+        code: 'SUBAGENTFLOW_INVALID_MEMORY',
+        message: `SubAgentFlow memory must be one of: ${validMemoryScopes.join(', ')}`,
+        field: `nodes[${node.id}].data.memory`,
+      });
+    }
   }
 
   return errors;

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -111,6 +111,8 @@ export interface SubAgentData {
   prompt: string;
   tools?: string;
   model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  /** Persistent memory scope for cross-conversation knowledge retention */
+  memory?: 'user' | 'project' | 'local';
   color?: 'red' | 'blue' | 'green' | 'yellow' | 'purple' | 'orange' | 'pink' | 'cyan';
   outputPorts: number;
 }
@@ -296,6 +298,8 @@ export interface SubAgentFlowNodeData {
   outputPorts: 1;
   /** Model to use for this sub-agent flow execution */
   model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  /** Persistent memory scope for cross-conversation knowledge retention */
+  memory?: 'user' | 'project' | 'local';
   /** Comma-separated list of allowed tools */
   tools?: string;
   /** Visual color for the node */

--- a/src/webview/src/components/PropertyOverlay.tsx
+++ b/src/webview/src/components/PropertyOverlay.tsx
@@ -25,6 +25,7 @@ import type { Node } from 'reactflow';
 import { getNodeTypeLabel } from '../constants/node-type-labels';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import { useTranslation } from '../i18n/i18n-context';
+import { openExternalUrl } from '../services/vscode-bridge';
 import { useWorkflowStore } from '../stores/workflow-store';
 import type { PromptNodeData } from '../types/node-types';
 import { extractVariables } from '../utils/template-utils';
@@ -488,6 +489,74 @@ const SubAgentProperties: React.FC<{
           <option value="haiku">Haiku</option>
           <option value="inherit">Inherit</option>
         </select>
+      </div>
+
+      {/* Memory Scope */}
+      <div>
+        <label
+          htmlFor="memory-select"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('property.memory')}
+        </label>
+        <select
+          id="memory-select"
+          value={data.memory || ''}
+          onChange={(e) =>
+            updateNodeData(node.id, {
+              memory:
+                e.target.value === ''
+                  ? undefined
+                  : (e.target.value as 'user' | 'project' | 'local'),
+            })
+          }
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        >
+          <option value="">-</option>
+          <option value="user">user</option>
+          <option value="project">project</option>
+          <option value="local">local</option>
+        </select>
+        <div
+          style={{
+            fontSize: '11px',
+            marginTop: '4px',
+            textAlign: 'right',
+          }}
+        >
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={() => openExternalUrl(t('property.memory.referenceUrl'))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                openExternalUrl(t('property.memory.referenceUrl'));
+              }
+            }}
+            style={{
+              color: 'var(--vscode-textLink-foreground)',
+              cursor: 'pointer',
+              textDecoration: 'none',
+            }}
+          >
+            Persistent Memory Reference
+          </span>
+        </div>
       </div>
 
       {/* Tools */}
@@ -2667,6 +2736,74 @@ const SubAgentFlowProperties: React.FC<{
           <option value="haiku">Haiku</option>
           <option value="inherit">Inherit</option>
         </select>
+      </div>
+
+      {/* Memory Scope */}
+      <div>
+        <label
+          htmlFor="subagentflow-memory-select"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('property.memory')}
+        </label>
+        <select
+          id="subagentflow-memory-select"
+          value={data.memory || ''}
+          onChange={(e) =>
+            updateNodeData(node.id, {
+              memory:
+                e.target.value === ''
+                  ? undefined
+                  : (e.target.value as 'user' | 'project' | 'local'),
+            })
+          }
+          className="nodrag"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        >
+          <option value="">-</option>
+          <option value="user">user</option>
+          <option value="project">project</option>
+          <option value="local">local</option>
+        </select>
+        <div
+          style={{
+            fontSize: '11px',
+            marginTop: '4px',
+            textAlign: 'right',
+          }}
+        >
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={() => openExternalUrl(t('property.memory.referenceUrl'))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                openExternalUrl(t('property.memory.referenceUrl'));
+              }
+            }}
+            style={{
+              color: 'var(--vscode-textLink-foreground)',
+              cursor: 'pointer',
+              textDecoration: 'none',
+            }}
+          >
+            Persistent Memory Reference
+          </span>
+        </div>
       </div>
 
       {/* Tools */}

--- a/src/webview/src/components/nodes/SubAgentFlowNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentFlowNode.tsx
@@ -128,6 +128,23 @@ export const SubAgentFlowNodeComponent: React.FC<NodeProps<SubAgentFlowNodeData>
             </div>
           )}
 
+          {/* Memory Badge */}
+          {data.memory && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: 'var(--vscode-badge-foreground)',
+                backgroundColor: 'var(--vscode-badge-background)',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                fontWeight: 600,
+              }}
+            >
+              memory: {data.memory}
+            </div>
+          )}
+
           {/* Color Badge */}
           {data.color && (
             <div

--- a/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -94,6 +94,23 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
             </div>
           )}
 
+          {/* Memory Badge */}
+          {data.memory && (
+            <div
+              style={{
+                fontSize: '10px',
+                color: 'var(--vscode-badge-foreground)',
+                backgroundColor: 'var(--vscode-badge-background)',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                display: 'inline-block',
+                fontWeight: 600,
+              }}
+            >
+              memory: {data.memory}
+            </div>
+          )}
+
           {/* Color Badge */}
           {data.color && (
             <div

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -227,6 +227,8 @@ export interface WebviewTranslationKeys {
   'property.tools': string;
   'property.tools.placeholder': string;
   'property.tools.help': string;
+  'property.memory': string;
+  'property.memory.referenceUrl': string;
   'properties.subAgent.color': string;
   'properties.subAgent.colorPlaceholder': string;
   'properties.subAgent.colorNone': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -239,6 +239,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.tools': 'Tools (comma-separated)',
   'property.tools.placeholder': 'e.g., Read,Write,Bash',
   'property.tools.help': 'Leave empty for all tools',
+  'property.memory': 'Memory',
+  'property.memory.referenceUrl':
+    'https://code.claude.com/docs/en/sub-agents#enable-persistent-memory',
   'properties.subAgent.color': 'Color',
   'properties.subAgent.colorPlaceholder': 'Select color...',
   'properties.subAgent.colorNone': 'None',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -237,6 +237,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.tools': 'ツール（カンマ区切り）',
   'property.tools.placeholder': '例: Read,Write,Bash',
   'property.tools.help': '空欄で全てのツールを使用',
+  'property.memory': 'メモリ',
+  'property.memory.referenceUrl':
+    'https://code.claude.com/docs/ja/sub-agents#永続メモリを有効にする',
   'properties.subAgent.color': '色',
   'properties.subAgent.colorPlaceholder': '色を選択...',
   'properties.subAgent.colorNone': 'なし',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -237,6 +237,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.tools': '도구 (쉼표로 구분)',
   'property.tools.placeholder': '예: Read,Write,Bash',
   'property.tools.help': '모든 도구를 사용하려면 비워 두세요',
+  'property.memory': '메모리',
+  'property.memory.referenceUrl': 'https://code.claude.com/docs/ko/sub-agents#지속적-메모리-활성화',
   'properties.subAgent.color': '색상',
   'properties.subAgent.colorPlaceholder': '색상 선택...',
   'properties.subAgent.colorNone': '없음',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -230,6 +230,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.tools': '工具（逗号分隔）',
   'property.tools.placeholder': '例如：Read,Write,Bash',
   'property.tools.help': '留空表示所有工具',
+  'property.memory': '记忆',
+  'property.memory.referenceUrl': 'https://code.claude.com/docs/zh-CN/sub-agents#启用持久内存',
   'properties.subAgent.color': '颜色',
   'properties.subAgent.colorPlaceholder': '选择颜色...',
   'properties.subAgent.colorNone': '无',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -230,6 +230,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.tools': '工具（逗號分隔）',
   'property.tools.placeholder': '例如：Read,Write,Bash',
   'property.tools.help': '留空表示所有工具',
+  'property.memory': '記憶',
+  'property.memory.referenceUrl': 'https://code.claude.com/docs/zh-TW/sub-agents#啟用持久記憶',
   'properties.subAgent.color': '顏色',
   'properties.subAgent.colorPlaceholder': '選擇顏色...',
   'properties.subAgent.colorNone': '無',


### PR DESCRIPTION
## Summary

Add support for Claude Code's persistent memory (`memory` field) to SubAgent and SubAgentFlow nodes, enabling cross-conversation knowledge retention with `user`, `project`, or `local` scopes.

Closes #540

## What Changed

### Before
- SubAgent and SubAgentFlow nodes had no way to configure persistent memory
- Exported `.md` files did not include `memory` in frontmatter

### After
- Memory dropdown (`user` / `project` / `local`) available in PropertyOverlay for both node types
- Memory badge displayed on canvas nodes when set
- Exported frontmatter includes `memory` field
- Link to official Persistent Memory documentation (per-language)

## Changes

- `src/shared/types/workflow-definition.ts` - Add `memory` field to `SubAgentData` and `SubAgentFlowNodeData`
- `src/webview/src/components/PropertyOverlay.tsx` - Add Memory dropdown with doc reference link (2 sections)
- `src/webview/src/components/nodes/SubAgentNode.tsx` - Add memory badge
- `src/webview/src/components/nodes/SubAgentFlowNode.tsx` - Add memory badge
- `resources/workflow-schema.json` - Add memory field definition (2 sections)
- `src/extension/utils/validate-workflow.ts` - Add memory enum validation (2 sections)
- `src/extension/services/export-service.ts` - Add memory to frontmatter export (2 functions)
- `src/webview/src/i18n/translation-keys.ts` - Add translation keys
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Add translations

## Testing

- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)