### PR TITLE
improvement: add edge animation on node/edge selection

### DIFF
--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -5,7 +5,7 @@
  * Based on: /specs/001-cc-wf-studio/research.md section 3.4
  */
 
-import { PanelLeftOpen } from 'lucide-react';
+import { Activity, PanelLeftOpen } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactFlow, {
@@ -18,6 +18,7 @@ import ReactFlow, {
   type Node,
   type NodeTypes,
   Panel,
+  applyNodeChanges,
 } from 'reactflow';
 import { CURRENT_ANNOUNCEMENT, cleanupDismissedAnnouncements } from '../constants/announcements';
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
@@ -25,6 +26,7 @@ import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
+import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
 import { DescriptionPanel } from './DescriptionPanel';
 // Custom edge with delete button
 import { DeletableEdge } from './edges/DeletableEdge';
@@ -115,8 +117,27 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     onEdgesChange,
     onConnect,
     setSelectedNodeId,
+    syncSelectedNodeId,
+    selectedNodeId,
     interactionMode,
   } = useWorkflowStore();
+
+  // Edge animation toggle (respects prefers-reduced-motion by default)
+  const [isEdgeAnimationEnabled, setIsEdgeAnimationEnabled] = useState(
+    () => !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+
+  // Animate edges: selected edge itself, or edges connected to selected node
+  const animatedEdges = useMemo(() => {
+    if (!isEdgeAnimationEnabled) return edges;
+    return edges.map((edge) => ({
+      ...edge,
+      animated:
+        edge.selected ||
+        (selectedNodeId != null &&
+          (edge.source === selectedNodeId || edge.target === selectedNodeId)),
+    }));
+  }, [edges, selectedNodeId, isEdgeAnimationEnabled]);
 
   /**
    * 接続制約の検証
@@ -149,12 +170,32 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     [nodes]
   );
 
-  // Memoize callbacks for performance (research.md section 3.1)
-  const handleNodesChange = useCallback(onNodesChange, [onNodesChange]);
+  // Sync selectedNodeId from post-change node state (side-effect-free)
+  const handleNodesChange = useCallback(
+    (changes: Parameters<typeof onNodesChange>[0]) => {
+      const hasSelectionChanges = changes.some((c) => c.type === 'select');
+      onNodesChange(changes);
+
+      if (hasSelectionChanges) {
+        // Determine selection from full post-change state, not from delta
+        const updatedNodes = applyNodeChanges(changes, nodes);
+        const selectedNodes = updatedNodes.filter((n) => n.selected);
+
+        if (selectedNodes.length === 1) {
+          syncSelectedNodeId(selectedNodes[0].id);
+        } else {
+          // Multi-select or no selection: clear selectedNodeId
+          syncSelectedNodeId(null);
+        }
+      }
+    },
+    [onNodesChange, syncSelectedNodeId, nodes]
+  );
+
   const handleEdgesChange = useCallback(onEdgesChange, [onEdgesChange]);
   const handleConnect = useCallback(onConnect, [onConnect]);
 
-  // Handle node selection
+  // Handle explicit node click (opens property overlay)
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
       setSelectedNodeId(node.id);
@@ -164,8 +205,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
 
   // Handle pane click (deselect)
   const handlePaneClick = useCallback(() => {
-    setSelectedNodeId(null);
-  }, [setSelectedNodeId]);
+    syncSelectedNodeId(null);
+  }, [syncSelectedNodeId]);
 
   // Memoize snap grid
   const snapGrid = useMemo<[number, number]>(() => [15, 15], []);
@@ -226,11 +267,12 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       <div style={{ flex: 1, position: 'relative' }}>
         <ReactFlow
           nodes={nodes}
-          edges={edges}
+          edges={animatedEdges}
           onNodesChange={handleNodesChange}
           onEdgesChange={handleEdgesChange}
           onConnect={handleConnect}
           onNodeClick={handleNodeClick}
+          onEdgeClick={() => syncSelectedNodeId(null)}
           onPaneClick={handlePaneClick}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
@@ -293,9 +335,48 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             </MinimapContainer>
           </Panel>
 
-          {/* Interaction Mode Toggle */}
+          {/* Interaction Mode Toggle & Edge Animation Toggle */}
           <Panel position="top-left">
