### PR TITLE
improvement: allow dragging nodes out of group nodes

### DIFF
--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -745,7 +745,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
         },
         // Normalize MCP node data for backwards compatibility
         data: node.type === 'mcp' ? normalizeMcpNodeData(node.data as McpNodeData) : node.data,
-        ...(node.parentId && { parentId: node.parentId, expandParent: true }),
+        ...(node.parentId && { parentId: node.parentId }),
         ...(node.style && { style: node.style }),
       }))
     );
@@ -787,7 +787,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
         },
         // Normalize MCP node data for backwards compatibility
         data: node.type === 'mcp' ? normalizeMcpNodeData(node.data as McpNodeData) : node.data,
-        ...(node.parentId && { parentId: node.parentId, expandParent: true }),
+        ...(node.parentId && { parentId: node.parentId }),
         ...(node.style && { style: node.style }),
       }))
     );
@@ -823,7 +823,7 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
           y: node.position.y,
         },
         data: node.data,
-        ...(node.parentId && { parentId: node.parentId, expandParent: true }),
+        ...(node.parentId && { parentId: node.parentId }),
         ...(node.style && { style: node.style }),
       }))
     );


### PR DESCRIPTION
## Summary

Allow nodes to be dragged out of Group Nodes, which was previously blocked by ReactFlow's `expandParent` behavior.

## What Changed

### Before
- Nodes placed inside a Group Node could not be dragged out — the group auto-expanded to keep the node inside

### After
- Nodes can be freely dragged in and out of Group Nodes

## Changes

- `src/webview/src/stores/workflow-store.ts` - Removed `expandParent: true` from 3 child node property spreads (`addGeneratedWorkflow`, `importWorkflowToCanvas`, deserialization)

## Testing

- [x] Manual E2E testing completed
- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted workflow node expansion behavior for improved consistency in node hierarchy display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->