### PR TITLE
chore: upgrade ajv dependency for ReDoS vulnerability patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
## Security Fix

Upgrades ajv to resolve **CVE-2025-69873** - Regular Expression Denial of Service (ReDoS) vulnerability.

### Problem

The project uses ajv@8.17.1 which is vulnerable to ReDoS attacks when the `$data` option is enabled. An attacker can cause excessive CPU consumption and make the Node.js process unresponsive by submitting specially crafted regular expressions.

### Solution

- Upgraded ajv from 8.17.1 to 8.18.0
- Maintains ajv as an implicit dependency via @modelcontextprotocol/sdk
- No breaking changes or API modifications

### Impact

- Resolves GitHub Code Scanning alert #9
- Security vulnerability eliminated
- No functional changes

### Testing

- [x] Code quality checks passed
- [x] Build completed successfully
- [x] No functional changes - dependency upgrade only

## Additional Context

This is part of the security vulnerability remediation effort:
- Alert #10: axios Prototype Pollution (CVE-2026-25639) - ✅ Fixed in PR #566
- Alert #9: ajv ReDoS (CVE-2025-69873) - ⏳ This PR
- Alert #11: qs arrayLimit bypass (CVE-2026-2391) - ✅ Fixed in PR #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)