### PR TITLE
chore: add .mcp.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ npm-debug.log*
 # Claude Code settings (contains private configuration)
 .claude/
 .vscode/workflows/
+.mcp.json
 
 # Temporary files
 *.tmp


### PR DESCRIPTION
## Summary

- Add `.mcp.json` to `.gitignore` to prevent committing local MCP configuration

## Notes

- `.mcp.json` contains project-local MCP server settings that are user-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)