### PR TITLE
fix: add GroupNode/CodexNode and icons to diff preview

### DIFF
--- a/src/webview/src/components/dialogs/DiffPreviewDialog.tsx
+++ b/src/webview/src/components/dialogs/DiffPreviewDialog.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import type { PlannedSubAgentFile } from '@shared/types/messages';
 import { FileText } from 'lucide-react';
 import type React from 'react';
+import { getNodeTypeIcon } from '../../constants/node-type-icons';
 import { useTranslation } from '../../i18n/i18n-context';
 import type { WorkflowDiffSummary } from '../../utils/workflow-diff';
 
@@ -147,54 +148,133 @@ export const DiffPreviewDialog: React.FC<DiffPreviewDialogProps> = ({
                   >
                     {t('dialog.diffPreview.nodes')}:
                   </div>
-                  {diffSummary.addedNodes.map((node) => (
-                    <div key={`add-${node.id}`} style={{ paddingLeft: '8px' }}>
-                      <span
+                  {diffSummary.addedNodes.map((node) => {
+                    const Icon = getNodeTypeIcon(node.type);
+                    return (
+                      <div
+                        key={`add-${node.id}`}
                         style={{
-                          color: 'var(--vscode-gitDecoration-addedResourceForeground, #73c991)',
+                          paddingLeft: '8px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
                         }}
                       >
-                        + {node.name}
-                      </span>
-                      <span
-                        style={{ color: 'var(--vscode-descriptionForeground)', marginLeft: '4px' }}
-                      >
-                        ({node.type})
-                      </span>
-                    </div>
-                  ))}
-                  {diffSummary.removedNodes.map((node) => (
-                    <div key={`rm-${node.id}`} style={{ paddingLeft: '8px' }}>
-                      <span
+                        <span
+                          style={{
+                            color: 'var(--vscode-gitDecoration-addedResourceForeground, #73c991)',
+                          }}
+                        >
+                          +
+                        </span>
+                        {Icon && (
+                          <Icon
+                            size={13}
+                            style={{
+                              color: 'var(--vscode-gitDecoration-addedResourceForeground, #73c991)',
+                              flexShrink: 0,
+                            }}
+                          />
+                        )}
+                        <span
+                          style={{
+                            color: 'var(--vscode-gitDecoration-addedResourceForeground, #73c991)',
+                          }}
+                        >
+                          {node.name}
+                        </span>
+                        <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                          ({node.type})
+                        </span>
+                      </div>
+                    );
+                  })}
+                  {diffSummary.removedNodes.map((node) => {
+                    const Icon = getNodeTypeIcon(node.type);
+                    return (
+                      <div
+                        key={`rm-${node.id}`}
                         style={{
-                          color: 'var(--vscode-gitDecoration-deletedResourceForeground, #e06c75)',
+                          paddingLeft: '8px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
                         }}
                       >
-                        - {node.name}
-                      </span>
-                      <span
-                        style={{ color: 'var(--vscode-descriptionForeground)', marginLeft: '4px' }}
-                      >
-                        ({node.type})
-                      </span>
-                    </div>
-                  ))}
-                  {diffSummary.modifiedNodes.map((node) => (
-                    <div key={`mod-${node.id}`} style={{ paddingLeft: '8px' }}>
-                      <span
+                        <span
+                          style={{
+                            color: 'var(--vscode-gitDecoration-deletedResourceForeground, #e06c75)',
+                          }}
+                        >
+                          -
+                        </span>
+                        {Icon && (
+                          <Icon
+                            size={13}
+                            style={{
+                              color:
+                                'var(--vscode-gitDecoration-deletedResourceForeground, #e06c75)',
+                              flexShrink: 0,
+                            }}
+                          />
+                        )}
+                        <span
+                          style={{
+                            color: 'var(--vscode-gitDecoration-deletedResourceForeground, #e06c75)',
+                          }}
+                        >
+                          {node.name}
+                        </span>
+                        <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                          ({node.type})
+                        </span>
+                      </div>
+                    );
+                  })}
+                  {diffSummary.modifiedNodes.map((node) => {
+                    const Icon = getNodeTypeIcon(node.type);
+                    return (
+                      <div
+                        key={`mod-${node.id}`}
                         style={{
-                          color: 'var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)',
+                          paddingLeft: '8px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
                         }}
                       >
-                        ~ {node.name}
-                      </span>
-                      <span
-                        style={{ color: 'var(--vscode-descriptionForeground)', marginLeft: '4px' }}
-                      >
-                        ({node.type})
-                      </span>
-                    </div>
-                  ))}
+                        <span
+                          style={{
+                            color:
+                              'var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)',
+                          }}
+                        >
+                          ~
+                        </span>
+                        {Icon && (
+                          <Icon
+                            size={13}
+                            style={{
+                              color:
+                                'var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)',
+                              flexShrink: 0,
+                            }}
+                          />
+                        )}
+                        <span
+                          style={{
+                            color:
+                              'var(--vscode-gitDecoration-modifiedResourceForeground, #e2c08d)',
+                          }}
+                        >
+                          {node.name}
+                        </span>
+                        <span style={{ color: 'var(--vscode-descriptionForeground)' }}>
+                          ({node.type})
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
 

--- a/src/webview/src/components/preview/PreviewCanvas.tsx
+++ b/src/webview/src/components/preview/PreviewCanvas.tsx
@@ -28,7 +28,9 @@ import { StyledTooltip } from '../common/StyledTooltip';
 import { DeletableEdge } from '../edges/DeletableEdge';
 import { AskUserQuestionNodeComponent } from '../nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from '../nodes/BranchNode';
+import { CodexNodeComponent } from '../nodes/CodexNode';
 import { EndNode } from '../nodes/EndNode';
+import { GroupNodeComponent } from '../nodes/GroupNode';
 import { IfElseNodeComponent } from '../nodes/IfElseNode';
 import { McpNodeComponent } from '../nodes/McpNode/McpNode';
 import { PromptNode } from '../nodes/PromptNode';
@@ -53,6 +55,8 @@ const nodeTypes: NodeTypes = {
   skill: SkillNodeComponent,
   mcp: McpNodeComponent,
   subAgentFlow: SubAgentFlowNodeComponent,
+  codex: CodexNodeComponent,
+  group: GroupNodeComponent,
 };
 
 /**


### PR DESCRIPTION
## Problem

The workflow diff preview (PreviewCanvas and DiffPreviewDialog) did not support recently added GroupNode and node type icons.

### Current Behavior
1. Open a workflow containing GroupNode in preview mode
2. ❌ GroupNode fails to render (missing from nodeTypes registry)
3. Open DiffPreviewDialog after AI workflow edit
4. ❌ Node list shows text only, no type icons

### Expected Behavior
1. Open a workflow containing GroupNode in preview mode
2. ✅ GroupNode renders correctly on the preview canvas
3. Open DiffPreviewDialog after AI workflow edit
4. ✅ Node list shows type-specific icons (matching main canvas)

## Solution

Register missing node types in PreviewCanvas and add node type icons to DiffPreviewDialog.

### Changes

**File**: `src/webview/src/components/preview/PreviewCanvas.tsx`

- Add `GroupNodeComponent` and `CodexNodeComponent` imports
- Register `group` and `codex` in the `nodeTypes` object

**File**: `src/webview/src/components/dialogs/DiffPreviewDialog.tsx`

- Import `getNodeTypeIcon` from existing `node-type-icons.ts` utility
- Render node type icons in added/removed/modified node rows

## Impact

- GroupNode workflows now render correctly in preview mode
- DiffPreviewDialog has visual consistency with the main canvas

## Testing

- [x] Manual testing completed
- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diff preview with color-coded icons and visual indicators for added, removed, and modified items.
  * Added support for previewing Group and Codex node types in the preview canvas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->