### PR TITLE
improvement: add Classic/Freehand scroll mode toggle to canvas

### DIFF
--- a/src/webview/src/components/ScrollModeToggle.tsx
+++ b/src/webview/src/components/ScrollModeToggle.tsx
@@ -1,0 +1,155 @@
+/**
+ * Claude Code Workflow Studio - Scroll Mode Toggle Component
+ *
+ * Canvas scroll mode toggle (classic/freehand)
+ */
+
+import * as Switch from '@radix-ui/react-switch';
+import { Move, ZoomIn } from 'lucide-react';
+import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
+import { useWorkflowStore } from '../stores/workflow-store';
+import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
+
+/**
+ * ScrollModeToggle Component
+ *
+ * Provides UI to switch between classic (scroll = zoom) and freehand (scroll = pan) modes
+ */
+export const ScrollModeToggle: React.FC = () => {
+  const { t } = useTranslation();
+  const { scrollMode, toggleScrollMode } = useWorkflowStore();
+
+  return (
+    <StyledTooltipProvider>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          backgroundColor: 'var(--vscode-editor-background)',
+          border: '1px solid var(--vscode-panel-border)',
+          borderRadius: '20px',
+          padding: '4px 6px',
+          opacity: 0.85,
+        }}
+      >
+        {/* Classic Mode Icon (Left) */}
+        <StyledTooltipItem content={t('toolbar.scrollMode.switchToClassic')}>
+          <div
+            onClick={() => {
+              if (scrollMode !== 'classic') {
+                toggleScrollMode();
+              }
+            }}
+            onKeyDown={(e) => {
+              if ((e.key === 'Enter' || e.key === ' ') && scrollMode !== 'classic') {
+                e.preventDefault();
+                toggleScrollMode();
+              }
+            }}
+            role="button"
+            tabIndex={scrollMode === 'classic' ? -1 : 0}
+            aria-label={t('toolbar.scrollMode.switchToClassic')}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '20px',
+              height: '20px',
+              borderRadius: '50%',
+              backgroundColor:
+                scrollMode === 'classic' ? 'var(--vscode-badge-background)' : 'transparent',
+              transition: 'background-color 150ms',
+              cursor: scrollMode === 'classic' ? 'default' : 'pointer',
+            }}
+          >
+            <ZoomIn
+              size={12}
+              style={{
+                color:
+                  scrollMode === 'classic'
+                    ? 'var(--vscode-badge-foreground)'
+                    : 'var(--vscode-disabledForeground)',
+              }}
+            />
+          </div>
+        </StyledTooltipItem>
+
+        {/* Switch */}
+        <Switch.Root
+          checked={scrollMode === 'freehand'}
+          onCheckedChange={toggleScrollMode}
+          aria-label="Canvas scroll mode"
+          style={{
+            all: 'unset',
+            width: '32px',
+            height: '18px',
+            backgroundColor: 'var(--vscode-input-background)',
+            borderRadius: '9px',
+            position: 'relative',
+            border: '1px solid var(--vscode-input-border)',
+            cursor: 'pointer',
+          }}
+        >
+          <Switch.Thumb
+            style={{
+              all: 'unset',
+              display: 'block',
+              width: '14px',
+              height: '14px',
+              backgroundColor: 'var(--vscode-button-background)',
+              borderRadius: '7px',
+              transition: 'transform 100ms',
+              transform: scrollMode === 'freehand' ? 'translateX(16px)' : 'translateX(2px)',
+              willChange: 'transform',
+              margin: '1px',
+            }}
+          />
+        </Switch.Root>
+
+        {/* Freehand Mode Icon (Right) */}
+        <StyledTooltipItem content={t('toolbar.scrollMode.switchToFreehand')}>
+          <div
+            onClick={() => {
+              if (scrollMode !== 'freehand') {
+                toggleScrollMode();
+              }
+            }}
+            onKeyDown={(e) => {
+              if ((e.key === 'Enter' || e.key === ' ') && scrollMode !== 'freehand') {
+                e.preventDefault();
+                toggleScrollMode();
+              }
+            }}
+            role="button"
+            tabIndex={scrollMode === 'freehand' ? -1 : 0}
+            aria-label={t('toolbar.scrollMode.switchToFreehand')}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '20px',
+              height: '20px',
+              borderRadius: '50%',
+              backgroundColor:
+                scrollMode === 'freehand' ? 'var(--vscode-badge-background)' : 'transparent',
+              transition: 'background-color 150ms',
+              cursor: scrollMode === 'freehand' ? 'default' : 'pointer',
+            }}
+          >
+            <Move
+              size={12}
+              style={{
+                color:
+                  scrollMode === 'freehand'
+                    ? 'var(--vscode-badge-foreground)'
+                    : 'var(--vscode-disabledForeground)',
+              }}
+            />
+          </div>
+        </StyledTooltipItem>
+      </div>
+    </StyledTooltipProvider>
+  );
+};

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -19,6 +19,7 @@ import ReactFlow, {
   type Node,
   type NodeTypes,
   Panel,
+  PanOnScrollMode,
 } from 'reactflow';
 import { CURRENT_ANNOUNCEMENT, cleanupDismissedAnnouncements } from '../constants/announcements';
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
@@ -46,6 +47,7 @@ import { StartNode } from './nodes/StartNode';
 import { SubAgentFlowNodeComponent } from './nodes/SubAgentFlowNode';
 import { SubAgentNodeComponent } from './nodes/SubAgentNode';
 import { SwitchNodeComponent } from './nodes/SwitchNode';
