### PR TITLE
refactor: extract Canvas Toolbar into reusable component

### DIFF
--- a/src/webview/src/components/CanvasToolbar.tsx
+++ b/src/webview/src/components/CanvasToolbar.tsx
@@ -1,0 +1,110 @@
+/**
+ * Claude Code Workflow Studio - Canvas Toolbar Component
+ *
+ * Toolbar overlay on the canvas with scroll mode, interaction mode,
+ * edge animation, and highlight toggles.
+ */
+
+import { Activity, Lightbulb, LightbulbOff } from 'lucide-react';
+import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
+import { useWorkflowStore } from '../stores/workflow-store';
+import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
+import { InteractionModeToggle } from './InteractionModeToggle';
+import { ScrollModeToggle } from './ScrollModeToggle';
+
+interface CanvasToolbarProps {
+  isEdgeAnimationEnabled: boolean;
+  onToggleEdgeAnimation: () => void;
+}
+
+export const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
+  isEdgeAnimationEnabled,
+  onToggleEdgeAnimation,
+}) => {
+  const { t } = useTranslation();
+  const { isHighlightEnabled, toggleHighlightEnabled, highlightedGroupNodeId } = useWorkflowStore();
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+      <ScrollModeToggle />
+      <InteractionModeToggle />
+      <StyledTooltipProvider>
+        <StyledTooltipItem
+          content={
+            isEdgeAnimationEnabled
+              ? t('toolbar.edgeAnimation.disable')
+              : t('toolbar.edgeAnimation.enable')
+          }
+        >
+          <button
+            type="button"
+            onClick={onToggleEdgeAnimation}
+            aria-label={
+              isEdgeAnimationEnabled
+                ? t('toolbar.edgeAnimation.disable')
+                : t('toolbar.edgeAnimation.enable')
+            }
+            style={{
+              all: 'unset',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '28px',
+              height: '28px',
+              borderRadius: '20px',
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              cursor: 'pointer',
+              opacity: 0.85,
+              color: isEdgeAnimationEnabled
+                ? 'var(--vscode-foreground)'
+                : 'var(--vscode-disabledForeground)',
+            }}
+          >
+            <Activity size={14} />
+          </button>
+        </StyledTooltipItem>
+        <StyledTooltipItem
+          content={
+            isHighlightEnabled ? t('toolbar.highlight.disable') : t('toolbar.highlight.enable')
+          }
+        >
+          <button
+            type="button"
+            onClick={toggleHighlightEnabled}
+            aria-label={
+              isHighlightEnabled ? t('toolbar.highlight.disable') : t('toolbar.highlight.enable')
+            }
+            style={{
+              all: 'unset',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '28px',
+              height: '28px',
+              borderRadius: '20px',
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: highlightedGroupNodeId
+                ? '1px solid rgba(79, 195, 247, 0.6)'
+                : '1px solid var(--vscode-panel-border)',
+              cursor: 'pointer',
+              opacity: 0.85,
+              color: isHighlightEnabled
+                ? 'var(--vscode-foreground)'
+                : 'var(--vscode-disabledForeground)',
+              boxShadow: highlightedGroupNodeId ? '0 0 8px rgba(79, 195, 247, 0.4)' : 'none',
+              animation:
+                highlightedGroupNodeId &&
+                !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+                  ? 'highlight-btn-pulse 1.5s ease-in-out infinite'
+                  : 'none',
+            }}
+          >
+            {isHighlightEnabled ? <Lightbulb size={14} /> : <LightbulbOff size={14} />}
+          </button>
+        </StyledTooltipItem>
+      </StyledTooltipProvider>
+    </div>
+  );
+};

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -5,7 +5,7 @@
  * Based on: /specs/001-cc-wf-studio/research.md section 3.4
  */
 
-import { Activity, Lightbulb, LightbulbOff, PanelLeftOpen } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactFlow, {
@@ -26,12 +26,11 @@ import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
+import { CanvasToolbar } from './CanvasToolbar';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
-import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
 import { DescriptionPanel } from './DescriptionPanel';
 // Custom edge with delete button
 import { DeletableEdge } from './edges/DeletableEdge';
-import { InteractionModeToggle } from './InteractionModeToggle';
 import { MinimapContainer } from './MinimapContainer';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from './nodes/BranchNode';
@@ -47,7 +46,6 @@ import { StartNode } from './nodes/StartNode';
 import { SubAgentFlowNodeComponent } from './nodes/SubAgentFlowNode';
 import { SubAgentNodeComponent } from './nodes/SubAgentNode';
 import { SwitchNodeComponent } from './nodes/SwitchNode';
-import { ScrollModeToggle } from './ScrollModeToggle';
 
 /**
  * Node types registration (memoized outside component for performance)
@@ -126,8 +124,6 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     interactionMode,
     scrollMode,
     onNodeDragStop,
-    isHighlightEnabled,
-    toggleHighlightEnabled,
     highlightedGroupNodeId,
   } = useWorkflowStore();
 
@@ -400,94 +396,12 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             </MinimapContainer>
           </Panel>
 
-          {/* Interaction Mode Toggle & Edge Animation Toggle */}
+          {/* Canvas Toolbar */}
           <Panel position="top-left">
