### PR TITLE
feat: add Cursor editor provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
   <strong>Visual Workflow Editor for AI Agents</strong>
 </p>
 
-<span id="github-copilot-support"></span><span id="openai-codex-support"></span><span id="roo-code-support"></span><span id="gemini-cli-support"></span><span id="antigravity-support"></span>
-
 | Agent | Export Format | Requires |
 |-------|--------------|----------|
 | Claude Code | `.claude/agents/` `.claude/commands/` | [Claude Code](https://github.com/anthropics/claude-code) |
@@ -31,6 +29,7 @@
 | Roo Code | `.roo/skills/` | [Roo Code](https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline) |
 | Gemini CLI | `.gemini/skills/` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) |
 | Antigravity | `.agent/skills/` | [Antigravity](https://antigravity.google/) |
+| Cursor | `.cursor/agents/` `.cursor/skills/` | [Cursor](https://github.com/cursor/cursor) |
 
 > **Note:** Agents other than Claude Code require activation from Toolbar's **More** menu.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-wf-studio",
   "displayName": "Claude Code Workflow Studio",
-  "description": "Visual Workflow Editor for Claude Code, GitHub Copilot, Codex CLI, Roo Code, Gemini CLI, and Antigravity",
+  "description": "Visual Workflow Editor for Claude Code, GitHub Copilot, and more AI agents",
   "version": "3.25.0",
   "publisher": "breaking-brake",
   "icon": "resources/icon.png",
@@ -20,7 +20,8 @@
     "copilot",
     "roo",
     "gemini",
-    "antigravity"
+    "antigravity",
+    "cursor"
   ],
   "engines": {
     "vscode": "^1.80.0"

--- a/src/extension/commands/cursor-handlers.ts
+++ b/src/extension/commands/cursor-handlers.ts
@@ -1,0 +1,231 @@
+/**
+ * Claude Code Workflow Studio - Cursor Integration Handlers
+ *
+ * Handles Export/Run for Cursor (Anysphere VSCode fork) integration
+ */
+
+import * as vscode from 'vscode';
+import type {
+  CursorOperationFailedPayload,
+  ExportForCursorPayload,
+  ExportForCursorSuccessPayload,
+  RunForCursorPayload,
+  RunForCursorSuccessPayload,
+} from '../../shared/types/messages';
+import { isCursorInstalled, startCursorTask } from '../services/cursor-extension-service';
+import {
+  checkExistingCursorSkill,
+  exportWorkflowAsCursorSkill,
+} from '../services/cursor-skill-export-service';
+import type { FileService } from '../services/file-service';
+import {
+  hasNonStandardSkills,
+  promptAndNormalizeSkills,
+} from '../services/skill-normalization-service';
+
+/**
+ * Handle Export for Cursor request
+ *
+ * Exports workflow to Skills format (.cursor/skills/name/SKILL.md)
+ *
+ * @param fileService - File service instance
+ * @param webview - Webview for sending responses
+ * @param payload - Export payload
+ * @param requestId - Optional request ID for response correlation
+ */
+export async function handleExportForCursor(
+  fileService: FileService,
+  webview: vscode.Webview,
+  payload: ExportForCursorPayload,
+  requestId?: string
+): Promise<void> {
+  try {
+    const { workflow } = payload;
+
+    // Check for existing skill and ask for confirmation
+    const existingSkillPath = await checkExistingCursorSkill(workflow, fileService);
+    if (existingSkillPath) {
+      const result = await vscode.window.showWarningMessage(
+        `Skill already exists: ${existingSkillPath}\n\nOverwrite?`,
+        { modal: true },
+        'Overwrite',
+        'Cancel'
+      );
+      if (result !== 'Overwrite') {
+        webview.postMessage({
+          type: 'EXPORT_FOR_CURSOR_CANCELLED',
+          requestId,
+        });
+        return;
+      }
+    }
+
+    // Export workflow as skill to .cursor/skills/{name}/SKILL.md
+    const exportResult = await exportWorkflowAsCursorSkill(workflow, fileService);
+
+    if (!exportResult.success) {
+      const failedPayload: CursorOperationFailedPayload = {
+        errorCode: 'EXPORT_FAILED',
+        errorMessage: exportResult.errors?.join(', ') || 'Failed to export workflow as skill',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'EXPORT_FOR_CURSOR_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Send success response
+    const successPayload: ExportForCursorSuccessPayload = {
+      skillName: exportResult.skillName,
+      skillPath: exportResult.skillPath,
+      timestamp: new Date().toISOString(),
+    };
+
+    webview.postMessage({
+      type: 'EXPORT_FOR_CURSOR_SUCCESS',
+      requestId,
+      payload: successPayload,
+    });
+
+    vscode.window.showInformationMessage(
+      `Exported workflow as Cursor skill: ${exportResult.skillPath}`
+    );
+  } catch (error) {
+    const failedPayload: CursorOperationFailedPayload = {
+      errorCode: 'UNKNOWN_ERROR',
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
+    webview.postMessage({
+      type: 'EXPORT_FOR_CURSOR_FAILED',
+      requestId,
+      payload: failedPayload,
+    });
+  }
+}
+
+/**
+ * Handle Run for Cursor request
+ *
+ * Exports workflow to Skills format and runs it via Cursor
+ *
+ * @param fileService - File service instance
+ * @param webview - Webview for sending responses
+ * @param payload - Run payload
+ * @param requestId - Optional request ID for response correlation
+ */
+export async function handleRunForCursor(
+  fileService: FileService,
+  webview: vscode.Webview,
+  payload: RunForCursorPayload,
+  requestId?: string
+): Promise<void> {
+  try {
+    const { workflow } = payload;
+
+    // Step 0.5: Normalize skills (copy non-standard skills to .claude/skills/)
+    if (hasNonStandardSkills(workflow, 'cursor')) {
+      const normalizeResult = await promptAndNormalizeSkills(workflow, 'cursor');
+
+      if (!normalizeResult.success) {
+        if (normalizeResult.cancelled) {
+          webview.postMessage({
+            type: 'RUN_FOR_CURSOR_CANCELLED',
+            requestId,
+          });
+          return;
+        }
+        throw new Error(normalizeResult.error || 'Failed to copy skills to .claude/skills/');
+      }
+
+      // Log normalized skills
+      if (normalizeResult.normalizedSkills && normalizeResult.normalizedSkills.length > 0) {
+        console.log(
+          `[Cursor] Copied ${normalizeResult.normalizedSkills.length} skill(s) to .claude/skills/`
+        );
+      }
+    }
+
+    // Step 1: Check for existing skill and ask for confirmation
+    const existingSkillPath = await checkExistingCursorSkill(workflow, fileService);
+    if (existingSkillPath) {
+      const result = await vscode.window.showWarningMessage(
+        `Skill already exists: ${existingSkillPath}\n\nOverwrite?`,
+        { modal: true },
+        'Overwrite',
+        'Cancel'
+      );
+      if (result !== 'Overwrite') {
+        webview.postMessage({
+          type: 'RUN_FOR_CURSOR_CANCELLED',
+          requestId,
+        });
+        return;
+      }
+    }
+
+    // Step 2: Export workflow as skill to .cursor/skills/{name}/SKILL.md
+    const exportResult = await exportWorkflowAsCursorSkill(workflow, fileService);
+
+    if (!exportResult.success) {
+      const failedPayload: CursorOperationFailedPayload = {
+        errorCode: 'EXPORT_FAILED',
+        errorMessage: exportResult.errors?.join(', ') || 'Failed to export workflow as skill',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'RUN_FOR_CURSOR_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Step 3: Check if Cursor is installed
+    if (!isCursorInstalled()) {
+      const failedPayload: CursorOperationFailedPayload = {
+        errorCode: 'CURSOR_NOT_INSTALLED',
+        errorMessage: 'Cursor extension is not installed.',
+        timestamp: new Date().toISOString(),
+      };
+      webview.postMessage({
+        type: 'RUN_FOR_CURSOR_FAILED',
+        requestId,
+        payload: failedPayload,
+      });
+      return;
+    }
+
+    // Step 4: Launch Cursor with the skill
+    await startCursorTask(exportResult.skillName);
+
+    // Send success response
+    const successPayload: RunForCursorSuccessPayload = {
+      workflowName: workflow.name,
+      cursorOpened: true,
+      timestamp: new Date().toISOString(),
+    };
+
+    webview.postMessage({
+      type: 'RUN_FOR_CURSOR_SUCCESS',
+      requestId,
+      payload: successPayload,
+    });
+
+    vscode.window.showInformationMessage(`Running workflow via Cursor: ${workflow.name}`);
+  } catch (error) {
+    const failedPayload: CursorOperationFailedPayload = {
+      errorCode: 'UNKNOWN_ERROR',
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+    };
+    webview.postMessage({
+      type: 'RUN_FOR_CURSOR_FAILED',
+      requestId,
+      payload: failedPayload,
+    });
+  }
+}

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -46,6 +46,7 @@ import {
   handleRunForCopilot,
   handleRunForCopilotCli,
 } from './copilot-handlers';
+import { handleExportForCursor, handleRunForCursor } from './cursor-handlers';
 import { handleExportWorkflow, handleExportWorkflowForExecution } from './export-workflow';
 import { handleExportForGeminiCli, handleRunForGeminiCli } from './gemini-handlers';
 import { loadWorkflow } from './load-workflow';
@@ -600,6 +601,45 @@ export function registerOpenEditorCommand(
               } else {
                 webview.postMessage({
                   type: 'RUN_FOR_ANTIGRAVITY_FAILED',
+                  requestId: message.requestId,
+                  payload: {
+                    errorCode: 'UNKNOWN_ERROR',
+                    errorMessage: 'Workflow is required',
+                    timestamp: new Date().toISOString(),
+                  },
+                });
+              }
+              break;
+
+            case 'EXPORT_FOR_CURSOR':
+              // Export workflow for Cursor (Skills format)
+              if (message.payload?.workflow) {
+                await handleExportForCursor(
+                  fileService,
+                  webview,
+                  message.payload,
+                  message.requestId
+                );
+              } else {
+                webview.postMessage({
+                  type: 'EXPORT_FOR_CURSOR_FAILED',
+                  requestId: message.requestId,
+                  payload: {
+                    errorCode: 'UNKNOWN_ERROR',
+                    errorMessage: 'Workflow is required',
+                    timestamp: new Date().toISOString(),
+                  },
+                });
+              }
+              break;
+
+            case 'RUN_FOR_CURSOR':
+              // Run workflow for Cursor
+              if (message.payload?.workflow) {
+                await handleRunForCursor(fileService, webview, message.payload, message.requestId);
+              } else {
+                webview.postMessage({
+                  type: 'RUN_FOR_CURSOR_FAILED',
                   requestId: message.requestId,
                   payload: {
                     errorCode: 'UNKNOWN_ERROR',

--- a/src/extension/services/ai-editing-skill-service.ts
+++ b/src/extension/services/ai-editing-skill-service.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { log } from '../extension';
 import { isAntigravityInstalled } from './antigravity-extension-service';
+import { isCursorInstalled } from './cursor-extension-service';
 import { isRooCodeInstalled, startRooCodeTask } from './roo-code-extension-service';
 
 export type AiEditingProvider =
@@ -20,7 +21,8 @@ export type AiEditingProvider =
   | 'codex'
   | 'roo-code'
   | 'gemini'
-  | 'antigravity';
+  | 'antigravity'
+  | 'cursor';
 
 const SKILL_NAME = 'cc-workflow-ai-editor';
 
@@ -43,6 +45,8 @@ function getSkillDestination(provider: AiEditingProvider, workingDirectory: stri
       return path.join(workingDirectory, '.gemini', 'skills', SKILL_NAME, 'SKILL.md');
     case 'antigravity':
       return path.join(workingDirectory, '.agent', 'skills', SKILL_NAME, 'SKILL.md');
+    case 'cursor':
+      return path.join(workingDirectory, '.cursor', 'skills', SKILL_NAME, 'SKILL.md');
   }
 }
 
@@ -152,6 +156,19 @@ async function launchProvider(
       // Launch is handled separately after MCP refresh dialog in open-editor.ts.
       if (!isAntigravityInstalled()) {
         throw new Error('Antigravity extension is not installed.');
+      }
+      break;
+    }
+
+    case 'cursor': {
+      // For Cursor, check installation and launch via chat command.
+      if (!isCursorInstalled()) {
+        throw new Error('Cursor extension is not installed.');
+      }
+      try {
+        await vscode.commands.executeCommand('workbench.action.chat.open', `/${SKILL_NAME}`);
+      } catch {
+        throw new Error('Failed to launch Cursor agent.');
       }
       break;
     }

--- a/src/extension/services/cursor-extension-service.ts
+++ b/src/extension/services/cursor-extension-service.ts
@@ -1,0 +1,47 @@
+/**
+ * Claude Code Workflow Studio - Cursor Extension Service
+ *
+ * Wrapper for Cursor (Anysphere VSCode fork) Extension.
+ * Uses VSCode commands to launch Cursor Agent with skill invocation.
+ */
+
+import * as vscode from 'vscode';
+
+const CURSOR_EXTENSION_ID = 'anysphere.cursor-agent';
+
+/**
+ * Check if Cursor extension is installed
+ *
+ * @returns True if Cursor extension is installed
+ */
+export function isCursorInstalled(): boolean {
+  return vscode.extensions.getExtension(CURSOR_EXTENSION_ID) !== undefined;
+}
+
+/**
+ * Start a task in Cursor via Agent
+ *
+ * Attempts to open Cursor's chat in agent mode with the given skill name.
+ *
+ * @param skillName - Skill name to invoke (e.g., "my-workflow")
+ * @returns True if the task was started successfully
+ */
+export async function startCursorTask(skillName: string): Promise<boolean> {
+  const extension = vscode.extensions.getExtension(CURSOR_EXTENSION_ID);
+  if (!extension) {
+    return false;
+  }
+
+  if (!extension.isActive) {
+    await extension.activate();
+  }
+
+  const prompt = `/${skillName}`;
+
+  try {
+    await vscode.commands.executeCommand('workbench.action.chat.open', prompt);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/extension/services/cursor-skill-export-service.ts
+++ b/src/extension/services/cursor-skill-export-service.ts
@@ -1,0 +1,199 @@
+/**
+ * Claude Code Workflow Studio - Cursor Skill Export Service
+ *
+ * Handles workflow export to Cursor Skills format (.cursor/skills/name/SKILL.md)
+ * Cursor reads skills from .cursor/skills/ directory.
+ */
+
+import * as path from 'node:path';
+import type {
+  SubAgentFlowNode,
+  SubAgentNode,
+  Workflow,
+} from '../../shared/types/workflow-definition';
+import {
+  generateSubAgentFile,
+  generateSubAgentFlowAgentFile,
+  nodeNameToFileName,
+} from './export-service';
+import type { FileService } from './file-service';
+import {
+  generateExecutionInstructions,
+  generateMermaidFlowchart,
+} from './workflow-prompt-generator';
+
+/**
+ * Cursor skill export result
+ */
+export interface CursorSkillExportResult {
+  success: boolean;
+  skillPath: string;
+  skillName: string;
+  errors?: string[];
+}
+
+/**
+ * Generate SKILL.md content from workflow for Cursor
+ *
+ * @param workflow - Workflow to convert
+ * @returns SKILL.md content as string
+ */
+export function generateCursorSkillContent(workflow: Workflow): string {
+  const skillName = nodeNameToFileName(workflow.name);
+
+  // Generate description from workflow metadata or create default
+  const description =
+    workflow.metadata?.description ||
+    `Execute the "${workflow.name}" workflow. This skill guides through a structured workflow with defined steps and decision points.`;
+
+  // Generate YAML frontmatter
+  const frontmatter = `---
+name: ${skillName}
+description: ${description}
+---`;
+
+  // Generate Mermaid flowchart
+  const mermaidContent = generateMermaidFlowchart({
+    nodes: workflow.nodes,
+    connections: workflow.connections,
+  });
+
+  // Generate execution instructions
+  const instructions = generateExecutionInstructions(workflow, {
+    provider: 'cursor',
+    parentWorkflowName: nodeNameToFileName(workflow.name),
+    subAgentFlows: workflow.subAgentFlows,
+  });
+
+  // Compose SKILL.md body
+  const body = `# ${workflow.name}
+
+## Workflow Diagram
+
+${mermaidContent}
+
+## Execution Instructions
+
+${instructions}`;
+
+  return `${frontmatter}\n\n${body}`;
+}
+
+/**
+ * Check if Cursor skill already exists
+ *
+ * @param workflow - Workflow to check
+ * @param fileService - File service instance
+ * @returns Path to existing skill file, or null if not exists
+ */
+export async function checkExistingCursorSkill(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<string | null> {
+  const workspacePath = fileService.getWorkspacePath();
+  const skillName = nodeNameToFileName(workflow.name);
+  const skillPath = path.join(workspacePath, '.cursor', 'skills', skillName, 'SKILL.md');
+
+  if (await fileService.fileExists(skillPath)) {
+    return skillPath;
+  }
+
+  // Check Sub-Agent files in .cursor/agents/
+  const agentsDir = path.join(workspacePath, '.cursor', 'agents');
+  const subAgentNodes = workflow.nodes.filter((n) => n.type === 'subAgent');
+  for (const node of subAgentNodes) {
+    const fileName = nodeNameToFileName(node.name);
+    const filePath = path.join(agentsDir, `${fileName}.md`);
+    if (await fileService.fileExists(filePath)) {
+      return filePath;
+    }
+  }
+
+  // Check SubAgentFlow agent files
+  if (workflow.subAgentFlows && workflow.subAgentFlows.length > 0) {
+    const workflowBaseName = nodeNameToFileName(workflow.name);
+    for (const flow of workflow.subAgentFlows) {
+      const flowFileName = nodeNameToFileName(flow.name);
+      const fileName = `${workflowBaseName}_${flowFileName}`;
+      const filePath = path.join(agentsDir, `${fileName}.md`);
+      if (await fileService.fileExists(filePath)) {
+        return filePath;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Export workflow as Cursor Skill
+ *
+ * Exports to .cursor/skills/{name}/SKILL.md
+ *
+ * @param workflow - Workflow to export
+ * @param fileService - File service instance
+ * @returns Export result
+ */
+export async function exportWorkflowAsCursorSkill(
+  workflow: Workflow,
+  fileService: FileService
+): Promise<CursorSkillExportResult> {
+  try {
+    const workspacePath = fileService.getWorkspacePath();
+    const skillName = nodeNameToFileName(workflow.name);
+    const skillDir = path.join(workspacePath, '.cursor', 'skills', skillName);
+    const skillPath = path.join(skillDir, 'SKILL.md');
+
+    // Ensure directory exists
+    await fileService.createDirectory(skillDir);
+
+    // Generate and write SKILL.md content
+    const content = generateCursorSkillContent(workflow);
+    await fileService.writeFile(skillPath, content);
+
+    // Export Sub-Agent node files to .cursor/agents/
+    const subAgentNodes = workflow.nodes.filter((n) => n.type === 'subAgent') as SubAgentNode[];
+    if (subAgentNodes.length > 0 || (workflow.subAgentFlows && workflow.subAgentFlows.length > 0)) {
+      const agentsDir = path.join(workspacePath, '.cursor', 'agents');
+      await fileService.createDirectory(agentsDir);
+
+      // SubAgent nodes
+      for (const node of subAgentNodes) {
+        const fileName = nodeNameToFileName(node.name);
+        const filePath = path.join(agentsDir, `${fileName}.md`);
+        const agentContent = generateSubAgentFile(node);
+        await fileService.writeFile(filePath, agentContent);
+      }
+
+      // SubAgentFlow nodes
+      if (workflow.subAgentFlows && workflow.subAgentFlows.length > 0) {
+        const workflowBaseName = nodeNameToFileName(workflow.name);
+        const subAgentFlowNodes = workflow.nodes.filter(
+          (n) => n.type === 'subAgentFlow'
+        ) as SubAgentFlowNode[];
+
+        for (const flow of workflow.subAgentFlows) {
+          const flowFileName = nodeNameToFileName(flow.name);
+          const fileName = `${workflowBaseName}_${flowFileName}`;
+          const filePath = path.join(agentsDir, `${fileName}.md`);
+          const referencingNode = subAgentFlowNodes.find((n) => n.data.subAgentFlowId === flow.id);
+          const agentContent = generateSubAgentFlowAgentFile(flow, fileName, referencingNode);
+          await fileService.writeFile(filePath, agentContent);
+        }
+      }
+    }
+
+    return {
+      success: true,
+      skillPath,
+      skillName,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      skillPath: '',
+      skillName: '',
+      errors: [error instanceof Error ? error.message : 'Unknown error'],
+    };
+  }
+}

--- a/src/extension/services/export-service.ts
+++ b/src/extension/services/export-service.ts
@@ -212,7 +212,7 @@ export function nodeNameToFileName(name: string): string {
  * @param node - Sub-Agent node
  * @returns Markdown content with YAML frontmatter
  */
-function generateSubAgentFile(node: SubAgentNode): string {
+export function generateSubAgentFile(node: SubAgentNode): string {
   const { name, data } = node;
   const agentName = nodeNameToFileName(name);
 
@@ -259,7 +259,7 @@ function generateSubAgentFile(node: SubAgentNode): string {
  * @param referencingNode - Optional SubAgentFlowNode that references this flow (for model/tools/color)
  * @returns Markdown content with YAML frontmatter
  */
-function generateSubAgentFlowAgentFile(
+export function generateSubAgentFlowAgentFile(
   subAgentFlow: SubAgentFlow,
   agentFileName: string,
   referencingNode?: SubAgentFlowNode

--- a/src/extension/services/mcp-server-config-writer.ts
+++ b/src/extension/services/mcp-server-config-writer.ts
@@ -11,6 +11,7 @@
  * - Copilot CLI: ~/.copilot/mcp-config.json (global)
  * - Codex CLI: ~/.codex/config.toml (global)
  * - Antigravity: ~/.gemini/antigravity/mcp_config.json (global)
+ * - Cursor: ~/.cursor/mcp.json (global)
  */
 
 import * as fs from 'node:fs/promises';
@@ -52,6 +53,8 @@ function getConfigPath(target: McpConfigTarget, workspacePath: string): string {
       return path.join(os.homedir(), '.gemini', 'settings.json');
     case 'antigravity':
       return path.join(os.homedir(), '.gemini', 'antigravity', 'mcp_config.json');
+    case 'cursor':
+      return path.join(os.homedir(), '.cursor', 'mcp.json');
   }
 }
 
@@ -278,6 +281,8 @@ export function getConfigTargetsForProvider(provider: AiEditingProvider): McpCon
       return ['gemini'];
     case 'antigravity':
       return ['antigravity'];
+    case 'cursor':
+      return ['cursor'];
   }
 }
 
@@ -293,6 +298,7 @@ export async function removeAllAgentConfigs(workspacePath: string): Promise<void
     'codex',
     'gemini',
     'antigravity',
+    'cursor',
   ];
 
   for (const target of allTargets) {

--- a/src/extension/services/skill-normalization-service.ts
+++ b/src/extension/services/skill-normalization-service.ts
@@ -34,6 +34,7 @@ const NON_STANDARD_SKILL_PATTERNS = [
   '.roo/skills/', // Roo Code
   '.gemini/skills/', // Google Gemini CLI
   '.agent/skills/', // Google Antigravity
+  '.cursor/skills/', // Cursor (Anysphere)
 ] as const;
 
 /**
@@ -49,7 +50,14 @@ export type SkillSourceType = 'github' | 'copilot' | 'codex' | 'roo-code' | 'gem
  * - 'copilot': .claude/skills/, .github/skills/, AND .copilot/skills/ are standard
  * - 'codex': .claude/skills/ AND .codex/skills/ are standard
  */
-export type TargetCli = 'claude' | 'copilot' | 'codex' | 'roo-code' | 'gemini' | 'antigravity';
+export type TargetCli =
+  | 'claude'
+  | 'copilot'
+  | 'codex'
+  | 'roo-code'
+  | 'gemini'
+  | 'antigravity'
+  | 'cursor';
 
 /**
  * Get the list of skill directory patterns that are considered "standard" for a given CLI
@@ -81,6 +89,10 @@ function getStandardSkillPatterns(targetCli: TargetCli): string[] {
     case 'antigravity':
       // Antigravity reads from .agent/skills/
       patterns.push('.agent/skills/');
+      break;
+    case 'cursor':
+      // Cursor reads from .cursor/skills/
+      patterns.push('.cursor/skills/');
       break;
     // case 'claude' falls through to default
     // Claude Code only uses .claude/skills/

--- a/src/extension/services/skill-service.ts
+++ b/src/extension/services/skill-service.ts
@@ -16,6 +16,8 @@ import {
   getCodexProjectSkillsDir,
   getCodexUserSkillsDir,
   getCopilotUserSkillsDir,
+  getCursorProjectSkillsDir,
+  getCursorUserSkillsDir,
   getGeminiProjectSkillsDir,
   getGeminiUserSkillsDir,
   getGithubSkillsDir,
@@ -48,7 +50,7 @@ import { parseSkillFrontmatter, type SkillMetadata } from './yaml-parser';
 export async function scanSkills(
   baseDir: string,
   scope: 'user' | 'project' | 'local',
-  source?: 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity'
+  source?: 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity' | 'cursor'
 ): Promise<SkillReference[]> {
   const skills: SkillReference[] = [];
 
@@ -400,6 +402,7 @@ export async function scanAllSkills(): Promise<{
   const rooUserDir = getRooUserSkillsDir();
   const geminiUserDir = getGeminiUserSkillsDir();
   const antigravityUserDir = getAntigravityUserSkillsDir();
+  const cursorUserDir = getCursorUserSkillsDir();
 
   // Project directories
   const claudeProjectDir = getProjectSkillsDir();
@@ -408,6 +411,7 @@ export async function scanAllSkills(): Promise<{
   const rooProjectDir = getRooProjectSkillsDir();
   const geminiProjectDir = getGeminiProjectSkillsDir();
   const antigravityProjectDir = getAntigravityProjectSkillsDir();
+  const cursorProjectDir = getCursorProjectSkillsDir();
 
   const [
     claudeUserSkills,
@@ -416,12 +420,14 @@ export async function scanAllSkills(): Promise<{
     rooUserSkills,
     geminiUserSkills,
     antigravityUserSkills,
+    cursorUserSkills,
     claudeProjectSkills,
     githubProjectSkills,
     codexProjectSkills,
     rooProjectSkills,
     geminiProjectSkills,
     antigravityProjectSkills,
+    cursorProjectSkills,
     pluginSkills,
   ] = await Promise.all([
     // User-scope scans
@@ -431,6 +437,7 @@ export async function scanAllSkills(): Promise<{
     scanSkills(rooUserDir, 'user', 'roo'),
     scanSkills(geminiUserDir, 'user', 'gemini'),
     scanSkills(antigravityUserDir, 'user', 'antigravity'),
+    scanSkills(cursorUserDir, 'user', 'cursor'),
     // Project-scope scans
     claudeProjectDir ? scanSkills(claudeProjectDir, 'project', 'claude') : Promise.resolve([]),
     githubProjectDir ? scanSkills(githubProjectDir, 'project', 'copilot') : Promise.resolve([]),
@@ -440,6 +447,7 @@ export async function scanAllSkills(): Promise<{
     antigravityProjectDir
       ? scanSkills(antigravityProjectDir, 'project', 'antigravity')
       : Promise.resolve([]),
+    cursorProjectDir ? scanSkills(cursorProjectDir, 'project', 'cursor') : Promise.resolve([]),
     // Plugin skills
     scanPluginSkills(),
   ]);
@@ -452,6 +460,7 @@ export async function scanAllSkills(): Promise<{
     ...rooUserSkills,
     ...geminiUserSkills,
     ...antigravityUserSkills,
+    ...cursorUserSkills,
   ];
 
   // Merge project skills: include all sources (no deduplication - show all available skills)
@@ -462,6 +471,7 @@ export async function scanAllSkills(): Promise<{
     ...rooProjectSkills,
     ...geminiProjectSkills,
     ...antigravityProjectSkills,
+    ...cursorProjectSkills,
   ];
 
   // Separate plugin skills by their scope

--- a/src/extension/services/workflow-prompt-generator.ts
+++ b/src/extension/services/workflow-prompt-generator.ts
@@ -405,7 +405,8 @@ export type ExportProvider =
   | 'codex'
   | 'gemini'
   | 'roo-code'
-  | 'antigravity';
+  | 'antigravity'
+  | 'cursor';
 
 /**
  * Get the provider-specific sub-agent execution description for rectangle nodes.
@@ -425,6 +426,8 @@ function getSubAgentDescription(provider: ExportProvider): string {
     case 'roo-code':
       return '- **Rectangle nodes (Sub-Agent: ...)**: Execute Sub-Agents';
     case 'antigravity':
+      return '- **Rectangle nodes (Sub-Agent: ...)**: Execute Sub-Agents';
+    case 'cursor':
       return '- **Rectangle nodes (Sub-Agent: ...)**: Execute Sub-Agents';
     default: {
       const _exhaustiveCheck: never = provider;
@@ -452,6 +455,8 @@ function getAskUserQuestionDescription(provider: ExportProvider): string {
       return '- **Diamond nodes (AskUserQuestion:...)**: Use the ask_followup_question tool to prompt the user and branch based on their response';
     case 'antigravity':
       return '- **Diamond nodes (AskUserQuestion:...)**: Prompt the user with a question and branch based on their response';
+    case 'cursor':
+      return '- **Diamond nodes (AskUserQuestion:...)**: Prompt the user with a question and branch based on their response';
     default: {
       const _exhaustiveCheck: never = provider;
       throw new Error(`Unknown provider: ${_exhaustiveCheck}`);
@@ -478,6 +483,8 @@ function getAgentName(provider: ExportProvider): string {
       return 'Roo Code';
     case 'antigravity':
       return 'Antigravity';
+    case 'cursor':
+      return 'Cursor';
     default: {
       const _exhaustiveCheck: never = provider;
       throw new Error(`Unknown provider: ${_exhaustiveCheck}`);
@@ -503,6 +510,8 @@ function getShellToolDescription(provider: ExportProvider): string {
     case 'roo-code':
       return 'Use the execute_command tool to run';
     case 'antigravity':
+      return 'Use the Bash tool to run';
+    case 'cursor':
       return 'Use the Bash tool to run';
     default: {
       const _exhaustiveCheck: never = provider;

--- a/src/extension/utils/path-utils.ts
+++ b/src/extension/utils/path-utils.ts
@@ -211,6 +211,36 @@ export function getAntigravityProjectSkillsDir(): string | null {
   return path.join(workspaceRoot, '.agent', 'skills');
 }
 
+/**
+ * Get the Cursor (Anysphere VSCode fork) user-scope Skills directory path
+ *
+ * @returns Absolute path to ~/.cursor/skills/
+ *
+ * @example
+ * // Unix: /Users/username/.cursor/skills
+ * // Windows: C:\Users\username\.cursor\skills
+ */
+export function getCursorUserSkillsDir(): string {
+  return path.join(os.homedir(), '.cursor', 'skills');
+}
+
+/**
+ * Get the Cursor (Anysphere VSCode fork) project-scope Skills directory path
+ *
+ * @returns Absolute path to .cursor/skills/ in workspace root, or null if no workspace
+ *
+ * @example
+ * // Unix: /workspace/myproject/.cursor/skills
+ * // Windows: C:\workspace\myproject\.cursor\skills
+ */
+export function getCursorProjectSkillsDir(): string | null {
+  const workspaceRoot = getWorkspaceRoot();
+  if (!workspaceRoot) {
+    return null;
+  }
+  return path.join(workspaceRoot, '.cursor', 'skills');
+}
+
 // =====================================================================
 // MCP Configuration Paths
 // =====================================================================
@@ -302,6 +332,21 @@ export function getGeminiProjectMcpConfigPath(): string | null {
  */
 export function getAntigravityUserMcpConfigPath(): string {
   return path.join(os.homedir(), '.gemini', 'antigravity', 'mcp_config.json');
+}
+
+/**
+ * Get the Cursor user-scope MCP config path (~/.cursor/mcp.json)
+ *
+ * Note: Cursor only supports user-scope MCP configuration.
+ *
+ * @returns Absolute path to ~/.cursor/mcp.json
+ *
+ * @example
+ * // Unix: /Users/username/.cursor/mcp.json
+ * // Windows: C:\Users\username\.cursor\mcp.json
+ */
+export function getCursorUserMcpConfigPath(): string {
+  return path.join(os.homedir(), '.cursor', 'mcp.json');
 }
 
 /**

--- a/src/shared/types/mcp-node.ts
+++ b/src/shared/types/mcp-node.ts
@@ -9,7 +9,14 @@
 /**
  * MCP configuration source provider
  */
-export type McpConfigSource = 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo' | 'antigravity';
+export type McpConfigSource =
+  | 'claude'
+  | 'copilot'
+  | 'codex'
+  | 'gemini'
+  | 'roo'
+  | 'antigravity'
+  | 'cursor';
 
 /**
  * MCP server reference information (from 'claude mcp list')

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -190,9 +190,10 @@ export interface SkillReference {
    * - 'roo': from ~/.roo/skills/ (user) or .roo/skills/ (project)
    * - 'gemini': from ~/.gemini/skills/ (user) or .gemini/skills/ (project)
    * - 'antigravity': from ~/.agent/skills/ (user) or .agent/skills/ (project)
+   * - 'cursor': from ~/.cursor/skills/ (user) or .cursor/skills/ (project)
    * - undefined: for local scope or legacy data
    */
-  source?: 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity';
+  source?: 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity' | 'cursor';
 }
 
 export interface CreateSkillPayload {
@@ -810,6 +811,12 @@ export type ExtensionMessage =
   | Message<RunForAntigravitySuccessPayload, 'RUN_FOR_ANTIGRAVITY_SUCCESS'>
   | Message<void, 'RUN_FOR_ANTIGRAVITY_CANCELLED'>
   | Message<AntigravityOperationFailedPayload, 'RUN_FOR_ANTIGRAVITY_FAILED'>
+  | Message<ExportForCursorSuccessPayload, 'EXPORT_FOR_CURSOR_SUCCESS'>
+  | Message<void, 'EXPORT_FOR_CURSOR_CANCELLED'>
+  | Message<CursorOperationFailedPayload, 'EXPORT_FOR_CURSOR_FAILED'>
+  | Message<RunForCursorSuccessPayload, 'RUN_FOR_CURSOR_SUCCESS'>
+  | Message<void, 'RUN_FOR_CURSOR_CANCELLED'>
+  | Message<CursorOperationFailedPayload, 'RUN_FOR_CURSOR_FAILED'>
   | Message<GetCurrentWorkflowRequestPayload, 'GET_CURRENT_WORKFLOW_REQUEST'>
   | Message<ApplyWorkflowFromMcpPayload, 'APPLY_WORKFLOW_FROM_MCP'>
   | Message<McpServerStatusPayload, 'MCP_SERVER_STATUS'>
@@ -1535,6 +1542,63 @@ export interface AntigravityOperationFailedPayload {
 }
 
 // ============================================================================
+// Cursor Integration Payloads (Beta)
+// ============================================================================
+
+/**
+ * Export workflow for Cursor payload (Skills format)
+ * Exports to .cursor/skills/{name}/SKILL.md
+ */
+export interface ExportForCursorPayload {
+  /** Workflow to export */
+  workflow: Workflow;
+}
+
+/**
+ * Export for Cursor success payload
+ */
+export interface ExportForCursorSuccessPayload {
+  /** Skill name */
+  skillName: string;
+  /** Skill file path */
+  skillPath: string;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+/**
+ * Run workflow for Cursor payload
+ */
+export interface RunForCursorPayload {
+  /** Workflow to run */
+  workflow: Workflow;
+}
+
+/**
+ * Run for Cursor success payload
+ */
+export interface RunForCursorSuccessPayload {
+  /** Workflow name */
+  workflowName: string;
+  /** Whether Cursor was opened */
+  cursorOpened: boolean;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+/**
+ * Cursor operation failed payload
+ */
+export interface CursorOperationFailedPayload {
+  /** Error code */
+  errorCode: 'CURSOR_NOT_INSTALLED' | 'EXPORT_FAILED' | 'UNKNOWN_ERROR';
+  /** Error message */
+  errorMessage: string;
+  /** Timestamp */
+  timestamp: string; // ISO 8601
+}
+
+// ============================================================================
 // AI Editing Skill Payloads (MCP-based AI editing)
 // ============================================================================
 
@@ -1548,7 +1612,8 @@ export type AiEditingProvider =
   | 'codex'
   | 'roo-code'
   | 'gemini'
-  | 'antigravity';
+  | 'antigravity'
+  | 'cursor';
 
 /**
  * Run AI editing skill request payload (Webview → Extension)
@@ -1621,7 +1686,8 @@ export type McpConfigTarget =
   | 'copilot-cli'
   | 'codex'
   | 'gemini'
-  | 'antigravity';
+  | 'antigravity'
+  | 'cursor';
 
 /**
  * Start MCP Server request payload (Webview → Extension)
@@ -1812,6 +1878,8 @@ export type WebviewMessage =
   | Message<RunForGeminiCliPayload, 'RUN_FOR_GEMINI_CLI'>
   | Message<ExportForAntigravityPayload, 'EXPORT_FOR_ANTIGRAVITY'>
   | Message<RunForAntigravityPayload, 'RUN_FOR_ANTIGRAVITY'>
+  | Message<ExportForCursorPayload, 'EXPORT_FOR_CURSOR'>
+  | Message<RunForCursorPayload, 'RUN_FOR_CURSOR'>
   | Message<GetCurrentWorkflowResponsePayload, 'GET_CURRENT_WORKFLOW_RESPONSE'>
   | Message<ApplyWorkflowFromMcpResponsePayload, 'APPLY_WORKFLOW_FROM_MCP_RESPONSE'>
   | Message<StartMcpServerPayload, 'START_MCP_SERVER'>

--- a/src/webview/src/components/chat/McpServerSection.tsx
+++ b/src/webview/src/components/chat/McpServerSection.tsx
@@ -33,6 +33,7 @@ const AI_EDIT_BUTTONS: AiEditButton[] = [
   { provider: 'roo-code', label: 'Roo Code' },
   { provider: 'gemini', label: 'Gemini CLI' },
   { provider: 'antigravity', label: 'Antigravity' },
+  { provider: 'cursor', label: 'Cursor' },
 ];
 
 interface McpServerSectionProps {
@@ -55,6 +56,7 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
     isRooCodeEnabled,
     isGeminiEnabled,
     isAntigravityEnabled,
+    isCursorEnabled,
   } = useRefinementStore();
 
   const visibleButtons = useMemo(() => {
@@ -74,6 +76,8 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
           return isGeminiEnabled;
         case 'antigravity':
           return isAntigravityEnabled;
+        case 'cursor':
+          return isCursorEnabled;
         default:
           return false;
       }
@@ -85,6 +89,7 @@ export function McpServerSection({ isCollapsed, onToggleCollapse }: McpServerSec
     isRooCodeEnabled,
     isGeminiEnabled,
     isAntigravityEnabled,
+    isCursorEnabled,
   ]);
 
   // Listen for MCP server status updates

--- a/src/webview/src/components/common/AIProviderBadge.tsx
+++ b/src/webview/src/components/common/AIProviderBadge.tsx
@@ -13,7 +13,14 @@ import { useVSCodeTheme } from '../../hooks/useVSCodeTheme';
  * Supported AI provider types
  * Add new providers here as needed
  */
-export type AIProviderType = 'copilot' | 'claude' | 'codex' | 'roo' | 'gemini' | 'antigravity';
+export type AIProviderType =
+  | 'copilot'
+  | 'claude'
+  | 'codex'
+  | 'roo'
+  | 'gemini'
+  | 'antigravity'
+  | 'cursor';
 
 /**
  * Configuration for each AI provider
@@ -70,6 +77,17 @@ const PROVIDER_CONFIG: Record<
     colors: {
       light: '#34A853', // Google Green
       dark: '#1E8E3E', // Darker Google Green
+    },
+  },
+  cursor: {
+    label: 'Cursor',
+    colors: {
+      light: '#FFFFFF', // White background (light theme)
+      dark: '#1E1E1E', // Black background (dark theme)
+    },
+    textColors: {
+      light: '#1E1E1E', // Black text (light theme)
+      dark: '#FFFFFF', // White text (dark theme)
     },
   },
 };

--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -17,7 +17,7 @@ import { useWorkflowStore } from '../../stores/workflow-store';
 import { AIProviderBadge, type AIProviderType } from '../common/AIProviderBadge';
 import { type CreateSkillFormData, SkillCreationDialog } from './SkillCreationDialog';
 
-type SourceType = 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity';
+type SourceType = 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity' | 'cursor';
 
 interface GroupedSkills {
   source: SourceType;
@@ -29,7 +29,15 @@ interface GroupedSkills {
  * Skills without a source are treated as 'claude' for backward compatibility.
  */
 function groupSkillsBySource(skills: SkillReference[]): GroupedSkills[] {
-  const sourceOrder: SourceType[] = ['claude', 'copilot', 'codex', 'roo', 'gemini', 'antigravity'];
+  const sourceOrder: SourceType[] = [
+    'claude',
+    'copilot',
+    'codex',
+    'roo',
+    'gemini',
+    'antigravity',
+    'cursor',
+  ];
   const groups = new Map<SourceType, SkillReference[]>();
 
   // Initialize all groups

--- a/src/webview/src/components/mcp/McpServerList.tsx
+++ b/src/webview/src/components/mcp/McpServerList.tsx
@@ -15,7 +15,7 @@ import { listMcpServers, refreshMcpCache } from '../../services/mcp-service';
 import { AIProviderBadge, type AIProviderType } from '../common/AIProviderBadge';
 import { IndeterminateProgressBar } from '../common/IndeterminateProgressBar';
 
-type SourceType = 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo' | 'antigravity';
+type SourceType = 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo' | 'antigravity' | 'cursor';
 
 interface GroupedServers {
   source: SourceType;
@@ -27,7 +27,15 @@ interface GroupedServers {
  * Servers without a source are treated as 'claude' for backward compatibility.
  */
 function groupServersBySource(servers: McpServerReference[]): GroupedServers[] {
-  const sourceOrder: SourceType[] = ['claude', 'copilot', 'codex', 'roo', 'gemini', 'antigravity'];
+  const sourceOrder: SourceType[] = [
+    'claude',
+    'copilot',
+    'codex',
+    'roo',
+    'gemini',
+    'antigravity',
+    'cursor',
+  ];
   const groups = new Map<SourceType, McpServerReference[]>();
 
   // Initialize all groups

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -45,6 +45,8 @@ interface MoreActionsDropdownProps {
   onToggleGeminiBeta: () => void;
   isAntigravityEnabled: boolean;
   onToggleAntigravityBeta: () => void;
+  isCursorEnabled: boolean;
+  onToggleCursorBeta: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -67,6 +69,8 @@ export function MoreActionsDropdown({
   onToggleGeminiBeta,
   isAntigravityEnabled,
   onToggleAntigravityBeta,
+  isCursorEnabled,
+  onToggleCursorBeta,
   open,
   onOpenChange,
 }: MoreActionsDropdownProps) {
@@ -342,6 +346,29 @@ export function MoreActionsDropdown({
                   <Bot size={14} />
                   <span style={{ flex: 1 }}>Antigravity</span>
                   {isAntigravityEnabled && <Check size={14} />}
+                </DropdownMenu.Item>
+
+                {/* Cursor Toggle */}
+                <DropdownMenu.Item
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    onToggleCursorBeta();
+                  }}
+                  style={{
+                    padding: '8px 12px',
+                    fontSize: `${FONT_SIZES.small}px`,
+                    color: 'var(--vscode-foreground)',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    outline: 'none',
+                    borderRadius: '2px',
+                  }}
+                >
+                  <Bot size={14} />
+                  <span style={{ flex: 1 }}>Cursor</span>
+                  {isCursorEnabled && <Check size={14} />}
                 </DropdownMenu.Item>
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>

--- a/src/webview/src/stores/refinement-store.ts
+++ b/src/webview/src/stores/refinement-store.ts
@@ -37,6 +37,8 @@ const ROO_CODE_ENABLED_STORAGE_KEY = 'cc-wf-studio:roo-code-beta-enabled';
 const GEMINI_ENABLED_STORAGE_KEY = 'cc-wf-studio:gemini-beta-enabled';
 // Note: This key is shared with Toolbar.tsx for the "Antigravity (Beta)" toggle
 const ANTIGRAVITY_ENABLED_STORAGE_KEY = 'cc-wf-studio:antigravity-enabled';
+// Note: This key is shared with Toolbar.tsx for the "Cursor (Beta)" toggle
+const CURSOR_ENABLED_STORAGE_KEY = 'cc-wf-studio:cursor-enabled';
 
 // Available tools for Claude Code CLI (used in AI editing allowed tools)
 export const AVAILABLE_TOOLS = [
@@ -450,6 +452,29 @@ function saveAntigravityEnabledToStorage(enabled: boolean): void {
   }
 }
 
+/**
+ * Load Cursor enabled state from localStorage
+ */
+function loadCursorEnabledFromStorage(): boolean {
+  try {
+    const saved = localStorage.getItem(CURSOR_ENABLED_STORAGE_KEY);
+    return saved === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Save Cursor enabled state to localStorage
+ */
+function saveCursorEnabledToStorage(enabled: boolean): void {
+  try {
+    localStorage.setItem(CURSOR_ENABLED_STORAGE_KEY, String(enabled));
+  } catch {
+    // localStorage may not be available in some contexts
+  }
+}
+
 // ============================================================================
 // Session Status Type
 // ============================================================================
@@ -488,6 +513,7 @@ interface RefinementStore {
   isRooCodeEnabled: boolean;
   isGeminiEnabled: boolean;
   isAntigravityEnabled: boolean;
+  isCursorEnabled: boolean;
 
   // Dynamic Copilot Models State
   availableCopilotModels: CopilotModelInfo[];
@@ -522,6 +548,7 @@ interface RefinementStore {
   toggleRooCodeEnabled: () => void;
   toggleGeminiEnabled: () => void;
   toggleAntigravityEnabled: () => void;
+  toggleCursorEnabled: () => void;
   fetchCopilotModels: () => Promise<void>;
   initConversation: () => void;
   loadConversationHistory: (history: ConversationHistory | undefined) => void;
@@ -621,6 +648,7 @@ export const useRefinementStore = create<RefinementStore>((set, get) => ({
   isRooCodeEnabled: loadRooCodeEnabledFromStorage(), // Load from localStorage, default: false
   isGeminiEnabled: loadGeminiEnabledFromStorage(), // Load from localStorage, default: false
   isAntigravityEnabled: loadAntigravityEnabledFromStorage(), // Load from localStorage, default: false
+  isCursorEnabled: loadCursorEnabledFromStorage(), // Load from localStorage, default: false
 
   // Dynamic Copilot Models Initial State
   availableCopilotModels: [],
@@ -762,6 +790,13 @@ export const useRefinementStore = create<RefinementStore>((set, get) => ({
     const newEnabled = !currentEnabled;
     saveAntigravityEnabledToStorage(newEnabled);
     set({ isAntigravityEnabled: newEnabled });
+  },
+
+  toggleCursorEnabled: () => {
+    const currentEnabled = get().isCursorEnabled;
+    const newEnabled = !currentEnabled;
+    saveCursorEnabledToStorage(newEnabled);
+    set({ isCursorEnabled: newEnabled });
   },
 
   fetchCopilotModels: async () => {


### PR DESCRIPTION
## Summary

Add Cursor as a new AI editing provider, enabling workflow export to `.cursor/skills/` and `.cursor/agents/` formats, MCP config integration, and AI-assisted workflow editing via Cursor.

## Motivation

Cursor is a popular AI-powered code editor. Adding Cursor as a supported provider allows users to export workflows and use AI editing features with Cursor, expanding the multi-agent ecosystem support.

## Changes

**New Files:**
- `src/extension/commands/cursor-handlers.ts` - Cursor-specific command handlers (export, run, skill browser)
- `src/extension/services/cursor-extension-service.ts` - Cursor extension detection and launch service
- `src/extension/services/cursor-skill-export-service.ts` - Workflow export to `.cursor/skills/` and `.cursor/agents/`

**Modified Files:**
- `src/extension/commands/open-editor.ts` - Register Cursor message handlers
- `src/extension/services/ai-editing-skill-service.ts` - Add Cursor provider support
- `src/extension/services/export-service.ts` - Export `generateSubAgentFile()` and `generateSubAgentFlowAgentFile()` for reuse
- `src/extension/services/mcp-config-reader.ts` - Read Cursor MCP config (`~/.cursor/mcp.json`)
- `src/extension/services/mcp-server-config-writer.ts` - Write MCP config for Cursor
- `src/extension/services/skill-normalization-service.ts` - Cursor skill normalization
- `src/extension/services/skill-service.ts` - Cursor skill discovery
- `src/extension/services/workflow-prompt-generator.ts` - Cursor provider in export instructions
- `src/extension/utils/path-utils.ts` - Cursor path utilities
- `src/shared/types/mcp-node.ts` - Cursor MCP config types
- `src/shared/types/messages.ts` - Cursor message types
- `src/webview/src/components/Toolbar.tsx` - Cursor export/run buttons
- `src/webview/src/components/chat/McpServerSection.tsx` - Cursor MCP server display
- `src/webview/src/components/common/AIProviderBadge.tsx` - Cursor provider badge
- `src/webview/src/components/dialogs/SkillBrowserDialog.tsx` - Cursor skill browser
- `src/webview/src/components/mcp/McpServerList.tsx` - Cursor MCP server list
- `src/webview/src/components/toolbar/MoreActionsDropdown.tsx` - Cursor menu item
- `src/webview/src/services/vscode-bridge.ts` - Cursor bridge methods
- `src/webview/src/stores/refinement-store.ts` - Cursor provider state
- `README.md` - Add Cursor to supported agents table, remove unused anchor spans
- `package.json` - Update description and keywords

## Testing

- [x] `npm run format && npm run lint && npm run check` passed
- [x] `npm run build` passed
- [x] Manual E2E testing in Cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)