+import { ScrollModeToggle } from './ScrollModeToggle';
 
 /**
  * Node types registration (memoized outside component for performance)
@@ -122,6 +124,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     syncSelectedNodeId,
     selectedNodeId,
     interactionMode,
+    scrollMode,
     onNodeDragStop,
     isHighlightEnabled,
     toggleHighlightEnabled,
@@ -338,6 +341,10 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           snapGrid={snapGrid}
           panOnDrag={panOnDrag}
           selectionOnDrag={selectionOnDrag}
+          panOnScroll={scrollMode === 'freehand'}
+          panOnScrollMode={PanOnScrollMode.Free}
+          zoomOnScroll={scrollMode === 'classic'}
+          zoomOnPinch={true}
           fitView
           attributionPosition="bottom-left"
         >
@@ -396,6 +403,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           {/* Interaction Mode Toggle & Edge Animation Toggle */}
           <Panel position="top-left">
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <ScrollModeToggle />
               <InteractionModeToggle />
               <StyledTooltipProvider>
                 <StyledTooltipItem

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -21,6 +21,7 @@ import ReactFlow, {
   type Node,
   type NodeTypes,
   Panel,
+  PanOnScrollMode,
   ReactFlowProvider,
 } from 'reactflow';
 import { useAutoFocusNode } from '../../hooks/useAutoFocusNode';
@@ -110,6 +111,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
     onEdgesChange,
     onConnect,
     interactionMode,
+    scrollMode,
     activeSubAgentFlowId,
     subAgentFlows,
     updateSubAgentFlow,
@@ -639,6 +641,10 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                   snapGrid={snapGrid}
                   panOnDrag={panOnDrag}
                   selectionOnDrag={selectionOnDrag}
