### PR TITLE
improvement: rename Codex to Codex CLI in UI labels

### DIFF
--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -1488,7 +1488,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       whiteSpace: 'nowrap',
                     }}
                   >
-                    Codex
+                    Codex CLI
                   </span>
                   <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
                     <div style={{ display: 'flex' }}>

--- a/src/webview/src/components/chat/SettingsDropdown.tsx
+++ b/src/webview/src/components/chat/SettingsDropdown.tsx
@@ -41,7 +41,7 @@ const MODEL_PRESETS: { value: ClaudeModel; label: string }[] = [
 const PROVIDER_PRESETS: { value: AiCliProvider; label: string }[] = [
   { value: 'claude-code', label: 'Claude Code' },
   { value: 'copilot', label: 'Copilot' },
-  { value: 'codex', label: 'Codex' },
+  { value: 'codex', label: 'Codex CLI' },
 ];
 
 // Fixed font sizes for dropdown menu (not responsive)

--- a/src/webview/src/components/common/AIProviderBadge.tsx
+++ b/src/webview/src/components/common/AIProviderBadge.tsx
@@ -41,7 +41,7 @@ const PROVIDER_CONFIG: Record<
     },
   },
   codex: {
-    label: 'Codex',
+    label: 'Codex CLI',
     colors: {
       light: '#10A37F', // Bright green
       dark: '#0D8A6A', // Dark green

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -267,7 +267,7 @@ export function MoreActionsDropdown({
                   }}
                 >
                   <Terminal size={14} />
-                  <span style={{ flex: 1 }}>Codex</span>
+                  <span style={{ flex: 1 }}>Codex CLI</span>
                   {isCodexEnabled && <Check size={14} />}
                 </DropdownMenu.Item>
 


### PR DESCRIPTION
## Summary

Rename "Codex" display labels to "Codex CLI" across all UI components for consistency with the official product name.

## What Changed

### Before
- UI labels displayed "Codex" in toolbar, dropdown menus, and provider badges

### After
- UI labels now display "Codex CLI" consistently across all locations

## Changes

- `src/webview/src/components/Toolbar.tsx` - Updated label above convert/execute buttons
- `src/webview/src/components/toolbar/MoreActionsDropdown.tsx` - Updated toggle label
- `src/webview/src/components/chat/SettingsDropdown.tsx` - Updated provider preset label
- `src/webview/src/components/common/AIProviderBadge.tsx` - Updated badge display label

## Testing

- [x] `npm run format && npm run lint && npm run check && npm run build` passed
- [x] Manual E2E testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)