### PR TITLE
improvement: simplify Skill node description in exported MD files

### DIFF
--- a/src/extension/services/workflow-prompt-generator.ts
+++ b/src/extension/services/workflow-prompt-generator.ts
@@ -441,40 +441,16 @@ export function generateExecutionInstructions(
     for (const node of skillNodes) {
       const nodeId = sanitizeNodeId(node.id);
       const executionMode = node.data.executionMode || 'execute';
+      const skillName = node.data.name;
 
-      sections.push(`#### ${nodeId}(${node.data.name})`);
+      sections.push(`#### ${nodeId}(${skillName})`);
       sections.push('');
-      sections.push(`**Description**: ${node.data.description}`);
-      sections.push('');
-      sections.push(`**Scope**: ${node.data.scope}`);
-      sections.push('');
-      sections.push(`**Validation Status**: ${node.data.validationStatus}`);
-      sections.push('');
-      if (node.data.allowedTools) {
-        sections.push(`**Allowed Tools**: ${node.data.allowedTools}`);
-        sections.push('');
-      }
-      sections.push(`**Skill Path**: \`${node.data.skillPath}\``);
-      sections.push('');
-      sections.push(`**Execution Mode**: ${executionMode}`);
-      sections.push('');
-
       if (executionMode === 'load') {
-        sections.push(
-          'Load the Skill knowledge from the SKILL.md file at the path shown above. Read and internalize the content as context for subsequent steps, but do NOT execute the Skill itself.'
-        );
+        sections.push(`- **Prompt**: skill "${skillName}" load-skill-knowledge-into-context-only`);
+      } else if (node.data.executionPrompt) {
+        sections.push(`- **Prompt**: skill "${skillName}" "${node.data.executionPrompt}"`);
       } else {
-        sections.push(
-          'This node executes a Claude Code Skill. The Skill definition is stored in the SKILL.md file at the path shown above.'
-        );
-        if (node.data.executionPrompt) {
-          sections.push('');
-          sections.push('**Execution Instructions**:');
-          sections.push('');
-          sections.push('```');
-          sections.push(node.data.executionPrompt);
-          sections.push('```');
-        }
+        sections.push(`- **Prompt**: skill "${skillName}"`);
       }
       sections.push('');
     }


### PR DESCRIPTION
## Summary

Simplify Skill node output in exported MD files to prevent AI coding agents from misinterpreting verbose descriptions.

## What Changed

Skill node descriptions in exported slash command / skill MD files were too verbose, causing some AI agents to read the MD file content instead of executing the Skill properly.

### Before
- Exported Skill nodes included 7+ lines of metadata (Description, Scope, ValidationStatus, SkillPath, ExecutionMode, etc.)
- Verbose execution instructions confused AI agents into "reading and interpreting" instead of "executing as Skill"

### After
- Concise single-line prompt format: `skill "name"`, `skill "name" "prompt"`, or `skill "name" load-skill-knowledge-into-context-only`
- Clear, actionable instructions that AI agents can follow without ambiguity

## Changes

- `src/extension/services/workflow-prompt-generator.ts` - Simplified Skill node section in `generateExecutionInstructions()` from ~30 lines to ~6 lines per node

## Testing

- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)
- [x] Manual E2E testing pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)