### PR TITLE
improvement: add Roo Code MCP server detection for tool nodes

### DIFF
--- a/src/extension/utils/path-utils.ts
+++ b/src/extension/utils/path-utils.ts
@@ -262,6 +262,23 @@ export function getGeminiProjectMcpConfigPath(): string | null {
 }
 
 /**
+ * Get the Roo Code project-scope MCP config path (.roo/mcp.json)
+ *
+ * @returns Absolute path to project MCP config, or null if no workspace
+ *
+ * @example
+ * // Unix: /workspace/myproject/.roo/mcp.json
+ * // Windows: C:\workspace\myproject\.roo\mcp.json
+ */
+export function getRooProjectMcpConfigPath(): string | null {
+  const workspaceRoot = getWorkspaceRoot();
+  if (!workspaceRoot) {
+    return null;
+  }
+  return path.join(workspaceRoot, '.roo', 'mcp.json');
+}
+
+/**
  * Get the installed plugins JSON path
  *
  * @returns Absolute path to ~/.claude/plugins/installed_plugins.json

--- a/src/shared/types/mcp-node.ts
+++ b/src/shared/types/mcp-node.ts
@@ -9,7 +9,7 @@
 /**
  * MCP configuration source provider
  */
-export type McpConfigSource = 'claude' | 'copilot' | 'codex' | 'gemini';
+export type McpConfigSource = 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo';
 
 /**
  * MCP server reference information (from 'claude mcp list')

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -309,8 +309,8 @@ export interface SubAgentFlowNodeData {
 export interface McpNodeData {
   /** MCP server identifier (from 'claude mcp list') */
   serverId: string;
-  /** Source provider of the MCP server (claude, copilot, codex, gemini) */
-  source?: 'claude' | 'copilot' | 'codex' | 'gemini';
+  /** Source provider of the MCP server (claude, copilot, codex, gemini, roo) */
+  source?: 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo';
   /** Tool function name from the MCP server (optional for aiToolSelection mode) */
   toolName?: string;
   /** Human-readable description of the tool's functionality (optional for aiToolSelection mode) */

--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -15,7 +15,7 @@ import { listMcpServers, refreshMcpCache } from '../../services/mcp-service';
 import { AIProviderBadge, type AIProviderType } from '../common/AIProviderBadge';
 import { IndeterminateProgressBar } from '../common/IndeterminateProgressBar';
 
-type SourceType = 'claude' | 'copilot' | 'codex' | 'gemini';
+type SourceType = 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo';
 
 interface GroupedServers {
   source: SourceType;
@@ -27,7 +27,7 @@ interface GroupedServers {
  * Servers without a source are treated as 'claude' for backward compatibility.
  */
 function groupServersBySource(servers: McpServerReference[]): GroupedServers[] {
-  const sourceOrder: SourceType[] = ['claude', 'copilot', 'codex', 'gemini'];
+  const sourceOrder: SourceType[] = ['claude', 'copilot', 'codex', 'roo', 'gemini'];
   const groups = new Map<SourceType, McpServerReference[]>();
 
   // Initialize all groups


### PR DESCRIPTION
## Summary

Add Roo Code as a supported MCP configuration source for MCP Tool nodes, enabling detection of MCP servers configured in `.roo/mcp.json`.

## What Changed

### Before
- MCP Tool node detection supported 4 sources: Claude Code, Copilot, Codex, Gemini
- Roo Code's `.roo/mcp.json` was not read for MCP server discovery
- `streamable-http` transport type (used by Roo Code) was not recognized

### After
- MCP Tool node detection supports 5 sources: Claude Code, Copilot, Codex, Roo Code, Gemini
- `.roo/mcp.json` is read at Priority 11 (lowest, since Roo configs are often synced from other sources)
- `streamable-http` transport type is normalized to `http` for compatibility
- Roo Code servers appear in the MCP server list UI between Codex and Gemini

## Changes

- `src/shared/types/mcp-node.ts` - Added `'roo'` to `McpConfigSource` type
- `src/shared/types/workflow-definition.ts` - Added `'roo'` to `McpNodeData.source` type
- `src/extension/utils/path-utils.ts` - Added `getRooProjectMcpConfigPath()` for `.roo/mcp.json`
- `src/extension/services/mcp-config-reader.ts` - Added `readRooMcpConfig()`, integrated Roo Code into all reader functions, normalized `streamable-http` to `http`
- `src/webview/src/components/mcp/McpServerList.tsx` - Added `'roo'` to `SourceType` and display order

## Testing

- [x] Manual E2E testing completed
- [x] `npm run format && npm run lint && npm run check && npm run build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)