### PR TITLE
feat: move reviewBeforeApply setting to UI toggle in McpServerSection

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -13,6 +13,7 @@ import type {
   LaunchAiAgentPayload,
   McpConfigTarget,
   RunAiEditingSkillPayload,
+  SetReviewBeforeApplyPayload,
   StartMcpServerPayload,
   WebviewMessage,
 } from '../../shared/types/messages';
@@ -1148,7 +1149,12 @@ export function registerOpenEditorCommand(
               if (!startManager) {
                 webview.postMessage({
                   type: 'MCP_SERVER_STATUS',
-                  payload: { running: false, port: null, configsWritten: [] },
+                  payload: {
+                    running: false,
+                    port: null,
+                    configsWritten: [],
+                    reviewBeforeApply: true,
+                  },
                 });
                 break;
               }
@@ -1182,6 +1188,7 @@ export function registerOpenEditorCommand(
                     running: true,
                     port,
                     configsWritten,
+                    reviewBeforeApply: startManager.getReviewBeforeApply(),
                   },
                 });
 
@@ -1197,6 +1204,7 @@ export function registerOpenEditorCommand(
                     running: false,
                     port: null,
                     configsWritten: [],
+                    reviewBeforeApply: startManager.getReviewBeforeApply(),
                   },
                 });
               }
@@ -1209,7 +1217,12 @@ export function registerOpenEditorCommand(
               if (!stopManager) {
                 webview.postMessage({
                   type: 'MCP_SERVER_STATUS',
-                  payload: { running: false, port: null, configsWritten: [] },
+                  payload: {
+                    running: false,
+                    port: null,
+                    configsWritten: [],
+                    reviewBeforeApply: true,
+                  },
                 });
                 break;
               }
@@ -1230,6 +1243,7 @@ export function registerOpenEditorCommand(
                     running: false,
                     port: null,
                     configsWritten: [],
+                    reviewBeforeApply: stopManager.getReviewBeforeApply(),
                   },
                 });
 
@@ -1240,7 +1254,12 @@ export function registerOpenEditorCommand(
                 });
                 webview.postMessage({
                   type: 'MCP_SERVER_STATUS',
-                  payload: { running: false, port: null, configsWritten: [] },
+                  payload: {
+                    running: false,
+                    port: null,
+                    configsWritten: [],
+                    reviewBeforeApply: stopManager.getReviewBeforeApply(),
+                  },
                 });
               }
               break;
@@ -1253,8 +1272,24 @@ export function registerOpenEditorCommand(
               const statusPort = running ? (statusManager?.getPort() ?? null) : null;
               webview.postMessage({
                 type: 'MCP_SERVER_STATUS',
-                payload: { running, port: statusPort, configsWritten: [] },
+                payload: {
+                  running,
+                  port: statusPort,
+                  configsWritten: [],
+                  reviewBeforeApply: statusManager?.getReviewBeforeApply() ?? true,
+                },
               });
+              break;
+            }
+
+            case 'SET_REVIEW_BEFORE_APPLY': {
+              const reviewPayload = message.payload as SetReviewBeforeApplyPayload | undefined;
+              if (reviewPayload != null) {
+                const reviewManager = getMcpServerManager();
+                if (reviewManager) {
+                  reviewManager.setReviewBeforeApply(reviewPayload.value);
+                }
+              }
               break;
             }
 
@@ -1337,6 +1372,7 @@ export function registerOpenEditorCommand(
                     running: true,
                     port: serverPort,
                     configsWritten: [...launchManager.getWrittenConfigs()],
+                    reviewBeforeApply: launchManager.getReviewBeforeApply(),
                   },
                 });
 

