### PR TITLE
improvement: remove redundant validate_workflow MCP tool

### DIFF
--- a/resources/ai-editing-skill-template.md
+++ b/resources/ai-editing-skill-template.md
@@ -1,11 +1,10 @@
 ---
 name: cc-workflow-ai-editor
-description: AI workflow editor for CC Workflow Studio. Create and edit visual AI agent workflows through interactive conversation using MCP tools (get_workflow_schema, get_current_workflow, apply_workflow, validate_workflow). Use when the user wants to create a new workflow, modify an existing workflow, or edit the workflow canvas in CC Workflow Studio via the built-in MCP server.
+description: AI workflow editor for CC Workflow Studio. Create and edit visual AI agent workflows through interactive conversation using MCP tools (get_workflow_schema, get_current_workflow, apply_workflow). Use when the user wants to create a new workflow, modify an existing workflow, or edit the workflow canvas in CC Workflow Studio via the built-in MCP server.
 ---
 
 1. Call `get_workflow_schema` via `cc-workflow-studio` MCP server
 2. Call `get_current_workflow` via `cc-workflow-studio` MCP server
 3. Ask the user what to create or modify
-4. Generate workflow JSON, call `validate_workflow` via `cc-workflow-studio` MCP server, fix errors if any
-5. Call `apply_workflow` via `cc-workflow-studio` MCP server
-6. Ask for feedback, repeat from step 4
+4. Generate workflow JSON, call `apply_workflow` via `cc-workflow-studio` MCP server, fix errors if any
+5. Ask for feedback, repeat from step 4

--- a/src/extension/services/mcp-server-tools.ts
+++ b/src/extension/services/mcp-server-tools.ts
@@ -8,7 +8,6 @@
  * - get_current_workflow: Get the currently active workflow from the canvas
  * - get_workflow_schema: Get the workflow JSON schema for generating valid workflows
  * - apply_workflow: Apply a workflow to the canvas (validates first)
- * - validate_workflow: Validate a workflow JSON without applying
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -217,74 +216,6 @@ export function registerMcpTools(server: McpServer, manager: McpServerManager): 
               text: JSON.stringify({
                 success: false,
                 error: error instanceof Error ? error.message : String(error),
-              }),
-            },
-          ],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Tool 4: validate_workflow
-  server.tool(
-    'validate_workflow',
-    'Validate a workflow JSON without applying it to the canvas. Returns validation results with any errors found.',
-    {
-      workflow: z.string().describe('The workflow JSON string to validate'),
-    },
-    async ({ workflow: workflowJson }) => {
-      try {
-        // Parse JSON
-        let parsedWorkflow: unknown;
-        try {
-          parsedWorkflow = JSON.parse(workflowJson);
-        } catch {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({
-                  valid: false,
-                  errors: [
-                    {
-                      code: 'PARSE_ERROR',
-                      message: 'Invalid JSON: Failed to parse workflow string',
-                    },
-                  ],
-                }),
-              },
-            ],
-          };
-        }
-
-        // Validate
-        const validation = validateAIGeneratedWorkflow(parsedWorkflow);
-
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                valid: validation.valid,
-                errors: validation.errors,
-              }),
-            },
-          ],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                valid: false,
-                errors: [
-                  {
-                    code: 'UNKNOWN_ERROR',
-                    message: error instanceof Error ? error.message : String(error),
-                  },
-                ],
               }),
             },
           ],


### PR DESCRIPTION
## Summary

Remove the redundant `validate_workflow` MCP tool and simplify the AI editing flow from 6 steps to 5.

Closes #571

## What Changed

The `validate_workflow` MCP tool performed the exact same validation that `apply_workflow` already runs internally (both call `validateAIGeneratedWorkflow`). This caused AI agents to make an unnecessary extra tool call on every edit cycle.

### Before
- AI editing flow: 6 steps with separate `validate_workflow` → `apply_workflow` calls
- 4 MCP tools exposed: `get_workflow_schema`, `get_current_workflow`, `apply_workflow`, `validate_workflow`

### After
- AI editing flow: 5 steps with `apply_workflow` handling validation internally
- 3 MCP tools exposed: `get_workflow_schema`, `get_current_workflow`, `apply_workflow`
- Reduced token consumption and latency per edit cycle

## Changes

- `src/extension/services/mcp-server-tools.ts` - Removed `validate_workflow` tool definition (68 lines)
- `resources/ai-editing-skill-template.md` - Simplified steps 4-6 to 4-5, removed `validate_workflow` from description

## Testing

- [x] `npm run format && npm run lint && npm run check && npm run build` passes
- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)