### PR TITLE
chore: add claude-code keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "keywords": [
     "ai",
     "claude",
+    "claude code",
+    "claude-code",
     "codex",
     "copilot",
     "roo",


### PR DESCRIPTION
## Summary
- Added `"claude code"` and `"claude-code"` to `package.json` keywords for better VS Code Marketplace discoverability

## Changes
- `package.json`: Added two new keywords to the `keywords` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)