### PR TITLE
fix: clarify connection constraints for parallel execution

### DIFF
--- a/resources/workflow-schema-basic.json
+++ b/resources/workflow-schema-basic.json
@@ -475,10 +475,10 @@
         "Start node cannot have input connections",
         "End node cannot have output connections",
         "No cycles allowed",
-        "No self-connections",
-        "One connection per output port"
+        "No self-connections"
       ],
       "required": [
+        "At least one connection per output port",
         "Exactly one Start node per workflow",
         "At least one End node per workflow",
         "All non-Start nodes must have input connection",
@@ -617,12 +617,12 @@
         "rules": [
           {
             "id": "START_OUTPUT",
-            "rule": "Every Start node's 'output' port MUST have exactly one outgoing connection",
+            "rule": "Every Start node's 'output' port MUST have at least one outgoing connection",
             "aiGuidance": "When generating/adding a Start node, immediately create a connection from its 'output' port to the next node"
           },
           {
             "id": "NON_END_OUTPUT",
-            "rule": "Every non-End node's output port(s) MUST have exactly one outgoing connection per port",
+            "rule": "Every non-End node's output port(s) MUST have at least one outgoing connection per port",
             "example": "IfElse node with branch-0 and branch-1 requires both branches to be connected"
           },
           {

--- a/resources/workflow-schema-basic.toon
+++ b/resources/workflow-schema-basic.toon
@@ -321,8 +321,8 @@ connections:
   description: "Comprehensive specification for workflow connections. Defines connection object structure, port naming conventions, and completeness rules for AI-generated workflows."
   overview:
     description: High-level connection constraints that apply to all workflows
-    forbidden[5]: Start node cannot have input connections,End node cannot have output connections,No cycles allowed,No self-connections,One connection per output port
-    required[4]: Exactly one Start node per workflow,At least one End node per workflow,All non-Start nodes must have input connection,All non-End nodes must have output connection
+    forbidden[4]: Start node cannot have input connections,End node cannot have output connections,No cycles allowed,No self-connections
+    required[5]: At least one connection per output port,Exactly one Start node per workflow,At least one End node per workflow,All non-Start nodes must have input connection,All non-End nodes must have output connection
   format:
     description: Connection object structure in connections array
     objectStructure:
@@ -421,10 +421,10 @@ connections:
       description: Guidelines for AI-generated and AI-refined workflows. The AI system should ensure these rules are satisfied when generating/refining workflows. These guarantee that generated workflows are complete and ready to export.
       rules[10]:
         - id: START_OUTPUT
-          rule: Every Start node's 'output' port MUST have exactly one outgoing connection
+          rule: Every Start node's 'output' port MUST have at least one outgoing connection
           aiGuidance: "When generating/adding a Start node, immediately create a connection from its 'output' port to the next node"
         - id: NON_END_OUTPUT
-          rule: Every non-End node's output port(s) MUST have exactly one outgoing connection per port
+          rule: Every non-End node's output port(s) MUST have at least one outgoing connection per port
           example: IfElse node with branch-0 and branch-1 requires both branches to be connected
         - id: NON_START_INPUT
           rule: Every non-Start node's 'input' port MUST have exactly one incoming connection

--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -469,10 +469,10 @@
         "Start node cannot have input connections",
         "End node cannot have output connections",
         "No cycles allowed",
-        "No self-connections",
-        "One connection per output port"
+        "No self-connections"
       ],
       "required": [
+        "At least one connection per output port",
         "Exactly one Start node per workflow",
         "At least one End node per workflow",
         "All non-Start nodes must have input connection",
@@ -599,12 +599,12 @@
         "rules": [
           {
             "id": "START_OUTPUT",
-            "rule": "Every Start node's 'output' port MUST have exactly one outgoing connection",
+            "rule": "Every Start node's 'output' port MUST have at least one outgoing connection",
             "aiGuidance": "When generating/adding a Start node, immediately create a connection from its 'output' port to the next node"
           },
           {
             "id": "NON_END_OUTPUT",
-            "rule": "Every non-End node's output port(s) MUST have exactly one outgoing connection per port",
+            "rule": "Every non-End node's output port(s) MUST have at least one outgoing connection per port",
             "example": "IfElse node with branch-0 and branch-1 requires both branches to be connected"
           },
           {

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -433,8 +433,8 @@ connections:
   description: "Comprehensive specification for workflow connections. Defines connection object structure, port naming conventions, and completeness rules for AI-generated workflows."
   overview:
     description: High-level connection constraints that apply to all workflows
-    forbidden[5]: Start node cannot have input connections,End node cannot have output connections,No cycles allowed,No self-connections,One connection per output port
-    required[4]: Exactly one Start node per workflow,At least one End node per workflow,All non-Start nodes must have input connection,All non-End nodes must have output connection
+    forbidden[4]: Start node cannot have input connections,End node cannot have output connections,No cycles allowed,No self-connections
+    required[5]: At least one connection per output port,Exactly one Start node per workflow,At least one End node per workflow,All non-Start nodes must have input connection,All non-End nodes must have output connection
   format:
     description: Connection object structure in connections array
     objectStructure:
@@ -533,10 +533,10 @@ connections:
       description: Guidelines for AI-generated and AI-refined workflows. The AI system should ensure these rules are satisfied when generating/refining workflows. These guarantee that generated workflows are complete and ready to export.
       rules[10]:
         - id: START_OUTPUT
-          rule: Every Start node's 'output' port MUST have exactly one outgoing connection
+          rule: Every Start node's 'output' port MUST have at least one outgoing connection
           aiGuidance: "When generating/adding a Start node, immediately create a connection from its 'output' port to the next node"
         - id: NON_END_OUTPUT
-          rule: Every non-End node's output port(s) MUST have exactly one outgoing connection per port
+          rule: Every non-End node's output port(s) MUST have at least one outgoing connection per port
           example: IfElse node with branch-0 and branch-1 requires both branches to be connected
         - id: NON_START_INPUT
           rule: Every non-Start node's 'input' port MUST have exactly one incoming connection


### PR DESCRIPTION
## Problem

The workflow schema documentation contained contradictory rules that could mislead users (including AI agents) about parallel execution capabilities.

### Current Behavior
1. Schema `aiGenerationRules` stated: "Every Start node's 'output' port MUST have **exactly one** outgoing connection"
2. Schema `aiGenerationRules` stated: "Every non-End node's output port(s) MUST have **exactly one** outgoing connection per port"
3. Schema listed "One connection per output port" as a forbidden constraint
4. ❌ Result: Users believed parallel execution was not allowed, even though the validation rules actually permitted it

### Expected Behavior
1. Schema should clarify that Start nodes can have **at least one** outgoing connection
2. Schema should clarify that non-End nodes can have **at least one** outgoing connection per port
3. Documentation should reflect that parallel execution (multiple connections from a single port) is supported
4. ✅ AI agents and users can confidently create workflows with parallel execution paths

## Solution

Updated schema documentation to accurately reflect actual workflow validation behavior and enable parallel execution support.

### Changes

**Files Modified**: 
- `resources/workflow-schema.json`
- `resources/workflow-schema-basic.json`
- `resources/workflow-schema.toon` (auto-generated)
- `resources/workflow-schema-basic.toon` (auto-generated)

**Schema Updates**:
1. Changed START_OUTPUT rule: "exactly one" → "**at least one** outgoing connection"
2. Changed NON_END_OUTPUT rule: "exactly one" → "**at least one** outgoing connection per port"
3. Moved "One connection per output port" from `forbidden` to `required` section as "At least one connection per output port"
4. Aligns documentation with actual `exportValidationRules` that only require connectivity, not single connections

## Impact

- Enables clear guidance for AI-generated workflows to support parallel execution
- Aligns schema documentation with actual validation behavior
- Users can now confidently create workflows with multiple downstream connections
- Conditional nodes (ifElse, switch) continue to work correctly with multiple branches

## Testing

- [x] Format check: `npm run format` ✅
- [x] Lint check: `npm run lint` ✅
- [x] Full check: `npm run check` ✅
- [x] Build verification: `npm run build` ✅
- [x] Schema generation verified (TOON schemas updated correctly)

## Related Issues

Addresses #564 - Clarify 'completenessRules.aiGenerationRules' for parallel execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)