### PR TITLE
feat: add Roo Code skills integration (export & run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <strong>Accelerate Claude Code/GitHub Copilot<a href="#github-copilot-support">(※1)</a>/OpenAI Codex<a href="#openai-codex-support">(※2)</a> automation with a visual workflow editor</strong>
+  <strong>Accelerate Claude Code/GitHub Copilot<a href="#github-copilot-support">(※1)</a>/OpenAI Codex<a href="#openai-codex-support">(※2)</a>/Roo Code<a href="#roo-code-support">(※3)</a> automation with a visual workflow editor</strong>
 </p>
 
 <p align="center">
@@ -62,6 +62,7 @@
   - **GitHub Copilot Chat**<a href="#github-copilot-support">(※1)</a>: `.github/prompts/`
   - **GitHub Copilot CLI**<a href="#github-copilot-support">(※1)</a>: `.github/skills/`
   - **OpenAI Codex CLI**<a href="#openai-codex-support">(※2)</a>: `.codex/skills/`
+  - **Roo Code**<a href="#roo-code-support">(※3)</a>: `.roo/skills/`
 
 <span id="github-copilot-support">🤖</span> **GitHub Copilot Support (※1 β)** - Export & Run workflows to Copilot Chat or Copilot CLI, and use Copilot as AI provider for Edit with AI.
 
@@ -75,6 +76,13 @@
   **Note:**
   - Enable **Codex** option in Toolbar's **More** menu to activate
   - Requires [Codex CLI](https://github.com/openai/codex) to be installed
+  - Experimental feature; some workflows may not work as expected
+
+<span id="roo-code-support">🤖</span> **Roo Code Support (※3 β)** - Export & Run workflows to Roo Code (Skills format). Run launches Roo Code directly via Extension API.
+
+  **Note:**
+  - Enable **Roo Code** option in Toolbar's **More** menu to activate
+  - Requires [Roo Code](https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline) extension to be installed
   - Experimental feature; some workflows may not work as expected
 
 ## How to Use

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-wf-studio",
-  "displayName": "CC Workflow Studio - for Claude Code, Copilot, Codex",
-  "description": "Accelerate Claude Code, GitHub Copilot, Codex CLI automation with a visual workflow editor",
+  "displayName": "CC Workflow Studio - for Claude Code, Copilot, Codex, Roo Code",
+  "description": "Accelerate Claude Code, GitHub Copilot, Codex CLI, Roo Code automation with a visual workflow editor",
   "version": "3.19.2",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
@@ -17,7 +17,8 @@
     "claude-code",
     "cli",
     "codex",
-    "copilot"
+    "copilot",
+    "roo-code"
   ],
   "engines": {
     "vscode": "^1.80.0"

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -33,6 +33,7 @@ import {
   handleListMcpServers,
   handleRefreshMcpCache,
 } from './mcp-handlers';
+import { handleExportForRooCode, handleRunForRooCode } from './roo-code-handlers';
 import { saveWorkflow } from './save-workflow';
 import { handleBrowseSkills, handleCreateSkill, handleValidateSkillFile } from './skill-operations';
 import { handleConnectSlackManual } from './slack-connect-manual';
@@ -438,6 +439,45 @@ export function registerOpenEditorCommand(
               } else {
                 webview.postMessage({
                   type: 'RUN_FOR_CODEX_CLI_FAILED',
+                  requestId: message.requestId,
+                  payload: {
+                    errorCode: 'UNKNOWN_ERROR',
+                    errorMessage: 'Workflow is required',
+                    timestamp: new Date().toISOString(),
+                  },
+                });
+              }
+              break;
+
+            case 'EXPORT_FOR_ROO_CODE':
+              // Export workflow for Roo Code (Skills format)
+              if (message.payload?.workflow) {
+                await handleExportForRooCode(
+                  fileService,
+                  webview,
+                  message.payload,
+                  message.requestId
+                );
+              } else {
+                webview.postMessage({
+                  type: 'EXPORT_FOR_ROO_CODE_FAILED',
+                  requestId: message.requestId,
+                  payload: {
+                    errorCode: 'UNKNOWN_ERROR',
+                    errorMessage: 'Workflow is required',
+                    timestamp: new Date().toISOString(),
+                  },
+                });
+              }
+              break;
+
+            case 'RUN_FOR_ROO_CODE':
+              // Run workflow for Roo Code (via Extension API)
+              if (message.payload?.workflow) {
+                await handleRunForRooCode(fileService, webview, message.payload, message.requestId);
+              } else {
+                webview.postMessage({
+                  type: 'RUN_FOR_ROO_CODE_FAILED',
                   requestId: message.requestId,
                   payload: {
                     errorCode: 'UNKNOWN_ERROR',

--- a/src/extension/commands/roo-code-handlers.ts
+++ b/src/extension/commands/roo-code-handlers.ts
@@ -1,0 +1,265 @@
+/**
+ * Claude Code Workflow Studio - Roo Code Integration Handlers
+ *
+ * Handles Export/Run for Roo Code integration
+ *
+ * @beta This is a PoC feature for Roo Code integration
+ */
+
+import * as vscode from 'vscode';
+import type {
+  ExportForRooCodePayload,
+  ExportForRooCodeSuccessPayload,
+  RooCodeOperationFailedPayload,
+  RunForRooCodePayload,
+  RunForRooCodeSuccessPayload,
+} from '../../shared/types/messages';
+import { extractMcpServerIdsFromWorkflow } from '../services/copilot-export-service';
+import { nodeNameToFileName } from '../services/export-service';
+import type { FileService } from '../services/file-service';
+import { isRooCodeInstalled, startRooCodeTask } from '../services/roo-code-extension-service';
+import {
+  previewMcpSyncForRooCode,
+  syncMcpConfigForRooCode,
+} from '../services/roo-code-mcp-sync-service';
+import {
+  checkExistingRooCodeSkill,
+  exportWorkflowAsRooCodeSkill,
+} from '../services/roo-code-skill-export-service';
+import {
+  hasNonStandardSkills,
+  promptAndNormalizeSkills,
+} from '../services/skill-normalization-service';
+
+/**
+ * Handle Export for Roo Code request
+ *
+ * Exports workflow to Skills format (.roo/skills/name/SKILL.md)
+ *
+ * @param fileService - File service instance
+ * @param webview - Webview for sending responses
+ * @param payload - Export payload
+ * @param requestId - Optional request ID for response correlation
+ */
+export async function handleExportForRooCode(
+  fileService: FileService,
+  webview: vscode.Webview,
+  payload: ExportForRooCodePayload,
+  requestId?: string
+): Promise<void> {
+  try {
+    const { workflow } = payload;
+
+    // Check for existing skill and ask for confirmation
+    const existingSkillPath = await checkExistingRooCodeSkill(workflow, fileService);
+    if (existingSkillPath) {
+      const result = await vscode.window.showWarningMessage(
+        `Skill already exists: ${existingSkillPath}\n\nOverwrite?`,
+        { modal: true },
+        'Overwrite',
+        'Cancel'
+      );
+      if (result !== 'Overwrite') {
+        webview.postMessage({
+          type: 'EXPORT_FOR_ROO_CODE_CANCELLED',
+          requestId,
+        });
+        return;
+      }
+    }
+
+    // Export workflow as skill to .roo/skills/{name}/SKILL.md
+    const exportResult = await exportWorkflowAsRooCodeSkill(workflow, fileService);
+
+    if (!exportResult.success) {
+      const failedPayload: RooCodeOperationFailedPayload = {
+        errorCode: 'EXPORT_FAILED',
+        errorMessage: exportResult.errors?.join(', ') || 'Failed to export workflow as skill',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'EXPORT_FOR_ROO_CODE_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Send success response
+    const successPayload: ExportForRooCodeSuccessPayload = {
+      skillName: exportResult.skillName,
+      skillPath: exportResult.skillPath,
+      timestamp: new Date().toISOString(),
+    };
+
+    webview.postMessage({
+      type: 'EXPORT_FOR_ROO_CODE_SUCCESS',
+      requestId,
+      payload: successPayload,
+    });
+
+    vscode.window.showInformationMessage(
+      `Exported workflow as Roo Code skill: ${exportResult.skillPath}`
+    );
+  } catch (error) {
+    const failedPayload: RooCodeOperationFailedPayload = {
+      errorCode: 'UNKNOWN_ERROR',
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
+    webview.postMessage({
+      type: 'EXPORT_FOR_ROO_CODE_FAILED',
+      requestId,
+      payload: failedPayload,
+    });
+  }
+}
+
+/**
+ * Handle Run for Roo Code request
+ *
+ * Exports workflow to Skills format, syncs MCP config,
+ * and starts Roo Code with :skill command via Extension API
+ *
+ * @param fileService - File service instance
+ * @param webview - Webview for sending responses
+ * @param payload - Run payload
+ * @param requestId - Optional request ID for response correlation
+ */
+export async function handleRunForRooCode(
+  fileService: FileService,
+  webview: vscode.Webview,
+  payload: RunForRooCodePayload,
+  requestId?: string
+): Promise<void> {
+  try {
+    const { workflow } = payload;
+    const workspacePath = fileService.getWorkspacePath();
+
+    // Step 0.5: Normalize skills (copy non-standard skills to .claude/skills/)
+    if (hasNonStandardSkills(workflow, 'roo-code')) {
+      const normalizeResult = await promptAndNormalizeSkills(workflow, 'roo-code');
+
+      if (!normalizeResult.success) {
+        if (normalizeResult.cancelled) {
+          webview.postMessage({
+            type: 'RUN_FOR_ROO_CODE_CANCELLED',
+            requestId,
+          });
+          return;
+        }
+        throw new Error(normalizeResult.error || 'Failed to copy skills to .claude/skills/');
+      }
+
+      if (normalizeResult.normalizedSkills && normalizeResult.normalizedSkills.length > 0) {
+        console.log(
+          `[Roo Code] Copied ${normalizeResult.normalizedSkills.length} skill(s) to .claude/skills/`
+        );
+      }
+    }
+
+    // Step 1: Check if MCP servers need to be synced to .roo/mcp.json
+    const mcpServerIds = extractMcpServerIdsFromWorkflow(workflow);
+    let mcpSyncConfirmed = false;
+
+    if (mcpServerIds.length > 0) {
+      const mcpSyncPreview = await previewMcpSyncForRooCode(mcpServerIds, workspacePath);
+
+      if (mcpSyncPreview.serversToAdd.length > 0) {
+        const serverList = mcpSyncPreview.serversToAdd.map((s) => `  • ${s}`).join('\n');
+        const result = await vscode.window.showInformationMessage(
+          `The following MCP servers will be added to .roo/mcp.json for Roo Code:\n\n${serverList}\n\nProceed?`,
+          { modal: true },
+          'Yes',
+          'No'
+        );
+        mcpSyncConfirmed = result === 'Yes';
+      }
+    }
+
+    // Step 2: Check for existing skill and ask for confirmation
+    const existingSkillPath = await checkExistingRooCodeSkill(workflow, fileService);
+    if (existingSkillPath) {
+      const result = await vscode.window.showWarningMessage(
+        `Skill already exists: ${existingSkillPath}\n\nOverwrite?`,
+        { modal: true },
+        'Overwrite',
+        'Cancel'
+      );
+      if (result !== 'Overwrite') {
+        webview.postMessage({
+          type: 'RUN_FOR_ROO_CODE_CANCELLED',
+          requestId,
+        });
+        return;
+      }
+    }
+
+    // Step 3: Export workflow as skill to .roo/skills/{name}/SKILL.md
+    const exportResult = await exportWorkflowAsRooCodeSkill(workflow, fileService);
+
+    if (!exportResult.success) {
+      const failedPayload: RooCodeOperationFailedPayload = {
+        errorCode: 'EXPORT_FAILED',
+        errorMessage: exportResult.errors?.join(', ') || 'Failed to export workflow as skill',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'RUN_FOR_ROO_CODE_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Step 4: Sync MCP servers to .roo/mcp.json if confirmed
+    let syncedMcpServers: string[] = [];
+    if (mcpSyncConfirmed) {
+      syncedMcpServers = await syncMcpConfigForRooCode(mcpServerIds, workspacePath);
+    }
+
+    // Step 5: Start Roo Code with :skill command via Extension API
+    const skillName = nodeNameToFileName(workflow.name);
+    let rooCodeOpened = false;
+
+    if (isRooCodeInstalled()) {
+      rooCodeOpened = await startRooCodeTask(`:skill ${skillName}`);
+    }
+
+    // Send success response
+    const successPayload: RunForRooCodeSuccessPayload = {
+      workflowName: workflow.name,
+      rooCodeOpened,
+      timestamp: new Date().toISOString(),
+    };
+
+    webview.postMessage({
+      type: 'RUN_FOR_ROO_CODE_SUCCESS',
+      requestId,
+      payload: successPayload,
+    });
+
+    // Show notification
+    const configInfo =
+      syncedMcpServers.length > 0
+        ? ` (MCP servers: ${syncedMcpServers.join(', ')} added to .roo/mcp.json)`
+        : '';
+    const rooCodeInfo = rooCodeOpened
+      ? ''
+      : ' (Roo Code extension not found - skill exported only)';
+    vscode.window.showInformationMessage(
+      `Running workflow via Roo Code: ${workflow.name}${configInfo}${rooCodeInfo}`
+    );
+  } catch (error) {
+    const failedPayload: RooCodeOperationFailedPayload = {
+      errorCode: 'UNKNOWN_ERROR',
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
+    webview.postMessage({
+      type: 'RUN_FOR_ROO_CODE_FAILED',
+      requestId,
+      payload: failedPayload,
+    });
+  }
+}

--- a/src/extension/services/roo-code-extension-service.ts
+++ b/src/extension/services/roo-code-extension-service.ts
@@ -1,0 +1,49 @@
+/**
+ * Claude Code Workflow Studio - Roo Code Extension Service
+ *
+ * Wrapper for Roo Code VSCode Extension API.
+ * Uses the extension's exported API to start new tasks with :skill command.
+ *
+ * @beta This is a PoC feature for Roo Code integration
+ */
+
+import * as vscode from 'vscode';
+
+const ROO_CODE_EXTENSION_ID = 'RooVeterinaryInc.roo-cline';
+
+/**
+ * Check if Roo Code extension is installed
+ *
+ * @returns True if Roo Code extension is installed
+ */
+export function isRooCodeInstalled(): boolean {
+  return vscode.extensions.getExtension(ROO_CODE_EXTENSION_ID) !== undefined;
+}
+
+/**
+ * Start a new task in Roo Code
+ *
+ * Activates the Roo Code extension if needed and calls startNewTask API.
+ *
+ * @param message - Message to send (e.g., ":skill my-skill")
+ * @returns True if the task was started successfully
+ */
+export async function startRooCodeTask(message: string): Promise<boolean> {
+  const extension = vscode.extensions.getExtension(ROO_CODE_EXTENSION_ID);
+  if (!extension) {
+    return false;
+  }
+
+  if (!extension.isActive) {
+    await extension.activate();
+  }
+
+  const api = extension.exports;
+
+  if (api?.startNewTask) {
+    await api.startNewTask({ text: message });
+    return true;
+  }
+
+  return false;
+}

--- a/src/extension/services/roo-code-mcp-sync-service.ts
+++ b/src/extension/services/roo-code-mcp-sync-service.ts
@@ -1,0 +1,210 @@
+/**
+ * Claude Code Workflow Studio - Roo Code MCP Sync Service
+ *
+ * Handles MCP server configuration sync to {workspace}/.roo/mcp.json
+ * for Roo Code execution.
+ *
+ * Note: Roo Code uses JSON format for MCP configuration:
+ * - Config path: {workspace}/.roo/mcp.json
+ * - MCP servers section: mcpServers.{server_name}
+ *
+ * @beta This is a PoC feature for Roo Code integration
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { getMcpServerConfig } from './mcp-config-reader';
+
+/**
+ * Roo Code mcp.json structure
+ */
+interface RooCodeMcpConfig {
+  mcpServers?: Record<string, RooCodeMcpServerEntry>;
+}
+
+/**
+ * MCP server configuration entry for Roo Code
+ */
+interface RooCodeMcpServerEntry {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+}
+
+/**
+ * Preview result for MCP server sync
+ */
+export interface RooCodeMcpSyncPreviewResult {
+  /** Server IDs that would be added to .roo/mcp.json */
+  serversToAdd: string[];
+  /** Server IDs that already exist in .roo/mcp.json */
+  existingServers: string[];
+  /** Server IDs not found in any Claude Code config */
+  missingServers: string[];
+}
+
+/**
+ * Get the Roo Code MCP config file path
+ */
+function getRooCodeMcpConfigPath(workspacePath: string): string {
+  return path.join(workspacePath, '.roo', 'mcp.json');
+}
+
+/**
+ * Read existing Roo Code MCP config
+ */
+async function readRooCodeMcpConfig(workspacePath: string): Promise<RooCodeMcpConfig> {
+  const configPath = getRooCodeMcpConfigPath(workspacePath);
+
+  try {
+    const content = await fs.readFile(configPath, 'utf-8');
+    return JSON.parse(content) as RooCodeMcpConfig;
+  } catch {
+    // File doesn't exist or invalid JSON
+    return { mcpServers: {} };
+  }
+}
+
+/**
+ * Write Roo Code MCP config to file
+ *
+ * @param workspacePath - Workspace path
+ * @param config - Config to write
+ */
+async function writeRooCodeMcpConfig(
+  workspacePath: string,
+  config: RooCodeMcpConfig
+): Promise<void> {
+  const configPath = getRooCodeMcpConfigPath(workspacePath);
+  const configDir = path.dirname(configPath);
+
+  // Ensure .roo directory exists
+  await fs.mkdir(configDir, { recursive: true });
+
+  // Serialize config to JSON
+  const jsonContent = JSON.stringify(config, null, 2);
+  await fs.writeFile(configPath, jsonContent);
+}
+
+/**
+ * Preview which MCP servers would be synced to .roo/mcp.json
+ *
+ * This function checks without actually writing, allowing for confirmation dialogs.
+ *
+ * @param serverIds - Server IDs to sync
+ * @param workspacePath - Workspace path for resolving project-scoped configs
+ * @returns Preview of servers to add, existing, and missing
+ */
+export async function previewMcpSyncForRooCode(
+  serverIds: string[],
+  workspacePath: string
+): Promise<RooCodeMcpSyncPreviewResult> {
+  if (serverIds.length === 0) {
+    return { serversToAdd: [], existingServers: [], missingServers: [] };
+  }
+
+  const existingConfig = await readRooCodeMcpConfig(workspacePath);
+  const existingServersMap = existingConfig.mcpServers || {};
+
+  const serversToAdd: string[] = [];
+  const existingServers: string[] = [];
+  const missingServers: string[] = [];
+
+  for (const serverId of serverIds) {
+    if (existingServersMap[serverId]) {
+      existingServers.push(serverId);
+    } else {
+      // Check if server config exists in Claude Code
+      const serverConfig = getMcpServerConfig(serverId, workspacePath);
+      if (serverConfig) {
+        serversToAdd.push(serverId);
+      } else {
+        missingServers.push(serverId);
+      }
+    }
+  }
+
+  return { serversToAdd, existingServers, missingServers };
+}
+
+/**
+ * Sync MCP server configurations to .roo/mcp.json for Roo Code
+ *
+ * Reads MCP server configs from all Claude Code scopes (project, local, user)
+ * and writes them to .roo/mcp.json in JSON format.
+ * Only adds servers that don't already exist in the config file.
+ *
+ * JSON output format:
+ * ```json
+ * {
+ *   "mcpServers": {
+ *     "server-name": {
+ *       "command": "npx",
+ *       "args": ["-y", "@some/mcp-server"],
+ *       "env": { "API_KEY": "xxx" }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param serverIds - Server IDs to sync
+ * @param workspacePath - Workspace path for resolving project-scoped configs
+ * @returns Array of synced server IDs
+ */
+export async function syncMcpConfigForRooCode(
+  serverIds: string[],
+  workspacePath: string
+): Promise<string[]> {
+  if (serverIds.length === 0) {
+    return [];
+  }
+
+  // Read existing config
+  const config = await readRooCodeMcpConfig(workspacePath);
+
+  if (!config.mcpServers) {
+    config.mcpServers = {};
+  }
+
+  // Sync servers from all Claude Code scopes (project, local, user)
+  const syncedServers: string[] = [];
+  for (const serverId of serverIds) {
+    // Skip if already exists in config
+    if (config.mcpServers[serverId]) {
+      continue;
+    }
+
+    // Get server config from Claude Code (searches all scopes)
+    const serverConfig = getMcpServerConfig(serverId, workspacePath);
+    if (!serverConfig) {
+      continue;
+    }
+
+    // Convert to Roo Code format
+    const rooCodeEntry: RooCodeMcpServerEntry = {};
+
+    if (serverConfig.command) {
+      rooCodeEntry.command = serverConfig.command;
+    }
+    if (serverConfig.args && serverConfig.args.length > 0) {
+      rooCodeEntry.args = serverConfig.args;
+    }
+    if (serverConfig.env && Object.keys(serverConfig.env).length > 0) {
+      rooCodeEntry.env = serverConfig.env;
+    }
+    if (serverConfig.url) {
+      rooCodeEntry.url = serverConfig.url;
+    }
+
+    config.mcpServers[serverId] = rooCodeEntry;
+    syncedServers.push(serverId);
+  }
+
+  // Write updated config if any servers were added
+  if (syncedServers.length > 0) {
+    await writeRooCodeMcpConfig(workspacePath, config);
+  }
+
+  return syncedServers;
+}

--- a/src/extension/services/roo-code-skill-export-service.ts
+++ b/src/extension/services/roo-code-skill-export-service.ts
@@ -1,0 +1,131 @@
+/**
+ * Claude Code Workflow Studio - Roo Code Skill Export Service
+ *
+ * Handles workflow export to Roo Code Skills format (.roo/skills/name/SKILL.md)
+ * Skills format enables Roo Code to execute workflows using :skill command.
+ *
+ * @beta This is a PoC feature for Roo Code integration
+ */
+
+import * as path from 'node:path';
+import type { Workflow } from '../../shared/types/workflow-definition';
+import { nodeNameToFileName } from './export-service';
+import type { FileService } from './file-service';
+import {
+  generateExecutionInstructions,
+  generateMermaidFlowchart,
+} from './workflow-prompt-generator';
+
+/**
+ * Roo Code skill export result
+ */
+export interface RooCodeSkillExportResult {
+  success: boolean;
+  skillPath: string;
+  skillName: string;
+  errors?: string[];
+}
+
+/**
+ * Generate SKILL.md content from workflow for Roo Code
+ *
+ * @param workflow - Workflow to convert
+ * @returns SKILL.md content as string
+ */
+export function generateRooCodeSkillContent(workflow: Workflow): string {
+  const skillName = nodeNameToFileName(workflow.name);
+
+  const description =
+    workflow.metadata?.description ||
+    `Execute the "${workflow.name}" workflow. This skill guides through a structured workflow with defined steps and decision points.`;
+
+  // Generate YAML frontmatter (Agent Skills specification)
+  const frontmatter = `---
+name: ${skillName}
+description: ${description}
+---`;
+
+  // Generate Mermaid flowchart
+  const mermaidContent = generateMermaidFlowchart({
+    nodes: workflow.nodes,
+    connections: workflow.connections,
+  });
+
+  // Generate execution instructions
+  const instructions = generateExecutionInstructions(workflow);
+
+  // Compose SKILL.md body
+  const body = `# ${workflow.name}
+
+## Workflow Diagram
+
+${mermaidContent}
+
+## Execution Instructions
+
+${instructions}`;
+
+  return `${frontmatter}\n\n${body}`;
+}
+
+/**
+ * Check if Roo Code skill already exists
+ *
+ * @param workflow - Workflow to check
+ * @param fileService - File service instance
+ * @returns Path to existing skill file, or null if not exists
+ */
+export async function checkExistingRooCodeSkill(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<string | null> {
+  const workspacePath = fileService.getWorkspacePath();
+  const skillName = nodeNameToFileName(workflow.name);
+  const skillPath = path.join(workspacePath, '.roo', 'skills', skillName, 'SKILL.md');
+
+  if (await fileService.fileExists(skillPath)) {
+    return skillPath;
+  }
+  return null;
+}
+
+/**
+ * Export workflow as Roo Code Skill
+ *
+ * Exports to .roo/skills/{name}/SKILL.md
+ *
+ * @param workflow - Workflow to export
+ * @param fileService - File service instance
+ * @returns Export result
+ */
+export async function exportWorkflowAsRooCodeSkill(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<RooCodeSkillExportResult> {
+  try {
+    const workspacePath = fileService.getWorkspacePath();
+    const skillName = nodeNameToFileName(workflow.name);
+    const skillDir = path.join(workspacePath, '.roo', 'skills', skillName);
+    const skillPath = path.join(skillDir, 'SKILL.md');
+
+    // Ensure directory exists
+    await fileService.createDirectory(skillDir);
+
+    // Generate and write SKILL.md content
+    const content = generateRooCodeSkillContent(workflow);
+    await fileService.writeFile(skillPath, content);
+
+    return {
+      success: true,
+      skillPath,
+      skillName,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      skillPath: '',
+      skillName: '',
+      errors: [error instanceof Error ? error.message : 'Unknown error'],
+    };
+  }
+}

--- a/src/extension/services/skill-normalization-service.ts
+++ b/src/extension/services/skill-normalization-service.ts
@@ -31,13 +31,14 @@ const NON_STANDARD_SKILL_PATTERNS = [
   '.github/skills/', // GitHub Copilot CLI
   '.copilot/skills/', // GitHub Copilot CLI (alternative)
   '.codex/skills/', // OpenAI Codex CLI
+  '.roo/skills/', // Roo Code
   // Future: '.gemini/skills/', '.cursor/skills/', etc.
 ] as const;
 
 /**
  * Source type for skill directories
  */
-export type SkillSourceType = 'github' | 'copilot' | 'codex' | 'other';
+export type SkillSourceType = 'github' | 'copilot' | 'codex' | 'roo-code' | 'other';
 
 /**
  * Target CLI for workflow execution
@@ -47,7 +48,7 @@ export type SkillSourceType = 'github' | 'copilot' | 'codex' | 'other';
  * - 'copilot': .claude/skills/, .github/skills/, AND .copilot/skills/ are standard
  * - 'codex': .claude/skills/ AND .codex/skills/ are standard
  */
-export type TargetCli = 'claude' | 'copilot' | 'codex';
+export type TargetCli = 'claude' | 'copilot' | 'codex' | 'roo-code';
 
 /**
  * Get the list of skill directory patterns that are considered "standard" for a given CLI
@@ -67,6 +68,10 @@ function getStandardSkillPatterns(targetCli: TargetCli): string[] {
     case 'codex':
       // Codex CLI considers .codex/skills/ as native
       patterns.push('.codex/skills/');
+      break;
+    case 'roo-code':
+      // Roo Code considers .roo/skills/ as native
+      patterns.push('.roo/skills/');
       break;
     // case 'claude' falls through to default
     // Claude Code only uses .claude/skills/
@@ -190,6 +195,9 @@ function getSourceType(skillPath: string): SkillSourceType {
   if (normalizedPath.includes('.codex/skills/')) {
     return 'codex';
   }
+  if (normalizedPath.includes('.roo/skills/')) {
+    return 'roo-code';
+  }
   return 'other';
 }
 
@@ -216,6 +224,8 @@ function _getSourceSkillsDir(sourceType: SkillSourceType): string | null {
       return path.join(workspaceRoot, '.copilot', 'skills');
     case 'codex':
       return path.join(workspaceRoot, '.codex', 'skills');
+    case 'roo-code':
+      return path.join(workspaceRoot, '.roo', 'skills');
     default:
       return null;
   }
@@ -352,6 +362,9 @@ function getSourceDescription(skills: SkillToNormalize[]): string {
   }
   if (sources.has('codex')) {
     descriptions.push('.codex/skills/');
+  }
+  if (sources.has('roo-code')) {
+    descriptions.push('.roo/skills/');
   }
   if (sources.has('other')) {
     descriptions.push('non-standard directories');

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -788,7 +788,13 @@ export type ExtensionMessage =
   | Message<CodexOperationFailedPayload, 'EXPORT_FOR_CODEX_CLI_FAILED'>
   | Message<RunForCodexCliSuccessPayload, 'RUN_FOR_CODEX_CLI_SUCCESS'>
   | Message<void, 'RUN_FOR_CODEX_CLI_CANCELLED'>
-  | Message<CodexOperationFailedPayload, 'RUN_FOR_CODEX_CLI_FAILED'>;
+  | Message<CodexOperationFailedPayload, 'RUN_FOR_CODEX_CLI_FAILED'>
+  | Message<ExportForRooCodeSuccessPayload, 'EXPORT_FOR_ROO_CODE_SUCCESS'>
+  | Message<void, 'EXPORT_FOR_ROO_CODE_CANCELLED'>
+  | Message<RooCodeOperationFailedPayload, 'EXPORT_FOR_ROO_CODE_FAILED'>
+  | Message<RunForRooCodeSuccessPayload, 'RUN_FOR_ROO_CODE_SUCCESS'>
+  | Message<void, 'RUN_FOR_ROO_CODE_CANCELLED'>
+  | Message<RooCodeOperationFailedPayload, 'RUN_FOR_ROO_CODE_FAILED'>;
 
 // ============================================================================
 // AI Slack Description Generation Payloads
@@ -1341,6 +1347,64 @@ export interface CodexOperationFailedPayload {
 }
 
 // ============================================================================
+// Roo Code Integration Payloads (Beta)
+// ============================================================================
+
+/**
+ * Export workflow for Roo Code payload (Skills format)
+ * Exports to .roo/skills/{name}/SKILL.md
+ */
+export interface ExportForRooCodePayload {
+  /** Workflow to export */
+  workflow: Workflow;
+}
+
+/**
+ * Export for Roo Code success payload
+ */
+export interface ExportForRooCodeSuccessPayload {
+  /** Skill name */
+  skillName: string;
+  /** Skill file path */
+  skillPath: string;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+/**
+ * Run workflow for Roo Code payload
+ * Exports and runs via Roo Code Extension API
+ */
+export interface RunForRooCodePayload {
+  /** Workflow to run */
+  workflow: Workflow;
+}
+
+/**
+ * Run for Roo Code success payload
+ */
+export interface RunForRooCodeSuccessPayload {
+  /** Workflow name */
+  workflowName: string;
+  /** Whether Roo Code was opened */
+  rooCodeOpened: boolean;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+/**
+ * Roo Code operation failed payload
+ */
+export interface RooCodeOperationFailedPayload {
+  /** Error code */
+  errorCode: 'ROO_CODE_NOT_INSTALLED' | 'EXPORT_FAILED' | 'UNKNOWN_ERROR';
+  /** Error message */
+  errorMessage: string;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+// ============================================================================
 // Edit in VSCode Editor Payloads
 // ============================================================================
 
@@ -1449,7 +1513,9 @@ export type WebviewMessage =
   | Message<RunForCopilotCliPayload, 'RUN_FOR_COPILOT_CLI'>
   | Message<ExportForCopilotCliPayload, 'EXPORT_FOR_COPILOT_CLI'>
   | Message<ExportForCodexCliPayload, 'EXPORT_FOR_CODEX_CLI'>
-  | Message<RunForCodexCliPayload, 'RUN_FOR_CODEX_CLI'>;
+  | Message<RunForCodexCliPayload, 'RUN_FOR_CODEX_CLI'>
+  | Message<ExportForRooCodePayload, 'EXPORT_FOR_ROO_CODE'>
+  | Message<RunForRooCodePayload, 'RUN_FOR_ROO_CODE'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -37,6 +37,8 @@ interface MoreActionsDropdownProps {
   onToggleCopilotBeta: () => void;
   isCodexEnabled: boolean;
   onToggleCodexBeta: () => void;
+  isRooCodeEnabled: boolean;
+  onToggleRooCodeBeta: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -51,6 +53,8 @@ export function MoreActionsDropdown({
   onToggleCopilotBeta,
   isCodexEnabled,
   onToggleCodexBeta,
+  isRooCodeEnabled,
+  onToggleRooCodeBeta,
   open,
   onOpenChange,
 }: MoreActionsDropdownProps) {
@@ -198,6 +202,29 @@ export function MoreActionsDropdown({
               <BetaBadge style={{ marginLeft: '4px' }} />
             </span>
             {isCodexEnabled && <Check size={14} />}
+          </DropdownMenu.Item>
+
+          {/* Roo Code Beta Toggle */}
+          <DropdownMenu.Item
+            onSelect={onToggleRooCodeBeta}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <Bot size={14} />
+            <span style={{ flex: 1 }}>
+              Roo Code
+              <BetaBadge style={{ marginLeft: '4px' }} />
+            </span>
+            {isRooCodeEnabled && <Check size={14} />}
           </DropdownMenu.Item>
 
           <DropdownMenu.Separator

--- a/src/webview/src/stores/refinement-store.ts
+++ b/src/webview/src/stores/refinement-store.ts
@@ -28,6 +28,8 @@ const PROVIDER_STORAGE_KEY = 'cc-wf-studio.refinement.selectedProvider';
 const COPILOT_ENABLED_STORAGE_KEY = 'cc-wf-studio:copilot-beta-enabled';
 // Note: This key is shared with Toolbar.tsx for the "Codex (Beta)" toggle
 const CODEX_ENABLED_STORAGE_KEY = 'cc-wf-studio:codex-beta-enabled';
+// Note: This key is shared with Toolbar.tsx for the "Roo Code (Beta)" toggle
+const ROO_CODE_ENABLED_STORAGE_KEY = 'cc-wf-studio:roo-code-beta-enabled';
 
 // Available tools for Claude Code CLI (used in AI editing allowed tools)
 export const AVAILABLE_TOOLS = [
@@ -312,6 +314,29 @@ function saveCodexEnabledToStorage(enabled: boolean): void {
   }
 }
 
+/**
+ * Load Roo Code enabled state from localStorage
+ */
+function loadRooCodeEnabledFromStorage(): boolean {
+  try {
+    const saved = localStorage.getItem(ROO_CODE_ENABLED_STORAGE_KEY);
+    return saved === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Save Roo Code enabled state to localStorage
+ */
+function saveRooCodeEnabledToStorage(enabled: boolean): void {
+  try {
+    localStorage.setItem(ROO_CODE_ENABLED_STORAGE_KEY, String(enabled));
+  } catch {
+    // localStorage may not be available in some contexts
+  }
+}
+
 // ============================================================================
 // Session Status Type
 // ============================================================================
@@ -346,6 +371,7 @@ interface RefinementStore {
   selectedProvider: AiCliProvider;
   isCopilotEnabled: boolean;
   isCodexEnabled: boolean;
+  isRooCodeEnabled: boolean;
 
   // Dynamic Copilot Models State
   availableCopilotModels: CopilotModelInfo[];
@@ -376,6 +402,7 @@ interface RefinementStore {
   setSelectedProvider: (provider: AiCliProvider) => void;
   toggleCopilotEnabled: () => void;
   toggleCodexEnabled: () => void;
+  toggleRooCodeEnabled: () => void;
   fetchCopilotModels: () => Promise<void>;
   initConversation: () => void;
   loadConversationHistory: (history: ConversationHistory | undefined) => void;
@@ -471,6 +498,7 @@ export const useRefinementStore = create<RefinementStore>((set, get) => ({
   selectedProvider: loadProviderFromStorage(), // Load from localStorage, default: 'claude-code'
   isCopilotEnabled: loadCopilotEnabledFromStorage(), // Load from localStorage, default: false
   isCodexEnabled: loadCodexEnabledFromStorage(), // Load from localStorage, default: false
+  isRooCodeEnabled: loadRooCodeEnabledFromStorage(), // Load from localStorage, default: false
 
   // Dynamic Copilot Models Initial State
   availableCopilotModels: [],
@@ -579,6 +607,13 @@ export const useRefinementStore = create<RefinementStore>((set, get) => ({
     } else {
       set({ isCodexEnabled: newEnabled });
     }
+  },
+
+  toggleRooCodeEnabled: () => {
+    const currentEnabled = get().isRooCodeEnabled;
+    const newEnabled = !currentEnabled;
+    saveRooCodeEnabledToStorage(newEnabled);
+    set({ isRooCodeEnabled: newEnabled });
   },
 
   fetchCopilotModels: async () => {


### PR DESCRIPTION
## Summary

Add Roo Code VSCode extension integration for exporting and running workflows as Roo Code Skills.

Closes #531

## Motivation

Roo Code is a popular AI coding agent VSCode extension. Users requested integration (Issue #531) to export workflows to `.roo/skills/` format and run them directly via the Roo Code Extension API. This follows the same pattern as the existing Copilot and Codex CLI integrations.

## Changes

**New Files:**
- `src/extension/commands/roo-code-handlers.ts` - Export/Run handler functions
- `src/extension/services/roo-code-skill-export-service.ts` - Export to `.roo/skills/{name}/SKILL.md`
- `src/extension/services/roo-code-mcp-sync-service.ts` - MCP config sync to `.roo/mcp.json`
- `src/extension/services/roo-code-extension-service.ts` - Roo Code Extension API wrapper (`startNewTask`)

**Modified Files:**
- `src/shared/types/messages.ts` - Add Roo Code payload types and message types
- `src/webview/src/services/vscode-bridge.ts` - Add `exportForRooCode()` / `runForRooCode()` bridge functions
- `src/webview/src/stores/refinement-store.ts` - Add `isRooCodeEnabled` state with localStorage persistence
- `src/webview/src/components/toolbar/MoreActionsDropdown.tsx` - Add Roo Code toggle menu item
- `src/webview/src/components/Toolbar.tsx` - Add Export/Run buttons and handlers
- `src/extension/commands/open-editor.ts` - Add message dispatch for `EXPORT_FOR_ROO_CODE` / `RUN_FOR_ROO_CODE`
- `src/extension/services/skill-normalization-service.ts` - Add `'roo-code'` to `TargetCli` and `.roo/skills/` pattern
- `package.json` - Update displayName, description, keywords
- `README.md` - Add Roo Code support documentation

## Testing

- [x] `npm run format && npm run lint && npm run check` passed
- [x] `npm run build` passed
- [x] Manual E2E testing completed (Export & Run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)