### PR TITLE
fix: upgrade axios and qs for security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2261,13 +2261,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -8266,9 +8266,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Problem

The project has two high-priority security vulnerabilities in transitive dependencies:
- **CVE-2026-25639**: Prototype Pollution in axios@1.13.2
- **CVE-2026-2391**: Allocation of Resources Without Limits in qs@6.14.1

These vulnerabilities were detected by GitHub Code Scanning (alerts #10 and #11).

### Current Behavior
1. Security scanning identifies 2 unresolved vulnerabilities
2. ❌ axios is vulnerable to prototype pollution attacks via mergeConfig
3. ❌ qs is vulnerable to arrayLimit bypass attacks via comma parsing

### Expected Behavior
1. Security scanning passes
2. ✅ axios upgraded to patched version (1.13.5+)
3. ✅ qs upgraded to patched version (6.15.0+)

## Solution

Upgraded both packages to secure versions via `npm audit fix`:
- axios: 1.13.2 → 1.13.5
- qs: 6.14.1 → 6.15.0
- Updated transitive dependencies: follow-redirects, form-data

## Impact

- Resolves security scanning alerts #10 and #11
- No breaking changes
- No API changes
- Build and tests pass successfully

## Testing

- [x] Code quality checks (format, lint, check) passed
- [x] Build completed successfully
- [x] Webview and extension compile without errors
- [x] No functional changes - dependency upgrade only

## Notes

- CVE-2026-25639 affects axios mergeConfig function when __proto__ properties are supplied
- CVE-2026-2391 affects qs when comma option is enabled in parsing
- Both vulnerabilities have been patched in the upgraded versions
- Remaining npm audit vulnerabilities (diff/mocha) are in devDependencies only

🤖 Generated with [Claude Code](https://claude.com/claude-code)