### PR TITLE
fix: support plugin skills in workflow detection and export

### DIFF
--- a/src/extension/services/skill-normalization-service.ts
+++ b/src/extension/services/skill-normalization-service.ts
@@ -108,8 +108,25 @@ function getStandardSkillPatterns(targetCli: TargetCli): string[] {
  * @param targetCli - Target CLI for execution
  * @returns True if the skill is from a standard directory for this CLI
  */
-function isSkillFromStandardDir(skillPath: string, targetCli: TargetCli): boolean {
+function isSkillFromStandardDir(
+  skillPath: string,
+  targetCli: TargetCli,
+  scope?: 'user' | 'project' | 'local'
+): boolean {
+  // Plugin skills and user-scope skills are resolved by name,
+  // not by path - no need to copy them to .claude/skills/
+  if (scope === 'local' || scope === 'user') {
+    return true;
+  }
+
   const normalizedPath = skillPath.replace(/\\/g, '/');
+
+  // Plugin skills (from .claude/plugins/) are always resolved by name
+  if (normalizedPath.includes('.claude/plugins/')) {
+    return true;
+  }
+
+  // Path-based check for project scope
   const standardPatterns = getStandardSkillPatterns(targetCli);
 
   return standardPatterns.some((pattern) => normalizedPath.includes(pattern));
@@ -305,7 +322,7 @@ export async function checkSkillsToNormalize(
     processedNames.add(skillName);
 
     // Skip skills from standard directories for the target CLI
-    if (isSkillFromStandardDir(skillPath, targetCli)) {
+    if (isSkillFromStandardDir(skillPath, targetCli, skillNode.data.scope)) {
       skippedSkills.push(skillName);
       continue;
     }
@@ -513,7 +530,9 @@ export async function normalizeSkillsWithoutPrompt(
  */
 export function hasNonStandardSkills(workflow: Workflow, targetCli: TargetCli = 'claude'): boolean {
   const skillNodes = extractSkillNodes(workflow);
-  return skillNodes.some((node) => !isSkillFromStandardDir(node.data.skillPath, targetCli));
+  return skillNodes.some(
+    (node) => !isSkillFromStandardDir(node.data.skillPath, targetCli, node.data.scope)
+  );
 }
 
 // ============================================================================

--- a/src/extension/services/skill-service.ts
+++ b/src/extension/services/skill-service.ts
@@ -71,10 +71,12 @@ export async function scanSkills(
         if (metadata) {
           // Convert to relative path for project Skills (T020)
           const pathToStore = scope === 'project' ? toRelativePath(skillPath, scope) : skillPath;
+          // Fall back to directory name if frontmatter has no name field
+          const skillName = metadata.name || dirent.name;
 
           skills.push({
             skillPath: pathToStore,
-            name: metadata.name,
+            name: skillName,
             description: metadata.description,
             scope,
             validationStatus: 'valid',
@@ -280,7 +282,8 @@ export async function scanPluginSkills(): Promise<SkillReference[]> {
         marketplace.installLocation,
         parsed.pluginName,
         skillScope,
-        skills
+        skills,
+        selectedInstallation.installPath
       );
     }
   } catch (_err) {
@@ -291,13 +294,66 @@ export async function scanPluginSkills(): Promise<SkillReference[]> {
 }
 
 /**
+ * Scan a skills directory and add found skills to the array
+ *
+ * @returns true if any skills were found
+ */
+async function scanSkillsDirectory(
+  skillsDir: string,
+  scope: 'user' | 'project' | 'local',
+  skills: SkillReference[],
+  pluginName?: string
+): Promise<boolean> {
+  try {
+    const skillDirs = await fs.readdir(skillsDir, { withFileTypes: true });
+    let found = false;
+
+    for (const skillDir of skillDirs) {
+      if (!skillDir.isDirectory()) continue;
+
+      const skillPath = path.join(skillsDir, skillDir.name, 'SKILL.md');
+
+      try {
+        const content = await fs.readFile(skillPath, 'utf-8');
+        const metadata = parseSkillFrontmatter(content);
+
+        if (metadata) {
+          // Fall back to directory name if frontmatter has no name field
+          const skillName = metadata.name || skillDir.name;
+          if (skills.some((s) => s.name === skillName)) continue;
+
+          skills.push({
+            skillPath,
+            name: skillName,
+            description: metadata.description,
+            scope,
+            validationStatus: 'valid',
+            allowedTools: metadata.allowedTools,
+            pluginName,
+          });
+          found = true;
+        }
+      } catch {
+        // Skill file not found or invalid - skip
+      }
+    }
+
+    return found;
+  } catch {
+    // Directory doesn't exist
+    return false;
+  }
+}
+
+/**
  * Scan skills from a specific plugin within a marketplace
  */
 async function scanMarketplacePlugin(
   marketplaceLocation: string,
   pluginName: string,
   scope: 'user' | 'project' | 'local',
-  skills: SkillReference[]
+  skills: SkillReference[],
+  installPath?: string
 ): Promise<void> {
   const marketplaceJsonPath = path.join(marketplaceLocation, '.claude-plugin', 'marketplace.json');
 
@@ -319,16 +375,19 @@ async function scanMarketplacePlugin(
           const metadata = parseSkillFrontmatter(content);
 
           if (metadata) {
+            // Fall back to directory name if frontmatter has no name field
+            const skillName = metadata.name || path.basename(skillDir);
             // Skip if skill with same name already exists (name-based dedup)
-            if (skills.some((s) => s.name === metadata.name)) continue;
+            if (skills.some((s) => s.name === skillName)) continue;
 
             skills.push({
               skillPath,
-              name: metadata.name,
+              name: skillName,
               description: metadata.description,
               scope,
               validationStatus: 'valid',
               allowedTools: metadata.allowedTools,
+              pluginName,
             });
           }
         } catch {
@@ -336,37 +395,17 @@ async function scanMarketplacePlugin(
         }
       }
     } else {
-      // Fallback: scan default 'skills/' directory
+      // Fallback 1: scan default 'skills/' directory in marketplace
       const defaultSkillsDir = path.join(marketplaceLocation, 'skills');
-      try {
-        const skillDirs = await fs.readdir(defaultSkillsDir, { withFileTypes: true });
-        for (const skillDir of skillDirs) {
-          if (!skillDir.isDirectory()) continue;
+      const foundSkills = await scanSkillsDirectory(defaultSkillsDir, scope, skills, pluginName);
 
-          const skillPath = path.join(defaultSkillsDir, skillDir.name, 'SKILL.md');
-
-          try {
-            const content = await fs.readFile(skillPath, 'utf-8');
-            const metadata = parseSkillFrontmatter(content);
-
-            if (metadata) {
-              if (skills.some((s) => s.name === metadata.name)) continue;
-
-              skills.push({
-                skillPath,
-                name: metadata.name,
-                description: metadata.description,
-                scope,
-                validationStatus: 'valid',
-                allowedTools: metadata.allowedTools,
-              });
-            }
-          } catch {
-            // Skill file not found or invalid - skip
-          }
+      // Fallback 2: scan 'skills/' directory in plugin installPath
+      if (!foundSkills && installPath) {
+        const installPathSkillsDir = path.join(installPath, 'skills');
+        // Avoid scanning same directory twice
+        if (path.normalize(installPathSkillsDir) !== path.normalize(defaultSkillsDir)) {
+          await scanSkillsDirectory(installPathSkillsDir, scope, skills, pluginName);
         }
-      } catch {
-        // No default skills directory
       }
     }
   } catch {

--- a/src/extension/services/workflow-prompt-generator.ts
+++ b/src/extension/services/workflow-prompt-generator.ts
@@ -644,7 +644,10 @@ export function generateExecutionInstructions(
     for (const node of skillNodes) {
       const nodeId = sanitizeNodeId(node.id);
       const executionMode = node.data.executionMode || 'execute';
-      const skillName = node.data.name;
+      // Plugin skills use 'pluginName:skillName' format for Claude Code resolution
+      const skillName = node.data.pluginName
+        ? `${node.data.pluginName}:${node.data.name}`
+        : node.data.name;
 
       sections.push(`#### ${nodeId}(${skillName})`);
       sections.push('');

--- a/src/extension/services/yaml-parser.ts
+++ b/src/extension/services/yaml-parser.ts
@@ -59,13 +59,13 @@ export function parseSkillFrontmatter(content: string): SkillMetadata | null {
   // Extract optional field
   const allowedTools = yaml.match(/^allowed-tools:\s*(.+)$/m)?.[1]?.trim();
 
-  // Validate required fields
-  if (!name || !description) {
-    return null; // Required fields missing
+  // Validate: at least description is required
+  if (!description) {
+    return null; // Description is required
   }
 
   return {
-    name,
+    name: name || '', // May be empty; callers can fall back to directory name
     description,
     allowedTools,
   };

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -224,6 +224,8 @@ export interface SkillReference {
    * - undefined: for local scope or legacy data
    */
   source?: 'claude' | 'copilot' | 'codex' | 'roo' | 'gemini' | 'antigravity' | 'cursor';
+  /** Plugin name for plugin-provided skills (e.g., 'with-me' for 'with-me:skill-name') */
+  pluginName?: string;
 }
 
 // ============================================================================

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -232,6 +232,8 @@ export interface SkillNodeData {
    * Only used when executionMode is 'execute' (or undefined).
    */
   executionPrompt?: string;
+  /** Plugin name for plugin-provided skills (e.g., 'with-me' for 'with-me:skill-name') */
+  pluginName?: string;
 }
 
 /**

--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -212,6 +212,7 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
         allowedTools: selectedSkill.allowedTools,
         outputPorts: 1,
         source: selectedSkill.source,
+        pluginName: selectedSkill.pluginName,
         executionMode: pendingExecutionMode,
         executionPrompt:
           pendingExecutionMode === 'execute' ? pendingExecutionPrompt || undefined : undefined,
@@ -251,16 +252,21 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
   // Compute filtered skills for ALL tabs simultaneously
   const filterLower = filterText.toLowerCase().trim();
 
+  const getSkillDisplayName = (skill: SkillReference): string =>
+    skill.pluginName ? `${skill.pluginName}:${skill.name}` : skill.name;
+
   const filteredUserSkills = filterLower
-    ? userSkills.filter((skill) => skill.name.toLowerCase().includes(filterLower))
+    ? userSkills.filter((skill) => getSkillDisplayName(skill).toLowerCase().includes(filterLower))
     : userSkills;
 
   const filteredProjectSkills = filterLower
-    ? projectSkills.filter((skill) => skill.name.toLowerCase().includes(filterLower))
+    ? projectSkills.filter((skill) =>
+        getSkillDisplayName(skill).toLowerCase().includes(filterLower)
+      )
     : projectSkills;
 
   const filteredLocalSkills = filterLower
-    ? localSkills.filter((skill) => skill.name.toLowerCase().includes(filterLower))
+    ? localSkills.filter((skill) => getSkillDisplayName(skill).toLowerCase().includes(filterLower))
     : localSkills;
 
   // Get skills for current tab (for list rendering)
@@ -665,7 +671,7 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
                                     color: 'var(--vscode-foreground)',
                                   }}
                                 >
-                                  {skill.name}
+                                  {getSkillDisplayName(skill)}
                                 </span>
                                 <span
                                   style={{
@@ -808,7 +814,7 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
                       marginBottom: '4px',
                     }}
                   >
-                    {selectedSkill.name}
+                    {getSkillDisplayName(selectedSkill)}
                   </div>
                   <div
                     style={{

--- a/src/webview/src/components/nodes/SkillNode.tsx
+++ b/src/webview/src/components/nodes/SkillNode.tsx
@@ -116,7 +116,7 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
             fontWeight: 500,
           }}
         >
-          {data.name || 'Untitled Skill'}
+          {data.pluginName ? `${data.pluginName}:${data.name}` : data.name || 'Untitled Skill'}
         </div>
 
         {/* Description or Execution Prompt */}
@@ -161,9 +161,9 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
           >
             {data.scope}
           </div>
-          {/* Source Badge for project and user skills */}
-          {(data.scope === 'project' || data.scope === 'user') && data.source && (
-            <AIProviderBadge provider={data.source as AIProviderType} size="small" />
+          {/* Source Badge - show provider badge for skills with source, default to 'claude' for plugin skills */}
+          {(data.source || data.pluginName) && (
+            <AIProviderBadge provider={(data.source || 'claude') as AIProviderType} size="small" />
           )}
           {/* Execution Mode Badge (only show for 'load' mode) */}
           {data.executionMode === 'load' && (


### PR DESCRIPTION
## Problem

Plugin skills (from Claude Code marketplace plugins) could not be properly detected, displayed, or exported in workflows. (Closes #651)

### Current Behavior
1. Add a plugin skill (e.g., `example-plugin:example-skill`) to a workflow
2. ❌ Skill not detected if `marketplace.json` lacks `skills` array and marketplace root has no `skills/` directory
3. ❌ Export shows unnecessary "Copy to .claude/skills/?" prompt for plugin skills
4. ❌ Export generates `skill "example-skill"` instead of `skill "example-plugin:example-skill"`
5. ❌ Plugin skills missing "Claude Code" badge on canvas
6. ❌ Skills with no `name` in SKILL.md frontmatter are silently skipped

### Expected Behavior
1. Add a plugin skill to a workflow
2. ✅ Skill detected via `installPath/skills/` fallback
3. ✅ No copy prompt for plugin/user-scope skills
4. ✅ Export generates `skill "example-plugin:example-skill"` format
5. ✅ Plugin skills show "Claude Code" badge on canvas
6. ✅ Directory name used as fallback when `name` field is missing

## Solution

Multi-layered fix addressing plugin skill detection, export, and display.

### Changes

**File**: `src/extension/services/skill-service.ts`
- Add `installPath` fallback when `marketplace.json` has no `skills` array and marketplace `skills/` dir is empty
- Extract `scanSkillsDirectory()` helper to eliminate duplicate code
- Add `pluginName` field to skill references
- Fall back to directory name when SKILL.md has no `name` in frontmatter

**File**: `src/extension/services/yaml-parser.ts`
- Allow `parseSkillFrontmatter()` to return metadata when `name` is missing (only `description` required)

**File**: `src/extension/services/skill-normalization-service.ts`
- Add `scope` parameter to `isSkillFromStandardDir()`
- Skip copy prompt for `user`/`local` scope and `.claude/plugins/` paths

**File**: `src/extension/services/workflow-prompt-generator.ts`
- Use `pluginName:skillName` format in generated prompts

**File**: `src/shared/types/messages.ts` & `src/shared/types/workflow-definition.ts`
- Add optional `pluginName` field to `SkillReference` and `SkillNodeData`

**File**: `src/webview/src/components/dialogs/SkillBrowserDialog.tsx`
- Display `pluginName:skillName` in skill list, detail view, and filter
- Pass `pluginName` through to node data

**File**: `src/webview/src/components/nodes/SkillNode.tsx`
- Display `pluginName:skillName` format on canvas
- Show "Claude Code" badge for plugin skills

## Impact

- Plugin skills from any marketplace plugin are now properly detected and usable in workflows
- No breaking changes to existing skill handling (all new fields are optional)

## Testing

- [x] Plugin skill detection via installPath fallback
- [x] No copy prompt on export for plugin skills
- [x] Correct `pluginName:skillName` format in export prompt
- [x] Claude Code badge displayed for plugin skills on canvas
- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin-provided skills are now clearly identified with their plugin name (displayed as "pluginName:skillName").
  * Enhanced skill discovery with improved fallback naming when explicit names are unavailable.

* **Bug Fixes**
  * Improved handling of skill validation and scope-based categorization.
  * Better skill scanning with fallback locations for plugin installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->