### PR TITLE
Release: v3.29.1

### DIFF
--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -8,7 +8,19 @@
 import type { CommandReference } from '@shared/types/messages';
 import type { SubAgentFlow } from '@shared/types/workflow-definition';
 import { NodeType } from '@shared/types/workflow-definition';
-import { PanelLeftClose } from 'lucide-react';
+import {
+  Bot,
+  GitBranch,
+  GitFork,
+  MessageSquare,
+  PanelLeftClose,
+  Plug,
+  ShieldQuestion,
+  Square,
+  SquareDashed,
+  Terminal,
+  Zap,
+} from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
@@ -450,7 +462,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.prompt.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <MessageSquare size={14} />
+          {t('node.prompt.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -493,7 +508,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
             e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
           }}
         >
-          <div style={{ fontWeight: 600 }}>{t('node.subAgent.title')}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <Bot size={14} />
+            {t('node.subAgent.title')}
+          </div>
           {!isCompact && (
             <div
               style={{
@@ -537,7 +555,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
             e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
           }}
         >
-          <div style={{ fontWeight: 600 }}>{t('node.subAgentFlow.title')}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <Bot size={14} />
+            {t('node.subAgentFlow.title')}
+          </div>
           {!isCompact && (
             <div
               style={{
@@ -580,7 +601,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.skill.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <Zap size={14} />
+          {t('node.skill.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -622,7 +646,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.mcp.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <Plug size={14} />
+          {t('node.mcp.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -690,6 +717,7 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
                 fontWeight: 600,
               }}
             >
+              <Terminal size={14} />
               {t('node.codex.title')}
               <BetaBadge style={{ borderRadius: '3px' }} />
             </div>
@@ -751,7 +779,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.group.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <SquareDashed size={14} />
+          {t('node.group.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -808,7 +839,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.ifElse.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <GitBranch size={14} />
+          {t('node.ifElse.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -850,7 +884,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.switch.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <GitFork size={14} />
+          {t('node.switch.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -893,7 +930,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
             e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
           }}
         >
-          <div style={{ fontWeight: 600 }}>{t('node.askUserQuestion.title')}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <ShieldQuestion size={14} />
+            {t('node.askUserQuestion.title')}
+          </div>
           {!isCompact && (
             <div
               style={{
@@ -936,7 +976,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
           e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
         }}
       >
-        <div style={{ fontWeight: 600 }}>{t('node.end.title')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+          <Square size={14} />
+          {t('node.end.title')}
+        </div>
         {!isCompact && (
           <div
             style={{
@@ -979,7 +1022,8 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
             e.currentTarget.style.opacity = '0.7';
           }}
         >
-          <div style={{ fontWeight: 600 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <GitBranch size={14} />
             {t('node.branch.title')}{' '}
             <span style={{ fontSize: isCompact ? '9px' : '10px' }}>(Legacy)</span>
           </div>

--- a/src/webview/src/components/nodes/AskUserQuestionNode.tsx
+++ b/src/webview/src/components/nodes/AskUserQuestionNode.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { AskUserQuestionData } from '@shared/types/workflow-definition';
+import { ShieldQuestion } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
@@ -53,8 +54,12 @@ export const AskUserQuestionNodeComponent: React.FC<NodeProps<AskUserQuestionDat
               color: 'var(--vscode-descriptionForeground)',
               textTransform: 'uppercase',
               letterSpacing: '0.5px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
             }}
           >
+            <ShieldQuestion size={18} />
             Ask User Question
           </div>
           <div style={{ display: 'flex', gap: '4px' }}>

--- a/src/webview/src/components/nodes/BranchNode.tsx
+++ b/src/webview/src/components/nodes/BranchNode.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { BranchNodeData } from '@shared/types/workflow-definition';
+import { GitBranch } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
@@ -47,8 +48,12 @@ export const BranchNodeComponent: React.FC<NodeProps<BranchNodeData>> = React.me
             marginBottom: '8px',
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
           }}
         >
+          <GitBranch size={18} />
           {nodeTitle}
         </div>
 

--- a/src/webview/src/components/nodes/CodexNode.tsx
+++ b/src/webview/src/components/nodes/CodexNode.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { CodexNodeData } from '@shared/types/workflow-definition';
+import { Terminal } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
@@ -131,8 +132,12 @@ export const CodexNodeComponent: React.FC<NodeProps<CodexNodeData>> = React.memo
             marginBottom: '8px',
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
           }}
         >
+          <Terminal size={18} />
           {t('node.codex.title')}
         </div>
 

--- a/src/webview/src/components/nodes/EndNode.tsx
+++ b/src/webview/src/components/nodes/EndNode.tsx
@@ -11,6 +11,7 @@
  * Based on: /specs/001-node-types-extension/quickstart.md
  */
 
+import { Square } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import type { EndNodeData } from '../../types/node-types';
@@ -51,7 +52,7 @@ export const EndNode: React.FC<NodeProps<EndNodeData>> = React.memo(({ id, data,
           gap: '8px',
         }}
       >
-        <span aria-hidden="true">■</span>
+        <Square size={18} />
         <span>{label}</span>
       </div>
 

--- a/src/webview/src/components/nodes/IfElseNode.tsx
+++ b/src/webview/src/components/nodes/IfElseNode.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { IfElseNodeData } from '@shared/types/workflow-definition';
+import { GitBranch } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
@@ -49,8 +50,12 @@ export const IfElseNodeComponent: React.FC<NodeProps<IfElseNodeData>> = React.me
             marginBottom: '8px',
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
           }}
         >
+          <GitBranch size={18} />
           If/Else
         </div>
 

--- a/src/webview/src/components/nodes/McpNode/McpNode.tsx
+++ b/src/webview/src/components/nodes/McpNode/McpNode.tsx
@@ -9,6 +9,7 @@
  */
 
 import type { McpNodeData } from '@shared/types/workflow-definition';
+import { Plug } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../../i18n/i18n-context';
@@ -131,6 +132,7 @@ export const McpNodeComponent: React.FC<NodeProps<McpNodeData>> = React.memo(
             gap: '6px',
           }}
         >
+          <Plug size={18} />
           <span>MCP Tool</span>
           {/* Source Provider Badge */}
           <AIProviderBadge provider={(data.source || 'claude') as AIProviderType} size="small" />

--- a/src/webview/src/components/nodes/PromptNode.tsx
+++ b/src/webview/src/components/nodes/PromptNode.tsx
@@ -11,6 +11,7 @@
  * Based on: /specs/001-node-types-extension/quickstart.md
  */
 
+import { MessageSquare } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import type { PromptNodeData } from '../../types/node-types';
@@ -58,8 +59,12 @@ export const PromptNode: React.FC<NodeProps<PromptNodeData>> = React.memo(
             marginBottom: '8px',
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
           }}
         >
+          <MessageSquare size={18} />
           Prompt
         </div>
 

--- a/src/webview/src/components/nodes/SkillNode.tsx
+++ b/src/webview/src/components/nodes/SkillNode.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { SkillNodeData } from '@shared/types/workflow-definition';
+import { Zap } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
@@ -91,6 +92,7 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
             gap: '6px',
           }}
         >
+          <Zap size={18} />
           <span>Skill</span>
           {/* Validation Status Icon */}
           <span

--- a/src/webview/src/components/nodes/StartNode.tsx
+++ b/src/webview/src/components/nodes/StartNode.tsx
@@ -11,6 +11,7 @@
  * Based on: /specs/001-node-types-extension/quickstart.md
  */
 
+import { Play } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import type { StartNodeData } from '../../types/node-types';
@@ -46,7 +47,7 @@ export const StartNode: React.FC<NodeProps<StartNodeData>> = React.memo(({ data,
           gap: '8px',
         }}
       >
-        <span aria-hidden="true">▶</span>
+        <Play size={18} />
         <span>{label}</span>
       </div>
 

--- a/src/webview/src/components/nodes/SubAgentFlowNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentFlowNode.tsx
@@ -10,7 +10,7 @@
 
 import type { SubAgentFlowNodeData } from '@shared/types/workflow-definition';
 import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
-import { GitBranch } from 'lucide-react';
+import { Bot } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
@@ -62,7 +62,7 @@ export const SubAgentFlowNodeComponent: React.FC<NodeProps<SubAgentFlowNodeData>
             gap: '6px',
           }}
         >
-          <GitBranch size={12} />
+          <Bot size={18} />
           <span>{t('node.subAgentFlow.title')}</span>
           {/* Warning indicator for unlinked state */}
           {!isLinked && (

--- a/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -7,6 +7,7 @@
 
 import type { SubAgentData } from '@shared/types/workflow-definition';
 import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
+import { Bot } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
@@ -40,8 +41,12 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
             marginBottom: '8px',
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
           }}
         >
+          <Bot size={18} />
           Sub-Agent
         </div>
 

--- a/src/webview/src/components/nodes/SwitchNode.tsx
+++ b/src/webview/src/components/nodes/SwitchNode.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { SwitchNodeData } from '@shared/types/workflow-definition';
+import { GitFork } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
@@ -46,8 +47,12 @@ export const SwitchNodeComponent: React.FC<NodeProps<SwitchNodeData>> = React.me
             marginBottom: '8px',
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
           }}
         >
+          <GitFork size={18} />
           Switch
         </div>
 

--- a/src/webview/src/constants/node-type-icons.ts
+++ b/src/webview/src/constants/node-type-icons.ts
@@ -1,0 +1,46 @@
+/**
+ * Node type icon mapping
+ *
+ * Maps each NodeType to a lucide-react icon component.
+ */
+
+import type { LucideIcon } from 'lucide-react';
+import {
+  Bot,
+  GitBranch,
+  GitFork,
+  MessageSquare,
+  Play,
+  Plug,
+  ShieldQuestion,
+  Square,
+  SquareDashed,
+  Terminal,
+  Zap,
+} from 'lucide-react';
+
+export const NODE_TYPE_ICONS: Record<string, LucideIcon> = {
+  start: Play,
+  end: Square,
+  prompt: MessageSquare,
+  subAgent: Bot,
+  subAgentFlow: Bot,
+  codex: Terminal,
+  skill: Zap,
+  mcp: Plug,
+  ifElse: GitBranch,
+  switch: GitFork,
+  askUserQuestion: ShieldQuestion,
+  branch: GitBranch,
+  group: SquareDashed,
+} as const;
+
+/**
+ * Get the icon component for a node type
+ * @param nodeType - The node type string
+ * @returns The LucideIcon component, or undefined if not found
+ */
+export const getNodeTypeIcon = (nodeType: string | undefined): LucideIcon | undefined => {
+  if (!nodeType) return undefined;
+  return NODE_TYPE_ICONS[nodeType];
+};


### PR DESCRIPTION
## Summary

Merge latest changes from `main` to `production` for automated release v3.29.1.

## Included Changes

### Improvements
- improvement: allow dragging nodes out of group nodes (#656)
- improvement: add lucide-react icons to node palette and canvas nodes (#654)

## Release Version Calculation

**v3.29.1** (patch bump)

Semantic Release will analyze commits since v3.29.0:
- ✅ `improvement: allow dragging nodes out of group nodes` (#656) → **patch bump**
- ✅ `improvement: add lucide-react icons to node palette and canvas nodes` (#654) → **patch bump**

Result: **3.29.0 + patch = 3.29.1**

## CHANGELOG.md Contents

The following improvements will be included:
- Allow dragging nodes out of group nodes (#656)
- Add lucide-react icons to node palette and canvas nodes (#654)

## Release Automation

This merge will trigger:
1. Analyze commit messages (3.29.0 → 3.29.1)
2. Update version in package.json files
3. Generate CHANGELOG.md with improvements
4. Create GitHub release
5. Build and upload VSIX package
6. Sync version changes back to main

## Merge Strategy

**Use merge commit** (not squash) to preserve commit history for Semantic Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)