### PR TITLE
chore: update Slack review notice to reflect unreviewed status

### DIFF
--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -842,7 +842,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
     'Complete the authentication in your browser, then return here.',
   'slack.oauth.cancelled': 'Authentication was cancelled',
   'slack.oauth.reviewNotice.message':
-    'The Slack App used for sharing is pending Slack review.\nA warning will be displayed on the permission screen until the review is approved.',
+    'This Slack App has not been submitted to the Slack Marketplace.\nA warning will be displayed on the permission screen.',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -837,7 +837,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': 'ブラウザで認証を完了し、こちらに戻ってください。',
   'slack.oauth.cancelled': '認証がキャンセルされました',
   'slack.oauth.reviewNotice.message':
-    '共有に使用するSlack AppはSlackへの審査を予定しています。\n審査の承認が下りるまで、許可画面で警告が表示されます。',
+    'このSlack AppはSlack Marketplaceに未申請です。\n許可画面で警告が表示されます。',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Slackに再接続',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -831,7 +831,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': '브라우저에서 인증을 완료한 후 여기로 돌아오세요.',
   'slack.oauth.cancelled': '인증이 취소되었습니다',
   'slack.oauth.reviewNotice.message':
-    '공유에 사용되는 Slack 앱은 Slack 심사 예정입니다.\n심사 승인이 완료될 때까지 권한 화면에 경고가 표시됩니다.',
+    '이 Slack 앱은 Slack Marketplace에 제출되지 않았습니다.\n권한 화면에 경고가 표시됩니다.',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -801,7 +801,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': '在浏览器中完成身份验证后返回此处。',
   'slack.oauth.cancelled': '身份验证已取消',
   'slack.oauth.reviewNotice.message':
-    '用于共享的 Slack 应用计划进行 Slack 审核。\n在审核通过之前，权限画面会显示警告。',
+    '此 Slack 应用尚未提交至 Slack Marketplace。\n权限画面会显示警告。',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -801,7 +801,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'slack.oauth.status.waitingHint': '在瀏覽器中完成身份驗證後返回此處。',
   'slack.oauth.cancelled': '身份驗證已取消',
   'slack.oauth.reviewNotice.message':
-    '用於共享的 Slack 應用計劃進行 Slack 審核。\n在審核通過之前，權限畫面會顯示警告。',
+    '此 Slack 應用尚未提交至 Slack Marketplace。\n權限畫面會顯示警告。',
 
   // Slack Reconnect
   'slack.reconnect.button': 'Reconnect to Slack',


### PR DESCRIPTION
## Summary
- Updated the Slack OAuth review notice message across all 5 languages
- Changed from "pending Slack review" to "not submitted to Slack Marketplace"
- The Slack sharing feature will not be extended further, so the notice now accurately reflects the current status

Closes #136

## Test plan
- [ ] Verify the updated warning message displays correctly in the Slack connection dialog (OAuth tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Slack OAuth permission notice messages across multiple languages (English, Japanese, Korean, Simplified Chinese, Traditional Chinese) to clarify that the Slack App has not been submitted to the Slack Marketplace. Users will see the updated notice on the permission screen during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->