### PR TITLE
chore: hide refactor commits from CHANGELOG

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -36,7 +36,7 @@
             { "type": "docs", "section": "Documentation", "hidden": false },
             { "type": "style", "section": "Styles", "hidden": true },
             { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
-            { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+            { "type": "refactor", "section": "Code Refactoring", "hidden": true },
             { "type": "test", "section": "Tests", "hidden": true },
             { "type": "build", "section": "Build System", "hidden": true },
             { "type": "ci", "section": "Continuous Integration", "hidden": true }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Generated changelog groups commits by type:
 - **Improvements** (`improvement:`)
 - **Performance Improvements** (`perf:`)
 - **Reverts** (`revert:`)
-- **Code Refactoring** (`refactor:`) - visible
+- **Code Refactoring** (`refactor:`) - hidden
 - **Documentation** (`docs:`) - visible
 - **Styles** (`style:`) - hidden
 - **Tests** (`test:`) - hidden


### PR DESCRIPTION
## Summary

Hide `refactor:` commits from CHANGELOG.md since end users are not interested in internal code refactoring details.

## Changes

- `.releaserc.json` - Set `refactor` type `hidden` from `false` to `true`
- `CLAUDE.md` - Updated changelog section documentation to reflect the change

## Testing

- [x] Verified `.releaserc.json` syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes and changelog configuration to hide code refactoring changes from release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->