### PR TITLE
feat: add What's New dialog with unread release badge

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -35,6 +35,7 @@ import { SlackApiService } from '../services/slack-api-service';
 import { executeSlashCommandInTerminal } from '../services/terminal-execution-service';
 import { listCopilotModels } from '../services/vscode-lm-service';
 import { AnthropicApiKeyManager } from '../utils/anthropic-api-key-manager';
+import { countUnreadVersions, extractVersions, parseChangelog } from '../utils/changelog-parser';
 import { migrateWorkflow } from '../utils/migrate-workflow';
 import { SlackTokenManager } from '../utils/slack-token-manager';
 import { validateWorkflowFile } from '../utils/workflow-validator';
@@ -228,13 +229,40 @@ export function registerOpenEditorCommand(
           const webview = currentPanel.webview;
 
           switch (message.type) {
-            case 'WEBVIEW_READY':
+            case 'WEBVIEW_READY': {
+              // Calculate unread release count for What's New badge
+              let unreadReleaseCount = 0;
+              try {
+                const changelogUri = vscode.Uri.joinPath(
+                  vscode.Uri.file(context.extensionPath),
+                  'CHANGELOG.md'
+                );
+                const changelogBytes = await vscode.workspace.fs.readFile(changelogUri);
+                const changelogContent = Buffer.from(changelogBytes).toString('utf-8');
+                const lastViewedVersion = context.globalState.get<string>(
+                  'whatsNewLastViewedVersion'
+                );
+                if (lastViewedVersion === undefined) {
+                  const versions = extractVersions(changelogContent);
+                  if (versions[0]) {
+                    await context.globalState.update('whatsNewLastViewedVersion', versions[0]);
+                  }
+                } else {
+                  unreadReleaseCount = countUnreadVersions(changelogContent, lastViewedVersion);
+                }
+              } catch {
+                // CHANGELOG.md not found or unreadable - ignore
+              }
+
               // Webview is fully initialized and ready to receive messages
               // This is more reliable than setTimeout (fixes Issue #396)
+              const showWhatsNewBadge = context.globalState.get<boolean>('showWhatsNewBadge', true);
               webview.postMessage({
                 type: 'INITIAL_STATE',
                 payload: {
                   hasAcceptedTerms,
+                  unreadReleaseCount: showWhatsNewBadge ? unreadReleaseCount : 0,
+                  showWhatsNewBadge,
                 },
               });
 
@@ -252,6 +280,7 @@ export function registerOpenEditorCommand(
                 }, 100);
               }
               break;
+            }
 
             case 'SAVE_WORKFLOW':
               // Save workflow
