### PR TITLE
chore: replace `as any` with explicit type in vscode-bridge

### DIFF
--- a/src/webview/src/services/vscode-bridge.ts
+++ b/src/webview/src/services/vscode-bridge.ts
@@ -1583,7 +1583,8 @@ export function getSkillVersionDetails(
         } else {
           reject(
             new Error(
-              (message.payload as any)?.errorMessage || 'Failed to get skill version details'
+              (message.payload as { errorMessage?: string })?.errorMessage ||
+                'Failed to get skill version details'
             )
           );
         }


### PR DESCRIPTION
## Summary

Replace `as any` type assertion with an explicit inline type to resolve Biome `noExplicitAny` lint warning.

## What Changed

### Before
- `(message.payload as any)?.errorMessage` — triggers `noExplicitAny` lint warning

### After
- `(message.payload as { errorMessage?: string })?.errorMessage` — no lint warnings

## Changes

- `src/webview/src/services/vscode-bridge.ts` - Replace `as any` with `as { errorMessage?: string }`

## Testing

- [x] `npm run format` — passed
- [x] `npm run lint` — 0 warnings
- [x] `npm run check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in error handling for better code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->