### PR TITLE
chore: clarify MCP server is built into CC Workflow Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,21 @@
 ```mermaid
 sequenceDiagram
     actor User
-    participant VSCode as CC Workflow Studio
-    participant MCP as MCP Server
+    box VS Code (CC Workflow Studio)
+        participant UI as Editor UI
+        participant MCP as MCP Server
+    end
     participant Agent as AI Agent
 
-    User->>VSCode: Click agent button
-    VSCode->>MCP: Auto start server
-    VSCode->>Agent: Launch with editing skill
+    User->>UI: Click agent button
+    UI->>MCP: Auto start server
+    UI->>Agent: Launch with editing skill
 
     loop AI edits workflow
         Agent->>MCP: get_workflow
         MCP-->>Agent: workflow JSON
         Agent->>MCP: apply_workflow
-        MCP->>VSCode: Update canvas
+        MCP->>UI: Update canvas
     end
 ```
 


### PR DESCRIPTION
## Summary

Improve the "Edit with AI" sequence diagram in README to clarify that the MCP server is a built-in component of CC Workflow Studio, not an external service.

## What Changed

### Before
- MCP Server appeared as a separate, independent participant in the sequence diagram
- It was unclear that CC Workflow Studio itself provides the MCP server

### After
- Editor UI and MCP Server are grouped inside a `box VS Code (CC Workflow Studio)` in the Mermaid diagram
- Visually clear that the MCP server is an internal component of the extension

## Changes

- `README.md` - Use Mermaid `box` notation to group Editor UI and MCP Server as internal components

## Testing

- [x] Mermaid `box` syntax is supported by GitHub rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)