-            <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-              <ScrollModeToggle />
-              <InteractionModeToggle />
-              <StyledTooltipProvider>
-                <StyledTooltipItem
-                  content={
-                    isEdgeAnimationEnabled
-                      ? t('toolbar.edgeAnimation.disable')
-                      : t('toolbar.edgeAnimation.enable')
-                  }
-                >
-                  <button
-                    type="button"
-                    onClick={() => setIsEdgeAnimationEnabled((prev) => !prev)}
-                    aria-label={
-                      isEdgeAnimationEnabled
-                        ? t('toolbar.edgeAnimation.disable')
-                        : t('toolbar.edgeAnimation.enable')
-                    }
-                    style={{
-                      all: 'unset',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '28px',
-                      height: '28px',
-                      borderRadius: '20px',
-                      backgroundColor: 'var(--vscode-editor-background)',
-                      border: '1px solid var(--vscode-panel-border)',
-                      cursor: 'pointer',
-                      opacity: 0.85,
-                      color: isEdgeAnimationEnabled
-                        ? 'var(--vscode-foreground)'
-                        : 'var(--vscode-disabledForeground)',
-                    }}
-                  >
-                    <Activity size={14} />
-                  </button>
-                </StyledTooltipItem>
-                <StyledTooltipItem
-                  content={
-                    isHighlightEnabled
-                      ? t('toolbar.highlight.disable')
-                      : t('toolbar.highlight.enable')
-                  }
-                >
-                  <button
-                    type="button"
-                    onClick={toggleHighlightEnabled}
-                    aria-label={
-                      isHighlightEnabled
-                        ? t('toolbar.highlight.disable')
-                        : t('toolbar.highlight.enable')
-                    }
-                    style={{
-                      all: 'unset',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '28px',
-                      height: '28px',
-                      borderRadius: '20px',
-                      backgroundColor: 'var(--vscode-editor-background)',
-                      border: highlightedGroupNodeId
-                        ? '1px solid rgba(79, 195, 247, 0.6)'
-                        : '1px solid var(--vscode-panel-border)',
-                      cursor: 'pointer',
-                      opacity: 0.85,
-                      color: isHighlightEnabled
-                        ? 'var(--vscode-foreground)'
-                        : 'var(--vscode-disabledForeground)',
-                      boxShadow: highlightedGroupNodeId
-                        ? '0 0 8px rgba(79, 195, 247, 0.4)'
-                        : 'none',
-                      animation:
-                        highlightedGroupNodeId &&
-                        !window.matchMedia('(prefers-reduced-motion: reduce)').matches
-                          ? 'highlight-btn-pulse 1.5s ease-in-out infinite'
-                          : 'none',
-                    }}
-                  >
-                    {isHighlightEnabled ? <Lightbulb size={14} /> : <LightbulbOff size={14} />}
-                  </button>
-                </StyledTooltipItem>
-              </StyledTooltipProvider>
-            </div>
+            <CanvasToolbar
+              isEdgeAnimationEnabled={isEdgeAnimationEnabled}
+              onToggleEdgeAnimation={() => setIsEdgeAnimationEnabled((prev) => !prev)}
+            />
           </Panel>
 
           {/* Description Panel for workflow description */}

--- a/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -33,11 +33,11 @@ import {
   generateWorkflowName,
 } from '../../services/ai-generation-service';
 import { useWorkflowStore } from '../../stores/workflow-store';
+import { CanvasToolbar } from '../CanvasToolbar';
 import { EditableNameField } from '../common/EditableNameField';
 import { StyledTooltip } from '../common/StyledTooltip';
 // Custom edge with delete button
 import { DeletableEdge } from '../edges/DeletableEdge';
-import { InteractionModeToggle } from '../InteractionModeToggle';
 import { MinimapContainer } from '../MinimapContainer';
 import { NodePalette } from '../NodePalette';
 import { AskUserQuestionNodeComponent } from '../nodes/AskUserQuestionNode';
@@ -112,6 +112,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
     onConnect,
     interactionMode,
     scrollMode,
+    highlightedGroupNodeId,
     activeSubAgentFlowId,
     subAgentFlows,
     updateSubAgentFlow,
