### PR TITLE
fix: detect Cursor editor via appName instead of extension ID

### DIFF
--- a/src/extension/services/cursor-extension-service.ts
+++ b/src/extension/services/cursor-extension-service.ts
@@ -7,15 +7,18 @@
 
 import * as vscode from 'vscode';
 
-const CURSOR_EXTENSION_ID = 'anysphere.cursor-agent';
-
 /**
- * Check if Cursor extension is installed
+ * Check if running inside Cursor editor
  *
- * @returns True if Cursor extension is installed
+ * Cursor is a VSCode fork, so built-in agent functionality
+ * is not a separate extension. Detect via appName or uriScheme.
+ *
+ * @returns True if running in Cursor
  */
 export function isCursorInstalled(): boolean {
-  return vscode.extensions.getExtension(CURSOR_EXTENSION_ID) !== undefined;
+  const appName = vscode.env.appName?.toLowerCase() ?? '';
+  const uriScheme = vscode.env.uriScheme?.toLowerCase() ?? '';
+  return appName.includes('cursor') || uriScheme.includes('cursor');
 }
 
 /**
@@ -27,13 +30,8 @@ export function isCursorInstalled(): boolean {
  * @returns True if the task was started successfully
  */
 export async function startCursorTask(skillName: string): Promise<boolean> {
-  const extension = vscode.extensions.getExtension(CURSOR_EXTENSION_ID);
-  if (!extension) {
+  if (!isCursorInstalled()) {
     return false;
-  }
-
-  if (!extension.isActive) {
-    await extension.activate();
   }
 
   const prompt = `/${skillName}`;


### PR DESCRIPTION
## Problem

Clicking the "Run for Cursor" button in the Toolbar shows "Cursor extension is not installed" even when running inside Cursor.

### Current Behavior
1. Open CC Workflow Studio inside Cursor
2. Click the Run (Cursor) button in the Toolbar
3. ❌ Error: "Cursor extension is not installed."

### Expected Behavior
1. Open CC Workflow Studio inside Cursor
2. Click the Run (Cursor) button in the Toolbar
3. ✅ Cursor Agent opens with the workflow skill

## Solution

The previous detection logic checked for a VSCode extension with ID `anysphere.cursor-agent`, but Cursor's Agent is a built-in feature of the Cursor editor (a VSCode fork), not a separately installed extension.

Changed detection to use `vscode.env.appName` and `vscode.env.uriScheme` to identify the Cursor environment.

### Changes

**File**: `src/extension/services/cursor-extension-service.ts`

- Replaced `vscode.extensions.getExtension('anysphere.cursor-agent')` with `vscode.env.appName` / `vscode.env.uriScheme` check
- Simplified `startCursorTask()` to use `isCursorInstalled()` instead of direct extension lookup and activation

## Impact

- Fixes Cursor Run button for all users running inside Cursor editor
- No impact on VSCode users (detection correctly returns false)

## Testing

- [x] Manual testing completed (confirmed in Cursor)
- [x] Build passes (`npm run format && npm run lint && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the Cursor extension detection mechanism to enhance reliability and reduce dependency on extension state queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->