### PR TITLE
chore: improve SEO for displayName, description, and keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-wf-studio",
-  "displayName": "CC Workflow Studio",
-  "description": "Visual Workflow Editor — Claude Code, Codex CLI, Copilot, Roo Code, and Gemini CLI",
+  "displayName": "Claude Code Workflow Studio",
+  "description": "Visual Workflow Editor for Claude Code, GitHub Copilot, Codex CLI, Roo Code, and Gemini CLI",
   "version": "3.22.2",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
@@ -14,12 +14,10 @@
   "keywords": [
     "ai",
     "claude",
-    "claude-code",
-    "cli",
     "codex",
     "copilot",
-    "roo-code",
-    "gemini-cli"
+    "roo",
+    "gemini"
   ],
   "engines": {
     "vscode": "^1.80.0"


### PR DESCRIPTION
## Summary
- Update `displayName` from "CC Workflow Studio" to "Claude Code Workflow Studio" for better VS Code Marketplace discoverability
- Reword `description` for improved readability and SEO
- Simplify `keywords` by removing redundant entries (`cli`, `claude-code`) and shortening others (`roo-code` → `roo`, `gemini-cli` → `gemini`)

## Test plan
- [x] `npm run build` passes successfully
- [x] Verify extension metadata displays correctly in VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)