### PR TITLE
fix: add DNS rebinding protection to MCP server

### DIFF
--- a/src/extension/services/mcp-server-service.ts
+++ b/src/extension/services/mcp-server-service.ts
@@ -74,8 +74,17 @@ export class McpServerManager {
       // CLI clients (e.g. Claude Code) don't send Origin, so only validate when present
       const origin = req.headers.origin;
       if (origin) {
-        const isLocalOrigin =
-          origin.startsWith('http://127.0.0.1') || origin.startsWith('http://localhost');
+        let isLocalOrigin = false;
+        try {
+          const originUrl = new URL(origin);
+          const originHost = originUrl.hostname.toLowerCase();
+          isLocalOrigin =
+            (originHost === '127.0.0.1' || originHost === 'localhost') &&
+            originUrl.protocol === 'http:';
+        } catch {
+          // Invalid URL format - treat as non-local
+          isLocalOrigin = false;
+        }
         if (!isLocalOrigin) {
           log('WARN', 'MCP Server: Rejected request with invalid Origin header', {
             origin,


### PR DESCRIPTION
## Problem

The built-in MCP server (`mcp-server-service.ts`) has no Host/Origin header validation, making it theoretically vulnerable to DNS rebinding attacks. The MCP specification requires Origin header validation as a MUST.

### Current Behavior
1. A malicious website performs DNS rebinding to resolve to `127.0.0.1`
2. ❌ The MCP server accepts requests with any Host/Origin header
3. ❌ URL construction trusts the unvalidated `Host` header

### Expected Behavior
1. A malicious website performs DNS rebinding to resolve to `127.0.0.1`
2. ✅ The MCP server rejects requests with non-local Host/Origin headers (403)
3. ✅ URL construction uses hardcoded `127.0.0.1` instead of trusting Host header

## Solution

Add HTTP-level Host and Origin header validation at the top of the request handler, before any request processing.

### Changes

**File**: `src/extension/services/mcp-server-service.ts`

- Validate `Host` header: only allow `127.0.0.1` and `localhost`
- Validate `Origin` header when present: only allow `http://127.0.0.1` and `http://localhost` (CLI clients don't send Origin, so absent Origin is allowed)
- Replace `http://${req.headers.host}` with hardcoded `http://127.0.0.1` for URL construction

## Impact

- Mitigates DNS rebinding attack vector against the MCP server
- Complies with MCP specification's MUST requirement for Origin validation
- No impact on legitimate CLI clients (Claude Code, etc.) which connect via `127.0.0.1`/`localhost`

## Testing

- [x] `curl -H "Host: evil.com" http://127.0.0.1:<port>/mcp` → 403
- [x] `curl -H "Origin: http://evil.com" http://127.0.0.1:<port>/mcp` → 403
- [x] `curl http://127.0.0.1:<port>/mcp` (no Origin) → passes validation
- [x] `npm run format && npm run lint && npm run check && npm run build` passes

## Notes

- Actual attack difficulty is high (dynamic port + localhost binding), but defense cost is minimal (~30 lines)
- Deprecated SDK options (`allowedHosts`/`enableDnsRebindingProtection`) are intentionally not used; validation is implemented at the HTTP handler level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened request validation: Host and Origin headers are now checked and non-local requests are rejected with a 403 JSON response.
  * Ensures URL handling uses a fixed local base, improving consistency for local requests.
  * Preserves existing routing behavior while preventing invalid cross-host/cross-origin access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->