@@ -786,11 +815,13 @@ export function registerOpenEditorCommand(
             case 'ACCEPT_TERMS':
               // User accepted terms of use (save current version)
               await context.globalState.update('acceptedTermsVersion', CURRENT_TERMS_VERSION);
-              // Update webview with new state
+              // Update webview with new state (unreadReleaseCount stays at whatever was set in INITIAL_STATE)
               webview.postMessage({
                 type: 'INITIAL_STATE',
                 payload: {
                   hasAcceptedTerms: true,
+                  unreadReleaseCount: 0,
+                  showWhatsNewBadge: context.globalState.get<boolean>('showWhatsNewBadge', true),
                 },
               });
               break;
@@ -1738,6 +1769,67 @@ export function registerOpenEditorCommand(
                 message.requestId
               );
               break;
+
+            case 'GET_CHANGELOG': {
+              try {
+                const changelogUri = vscode.Uri.joinPath(
+                  vscode.Uri.file(context.extensionPath),
+                  'CHANGELOG.md'
+                );
+                const changelogBytes = await vscode.workspace.fs.readFile(changelogUri);
+                const changelogContent = Buffer.from(changelogBytes).toString('utf-8');
+                const entries = parseChangelog(changelogContent, 5);
+                const lastViewed = context.globalState.get<string>('whatsNewLastViewedVersion');
+                const extensionPkg = require(
+                  vscode.Uri.joinPath(vscode.Uri.file(context.extensionPath), 'package.json').fsPath
+                );
+                webview.postMessage({
+                  type: 'GET_CHANGELOG_RESULT',
+                  requestId: message.requestId,
+                  payload: {
+                    entries,
+                    unreadCount: countUnreadVersions(changelogContent, lastViewed),
+                    currentVersion: extensionPkg.version,
+                  },
+                });
+              } catch {
+                webview.postMessage({
+                  type: 'GET_CHANGELOG_RESULT',
+                  requestId: message.requestId,
+                  payload: {
+                    entries: [],
+                    unreadCount: 0,
+                    currentVersion: '',
+                  },
+                });
+              }
+              break;
+            }
+
+            case 'MARK_CHANGELOG_READ': {
+              try {
+                const changelogUri = vscode.Uri.joinPath(
+                  vscode.Uri.file(context.extensionPath),
+                  'CHANGELOG.md'
+                );
+                const changelogBytes = await vscode.workspace.fs.readFile(changelogUri);
+                const changelogContent = Buffer.from(changelogBytes).toString('utf-8');
+                const versions = extractVersions(changelogContent);
+                const latestVersion = versions[0];
+                if (latestVersion) {
+                  await context.globalState.update('whatsNewLastViewedVersion', latestVersion);
+                }
+              } catch {
+                // Ignore errors
+              }
+              break;
+            }
+
+            case 'SET_WHATS_NEW_BADGE': {
+              const show = message.payload?.show ?? true;
+              await context.globalState.update('showWhatsNewBadge', show);
+              break;
+            }
 
             default:
               console.warn('Unknown message type:', message);

--- a/src/extension/utils/changelog-parser.ts
+++ b/src/extension/utils/changelog-parser.ts
@@ -1,0 +1,84 @@
+import type { ChangelogEntry, ChangelogItem, ChangelogSection } from '../../shared/types/messages';
+
+const VERSION_HEADER = /^## \[([^\]]+)\]\(([^)]+)\) \(([^)]+)\)/;
+const SECTION_HEADER = /^### (.+)/;
+// Match: * text ([#num](prUrl)) ([commitHash](commitUrl))
+// Captures: text, optional PR number, optional PR URL
+const ITEM_LINE = /^\* (.+?)(?:\s*\(\[#(\d+)\]\(([^)]+)\)\))?(?:\s*\(\[[a-f0-9]+\]\([^)]+\)\))?$/;
+
+export function parseChangelog(content: string, maxEntries = 5): ChangelogEntry[] {
+  const lines = content.split('\n');
+  const entries: ChangelogEntry[] = [];
+  let currentEntry: ChangelogEntry | null = null;
+  let currentSection: ChangelogSection | null = null;
+
+  for (const line of lines) {
+    const versionMatch = line.match(VERSION_HEADER);
+    if (versionMatch) {
+      if (currentSection && currentEntry) {
+        currentEntry.sections.push(currentSection);
+      }
+      if (currentEntry) {
+        entries.push(currentEntry);
+        if (entries.length >= maxEntries) break;
+      }
+      currentEntry = {
+        version: versionMatch[1],
+        compareUrl: versionMatch[2],
+        date: versionMatch[3],
+        sections: [],
+      };
+      currentSection = null;
+      continue;
+    }
+
+    const sectionMatch = line.match(SECTION_HEADER);
+    if (sectionMatch && currentEntry) {
+      if (currentSection) {
+        currentEntry.sections.push(currentSection);
+      }
+      currentSection = { title: sectionMatch[1], items: [] };
+      continue;
+    }
+
+    const itemMatch = line.match(ITEM_LINE);
+    if (itemMatch && currentSection) {
+      const item: ChangelogItem = { text: itemMatch[1].trim() };
+      if (itemMatch[2]) item.prNumber = `#${itemMatch[2]}`;
+      if (itemMatch[3]) item.prUrl = itemMatch[3];
+      currentSection.items.push(item);
+    }
+  }
+
+  // Push last section and entry
+  if (currentSection && currentEntry) {
+    currentEntry.sections.push(currentSection);
+  }
+  if (currentEntry && entries.length < maxEntries) {
+    entries.push(currentEntry);
+  }
+
+  return entries;
+}
+
+export function extractVersions(content: string): string[] {
+  const versions: string[] = [];
+  for (const line of content.split('\n')) {
+    const match = line.match(VERSION_HEADER);
+    if (match) {
+      versions.push(match[1]);
+    }
+  }
+  return versions;
+}
+
+export function countUnreadVersions(
+  content: string,
+  lastViewedVersion: string | undefined
+): number {
+  if (!lastViewedVersion) return 0;
+  const versions = extractVersions(content);
+  const lastViewedIndex = versions.indexOf(lastViewedVersion);
+  if (lastViewedIndex === -1) return versions.length;
+  return lastViewedIndex;
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -54,6 +54,36 @@ export interface WorkflowListPayload {
 
 export interface InitialStatePayload {
   hasAcceptedTerms: boolean;
+  unreadReleaseCount: number;
+  showWhatsNewBadge: boolean;
+}
+
+// ============================================================================
+// Changelog Payloads
+// ============================================================================
+
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  compareUrl: string;
+  sections: ChangelogSection[];
+}
+
+export interface ChangelogSection {
+  title: string;
+  items: ChangelogItem[];
+}
+
+export interface ChangelogItem {
+  text: string;
+  prNumber?: string;
+  prUrl?: string;
+}
+
+export interface GetChangelogResultPayload {
+  entries: ChangelogEntry[];
+  unreadCount: number;
+  currentVersion: string;
 }
 
 // ============================================================================
@@ -1015,6 +1045,7 @@ export type ExtensionMessage =
   | Message<SlackErrorPayload, 'SLACK_OAUTH_FAILED'>
   | Message<void, 'SLACK_OAUTH_CANCELLED'>
   | Message<GetLastSharedChannelSuccessPayload, 'GET_LAST_SHARED_CHANNEL_SUCCESS'>
+  | Message<GetChangelogResultPayload, 'GET_CHANGELOG_RESULT'>
   | Message<SlackDescriptionSuccessPayload, 'SLACK_DESCRIPTION_SUCCESS'>
   | Message<SlackDescriptionFailedPayload, 'SLACK_DESCRIPTION_FAILED'>
   | Message<WorkflowNameSuccessPayload, 'WORKFLOW_NAME_SUCCESS'>
@@ -2178,7 +2209,10 @@ export type WebviewMessage =
   | Message<void, 'GET_SAVED_MCP_SERVER_URLS'>
   | Message<SaveMcpServerUrlsPayload, 'SAVE_MCP_SERVER_URLS'>
   | Message<LookupMcpRegistryPayload, 'LOOKUP_MCP_REGISTRY'>
-  | Message<GetSkillVersionDetailsPayload, 'GET_SKILL_VERSION_DETAILS'>;
+  | Message<GetSkillVersionDetailsPayload, 'GET_SKILL_VERSION_DETAILS'>
+  | Message<void, 'GET_CHANGELOG'>
+  | Message<void, 'MARK_CHANGELOG_READ'>
+  | Message<{ show: boolean }, 'SET_WHATS_NEW_BADGE'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -183,6 +183,8 @@ const App: React.FC = () => {
     string | undefined
   >(undefined);
   const [isMoreActionsOpen, setIsMoreActionsOpen] = useState(false);
+  const [unreadReleaseCount, setUnreadReleaseCount] = useState(0);
+  const [showWhatsNewBadge, setShowWhatsNewBadge] = useState(true);
 
   // Pending MCP apply state for diff preview
   const [pendingMcpApply, setPendingMcpApply] = useState<{
@@ -300,6 +302,8 @@ const App: React.FC = () => {
           // Show terms dialog if not accepted
           setShowTermsDialog(true);
         }
+        setUnreadReleaseCount(payload.unreadReleaseCount ?? 0);
+        setShowWhatsNewBadge(payload.showWhatsNewBadge ?? true);
       } else if (message.type === 'IMPORT_WORKFLOW_FROM_SLACK') {
         // Handle import workflow request from Extension Host
         // Simply forward the message back to Extension Host to trigger the import process
@@ -536,6 +540,9 @@ const App: React.FC = () => {
         onShareToSlack={handleShareToSlack}
         moreActionsOpen={isMoreActionsOpen}
         onMoreActionsOpenChange={setIsMoreActionsOpen}
+        initialUnreadReleaseCount={unreadReleaseCount}
+        showWhatsNewBadge={showWhatsNewBadge}
+        onShowWhatsNewBadgeChange={setShowWhatsNewBadge}
       />
 
       {/* Main Content: 3-column layout */}

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -45,6 +45,7 @@ import { ProcessingOverlay } from './common/ProcessingOverlay';
 import { StyledTooltipProvider } from './common/StyledTooltip';
 import { ClaudeApiUploadDialog } from './dialogs/ClaudeApiUploadDialog';
 import { ConfirmDialog } from './dialogs/ConfirmDialog';
+import { WhatsNewDialog } from './dialogs/WhatsNewDialog';
 import { MoreActionsDropdown } from './toolbar/MoreActionsDropdown';
 import { SlashCommandOptionsDropdown } from './toolbar/SlashCommandOptionsDropdown';
 
@@ -54,6 +55,9 @@ interface ToolbarProps {
   onShareToSlack: () => void;
   moreActionsOpen?: boolean;
   onMoreActionsOpenChange?: (open: boolean) => void;
+  initialUnreadReleaseCount?: number;
+  showWhatsNewBadge?: boolean;
+  onShowWhatsNewBadgeChange?: (show: boolean) => void;
 }
 
 export const Toolbar: React.FC<ToolbarProps> = ({
@@ -62,6 +66,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onShareToSlack,
   moreActionsOpen,
   onMoreActionsOpenChange,
+  initialUnreadReleaseCount = 0,
+  showWhatsNewBadge = true,
+  onShowWhatsNewBadgeChange,
 }) => {
   const { t, locale } = useTranslation();
   const isCompact = useIsCompactMode();
@@ -144,6 +151,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   const [isCursorRunning, setIsCursorRunning] = useState(false);
   // Claude API Upload
   const [isClaudeApiUploadDialogOpen, setIsClaudeApiUploadDialogOpen] = useState(false);
+  // What's New
+  const [isWhatsNewDialogOpen, setIsWhatsNewDialogOpen] = useState(false);
+  const [unreadReleaseCount, setUnreadReleaseCount] = useState(initialUnreadReleaseCount);
+
+  useEffect(() => {
+    setUnreadReleaseCount(initialUnreadReleaseCount);
+  }, [initialUnreadReleaseCount]);
+
   const generationNameRequestIdRef = useRef<string | null>(null);
 
   // Workflow name validation pattern (lowercase, numbers, hyphens, underscores only)
@@ -2325,6 +2340,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               onToggleAntigravityBeta={toggleAntigravityEnabled}
               isCursorEnabled={isCursorEnabled}
               onToggleCursorBeta={toggleCursorEnabled}
+              onOpenWhatsNew={() => setIsWhatsNewDialogOpen(true)}
+              unreadReleaseCount={unreadReleaseCount}
               open={moreActionsOpen}
               onOpenChange={onMoreActionsOpenChange}
             />
@@ -2349,6 +2366,22 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           cancelLabel={t('common.cancel')}
           onConfirm={handleResetWorkflow}
           onCancel={() => setShowResetConfirm(false)}
+        />
+
+        {/* What's New Dialog */}
+        <WhatsNewDialog
+          isOpen={isWhatsNewDialogOpen}
+          onClose={() => {
+            setIsWhatsNewDialogOpen(false);
+            setUnreadReleaseCount(0);
+          }}
+          showBadge={showWhatsNewBadge}
+          onShowBadgeChange={(show) => {
+            onShowWhatsNewBadgeChange?.(show);
+            if (!show) {
+              setUnreadReleaseCount(0);
+            }
+          }}
         />
       </div>
     </StyledTooltipProvider>

--- a/src/webview/src/components/dialogs/WhatsNewDialog.tsx
+++ b/src/webview/src/components/dialogs/WhatsNewDialog.tsx
@@ -1,0 +1,335 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import type { ChangelogEntry } from '@shared/types/messages';
+import { ExternalLink, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
+import {
+  getChangelog,
+  markChangelogRead,
+  openExternalUrl,
+  setWhatsNewBadge,
+} from '../../services/vscode-bridge';
+
+interface WhatsNewDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  showBadge: boolean;
+  onShowBadgeChange: (show: boolean) => void;
+}
+
+export function WhatsNewDialog({
+  isOpen,
+  onClose,
+  showBadge,
+  onShowBadgeChange,
+}: WhatsNewDialogProps) {
+  const { t } = useTranslation();
+  const [entries, setEntries] = useState<ChangelogEntry[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+    getChangelog()
+      .then((result) => {
+        setEntries(result.entries);
+        setUnreadCount(result.unreadCount);
+        markChangelogRead();
+      })
+      .catch(() => {
+        setEntries([]);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [isOpen]);
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
+          }}
+        >
+          <Dialog.Content
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            style={{
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '4px',
+              padding: '24px',
+              minWidth: '500px',
+              maxWidth: '650px',
+              maxHeight: '70vh',
+              display: 'flex',
+              flexDirection: 'column',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              outline: 'none',
+            }}
+          >
+            {/* Header */}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: '16px',
+              }}
+            >
+              <Dialog.Title
+                style={{
+                  fontSize: '16px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                  margin: 0,
+                }}
+              >
+                {t('whatsNew.title')}
+              </Dialog.Title>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                {/* Badge toggle */}
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    cursor: 'pointer',
+                    fontSize: '11px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    userSelect: 'none',
+                  }}
+                >
+                  <span>{t('whatsNew.showBadge')}</span>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={showBadge}
+                    onClick={() => {
+                      const next = !showBadge;
+                      onShowBadgeChange(next);
+                      setWhatsNewBadge(next);
+                    }}
+                    style={{
+                      position: 'relative',
+                      width: '28px',
+                      height: '16px',
+                      borderRadius: '8px',
+                      border: 'none',
+                      cursor: 'pointer',
+                      backgroundColor: showBadge
+                        ? 'var(--vscode-button-background)'
+                        : 'var(--vscode-input-border)',
+                      transition: 'background-color 0.2s',
+                      padding: 0,
+                    }}
+                  >
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: '2px',
+                        left: showBadge ? '14px' : '2px',
+                        width: '12px',
+                        height: '12px',
+                        borderRadius: '50%',
+                        backgroundColor: 'white',
+                        transition: 'left 0.2s',
+                      }}
+                    />
+                  </button>
+                </label>
+                {/* Close button */}
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: 'var(--vscode-foreground)',
+                      cursor: 'pointer',
+                      padding: '4px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      opacity: 0.7,
+                    }}
+                  >
+                    <X size={16} />
+                  </button>
+                </Dialog.Close>
+              </div>
+            </div>
+
+            {/* Content */}
+            <div
+              style={{
+                overflowY: 'auto',
+                flex: 1,
+                fontSize: '12px',
+                color: 'var(--vscode-foreground)',
+                lineHeight: '1.6',
+              }}
+            >
+              {loading && (
+                <p style={{ color: 'var(--vscode-descriptionForeground)' }}>Loading...</p>
+              )}
+              {!loading && entries.length === 0 && (
+                <p style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                  No entries available.
+                </p>
+              )}
+              {!loading &&
+                entries.map((entry, entryIndex) => (
+                  <div
+                    key={entry.version}
+                    style={{
+                      marginBottom: '20px',
+                      borderLeft:
+                        entryIndex < unreadCount
+                          ? '3px solid var(--vscode-textLink-foreground)'
+                          : '3px solid transparent',
+                      paddingLeft: '12px',
+                    }}
+                  >
+                    {/* Version header */}
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '6px',
+                        marginBottom: '8px',
+                        paddingBottom: '6px',
+                        borderBottom: '1px solid var(--vscode-panel-border)',
+                      }}
+                    >
+                      <span style={{ fontSize: '14px', fontWeight: 600 }}>v{entry.version}</span>
+                      <span
+                        style={{
+                          fontSize: '11px',
+                          color: 'var(--vscode-descriptionForeground)',
+                        }}
+                      >
+                        ({entry.date})
+                      </span>
+                      {entry.compareUrl && (
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => openExternalUrl(entry.compareUrl)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              openExternalUrl(entry.compareUrl);
+                            }
+                          }}
+                          style={{
+                            display: 'inline-flex',
+                            cursor: 'pointer',
+                            color: 'var(--vscode-textLink-foreground)',
+                          }}
+                          title="View changes on GitHub"
+                        >
+                          <ExternalLink size={11} />
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Sections */}
+                    {entry.sections.map((section) => (
+                      <div key={section.title} style={{ marginBottom: '10px' }}>
+                        <div
+                          style={{
+                            fontSize: '11px',
+                            fontWeight: 600,
+                            color: 'var(--vscode-descriptionForeground)',
+                            marginBottom: '4px',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.5px',
+                          }}
+                        >
+                          {section.title}
+                        </div>
+                        <ul style={{ margin: 0, paddingLeft: '16px' }}>
+                          {section.items.map((item, idx) => (
+                            <li
+                              key={`${item.text}-${idx}`}
+                              style={{
+                                marginBottom: '3px',
+                                fontSize: '12px',
+                              }}
+                            >
+                              {item.text}
+                              {item.prNumber && item.prUrl && (
+                                <>
+                                  {' '}
+                                  <span
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={() => openExternalUrl(item.prUrl ?? '')}
+                                    onKeyDown={(e) => {
+                                      if (e.key === 'Enter' || e.key === ' ') {
+                                        openExternalUrl(item.prUrl ?? '');
+                                      }
+                                    }}
+                                    style={{
+                                      cursor: 'pointer',
+                                      color: 'var(--vscode-textLink-foreground)',
+                                      fontSize: '11px',
+                                    }}
+                                  >
+                                    ({item.prNumber})
+                                  </span>
+                                </>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              {!loading && entries.length > 0 && (
+                <div
+                  style={{
+                    textAlign: 'center',
+                    paddingTop: '8px',
+                    borderTop: '1px solid var(--vscode-panel-border)',
+                  }}
+                >
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={() =>
+                      openExternalUrl('https://github.com/breaking-brake/cc-wf-studio/releases')
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        openExternalUrl('https://github.com/breaking-brake/cc-wf-studio/releases');
+                      }
+                    }}
+                    style={{
+                      cursor: 'pointer',
+                      color: 'var(--vscode-textLink-foreground)',
+                      fontSize: '11px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                    }}
+                  >
+                    {t('whatsNew.viewAllReleases')}
+                    <ExternalLink size={11} />
+                  </span>
+                </div>
+              )}
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -15,6 +15,7 @@ import {
   Cloud,
   Focus,
   HelpCircle,
+  Info,
   MoreHorizontal,
   Share2,
   Terminal,
@@ -49,6 +50,8 @@ interface MoreActionsDropdownProps {
   onToggleAntigravityBeta: () => void;
   isCursorEnabled: boolean;
   onToggleCursorBeta: () => void;
+  onOpenWhatsNew: () => void;
+  unreadReleaseCount: number;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -74,6 +77,8 @@ export function MoreActionsDropdown({
   onToggleAntigravityBeta,
   isCursorEnabled,
   onToggleCursorBeta,
+  onOpenWhatsNew,
+  unreadReleaseCount,
   open,
   onOpenChange,
 }: MoreActionsDropdownProps) {
@@ -97,10 +102,33 @@ export function MoreActionsDropdown({
             display: 'flex',
             alignItems: 'center',
             gap: '4px',
+            position: 'relative',
           }}
         >
           <MoreHorizontal size={16} />
           {!isCompact && <span>{t('toolbar.moreActions')}</span>}
+          {unreadReleaseCount > 0 && (
+            <span
+              style={{
+                position: 'absolute',
+                top: -4,
+                right: -4,
+                backgroundColor: 'var(--vscode-badge-background)',
+                color: 'var(--vscode-badge-foreground)',
+                borderRadius: '50%',
+                minWidth: '16px',
+                height: '16px',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '10px',
+                fontWeight: 600,
+                lineHeight: 1,
+              }}
+            >
+              {unreadReleaseCount}
+            </span>
+          )}
         </button>
       </DropdownMenu.Trigger>
 
@@ -403,6 +431,44 @@ export function MoreActionsDropdown({
               margin: '4px 0',
             }}
           />
+
+          {/* What's New */}
+          <DropdownMenu.Item
+            onSelect={onOpenWhatsNew}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <Info size={14} />
+            <span style={{ flex: 1 }}>{t('toolbar.whatsNew')}</span>
+            {unreadReleaseCount > 0 && (
+              <span
+                style={{
+                  backgroundColor: 'var(--vscode-badge-background)',
+                  color: 'var(--vscode-badge-foreground)',
+                  borderRadius: '50%',
+                  minWidth: '16px',
+                  height: '16px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '10px',
+                  fontWeight: 600,
+                  lineHeight: 1,
+                }}
+              >
+                {unreadReleaseCount}
+              </span>
+            )}
+          </DropdownMenu.Item>
 
           {/* Help / Start Tour */}
           <DropdownMenu.Item

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -85,6 +85,12 @@ export interface WebviewTranslationKeys {
   // Toolbar more actions dropdown
   'toolbar.moreActions': string;
   'toolbar.help': string;
+  'toolbar.whatsNew': string;
+
+  // What's New dialog
+  'whatsNew.title': string;
+  'whatsNew.viewAllReleases': string;
+  'whatsNew.showBadge': string;
 
   // Copilot Execution Mode
   'copilot.mode.tooltip': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -91,6 +91,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'More',
   'toolbar.help': 'Help',
+  'toolbar.whatsNew': "What's New",
+  'whatsNew.title': "What's New",
+  'whatsNew.viewAllReleases': 'View all releases',
+  'whatsNew.showBadge': 'Unread badge',
 
   // Copilot Execution Mode
   'copilot.mode.tooltip': 'Select Copilot execution mode',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -91,6 +91,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar more actions dropdown
   'toolbar.moreActions': 'その他',
   'toolbar.help': 'ヘルプ',
+  'toolbar.whatsNew': '更新情報',
+  'whatsNew.title': '更新情報',
+  'whatsNew.viewAllReleases': 'すべての更新情報を見る',
+  'whatsNew.showBadge': '未読バッジ',
 
   // Copilot Execution Mode
   'copilot.mode.tooltip': 'Copilot実行モードを選択',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -90,6 +90,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar more actions dropdown
   'toolbar.moreActions': '더보기',
   'toolbar.help': '도움말',
+  'toolbar.whatsNew': '새 소식',
+  'whatsNew.title': '새 소식',
+  'whatsNew.viewAllReleases': '모든 업데이트 보기',
+  'whatsNew.showBadge': '읽지 않은 배지',
 
   // Copilot Execution Mode
   'copilot.mode.tooltip': 'Copilot 실행 모드 선택',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -88,6 +88,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '帮助',
+  'toolbar.whatsNew': '更新内容',
+  'whatsNew.title': '更新内容',
+  'whatsNew.viewAllReleases': '查看所有更新内容',
+  'whatsNew.showBadge': '未读徽章',
 
   // Copilot Execution Mode
   'copilot.mode.tooltip': '选择 Copilot 执行模式',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -88,6 +88,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Toolbar more actions dropdown
   'toolbar.moreActions': '更多',
   'toolbar.help': '說明',
+  'toolbar.whatsNew': '更新內容',
+  'whatsNew.title': '更新內容',
+  'whatsNew.viewAllReleases': '查看所有更新內容',
+  'whatsNew.showBadge': '未讀徽章',
 
   // Copilot Execution Mode
   'copilot.mode.tooltip': '選擇 Copilot 執行模式',

--- a/src/webview/src/services/vscode-bridge.ts
+++ b/src/webview/src/services/vscode-bridge.ts
@@ -29,6 +29,7 @@ import type {
   ExportForRooCodeSuccessPayload,
   ExportWorkflowPayload,
   ExtensionMessage,
+  GetChangelogResultPayload,
   GetMcpServerTypesResultPayload,
   GetSavedMcpServerUrlsResultPayload,
   GetSkillVersionDetailsSuccessPayload,
@@ -1599,4 +1600,44 @@ export function getSkillVersionDetails(
       reject(new Error('Request timed out'));
     }, 10000);
   });
+}
+
+/**
+ * Get changelog entries from CHANGELOG.md
+ */
+export function getChangelog(): Promise<GetChangelogResultPayload> {
+  return new Promise((resolve, reject) => {
+    const requestId = `req-${Date.now()}-${Math.random()}`;
+    const handler = (event: MessageEvent) => {
+      const message: ExtensionMessage = event.data;
+      if (message.requestId === requestId) {
+        window.removeEventListener('message', handler);
+        if (message.type === 'GET_CHANGELOG_RESULT') {
+          resolve(message.payload as GetChangelogResultPayload);
+        } else {
+          reject(new Error('Failed to get changelog'));
+        }
+      }
+    };
+    window.addEventListener('message', handler);
+    vscode.postMessage({ type: 'GET_CHANGELOG', requestId });
+    setTimeout(() => {
+      window.removeEventListener('message', handler);
+      reject(new Error('Request timed out'));
+    }, 10000);
+  });
+}
+
+/**
+ * Mark changelog as read (fire-and-forget)
+ */
+export function markChangelogRead(): void {
+  vscode.postMessage({ type: 'MARK_CHANGELOG_READ' });
+}
+
+/**
+ * Set whether to show the What's New badge (fire-and-forget)
+ */
+export function setWhatsNewBadge(show: boolean): void {
+  vscode.postMessage({ type: 'SET_WHATS_NEW_BADGE', payload: { show } });
 }


### PR DESCRIPTION
## Summary

Add a "What's New" feature to the More submenu that parses CHANGELOG.md and displays the latest 5 releases in a Radix UI dialog, with unread release count badges.

## Motivation

Users have no way to discover what changed between extension updates. This feature surfaces recent changes directly in the UI, improving awareness of new features and bug fixes.

## Changes

**New Files:**
- `src/extension/utils/changelog-parser.ts` - Regex-based CHANGELOG.md parser (no external deps)
- `src/webview/src/components/dialogs/WhatsNewDialog.tsx` - Radix UI dialog displaying changelog entries

**Modified Files:**
- `src/shared/types/messages.ts` - Added ChangelogEntry types, message definitions, InitialStatePayload extensions
- `src/extension/commands/open-editor.ts` - Handlers for GET_CHANGELOG, MARK_CHANGELOG_READ, SET_WHATS_NEW_BADGE; unread count in INITIAL_STATE
- `src/webview/src/services/vscode-bridge.ts` - Bridge functions: getChangelog(), markChangelogRead(), setWhatsNewBadge()
- `src/webview/src/components/toolbar/MoreActionsDropdown.tsx` - What's New menu item with badge, More button badge
- `src/webview/src/components/Toolbar.tsx` - Dialog state management, unread count tracking
- `src/webview/src/App.tsx` - Pass unreadReleaseCount and showWhatsNewBadge from INITIAL_STATE
- `src/webview/src/i18n/translation-keys.ts` - New translation keys
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Translations for 5 languages

## Testing

- [x] Manual E2E testing completed
- [x] `npm run format && npm run lint && npm run check && npm run build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "What's New" dialog to view recent software release updates and changelog entries
  * Unread badge indicator displays the number of available releases
  * Toggle badge visibility directly within the interface
  * Changelog entries include version details, release dates, and pull request links
  * Full multilingual support including English, Japanese, Korean, Simplified and Traditional Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->