### PR TITLE
fix: rename MCP tool list_available_commands to list_available_agents

### DIFF
--- a/resources/ai-editing-skill-template.md
+++ b/resources/ai-editing-skill-template.md
@@ -5,7 +5,7 @@ description: AI workflow editor for CC Workflow Studio. Create and edit visual A
 
 1. Call `get_workflow_schema` via `cc-workflow-studio` MCP server
 2. Call `get_current_workflow` via `cc-workflow-studio` MCP server
-3. Call `list_available_commands` via `cc-workflow-studio` MCP server to discover existing sub-agent command files
+3. Call `list_available_agents` via `cc-workflow-studio` MCP server to discover existing sub-agent files
 4. Ask the user what to create or modify
 5. Generate workflow JSON: existing sub-agents use commandFilePath reference, new sub-agents provide description/prompt/model etc. without commandFilePath (apply_workflow will auto-create .md files)
 6. Call `apply_workflow` via `cc-workflow-studio` MCP server, fix errors if any

--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -79,7 +79,7 @@
         "commandFilePath": {
           "type": "string",
           "required": true,
-          "description": "Absolute path to .claude/agents/*.md file. Use list_available_commands to discover existing commands, or create a new .md file first."
+          "description": "Absolute path to .claude/agents/*.md file. Use list_available_agents to discover existing commands, or create a new .md file first."
         },
         "commandScope": {
           "type": "string",
@@ -95,7 +95,7 @@
         "workflow": "SubAgent nodes MUST reference external .claude/agents/*.md files. Never embed prompt content inline.",
         "agentType": "Set 'claudeCode' if you are Claude Code, 'other' if you are a different AI agent (Cursor, Copilot, etc.). You know what you are.",
         "steps": [
-          "Call list_available_commands to discover existing agent files",
+          "Call list_available_agents to discover existing agent files",
           "If a matching agent exists, use its commandPath and scope",
           "If no match, provide description/prompt/model etc. without commandFilePath — apply_workflow will auto-create the .md file",
           "Set agentType based on your own runtime identity"

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -75,7 +75,7 @@ nodeTypes:
       commandFilePath:
         type: string
         required: true
-        description: "Absolute path to .claude/agents/*.md file. Use list_available_commands to discover existing commands, or create a new .md file first."
+        description: "Absolute path to .claude/agents/*.md file. Use list_available_agents to discover existing commands, or create a new .md file first."
       commandScope:
         type: string
         required: true
@@ -90,7 +90,7 @@ nodeTypes:
     aiGenerationGuidance:
       workflow: SubAgent nodes MUST reference external .claude/agents/*.md files. Never embed prompt content inline.
       agentType: "Set 'claudeCode' if you are Claude Code, 'other' if you are a different AI agent (Cursor, Copilot, etc.). You know what you are."
-      steps[4]: Call list_available_commands to discover existing agent files,"If a matching agent exists, use its commandPath and scope","If no match, provide description/prompt/model etc. without commandFilePath — apply_workflow will auto-create the .md file",Set agentType based on your own runtime identity
+      steps[4]: Call list_available_agents to discover existing agent files,"If a matching agent exists, use its commandPath and scope","If no match, provide description/prompt/model etc. without commandFilePath — apply_workflow will auto-create the .md file",Set agentType based on your own runtime identity
       frontmatterFormat: "---\ndescription: Short description\nmodel: sonnet\ntools: Bash, Read, Write\nmemory: project\n---\nPrompt content here..."
       example:
         type: subAgent

--- a/src/extension/services/mcp-server-tools.ts
+++ b/src/extension/services/mcp-server-tools.ts
@@ -8,7 +8,7 @@
  * - get_current_workflow: Get the currently active workflow from the canvas
  * - get_workflow_schema: Get the workflow JSON schema for generating valid workflows
  * - apply_workflow: Apply a workflow to the canvas (validates first)
- * - list_available_commands: List available .claude/agents/*.md command files
+ * - list_available_agents: List available .claude/agents/*.md agent files
  */
 
 import * as fs from 'node:fs/promises';
@@ -241,10 +241,10 @@ export function registerMcpTools(server: McpServer, manager: McpServerManager): 
     }
   );
 
-  // Tool 4: list_available_commands
+  // Tool 4: list_available_agents
   server.tool(
-    'list_available_commands',
-    'List available .claude/agents/*.md command files that can be referenced as sub-agent nodes in workflows. Returns both user-scope (~/.claude/agents/) and project-scope (.claude/agents/) commands.',
+    'list_available_agents',
+    'List available .claude/agents/*.md agent files that can be referenced as sub-agent nodes in workflows. Returns both user-scope (~/.claude/agents/) and project-scope (.claude/agents/) agents.',
     {
       includeContent: z
         .boolean()


### PR DESCRIPTION
## Problem

The MCP tool name `list_available_commands` was inconsistent with the actual directory path (`.claude/agents/`) and the workflow node type (`subAgent`). The tool description itself referenced "agents" directory while the tool name used "commands".

### Current Behavior
1. AI agent calls the MCP tool
2. ❌ Tool name `list_available_commands` suggests it lists "commands", not "agents"

### Expected Behavior
1. AI agent calls the MCP tool
2. ✅ Tool name `list_available_agents` accurately reflects that it lists agent files from `.claude/agents/`

## Solution

Renamed the MCP tool from `list_available_commands` to `list_available_agents` and updated all references.

### Changes

**File**: `src/extension/services/mcp-server-tools.ts`
- Renamed tool from `list_available_commands` to `list_available_agents`
- Updated description: "command files" → "agent files", "commands" → "agents"
- Updated comments

**File**: `resources/workflow-schema.json`
- Updated 2 references to the tool name

**File**: `resources/workflow-schema.toon`
- Updated 2 references to the tool name

**File**: `resources/ai-editing-skill-template.md`
- Updated tool name reference in workflow steps

## Impact

- External AI agents calling the MCP server need to use the new tool name `list_available_agents`
- No internal logic changes — only the API surface name and documentation

## Testing

- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)
- [ ] Manual E2E: verify `list_available_agents` tool is callable via MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidance and schema documentation to reflect the revised agent discovery mechanism for sub-agent resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->