+                  panOnScroll={scrollMode === 'freehand'}
+                  panOnScrollMode={PanOnScrollMode.Free}
+                  zoomOnScroll={scrollMode === 'classic'}
+                  zoomOnPinch={true}
                   fitView
                   attributionPosition="bottom-left"
                 >

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -43,6 +43,8 @@ export interface WebviewTranslationKeys {
   'toolbar.edgeAnimation.disable': string;
   'toolbar.highlight.enable': string;
   'toolbar.highlight.disable': string;
+  'toolbar.scrollMode.switchToClassic': string;
+  'toolbar.scrollMode.switchToFreehand': string;
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -45,6 +45,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': 'Disable edge animation',
   'toolbar.highlight.enable': 'Enable group node highlight',
   'toolbar.highlight.disable': 'Disable group node highlight',
+  'toolbar.scrollMode.switchToClassic': 'Switch to Classic mode (scroll = zoom)',
+  'toolbar.scrollMode.switchToFreehand': 'Switch to Freehand mode (scroll = pan)',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': 'Show Minimap',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -45,6 +45,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': 'エッジアニメーションを無効化',
   'toolbar.highlight.enable': 'グループノードハイライトを有効化',
   'toolbar.highlight.disable': 'グループノードハイライトを無効化',
+  'toolbar.scrollMode.switchToClassic': 'Classicモードに切り替え（スクロール=ズーム）',
+  'toolbar.scrollMode.switchToFreehand': 'Freehandモードに切り替え（スクロール=パン）',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': 'ミニマップを表示',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -45,6 +45,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': '엣지 애니메이션 비활성화',
   'toolbar.highlight.enable': '그룹 노드 하이라이트 활성화',
   'toolbar.highlight.disable': '그룹 노드 하이라이트 비활성화',
+  'toolbar.scrollMode.switchToClassic': 'Classic 모드로 전환 (스크롤 = 줌)',
+  'toolbar.scrollMode.switchToFreehand': 'Freehand 모드로 전환 (스크롤 = 팬)',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': '미니맵 표시',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -45,6 +45,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': '禁用边动画',
   'toolbar.highlight.enable': '启用组节点高亮',
   'toolbar.highlight.disable': '禁用组节点高亮',
+  'toolbar.scrollMode.switchToClassic': '切换到Classic模式（滚动=缩放）',
+  'toolbar.scrollMode.switchToFreehand': '切换到Freehand模式（滚动=平移）',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': '显示迷你地图',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -45,6 +45,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': '停用邊動畫',
   'toolbar.highlight.enable': '啟用群組節點高亮',
   'toolbar.highlight.disable': '停用群組節點高亮',
+  'toolbar.scrollMode.switchToClassic': '切換到Classic模式（滾動=縮放）',
+  'toolbar.scrollMode.switchToFreehand': '切換到Freehand模式（滾動=平移）',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.show': '顯示迷你地圖',

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -35,6 +35,13 @@ import { create } from 'zustand';
 export type InteractionMode = 'pan' | 'selection';
 
 /**
+ * Canvas scroll mode
+ * - classic: Scroll wheel zooms (default ReactFlow behavior)
+ * - freehand: Scroll wheel pans canvas (Miro/Figma-style), Ctrl+scroll to zoom
+ */
+export type ScrollMode = 'classic' | 'freehand';
+
+/**
  * Snapshot of main workflow state for restoration after Sub-Agent Flow editing
  */
 interface MainWorkflowSnapshot {
@@ -53,6 +60,7 @@ interface WorkflowStore {
   pendingDeleteNodeIds: string[];
   activeWorkflow: Workflow | null;
   interactionMode: InteractionMode;
+  scrollMode: ScrollMode;
   workflowName: string;
   workflowDescription: string;
   isPropertyOverlayOpen: boolean;
@@ -89,6 +97,7 @@ interface WorkflowStore {
   syncSelectedNodeId: (id: string | null) => void;
   setInteractionMode: (mode: InteractionMode) => void;
   toggleInteractionMode: () => void;
+  toggleScrollMode: () => void;
   setWorkflowName: (name: string) => void;
   setWorkflowDescription: (description: string) => void;
   openPropertyOverlay: () => void;
@@ -293,6 +302,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   pendingDeleteNodeIds: [],
   activeWorkflow: null,
   interactionMode: 'pan', // Default: pan mode
+  scrollMode: (() => {
+    const saved = localStorage.getItem('cc-wf-studio.scrollMode');
+    return saved === 'freehand' ? 'freehand' : 'classic'; // Default: classic
+  })() as ScrollMode,
   workflowName: 'my-workflow', // Default workflow name
   workflowDescription: '', // Default workflow description
   isPropertyOverlayOpen: true, // Property overlay is open by default
@@ -402,6 +415,12 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   toggleInteractionMode: () => {
     const currentMode = get().interactionMode;
     set({ interactionMode: currentMode === 'pan' ? 'selection' : 'pan' });
+  },
+
+  toggleScrollMode: () => {
+    const newMode = get().scrollMode === 'classic' ? 'freehand' : 'classic';
+    localStorage.setItem('cc-wf-studio.scrollMode', newMode);
+    set({ scrollMode: newMode });
   },
 
   setWorkflowName: (workflowName) => set({ workflowName }),


### PR DESCRIPTION
## Summary

Add a scroll mode toggle to the canvas toolbar, allowing users to switch between Classic (scroll = zoom) and Freehand (scroll = pan, Miro/Figma-style) modes.

## What Changed

### Before
- Mouse wheel always zooms the canvas (default ReactFlow behavior)
- No way to scroll/pan using the mouse wheel

### After
- New toggle switch in the top-left toolbar (left of InteractionModeToggle)
- **Classic mode**: Scroll wheel zooms (unchanged default)
- **Freehand mode**: Scroll wheel pans canvas freely, Ctrl+scroll to zoom
- Setting persists across sessions via localStorage
- Applied to both main canvas and SubAgentFlow dialog

## Changes

- `src/webview/src/components/ScrollModeToggle.tsx` - New component with Radix UI Switch (same design as InteractionModeToggle)
- `src/webview/src/components/WorkflowEditor.tsx` - Integrate ScrollModeToggle and ReactFlow scroll props
- `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx` - Add scroll mode ReactFlow props
- `src/webview/src/stores/workflow-store.ts` - Add ScrollMode type, state, and toggle action
- `src/webview/src/i18n/translation-keys.ts` + 5 translation files - i18n support (en, ja, ko, zh-CN, zh-TW)

## Testing

- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scroll mode toggle control to the canvas toolbar, allowing users to switch between classic mode (scroll to zoom) and freehand mode (scroll to pan).
  * Scroll mode preference is automatically saved and restored across sessions.
  * Added multi-language support for the new scroll mode feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->