@@ -123,6 +124,54 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
 
   // Local state for panel display (independent from main canvas)
   const [localSelectedNodeId, setLocalSelectedNodeId] = useState<string | null>(null);
+
+  // Edge animation toggle (respects prefers-reduced-motion by default)
+  const [isEdgeAnimationEnabled, setIsEdgeAnimationEnabled] = useState(
+    () => !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+
+  // Animate edges based on selection and highlight state
+  const animatedEdges = useMemo(() => {
+    let highlightChildIds: Set<string> | null = null;
+    if (highlightedGroupNodeId != null) {
+      highlightChildIds = new Set(
+        nodes.filter((n) => n.parentId === highlightedGroupNodeId).map((n) => n.id)
+      );
+    }
+
+    let selectionChildIds: Set<string> | null = null;
+    if (isEdgeAnimationEnabled && localSelectedNodeId != null) {
+      const selectedNode = nodes.find((n) => n.id === localSelectedNodeId);
+      if (selectedNode?.type === 'group') {
+        selectionChildIds = new Set(
+          nodes.filter((n) => n.parentId === localSelectedNodeId).map((n) => n.id)
+        );
+      }
+    }
+
+    const hasHighlight = highlightedGroupNodeId != null;
+    const hasSelection = isEdgeAnimationEnabled && localSelectedNodeId != null;
+    if (!hasHighlight && !hasSelection) return edges;
+
+    return edges.map((edge) => {
+      const isHighlightAnimated =
+        hasHighlight &&
+        (edge.source === highlightedGroupNodeId ||
+          edge.target === highlightedGroupNodeId ||
+          (highlightChildIds != null &&
+            (highlightChildIds.has(edge.source) || highlightChildIds.has(edge.target))));
+
+      const isSelectionAnimated =
+        hasSelection &&
+        (edge.selected ||
+          edge.source === localSelectedNodeId ||
+          edge.target === localSelectedNodeId ||
+          (selectionChildIds != null &&
+            (selectionChildIds.has(edge.source) || selectionChildIds.has(edge.target))));
+
+      return { ...edge, animated: isHighlightAnimated || isSelectionAnimated };
+    });
+  }, [edges, nodes, localSelectedNodeId, highlightedGroupNodeId, isEdgeAnimationEnabled]);
   const [isLocalPropertyOverlayOpen, setIsLocalPropertyOverlayOpen] = useState(false);
   const [isLocalRefinementPanelOpen, setIsLocalRefinementPanelOpen] = useState(false);
 
@@ -627,7 +676,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
               <div style={{ flex: 1, position: 'relative' }}>
                 <ReactFlow
                   nodes={nodes}
-                  edges={edges}
+                  edges={animatedEdges}
                   onNodesChange={onNodesChange}
                   onEdgesChange={onEdgesChange}
                   onConnect={onConnect}
@@ -693,9 +742,12 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
                     </MinimapContainer>
                   </Panel>
 
-                  {/* Interaction Mode Toggle */}
+                  {/* Canvas Toolbar */}
                   <Panel position="top-left">
-                    <InteractionModeToggle />
+                    <CanvasToolbar
+                      isEdgeAnimationEnabled={isEdgeAnimationEnabled}
+                      onToggleEdgeAnimation={() => setIsEdgeAnimationEnabled((prev) => !prev)}
+                    />
                   </Panel>
                 </ReactFlow>
 


### PR DESCRIPTION
## Summary

Extract the canvas top-left toolbar (ScrollMode, InteractionMode, EdgeAnimation, Highlight toggles) into a reusable `CanvasToolbar` component.

## What Changed

### Before
- Toolbar buttons were inlined directly in `WorkflowEditor.tsx` (~90 lines)
- `SubAgentFlowDialog` only had `InteractionModeToggle`, missing EdgeAnimation and Highlight toggles

### After
- New `CanvasToolbar` component encapsulates all 4 toolbar toggles
- `WorkflowEditor` and `SubAgentFlowDialog` both use `<CanvasToolbar>` with identical UI
- SubAgentFlowDialog now has full toolbar parity with the main canvas (including edge animation support via `animatedEdges`)

## Changes

- `src/webview/src/components/CanvasToolbar.tsx` - New reusable component
- `src/webview/src/components/WorkflowEditor.tsx` - Replaced inline toolbar with CanvasToolbar
- `src/webview/src/components/dialogs/SubAgentFlowDialog.tsx` - Replaced InteractionModeToggle with CanvasToolbar, added animatedEdges

## Testing

- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edge animations now respond intelligently to node highlighting and group selection states in the canvas.
  * Canvas toolbar includes enhanced visual feedback with active state indicators, dynamic styling, and animations.
  * Toolbar respects user accessibility preferences.

* **Refactor**
  * Reorganized toolbar component structure for improved code maintainability and better separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->