-            <InteractionModeToggle />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <InteractionModeToggle />
+              <StyledTooltipProvider>
+                <StyledTooltipItem
+                  content={
+                    isEdgeAnimationEnabled
+                      ? t('toolbar.edgeAnimation.disable')
+                      : t('toolbar.edgeAnimation.enable')
+                  }
+                >
+                  <button
+                    type="button"
+                    onClick={() => setIsEdgeAnimationEnabled((prev) => !prev)}
+                    aria-label={
+                      isEdgeAnimationEnabled
+                        ? t('toolbar.edgeAnimation.disable')
+                        : t('toolbar.edgeAnimation.enable')
+                    }
+                    style={{
+                      all: 'unset',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '28px',
+                      height: '28px',
+                      borderRadius: '20px',
+                      backgroundColor: 'var(--vscode-editor-background)',
+                      border: '1px solid var(--vscode-panel-border)',
+                      cursor: 'pointer',
+                      opacity: 0.85,
+                      color: isEdgeAnimationEnabled
+                        ? 'var(--vscode-foreground)'
+                        : 'var(--vscode-disabledForeground)',
+                    }}
+                  >
+                    <Activity size={14} />
+                  </button>
+                </StyledTooltipItem>
+              </StyledTooltipProvider>
+            </div>
           </Panel>
 
           {/* Description Panel for workflow description */}

--- a/src/webview/src/components/edges/DeletableEdge.tsx
+++ b/src/webview/src/components/edges/DeletableEdge.tsx
@@ -5,8 +5,15 @@
  * Shows delete button only when edge is selected.
  */
 
+import { X } from 'lucide-react';
 import type React from 'react';
-import { BaseEdge, type EdgeProps, getBezierPath, useReactFlow } from 'reactflow';
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getBezierPath,
+  useReactFlow,
+} from 'reactflow';
 
 /**
  * Deletable edge component
@@ -48,20 +55,17 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
       {/* Base edge */}
       <BaseEdge path={edgePath} style={style} markerEnd={markerEnd} />
 
-      {/* Show delete button only when selected */}
+      {/* Delete button rendered in HTML layer (outside SVG) to avoid animation flicker */}
       {selected && (
-        <foreignObject
-          x={labelX - 9}
-          y={labelY - 9}
-          width={18}
-          height={18}
-          className="edgebutton-foreignobject"
-          requiredExtensions="http://www.w3.org/1999/xhtml"
-        >
+        <EdgeLabelRenderer>
           <button
             type="button"
             onClick={handleDeleteClick}
+            className="nodrag nopan"
             style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: 'all',
               width: '18px',
               height: '18px',
               borderRadius: '3px',
@@ -72,8 +76,6 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: '14px',
-              fontWeight: 'bold',
               padding: 0,
             }}
             onMouseEnter={(e) => {
@@ -84,25 +86,9 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
             }}
             title="Delete connection"
           >
-            <svg
-              width="8"
-              height="8"
-              viewBox="0 0 8 8"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              style={{ display: 'block' }}
-              aria-labelledby="delete-edge-icon-title"
-            >
-              <title id="delete-edge-icon-title">Delete</title>
-              <path
-                d="M1 1L7 7M7 1L1 7"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
-            </svg>
+            <X size={12} strokeWidth={2.5} />
           </button>
