### PR TITLE
improvement: add Roo Code skills detection and documentation

### DIFF
--- a/src/extension/services/skill-service.ts
+++ b/src/extension/services/skill-service.ts
@@ -18,6 +18,8 @@ import {
   getInstalledPluginsJsonPath,
   getKnownMarketplacesJsonPath,
   getProjectSkillsDir,
+  getRooProjectSkillsDir,
+  getRooUserSkillsDir,
   getUserSkillsDir,
   getWorkspaceRoot,
   toRelativePath,
@@ -42,7 +44,7 @@ import { parseSkillFrontmatter, type SkillMetadata } from './yaml-parser';
 export async function scanSkills(
   baseDir: string,
   scope: 'user' | 'project' | 'local',
-  source?: 'claude' | 'copilot' | 'codex'
+  source?: 'claude' | 'copilot' | 'codex' | 'roo'
 ): Promise<SkillReference[]> {
   const skills: SkillReference[] = [];
 
@@ -391,41 +393,53 @@ export async function scanAllSkills(): Promise<{
   const claudeUserDir = getUserSkillsDir();
   const copilotUserDir = getCopilotUserSkillsDir();
   const codexUserDir = getCodexUserSkillsDir();
+  const rooUserDir = getRooUserSkillsDir();
 
   // Project directories
   const claudeProjectDir = getProjectSkillsDir();
   const githubProjectDir = getGithubSkillsDir();
   const codexProjectDir = getCodexProjectSkillsDir();
+  const rooProjectDir = getRooProjectSkillsDir();
 
   const [
     claudeUserSkills,
     copilotUserSkills,
     codexUserSkills,
+    rooUserSkills,
     claudeProjectSkills,
     githubProjectSkills,
     codexProjectSkills,
+    rooProjectSkills,
     pluginSkills,
   ] = await Promise.all([
     // User-scope scans
     scanSkills(claudeUserDir, 'user', 'claude'),
     scanSkills(copilotUserDir, 'user', 'copilot'),
     scanSkills(codexUserDir, 'user', 'codex'),
+    scanSkills(rooUserDir, 'user', 'roo'),
     // Project-scope scans
     claudeProjectDir ? scanSkills(claudeProjectDir, 'project', 'claude') : Promise.resolve([]),
     githubProjectDir ? scanSkills(githubProjectDir, 'project', 'copilot') : Promise.resolve([]),
     codexProjectDir ? scanSkills(codexProjectDir, 'project', 'codex') : Promise.resolve([]),
+    rooProjectDir ? scanSkills(rooProjectDir, 'project', 'roo') : Promise.resolve([]),
     // Plugin skills
     scanPluginSkills(),
   ]);
 
   // Merge user skills: include all sources (no deduplication - show all available skills)
-  const user: SkillReference[] = [...claudeUserSkills, ...copilotUserSkills, ...codexUserSkills];
+  const user: SkillReference[] = [
+    ...claudeUserSkills,
+    ...copilotUserSkills,
+    ...codexUserSkills,
+    ...rooUserSkills,
+  ];
 
   // Merge project skills: include all sources (no deduplication - show all available skills)
   const project: SkillReference[] = [
     ...claudeProjectSkills,
     ...githubProjectSkills,
     ...codexProjectSkills,
+    ...rooProjectSkills,
   ];
 
   // Separate plugin skills by their scope

--- a/src/extension/utils/path-utils.ts
+++ b/src/extension/utils/path-utils.ts
@@ -121,6 +121,36 @@ export function getCodexProjectSkillsDir(): string | null {
   return path.join(workspaceRoot, '.codex', 'skills');
 }
 
+/**
+ * Get the Roo Code user-scope Skills directory path
+ *
+ * @returns Absolute path to ~/.roo/skills/
+ *
+ * @example
+ * // Unix: /Users/username/.roo/skills
+ * // Windows: C:\Users\username\.roo\skills
+ */
+export function getRooUserSkillsDir(): string {
+  return path.join(os.homedir(), '.roo', 'skills');
+}
+
+/**
+ * Get the Roo Code project-scope Skills directory path
+ *
+ * @returns Absolute path to .roo/skills/ in workspace root, or null if no workspace
+ *
+ * @example
+ * // Unix: /workspace/myproject/.roo/skills
+ * // Windows: C:\workspace\myproject\.roo\skills
+ */
+export function getRooProjectSkillsDir(): string | null {
+  const workspaceRoot = getWorkspaceRoot();
+  if (!workspaceRoot) {
+    return null;
+  }
+  return path.join(workspaceRoot, '.roo', 'skills');
+}
+
 // =====================================================================
 // MCP Configuration Paths
 // =====================================================================

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -187,9 +187,10 @@ export interface SkillReference {
    * - 'claude': from ~/.claude/skills/ (user) or .claude/skills/ (project)
    * - 'copilot': from ~/.copilot/skills/ (user) or .github/skills/ (project)
    * - 'codex': from ~/.codex/skills/ (user) or .codex/skills/ (project)
+   * - 'roo': from ~/.roo/skills/ (user) or .roo/skills/ (project)
    * - undefined: for local scope or legacy data
    */
-  source?: 'claude' | 'copilot' | 'codex';
+  source?: 'claude' | 'copilot' | 'codex' | 'roo';
 }
 
 export interface CreateSkillPayload {

--- a/src/webview/src/components/common/AIProviderBadge.tsx
+++ b/src/webview/src/components/common/AIProviderBadge.tsx
@@ -13,7 +13,7 @@ import { useVSCodeTheme } from '../../hooks/useVSCodeTheme';
  * Supported AI provider types
  * Add new providers here as needed
  */
-export type AIProviderType = 'copilot' | 'claude' | 'codex';
+export type AIProviderType = 'copilot' | 'claude' | 'codex' | 'roo';
 
 /**
  * Configuration for each AI provider
@@ -23,6 +23,7 @@ const PROVIDER_CONFIG: Record<
   {
     label: string;
     colors: { dark: string; light: string };
+    textColors?: { dark: string; light: string };
   }
 > = {
   copilot: {
@@ -44,6 +45,17 @@ const PROVIDER_CONFIG: Record<
     colors: {
       light: '#10A37F', // Bright green
       dark: '#0D8A6A', // Dark green
+    },
+  },
+  roo: {
+    label: 'Roo Code',
+    colors: {
+      light: '#FFFFFF', // White background (light theme)
+      dark: '#1E1E1E', // Black background (dark theme)
+    },
+    textColors: {
+      light: '#1E1E1E', // Black text (light theme)
+      dark: '#FFFFFF', // White text (dark theme)
     },
   },
 };
@@ -107,8 +119,13 @@ export function AIProviderBadge({
       className={className}
       style={{
         ...sizeStyle,
-        color: '#ffffff',
+        color: config.textColors
+          ? isLightTheme
+            ? config.textColors.light
+            : config.textColors.dark
+          : '#ffffff',
         backgroundColor: isLightTheme ? config.colors.light : config.colors.dark,
+        border: config.textColors ? '1px solid var(--vscode-panel-border)' : 'none',
         borderRadius: '3px',
         display: 'inline-block',
         fontWeight: 600,

--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -17,7 +17,7 @@ import { useWorkflowStore } from '../../stores/workflow-store';
 import { AIProviderBadge, type AIProviderType } from '../common/AIProviderBadge';
 import { type CreateSkillFormData, SkillCreationDialog } from './SkillCreationDialog';
 
-type SourceType = 'claude' | 'copilot' | 'codex';
+type SourceType = 'claude' | 'copilot' | 'codex' | 'roo';
 
 interface GroupedSkills {
   source: SourceType;
@@ -25,11 +25,11 @@ interface GroupedSkills {
 }
 
 /**
- * Groups skills by their source (claude/copilot/codex).
+ * Groups skills by their source (claude/copilot/codex/roo).
  * Skills without a source are treated as 'claude' for backward compatibility.
  */
 function groupSkillsBySource(skills: SkillReference[]): GroupedSkills[] {
-  const sourceOrder: SourceType[] = ['claude', 'copilot', 'codex'];
+  const sourceOrder: SourceType[] = ['claude', 'copilot', 'codex', 'roo'];
   const groups = new Map<SourceType, SkillReference[]>();
 
   // Initialize all groups


### PR DESCRIPTION
## Summary

Add Roo Code (`.roo/skills/`) as a skill detection source in the Skill Browser, alongside existing Claude Code, Copilot, and Codex sources. Also adds comprehensive Roo Code configuration reference to the docs.

## What Changed

### Before
- Skill Browser only detected skills from `.claude/skills/`, `.github/skills/`, `.codex/skills/` (and their user-level equivalents)
- Roo Code skills were not discoverable in the workflow studio
- `ai-coding-tools-config-reference.md` did not include Roo Code

### After
- Skill Browser detects skills from `.roo/skills/` (project) and `~/.roo/skills/` (user)
- Roo Code skills appear with a dedicated black/white brand badge
- `ai-coding-tools-config-reference.md` includes full Roo Code section (Rules, Skills, Commands, Modes, MCP, Ignore, System Prompt Override)

## Changes

- `src/shared/types/messages.ts` - Added `'roo'` to `SkillReference.source` union type
- `src/extension/utils/path-utils.ts` - Added `getRooUserSkillsDir()` and `getRooProjectSkillsDir()`
- `src/extension/services/skill-service.ts` - Added Roo Code directories to `scanAllSkills()` parallel scan
- `src/webview/src/components/common/AIProviderBadge.tsx` - Added `'roo'` provider with black/white brand colors and `textColors` support
- `src/webview/src/components/dialogs/SkillBrowserDialog.tsx` - Added `'roo'` to `SourceType` and `groupSkillsBySource`
- `docs/ai-coding-tools-config-reference.md` - Added full Roo Code configuration reference section

## Testing

- [x] Manual E2E testing completed
- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)