--- a/src/extension/services/mcp-server-tools.ts
+++ b/src/extension/services/mcp-server-tools.ts
@@ -138,11 +138,17 @@ export function registerMcpTools(server: McpServer, manager: McpServerManager): 
   // Tool 3: apply_workflow
   server.tool(
     'apply_workflow',
-    'Apply a workflow to the CC Workflow Studio canvas. The workflow is validated before being applied. The editor must be open.',
+    'Apply a workflow to the CC Workflow Studio canvas. The workflow is validated before being applied. If the user has review mode enabled, they will see a diff preview and must accept changes before they are applied. If rejected, an error with message "User rejected the changes" is returned. The editor must be open.',
     {
       workflow: z.string().describe('The workflow JSON string to apply to the canvas'),
+      description: z
+        .string()
+        .optional()
+        .describe(
+          'A brief description of the changes being made (e.g., "Added error handling step after API call"). Shown to the user in the review dialog.'
+        ),
     },
-    async ({ workflow: workflowJson }) => {
+    async ({ workflow: workflowJson, description }) => {
       try {
         // Parse JSON
         let parsedWorkflow: unknown;
@@ -183,7 +189,8 @@ export function registerMcpTools(server: McpServer, manager: McpServerManager): 
 
         // Apply to canvas
         const applied = await manager.applyWorkflowToCanvas(
-          parsedWorkflow as import('../../shared/types/workflow-definition').Workflow
+          parsedWorkflow as import('../../shared/types/workflow-definition').Workflow,
+          description
         );
 
         return {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1581,6 +1581,15 @@ export interface McpServerStatusPayload {
   port: number | null;
   /** Config files that were written to */
   configsWritten: McpConfigTarget[];
+  /** Whether to show diff preview before applying AI changes */
+  reviewBeforeApply: boolean;
+}
+
+/**
+ * Set review before apply setting payload (Webview → Extension)
+ */
+export interface SetReviewBeforeApplyPayload {
+  value: boolean;
 }
 
 /**
@@ -1609,6 +1618,10 @@ export interface ApplyWorkflowFromMcpPayload {
   correlationId: string;
   /** Workflow to apply */
   workflow: Workflow;
+  /** Whether to show diff preview dialog before applying */
+  requireConfirmation: boolean;
+  /** AI agent's description of the changes (optional) */
+  description?: string;
 }
 
 /**
@@ -1743,7 +1756,8 @@ export type WebviewMessage =
   | Message<void, 'STOP_MCP_SERVER'>
   | Message<void, 'GET_MCP_SERVER_STATUS'>
   | Message<RunAiEditingSkillPayload, 'RUN_AI_EDITING_SKILL'>
-  | Message<LaunchAiAgentPayload, 'LAUNCH_AI_AGENT'>;
+  | Message<LaunchAiAgentPayload, 'LAUNCH_AI_AGENT'>
+  | Message<SetReviewBeforeApplyPayload, 'SET_REVIEW_BEFORE_APPLY'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/components/chat/McpServerSection.tsx
+++ b/src/webview/src/components/chat/McpServerSection.tsx
@@ -12,7 +12,7 @@
  */
 
 import type { AiEditingProvider, McpServerStatusPayload } from '@shared/types/messages';
-import { ChevronDown, ChevronRight, ExternalLink, Play, Plug, Square } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, ExternalLink, Play, Plug, Square } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 import { vscode } from '../../main';
@@ -43,6 +43,7 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
   const [isRunning, setIsRunning] = useState(false);
   const [port, setPort] = useState<number | null>(null);
   const [launchingProvider, setLaunchingProvider] = useState<AiEditingProvider | null>(null);
+  const [reviewBeforeApply, setReviewBeforeApply] = useState(true);
 
   const { isCopilotEnabled, isCodexEnabled, isRooCodeEnabled, isGeminiEnabled } =
     useRefinementStore();
@@ -75,6 +76,7 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
         const payload = message.payload as McpServerStatusPayload;
         setIsRunning(payload.running);
         setPort(payload.port);
+        setReviewBeforeApply(payload.reviewBeforeApply);
       }
     };
 
@@ -103,6 +105,11 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
 
   const handleStop = useCallback(() => {
     vscode.postMessage({ type: 'STOP_MCP_SERVER' });
+  }, []);
+
+  const handleReviewBeforeApplyChange = useCallback((checked: boolean) => {
+    setReviewBeforeApply(checked);
+    vscode.postMessage({ type: 'SET_REVIEW_BEFORE_APPLY', payload: { value: checked } });
   }, []);
 
   const ChevronIcon = isCollapsed ? ChevronRight : ChevronDown;
@@ -199,6 +206,42 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
             <br />
             {t('mcpSection.description.line2')}
           </p>
+
+          {/* Review Before Apply Toggle */}
+          <button
+            type="button"
+            onClick={() => handleReviewBeforeApplyChange(!reviewBeforeApply)}
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              marginBottom: '8px',
+              fontSize: '11px',
+              color: reviewBeforeApply
+                ? 'var(--vscode-foreground)'
+                : 'var(--vscode-disabledForeground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+              backgroundColor: 'transparent',
+              border: 'none',
+            }}
+          >
+            <div
+              style={{
+                width: '14px',
+                height: '14px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              {reviewBeforeApply && <Check size={14} />}
+            </div>
+            <span>{t('mcpSection.reviewBeforeApply')}</span>
+          </button>
 
           {/* AI Agent Buttons */}
           <div

--- a/src/webview/src/components/dialogs/DiffPreviewDialog.tsx
+++ b/src/webview/src/components/dialogs/DiffPreviewDialog.tsx
@@ -1,0 +1,285 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import type React from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
+import type { WorkflowDiffSummary } from '../../utils/workflow-diff';
+
+interface DiffPreviewDialogProps {
+  isOpen: boolean;
+  diffSummary: WorkflowDiffSummary | null;
+  description?: string;
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+export const DiffPreviewDialog: React.FC<DiffPreviewDialogProps> = ({
+  isOpen,
+  diffSummary,
+  description,
+  onAccept,
+  onReject,
+}) => {
+  const { t } = useTranslation();
+
+  if (!diffSummary) return null;
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onReject()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 10001,
+          }}
+        >
+          <Dialog.Content
+            style={{
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '24px',
+              minWidth: '440px',
+              maxWidth: '600px',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
+            }}
+            onEscapeKeyDown={onReject}
+          >
+            <Dialog.Title
+              style={{
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '12px',
+              }}
+            >
+              {t('dialog.diffPreview.title')}
+            </Dialog.Title>
+
+            <Dialog.Description
+              style={{
+                fontSize: '13px',
+                color: 'var(--vscode-descriptionForeground)',
+                marginBottom: description ? '12px' : '16px',
+                lineHeight: '1.5',
+              }}
+            >
+              {diffSummary.isNewWorkflow
+                ? t('dialog.diffPreview.newWorkflow')
+                : t('dialog.diffPreview.description')}
+            </Dialog.Description>
+
+            {/* Agent description */}
+            {description && (
+              <div
+                style={{
+                  marginBottom: '16px',
+                  padding: '8px 12px',
+                  borderLeft: '3px solid var(--vscode-textLink-foreground, #3794ff)',
+                  backgroundColor:
+                    'var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.1))',
+                  borderRadius: '0 2px 2px 0',
+                  fontSize: '13px',
+                  lineHeight: '1.5',
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {description}
+              </div>
+            )}
+
+            {/* Diff details */}
+            <div
+              style={{
+                fontSize: '13px',
+                lineHeight: '1.6',
+                color: 'var(--vscode-foreground)',
+                maxHeight: '300px',
+                overflowY: 'auto',
+                marginBottom: '20px',
+              }}
+            >
+              {/* No changes */}
+              {diffSummary.totalChanges === 0 && (
+                <div
+                  style={{
+                    color: 'var(--vscode-descriptionForeground)',
+                    fontStyle: 'italic',
+                  }}
+                >
+                  {t('dialog.diffPreview.noChanges')}
+                </div>
+              )}
+
+              {/* Name change */}
+              {diffSummary.nameChange && (
+                <div style={{ marginBottom: '12px' }}>
+                  <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                    {t('dialog.diffPreview.nameChange')}
+                  </span>{' '}
+                  <span style={{ textDecoration: 'line-through', opacity: 0.6 }}>
+                    {diffSummary.nameChange.from}
+                  </span>
+                  {' → '}
+                  <span style={{ fontWeight: 500 }}>{diffSummary.nameChange.to}</span>
+                </div>
+              )}
+
+              {/* Nodes section */}
+              {(diffSummary.addedNodes.length > 0 ||
+                diffSummary.removedNodes.length > 0 ||
+                diffSummary.modifiedNodes.length > 0) && (
+                <div style={{ marginBottom: '12px' }}>
+                  <div
+                    style={{
+                      fontWeight: 500,
+                      marginBottom: '4px',
+                      color: 'var(--vscode-descriptionForeground)',
+                    }}
+                  >
+                    {t('dialog.diffPreview.nodes')}:
+                  </div>
+                  {diffSummary.addedNodes.map((node) => (
+                    <div key={`add-${node.id}`} style={{ paddingLeft: '8px' }}>
+                      <span
+                        style={{
+                          color: 'var(--vscode-gitDecoration-addedResourceForeground, #73c991)',
+                        }}
+                      >
+                        + {node.name}
+                      </span>
+                      <span
+                        style={{ color: 'var(--vscode-descriptionForeground)', marginLeft: '4px' }}
+                      >
+                        ({node.type})
+                      </span>
+                    </div>
+                  ))}
+                  {diffSummary.removedNodes.map((node) => (
+                    <div key={`rm-${node.id}`} style={{ paddingLeft: '8px' }}>
+                      <span
+                        style={{
+                          color: 'var(--vscode-gitDecoration-deletedResourceForeground, #e06c75)',
+                        }}
+                      >
+                        - {node.name}
+                      </span>
+                      <span
+                        style={{ color: 'var(--vscode-descriptionForeground)', marginLeft: '4px' }}
+                      >
+                        ({node.type})
+                      </span>
+                    </div>
+                  ))}
+                  {diffSummary.modifiedNodes.map((node) => (
+                    <div key={`mod-${node.id}`} style={{ paddingLeft: '8px' }}>
+                      <span
+                        style={{
+                          color: 'var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)',
+                        }}
+                      >
+                        ~ {node.name}
+                      </span>
+                      <span
+                        style={{ color: 'var(--vscode-descriptionForeground)', marginLeft: '4px' }}
+                      >
+                        ({node.type})
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Connections section */}
+              {(diffSummary.addedConnections > 0 || diffSummary.removedConnections > 0) && (
+                <div>
+                  <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                    {t('dialog.diffPreview.connections')}:
+                  </span>{' '}
+                  {diffSummary.addedConnections > 0 && (
+                    <span
+                      style={{
+                        color: 'var(--vscode-gitDecoration-addedResourceForeground, #73c991)',
+                      }}
+                    >
+                      +{diffSummary.addedConnections} {t('dialog.diffPreview.connectionsAdded')}
+                    </span>
+                  )}
+                  {diffSummary.addedConnections > 0 && diffSummary.removedConnections > 0 && ', '}
+                  {diffSummary.removedConnections > 0 && (
+                    <span
+                      style={{
+                        color: 'var(--vscode-gitDecoration-deletedResourceForeground, #e06c75)',
+                      }}
+                    >
+                      -{diffSummary.removedConnections} {t('dialog.diffPreview.connectionsRemoved')}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Buttons */}
+            <div
+              style={{
+                display: 'flex',
+                gap: '8px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <button
+                type="button"
+                onClick={onReject}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryHoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    'var(--vscode-button-secondaryBackground)';
+                }}
+              >
+                {t('dialog.diffPreview.reject')}
+              </button>
+              <button
+                type="button"
+                onClick={onAccept}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+                  border: 'none',
+                  borderRadius: '2px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+                }}
+              >
+                {t('dialog.diffPreview.accept')}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -368,6 +368,20 @@ export interface WebviewTranslationKeys {
   'dialog.loadWorkflow.confirm': string;
   'dialog.loadWorkflow.cancel': string;
 
+  // Diff Preview Dialog (MCP apply_workflow)
+  'dialog.diffPreview.title': string;
+  'dialog.diffPreview.description': string;
+  'dialog.diffPreview.newWorkflow': string;
+  'dialog.diffPreview.nameChange': string;
+  'dialog.diffPreview.nodes': string;
+  'dialog.diffPreview.connections': string;
+  'dialog.diffPreview.connectionsAdded': string;
+  'dialog.diffPreview.connectionsRemoved': string;
+  'dialog.diffPreview.noChanges': string;
+  'dialog.diffPreview.agentDescription': string;
+  'dialog.diffPreview.accept': string;
+  'dialog.diffPreview.reject': string;
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': string;
   'toolbar.focusMode': string;
@@ -839,6 +853,7 @@ export interface WebviewTranslationKeys {
   // MCP Server Section
   'mcpSection.description.line1': string;
   'mcpSection.description.line2': string;
+  'mcpSection.reviewBeforeApply': string;
 
   // Description Panel (Canvas)
   'description.panel.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -405,6 +405,21 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'dialog.loadWorkflow.confirm': 'Discard & Load',
   'dialog.loadWorkflow.cancel': 'Cancel',
 
+  // Diff Preview Dialog (MCP apply_workflow)
+  'dialog.diffPreview.title': 'Review Workflow Changes',
+  'dialog.diffPreview.description':
+    'An AI agent is proposing the following changes to the workflow:',
+  'dialog.diffPreview.newWorkflow': 'An AI agent is creating a new workflow:',
+  'dialog.diffPreview.nameChange': 'Name:',
+  'dialog.diffPreview.nodes': 'Nodes',
+  'dialog.diffPreview.connections': 'Connections',
+  'dialog.diffPreview.connectionsAdded': 'added',
+  'dialog.diffPreview.connectionsRemoved': 'removed',
+  'dialog.diffPreview.noChanges': 'No changes detected.',
+  'dialog.diffPreview.agentDescription': 'Agent description',
+  'dialog.diffPreview.accept': 'Accept',
+  'dialog.diffPreview.reject': 'Reject',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'Reset Workflow',
   'toolbar.focusMode': 'Focus Mode',
@@ -930,6 +945,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // MCP Server Section
   'mcpSection.description.line1': 'Edit workflows interactively with AI.',
   'mcpSection.description.line2': 'Select an agent to get started.',
+  'mcpSection.reviewBeforeApply': 'Review changes before applying',
 
   // Description Panel (Canvas)
   'description.panel.title': 'Description',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -404,6 +404,21 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'dialog.loadWorkflow.confirm': '破棄して読み込む',
   'dialog.loadWorkflow.cancel': 'キャンセル',
 
+  // Diff Preview Dialog (MCP apply_workflow)
+  'dialog.diffPreview.title': 'ワークフロー変更の確認',
+  'dialog.diffPreview.description':
+    'AIエージェントがワークフローに以下の変更を適用しようとしています:',
+  'dialog.diffPreview.newWorkflow': 'AIエージェントが新しいワークフローを作成しようとしています:',
+  'dialog.diffPreview.nameChange': '名前:',
+  'dialog.diffPreview.nodes': 'ノード',
+  'dialog.diffPreview.connections': '接続',
+  'dialog.diffPreview.connectionsAdded': '追加',
+  'dialog.diffPreview.connectionsRemoved': '削除',
+  'dialog.diffPreview.noChanges': '変更はありません。',
+  'dialog.diffPreview.agentDescription': 'エージェントの説明',
+  'dialog.diffPreview.accept': '適用',
+  'dialog.diffPreview.reject': '却下',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'ワークフローをリセット',
   'toolbar.focusMode': '集中モード',
@@ -922,6 +937,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // MCP Server Section
   'mcpSection.description.line1': 'AIとの対話形式でワークフロー編集します。',
   'mcpSection.description.line2': '使用するエージェントを選択してください。',
+  'mcpSection.reviewBeforeApply': '適用前に変更を確認する',
 
   // Description Panel (Canvas)
   'description.panel.title': '説明',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -404,6 +404,20 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'dialog.loadWorkflow.confirm': '삭제 후 로드',
   'dialog.loadWorkflow.cancel': '취소',
 
+  // Diff Preview Dialog (MCP apply_workflow)
+  'dialog.diffPreview.title': '워크플로우 변경 검토',
+  'dialog.diffPreview.description': 'AI 에이전트가 워크플로우에 다음 변경을 적용하려고 합니다:',
+  'dialog.diffPreview.newWorkflow': 'AI 에이전트가 새 워크플로우를 생성하려고 합니다:',
+  'dialog.diffPreview.nameChange': '이름:',
+  'dialog.diffPreview.nodes': '노드',
+  'dialog.diffPreview.connections': '연결',
+  'dialog.diffPreview.connectionsAdded': '추가',
+  'dialog.diffPreview.connectionsRemoved': '삭제',
+  'dialog.diffPreview.noChanges': '변경 사항이 없습니다.',
+  'dialog.diffPreview.agentDescription': '에이전트 설명',
+  'dialog.diffPreview.accept': '적용',
+  'dialog.diffPreview.reject': '거부',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '워크플로우 초기화',
   'toolbar.focusMode': '집중 모드',
@@ -919,6 +933,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // MCP Server Section
   'mcpSection.description.line1': 'AI와 대화 형식으로 워크플로우를 편집합니다.',
   'mcpSection.description.line2': '사용할 에이전트를 선택하세요.',
+  'mcpSection.reviewBeforeApply': '적용 전 변경사항 확인',
 
   // Description Panel (Canvas)
   'description.panel.title': '설명',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -389,6 +389,20 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'dialog.loadWorkflow.confirm': '放弃并加载',
   'dialog.loadWorkflow.cancel': '取消',
 
+  // Diff Preview Dialog (MCP apply_workflow)
+  'dialog.diffPreview.title': '审核工作流变更',
+  'dialog.diffPreview.description': 'AI 代理正在尝试对工作流进行以下更改:',
+  'dialog.diffPreview.newWorkflow': 'AI 代理正在创建新的工作流:',
+  'dialog.diffPreview.nameChange': '名称:',
+  'dialog.diffPreview.nodes': '节点',
+  'dialog.diffPreview.connections': '连接',
+  'dialog.diffPreview.connectionsAdded': '添加',
+  'dialog.diffPreview.connectionsRemoved': '删除',
+  'dialog.diffPreview.noChanges': '未检测到更改。',
+  'dialog.diffPreview.agentDescription': '代理说明',
+  'dialog.diffPreview.accept': '接受',
+  'dialog.diffPreview.reject': '拒绝',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重置工作流',
   'toolbar.focusMode': '专注模式',
@@ -886,6 +900,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // MCP Server Section
   'mcpSection.description.line1': '通过与AI对话的方式编辑工作流。',
   'mcpSection.description.line2': '请选择要使用的代理。',
+  'mcpSection.reviewBeforeApply': '应用前确认更改',
 
   // Description Panel (Canvas)
   'description.panel.title': '描述',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -389,6 +389,20 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'dialog.loadWorkflow.confirm': '捨棄並載入',
   'dialog.loadWorkflow.cancel': '取消',
 
+  // Diff Preview Dialog (MCP apply_workflow)
+  'dialog.diffPreview.title': '審核工作流程變更',
+  'dialog.diffPreview.description': 'AI 代理正在嘗試對工作流程進行以下更改:',
+  'dialog.diffPreview.newWorkflow': 'AI 代理正在建立新的工作流程:',
+  'dialog.diffPreview.nameChange': '名稱:',
+  'dialog.diffPreview.nodes': '節點',
+  'dialog.diffPreview.connections': '連接',
+  'dialog.diffPreview.connectionsAdded': '新增',
+  'dialog.diffPreview.connectionsRemoved': '移除',
+  'dialog.diffPreview.noChanges': '未偵測到變更。',
+  'dialog.diffPreview.agentDescription': '代理說明',
+  'dialog.diffPreview.accept': '接受',
+  'dialog.diffPreview.reject': '拒絕',
+
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重設工作流程',
   'toolbar.focusMode': '專注模式',
@@ -887,6 +901,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // MCP Server Section
   'mcpSection.description.line1': '透過與AI對話的方式編輯工作流程。',
   'mcpSection.description.line2': '請選擇要使用的代理。',
+  'mcpSection.reviewBeforeApply': '套用前確認變更',
 
   // Description Panel (Canvas)
   'description.panel.title': '描述',

--- a/src/webview/src/utils/workflow-diff.ts
+++ b/src/webview/src/utils/workflow-diff.ts
@@ -1,0 +1,130 @@
+import type { Workflow } from '@shared/types/messages';
+import type { Edge, Node } from 'reactflow';
+
+export interface WorkflowDiffSummary {
+  nameChange: { from: string; to: string } | null;
+  addedNodes: { id: string; name: string; type: string }[];
+  removedNodes: { id: string; name: string; type: string }[];
+  modifiedNodes: { id: string; name: string; type: string }[];
+  addedConnections: number;
+  removedConnections: number;
+  totalChanges: number;
+  isNewWorkflow: boolean;
+}
+
+function getNodeName(node: Node): string {
+  return (node.data as { description?: string })?.description || node.id;
+}
+
+function makeEdgeKey(edge: Edge): string {
+  return `${edge.source}:${edge.sourceHandle ?? ''}→${edge.target}:${edge.targetHandle ?? ''}`;
+}
+
+function makeWorkflowEdgeKey(conn: {
+  from: string;
+  to: string;
+  fromPort: string;
+  toPort: string;
+}): string {
+  return `${conn.from}:${conn.fromPort}→${conn.to}:${conn.toPort}`;
+}
+
+export function computeWorkflowDiff(
+  currentNodes: Node[],
+  currentEdges: Edge[],
+  currentName: string,
+  incomingWorkflow: Workflow
+): WorkflowDiffSummary {
+  const isNewWorkflow =
+    currentNodes.length <= 2 &&
+    currentNodes.every((n) => n.type === 'start' || n.type === 'end') &&
+    currentEdges.length === 0;
+
+  // Name change
+  const nameChange =
+    currentName !== incomingWorkflow.name ? { from: currentName, to: incomingWorkflow.name } : null;
+
+  // Build node maps by ID
+  const currentNodeMap = new Map<string, Node>();
+  for (const node of currentNodes) {
+    currentNodeMap.set(node.id, node);
+  }
+
+  const incomingNodeMap = new Map<
+    string,
+    { id: string; type: string; name: string; data: string }
+  >();
+  for (const node of incomingWorkflow.nodes) {
+    incomingNodeMap.set(node.id, {
+      id: node.id,
+      type: node.type,
+      name: (node as { data?: { description?: string } }).data?.description || node.id,
+      data: JSON.stringify(node.data),
+    });
+  }
+
+  // Added nodes: in incoming but not in current
+  const addedNodes: WorkflowDiffSummary['addedNodes'] = [];
+  for (const [id, node] of incomingNodeMap) {
+    if (!currentNodeMap.has(id)) {
+      addedNodes.push({ id, name: node.name, type: node.type });
+    }
+  }
+
+  // Removed nodes: in current but not in incoming
+  const removedNodes: WorkflowDiffSummary['removedNodes'] = [];
+  for (const [id, node] of currentNodeMap) {
+    if (!incomingNodeMap.has(id)) {
+      removedNodes.push({ id, name: getNodeName(node), type: node.type || 'unknown' });
+    }
+  }
+
+  // Modified nodes: in both but data changed
+  const modifiedNodes: WorkflowDiffSummary['modifiedNodes'] = [];
+  for (const [id, incomingNode] of incomingNodeMap) {
+    const currentNode = currentNodeMap.get(id);
+    if (currentNode) {
+      const currentData = JSON.stringify(currentNode.data);
+      if (currentData !== incomingNode.data) {
+        modifiedNodes.push({ id, name: incomingNode.name, type: incomingNode.type });
+      }
+    }
+  }
+
+  // Edge comparison
+  const currentEdgeKeys = new Set(currentEdges.map(makeEdgeKey));
+  const incomingEdgeKeys = new Set(incomingWorkflow.connections.map(makeWorkflowEdgeKey));
+
+  let addedConnections = 0;
+  for (const key of incomingEdgeKeys) {
+    if (!currentEdgeKeys.has(key)) {
+      addedConnections++;
+    }
+  }
+
+  let removedConnections = 0;
+  for (const key of currentEdgeKeys) {
+    if (!incomingEdgeKeys.has(key)) {
+      removedConnections++;
+    }
+  }
+
+  const totalChanges =
+    (nameChange ? 1 : 0) +
+    addedNodes.length +
+    removedNodes.length +
+    modifiedNodes.length +
+    addedConnections +
+    removedConnections;
+
+  return {
+    nameChange,
+    addedNodes,
+    removedNodes,
+    modifiedNodes,
+    addedConnections,
+    removedConnections,
+    totalChanges,
+    isNewWorkflow,
+  };
+}


### PR DESCRIPTION
## Summary

Move the `ai.reviewBeforeApply` setting from VSCode Settings (`package.json` configuration) to an in-app UI toggle in the McpServerSection, giving users quicker access to control diff preview behavior during AI editing.

## Motivation

The `reviewBeforeApply` setting was previously only accessible via VSCode Settings, requiring users to navigate away from the workflow editor. By placing it directly in the McpServerSection (above the AI agent buttons), users can toggle it with a single click while working with AI agents.

## Changes

**New Files:**
- `src/webview/src/components/dialogs/DiffPreviewDialog.tsx` - Diff preview dialog for reviewing AI-generated workflow changes
- `src/webview/src/utils/workflow-diff.ts` - Utility functions for computing workflow diffs

**Modified Files:**
- `src/extension/services/mcp-server-service.ts` - Added `reviewBeforeApply` state field, getter/setter; replaced `vscode.workspace.getConfiguration` with instance field
- `src/shared/types/messages.ts` - Added `reviewBeforeApply` to `McpServerStatusPayload`, added `SetReviewBeforeApplyPayload`, added `SET_REVIEW_BEFORE_APPLY` message type
- `src/extension/commands/open-editor.ts` - Added `SET_REVIEW_BEFORE_APPLY` handler, included `reviewBeforeApply` in all `MCP_SERVER_STATUS` payloads (8 locations)
- `src/extension/services/mcp-server-tools.ts` - Updated to use new reviewBeforeApply state
- `src/webview/src/App.tsx` - Integrated DiffPreviewDialog
- `src/webview/src/components/chat/McpServerSection.tsx` - Added Check-icon toggle matching MoreActionsDropdown style, with disabled color when OFF
- `src/webview/src/i18n/translation-keys.ts` - Added `mcpSection.reviewBeforeApply` key
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Added translations for all 5 languages

## Testing

- [ ] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)