### PR TITLE
Release: v3.27.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@slack/web-api": "^7.13.0",
         "@toon-format/toon": "^2.1.0",
         "fflate": "^0.8.2",
+        "marked": "^15.0.12",
         "nano-spawn": "^2.0.0",
         "smol-toml": "^1.6.0"
       },
@@ -2169,9 +2170,9 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5053,7 +5054,6 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@slack/web-api": "^7.13.0",
     "@toon-format/toon": "^2.1.0",
     "fflate": "^0.8.2",
+    "marked": "^15.0.12",
     "nano-spawn": "^2.0.0",
     "smol-toml": "^1.6.0"
   }

--- a/src/extension/utils/changelog-parser.ts
+++ b/src/extension/utils/changelog-parser.ts
@@ -1,52 +1,110 @@
+import { Lexer, type Token, type Tokens } from 'marked';
 import type { ChangelogEntry, ChangelogItem, ChangelogSection } from '../../shared/types/messages';
 
-const VERSION_HEADER = /^## \[([^\]]+)\]\(([^)]+)\) \(([^)]+)\)/;
-const SECTION_HEADER = /^### (.+)/;
-// Match: * text ([#num](prUrl)) ([commitHash](commitUrl))
-// Captures: text, optional PR number, optional PR URL
-const ITEM_LINE = /^\* (.+?)(?:\s*\(\[#(\d+)\]\(([^)]+)\)\))?(?:\s*\(\[[a-f0-9]+\]\([^)]+\)\))?$/;
+/**
+ * Extract plain text and the first PR link from a list of inline tokens.
+ * Handles semantic-release format:
+ *   "description ([#num](url)) ([hash](url)), closes [#n](url) ..."
+ */
+function extractItemFromTokens(tokens: Token[]): ChangelogItem {
+  let text = '';
+  let prNumber: string | undefined;
+  let prUrl: string | undefined;
+  let foundPr = false;
+
+  for (const token of tokens) {
+    if (token.type === 'link' && !foundPr) {
+      // First link starting with # is the PR reference
+      if (token.text.startsWith('#')) {
+        prNumber = token.text;
+        prUrl = token.href;
+        foundPr = true;
+        continue;
+      }
+    }
+    // Skip commit hash links and "closes" references after PR link
+    if (foundPr) continue;
+
+    if (token.type === 'text') {
+      text += token.raw;
+    } else if (token.type === 'codespan') {
+      text += `\`${(token as Tokens.Codespan).text}\``;
+    } else if (token.type === 'strong') {
+      text += (token as Tokens.Strong).text;
+    } else if (token.type === 'em') {
+      text += (token as Tokens.Em).text;
+    }
+  }
+
+  const item: ChangelogItem = { text: text.replace(/\s*\($/, '').trim() };
+  if (prNumber) item.prNumber = prNumber;
+  if (prUrl) item.prUrl = prUrl;
+  return item;
+}
 
 export function parseChangelog(content: string, maxEntries = 5): ChangelogEntry[] {
-  const lines = content.split('\n');
+  const lexer = new Lexer();
+  const tokens = lexer.lex(content);
   const entries: ChangelogEntry[] = [];
   let currentEntry: ChangelogEntry | null = null;
   let currentSection: ChangelogSection | null = null;
 
-  for (const line of lines) {
-    const versionMatch = line.match(VERSION_HEADER);
-    if (versionMatch) {
+  for (const token of tokens) {
+    // ## [version](compareUrl) (date)
+    if (token.type === 'heading' && token.depth === 2) {
       if (currentSection && currentEntry) {
         currentEntry.sections.push(currentSection);
+        currentSection = null;
       }
       if (currentEntry) {
         entries.push(currentEntry);
         if (entries.length >= maxEntries) break;
       }
-      currentEntry = {
-        version: versionMatch[1],
-        compareUrl: versionMatch[2],
-        date: versionMatch[3],
-        sections: [],
-      };
-      currentSection = null;
+
+      // Parse version heading inline tokens
+      const inlineTokens = (token as Tokens.Heading).tokens || [];
+      let version = '';
+      let compareUrl = '';
+      let date = '';
+
+      for (const t of inlineTokens) {
+        if (t.type === 'link' && !version) {
+          version = t.text;
+          compareUrl = t.href;
+        } else if (t.type === 'text') {
+          const dateMatch = t.raw.match(/\(([^)]+)\)/);
+          if (dateMatch) date = dateMatch[1];
+        }
+      }
+
+      currentEntry = { version, compareUrl, date, sections: [] };
       continue;
     }
 
-    const sectionMatch = line.match(SECTION_HEADER);
-    if (sectionMatch && currentEntry) {
+    // ### Section Title
+    if (token.type === 'heading' && token.depth === 3 && currentEntry) {
       if (currentSection) {
         currentEntry.sections.push(currentSection);
       }
-      currentSection = { title: sectionMatch[1], items: [] };
+      currentSection = { title: token.text, items: [] };
       continue;
     }
 
-    const itemMatch = line.match(ITEM_LINE);
-    if (itemMatch && currentSection) {
-      const item: ChangelogItem = { text: itemMatch[1].trim() };
-      if (itemMatch[2]) item.prNumber = `#${itemMatch[2]}`;
-      if (itemMatch[3]) item.prUrl = itemMatch[3];
-      currentSection.items.push(item);
+    // List items
+    if (token.type === 'list' && currentSection) {
+      for (const listItem of (token as Tokens.List).items) {
+        const inlineTokens = (listItem as Tokens.ListItem).tokens;
+        // Flatten: list item may wrap content in a paragraph
+        let flatTokens: Token[] = [];
+        for (const t of inlineTokens) {
+          if (t.type === 'paragraph' || t.type === 'text') {
+            flatTokens = flatTokens.concat((t as Tokens.Paragraph).tokens || [t]);
+          } else {
+            flatTokens.push(t);
+          }
+        }
+        currentSection.items.push(extractItemFromTokens(flatTokens));
+      }
     }
   }
 
@@ -61,10 +119,12 @@ export function parseChangelog(content: string, maxEntries = 5): ChangelogEntry[
   return entries;
 }
 
+const VERSION_HEADING = /^## \[([^\]]+)\]/;
+
 export function extractVersions(content: string): string[] {
   const versions: string[] = [];
   for (const line of content.split('\n')) {
-    const match = line.match(VERSION_HEADER);
+    const match = line.match(VERSION_HEADING);
     if (match) {
       versions.push(match[1]);
     }


### PR DESCRIPTION
## Summary

Merge latest changes from `main` to `production` for automated release v3.27.1.

## Included Changes

### Bug Fixes
- fix: replace regex changelog parser with marked lexer (#642)

## Release Version Calculation

**v3.27.1** (patch bump)

Semantic Release will analyze commits since v3.27.0:
- ✅ `fix: replace regex changelog parser with marked lexer` (#642) → **patch bump**

Result: **3.27.0 + patch = 3.27.1**

## CHANGELOG.md Contents

The following will be included:
- Replace regex changelog parser with marked lexer (#642)

## Release Automation

This merge will trigger:
1. Analyze commit messages for version bump
2. Update version in package.json files
3. Generate CHANGELOG.md
4. Create GitHub release
5. Build and upload VSIX package
6. Sync version changes back to main

## Merge Strategy

**Use merge commit** (not squash) to preserve commit history for Semantic Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)