### PR TITLE
fix: support HTTP transport for MCP tool nodes

### DIFF
--- a/src/extension/services/mcp-config-reader.ts
+++ b/src/extension/services/mcp-config-reader.ts
@@ -126,12 +126,12 @@ function normalizeServerConfig(config: Partial<McpServerConfig>): McpServerConfi
     } as McpServerConfig;
   }
 
-  // Rule 2: If url exists, cannot infer (http or sse?)
+  // Rule 2: If url exists, assume http transport (same as Gemini config handling)
   if (config.url) {
-    log('WARN', 'Cannot infer MCP server type from url field', {
-      url: config.url,
-    });
-    return null;
+    return {
+      ...config,
+      type: 'http',
+    } as McpServerConfig;
   }
 
   // No type and no command/url - invalid configuration

--- a/src/shared/types/mcp-node.ts
+++ b/src/shared/types/mcp-node.ts
@@ -29,6 +29,8 @@ export interface McpServerReference {
   args: string[];
   /** MCP transport type */
   type: 'stdio' | 'sse' | 'http';
+  /** URL for HTTP/SSE transport (optional, not used for stdio) */
+  url?: string;
   /** Environment variables (optional) */
   environment?: Record<string, string>;
   /** Source provider (defaults to 'claude' if undefined for backwards compatibility) */


### PR DESCRIPTION
## Problem

MCP Tool nodes with HTTP transport type servers (e.g., `cc-workflow-studio` built-in MCP server) had two issues:

1. **Incorrect status display**: Showed "disconnected" even when actually connected
2. **Tool fetch error**: "MCP server uses unsupported transport type: http" when selecting "Choose tools manually"

### Current Behavior
1. Open MCP node dialog and select an HTTP transport server
2. ❌ Server shows "disconnected" status despite being connected
3. ❌ Selecting "Choose tools manually" fails with unsupported transport error

### Expected Behavior
1. Open MCP node dialog and select an HTTP transport server
2. ✅ Server shows correct connection status
3. ✅ Tool list is fetched and displayed via HTTP transport

## Solution

Added HTTP transport support using MCP SDK's `StreamableHTTPClientTransport`, and fixed server metadata merging to preserve accurate type/url from config files.

### Changes

**File**: `src/shared/types/mcp-node.ts`
- Added `url?: string` field to `McpServerReference` for HTTP/SSE transport

**File**: `src/extension/services/mcp-config-reader.ts`
- Updated `normalizeServerConfig()` to infer `type: 'http'` when only `url` is present (previously returned `null`)

**File**: `src/extension/services/mcp-sdk-client.ts`
- Added `connectToMcpServerHttp()` using `StreamableHTTPClientTransport`
- Added `listToolsFromMcpServerHttp()` for HTTP-based tool listing

**File**: `src/extension/services/mcp-cli-service.ts`
- Added `Url` key parsing in `parseMcpGetOutput()`
- Relaxed command/args validation for non-stdio transports
- Added HTTP routing in `listTools()` and `getToolSchema()` with SSE deprecation message

**File**: `src/extension/commands/mcp-handlers.ts`
- Built config server lookup map to supplement CLI results with accurate `type`/`url`
- Added `url` field to `convertToServerReference()`

## Impact

- HTTP transport MCP servers now show correct status and support tool listing
- SSE transport returns a clear deprecation message instead of crashing
- stdio transport behavior is unchanged (no regression)

## Testing

- [x] Manual E2E testing completed
  - [x] stdio servers: no regression in status display and tool listing
  - [x] HTTP servers: correct status, tool listing, and parameter configuration
  - [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)