### PR TITLE
improvement: clarify MCP node schema definitions

### DIFF
--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -259,6 +259,7 @@
             "taskDescription": {
               "type": "string",
               "required": true,
+              "minLength": 1,
               "description": "Natural language description of the task to accomplish"
             },
             "timestamp": {
@@ -276,6 +277,7 @@
             "description": {
               "type": "string",
               "required": true,
+              "minLength": 1,
               "description": "Natural language description of desired parameter values. NOT 'taskDescription' — use 'description' for this field."
             },
             "timestamp": {

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -280,6 +280,7 @@ nodeTypes:
           taskDescription:
             type: string
             required: true
+            minLength: 1
             description: Natural language description of the task to accomplish
           timestamp:
             type: string
@@ -293,6 +294,7 @@ nodeTypes:
           description:
             type: string
             required: true
+            minLength: 1
             description: Natural language description of desired parameter values. NOT 'taskDescription' — use 'description' for this field.
           timestamp:
             type: string


### PR DESCRIPTION
## Summary

Clarified MCP node schema definitions to align with implementation validation rules. AI agents can now generate valid workflows without validation errors related to missing field definitions and conflicting mode requirements.

## What Changed

The workflow schema now provides explicit field definitions and per-mode constraints for MCP nodes, matching the strict validation logic in the codebase.

### Before
- `aiParameterConfig` field was undefined in schema (properties only defined for `aiToolSelectionConfig`)
- `mode` description lacked per-mode required field guidance
- `parameters` guidance incorrectly stated "Can be empty for aiParameterConfig mode"
- Example node had `parameters: []` which fails `aiParameterConfig` validation
- No structured breakdown of required fields per mode

### After
- `aiParameterConfig` field fully defined with `description` and `timestamp` properties
- `mode` description documents all required fields for each of the 3 modes
- `parameters` guidance clarified: min 1 item for aiParameterConfig, empty OK for manualParameterConfig, optional for aiToolSelection
- Example node has valid parameter schema with 1 item
- `requiredFieldsPerMode` section provides structured per-mode requirements

## Changes

- `resources/workflow-schema.json`:
  - Added `aiParameterConfig` object definition (lines 271-291)
  - Expanded `mode` field description with per-mode requirements (line 256)
  - Added `requiredFieldsPerMode` to `aiGenerationGuidance` (lines 310-340)
  - Updated `parameters` guidance with mode-specific constraints (line 308)
  - Fixed example node to use valid `aiParameterConfig` with 1+ parameters (lines 337-365)

- `resources/workflow-schema.toon`:
  - Auto-generated by `npm run build` (TOON is derived format from JSON schema)

## Testing

- [x] Manual validation: `npm run format && npm run lint && npm run check && npm run build`
- [x] TOON file correctly auto-generated with new definitions
- [x] All 4 verification commands passed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * aiParameterConfig promoted as the default MCP mode, with a new description and timestamp field.
  * Per-mode validation introduced: distinct required fields for aiParameterConfig, manualParameterConfig, and aiToolSelection; task description now enforces non-empty input in tool-selection mode.

* **Documentation**
  * Updated workflow guidance, examples, and public schema text to reflect aiParameterConfig usage, parameter requirements, and per-mode validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->