-        </foreignObject>
+        </EdgeLabelRenderer>
       )}
     </>
   );

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -39,6 +39,8 @@ export interface WebviewTranslationKeys {
   'toolbar.interactionMode.rangeSelectionButton': string;
   'toolbar.interactionMode.switchToPan': string;
   'toolbar.interactionMode.switchToSelection': string;
+  'toolbar.edgeAnimation.enable': string;
+  'toolbar.edgeAnimation.disable': string;
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -41,6 +41,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.rangeSelectionButton': 'Select',
   'toolbar.interactionMode.switchToPan': 'Switch to Hand Tool mode',
   'toolbar.interactionMode.switchToSelection': 'Switch to Selection mode',
+  'toolbar.edgeAnimation.enable': 'Enable edge animation',
+  'toolbar.edgeAnimation.disable': 'Disable edge animation',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': 'Show Minimap',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -41,6 +41,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.rangeSelectionButton': '範囲選択',
   'toolbar.interactionMode.switchToPan': '手のひらモードに切り替え',
   'toolbar.interactionMode.switchToSelection': '範囲選択モードに切り替え',
+  'toolbar.edgeAnimation.enable': 'エッジアニメーションを有効化',
+  'toolbar.edgeAnimation.disable': 'エッジアニメーションを無効化',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': 'ミニマップを表示',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -41,6 +41,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.rangeSelectionButton': '범위 선택',
   'toolbar.interactionMode.switchToPan': '손바닥 모드로 전환',
   'toolbar.interactionMode.switchToSelection': '선택 모드로 전환',
+  'toolbar.edgeAnimation.enable': '엣지 애니메이션 활성화',
+  'toolbar.edgeAnimation.disable': '엣지 애니메이션 비활성화',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': '미니맵 표시',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -41,6 +41,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.rangeSelectionButton': '范围选择',
   'toolbar.interactionMode.switchToPan': '切换到手掌模式',
   'toolbar.interactionMode.switchToSelection': '切换到选择模式',
+  'toolbar.edgeAnimation.enable': '启用边动画',
+  'toolbar.edgeAnimation.disable': '禁用边动画',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': '显示迷你地图',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -41,6 +41,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.rangeSelectionButton': '範圍選擇',
   'toolbar.interactionMode.switchToPan': '切換到手掌模式',
   'toolbar.interactionMode.switchToSelection': '切換到選擇模式',
+  'toolbar.edgeAnimation.enable': '啟用邊動畫',
+  'toolbar.edgeAnimation.disable': '停用邊動畫',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': '顯示迷你地圖',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -77,6 +77,8 @@ interface WorkflowStore {
   setNodes: (nodes: Node[]) => void;
   setEdges: (edges: Edge[]) => void;
   setSelectedNodeId: (id: string | null) => void;
+  /** Update selectedNodeId without opening property overlay (for React Flow selection sync) */
+  syncSelectedNodeId: (id: string | null) => void;
   setInteractionMode: (mode: InteractionMode) => void;
   toggleInteractionMode: () => void;
   setWorkflowName: (name: string) => void;
@@ -326,8 +328,13 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   onConnect: (connection) => {
+    const currentNodes = get().nodes.map((node) => ({ ...node, selected: false }));
+    const currentEdges = get().edges.map((e) => ({ ...e, selected: false }));
+    const newEdges = addEdge({ ...connection, selected: true }, currentEdges);
     set({
-      edges: addEdge(connection, get().edges),
+      nodes: currentNodes,
+      edges: newEdges,
+      selectedNodeId: null,
     });
   },
 
@@ -343,6 +350,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     } else {
       set({ selectedNodeId });
     }
+  },
+
+  syncSelectedNodeId: (selectedNodeId) => {
+    set({ selectedNodeId });
   },
 
   setInteractionMode: (interactionMode) => set({ interactionMode }),


### PR DESCRIPTION
## Summary

Add visual flow direction animation to edges when nodes or edges are selected on the canvas.

## What Changed

### Before
- Edges were static lines with no animation
- Selecting an edge after a node left the node visually selected (bug)
- No visual indication of data flow direction on selection

### After
- Selecting a node animates all connected edges showing flow direction
- Selecting an edge animates that edge itself
- Node selection state properly clears when clicking edges or pane
- Selection state synced via `onNodesChange` to prevent animation desync

## Changes

- `src/webview/src/components/WorkflowEditor.tsx` - Add animated edge logic, sync selectedNodeId via onNodesChange, fix stale selection bug

## Testing

- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggleable edge animation from the toolbar to highlight selected edges and connections to the selected node.

* **Bug Fixes**
  * Selection handling improved: single/multi-select, connect actions, pane and edge clicks now consistently update and clear selection and animations.
  * Edge delete control moved to the HTML layer with a new X icon for smoother, flicker-free rendering.

* **Localization**
  * Added translation strings for enabling/disabling edge animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->