### PR TITLE
chore: fix undici vulnerabilities via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5472,9 +5472,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.0.tgz",
-      "integrity": "sha512-82gRxKrh/eY5UnNorkTFcdBQAGpgjWehkfGVqAGlJjejEtJZGGJUqjo3mbBTNbc5BTnPKGVtGPBZGhElujX5cw==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
+      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5553,7 +5553,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/config": "^10.7.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
@@ -5561,7 +5561,7 @@
         "@npmcli/package-json": "^7.0.5",
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.3",
+        "@npmcli/run-script": "^10.0.4",
         "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
@@ -5578,17 +5578,17 @@
         "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.3",
-        "libnpmexec": "^10.2.3",
-        "libnpmfund": "^7.0.17",
+        "libnpmdiff": "^8.1.4",
+        "libnpmexec": "^10.2.4",
+        "libnpmfund": "^7.0.18",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.3",
+        "libnpmpack": "^9.1.4",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
         "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.2",
+        "minimatch": "^10.2.4",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -5602,7 +5602,7 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.4.0",
+        "pacote": "^21.5.0",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
@@ -5611,7 +5611,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.9",
+        "tar": "^7.5.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -5712,11 +5712,12 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.0",
+      "version": "9.4.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -5925,7 +5926,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.3",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5934,8 +5935,7 @@
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0",
-        "which": "^6.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6105,7 +6105,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6495,12 +6495,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.3",
+      "version": "8.1.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -6514,13 +6514,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.3",
+      "version": "10.2.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -6537,12 +6537,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.17",
+      "version": "7.0.18",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.0"
+        "@npmcli/arborist": "^9.4.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6562,12 +6562,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.3",
+      "version": "9.1.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.0",
+        "@npmcli/arborist": "^9.4.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -6668,7 +6668,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.2",
+      "version": "10.2.4",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7006,7 +7006,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.4.0",
+      "version": "21.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7311,7 +7311,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.9",
+      "version": "7.5.11",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7471,12 +7471,11 @@
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -9672,9 +9671,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problem

6 open Dependabot security alerts for `undici` package vulnerabilities:
- CRLF Injection (#52, #56)
- HTTP Request/Response Smuggling (#48, #55)
- Malicious WebSocket 64-bit length overflow (#49, #54)
- Unbounded Memory Consumption in WebSocket
- Unhandled Exception in WebSocket Client

## Solution

Ran `npm audit fix` to update `undici` to a patched version (non-breaking change).

### Changes

**File**: `package-lock.json`

- Updated undici and related transitive dependencies to patched versions

## Impact

- Resolves 6 of 10 open Dependabot alerts
- No breaking changes (only `package-lock.json` updated)
- Remaining 4 alerts require breaking changes or npm bundled dependency updates

## Testing

- [x] `npm audit fix` completed successfully
- [x] Build verification in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)