### PR TITLE
chore: update hono 4.12.5 to 4.12.7 for prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4276,9 +4276,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
## Problem

`npm audit` reported a **moderate severity** Prototype Pollution vulnerability in `hono`'s `parseBody` function (v4.12.5).

### Current Behavior
1. Run `npm audit`
2. ❌ Reports moderate severity Prototype Pollution vulnerability in hono 4.12.5

### Expected Behavior
1. Run `npm audit`
2. ✅ No vulnerability reported for hono

## Solution

Applied `npm audit fix` (non-breaking) to update hono from 4.12.5 to 4.12.7, which patches the Prototype Pollution vulnerability.

### Changes

**File**: `package-lock.json`

- Updated hono version 4.12.5 → 4.12.7 (peer dependency, patch update only)

## Impact

- Resolves 1 moderate severity vulnerability
- No breaking changes (patch version update)
- No changes to `package.json` (hono is a peer dependency)

## Testing

- [x] `npm run format` passed
- [x] `npm run lint` passed
- [x] `npm run check` passed
- [x] `npm run build` passed

## Notes

- 9 remaining vulnerabilities require `--force` (breaking changes) and are out of scope for this PR
- These include issues in diff/mocha/@vscode/test-cli, minimatch/tar/npm/semantic-release, and serialize-javascript

🤖 Generated with [Claude Code](https://claude.com/claude-code)