### PR TITLE
improvement: add PulseMCP discovery link to MCP server selection

### DIFF
--- a/src/webview/src/components/dialogs/McpNodeDialog.tsx
+++ b/src/webview/src/components/dialogs/McpNodeDialog.tsx
@@ -9,15 +9,19 @@
 
 import * as Dialog from '@radix-ui/react-dialog';
 import { NodeType } from '@shared/types/workflow-definition';
+import { ExternalLink } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useMcpCreationWizard, WizardStep } from '../../hooks/useMcpCreationWizard';
 import { useTranslation } from '../../i18n/i18n-context';
 import { checkMcpBearerToken, deleteMcpBearerToken } from '../../services/mcp-service';
+import { openExternalUrl } from '../../services/vscode-bridge';
 import { useWorkflowStore } from '../../stores/workflow-store';
 import { WizardStepIndicator } from '../common/WizardStepIndicator';
 import { McpServerList } from '../mcp/McpServerList';
 import { McpToolList } from '../mcp/McpToolList';
 import { McpToolSearch } from '../mcp/McpToolSearch';
+
+const PULSE_MCP_URL = 'https://www.pulsemcp.com/servers';
 import { AiParameterConfigInput } from '../mode-selection/AiParameterConfigInput';
 import { AiToolSelectionInput } from '../mode-selection/AiToolSelectionInput';
 import { McpModeSelectionStep } from '../mode-selection/McpModeSelectionStep';
@@ -246,16 +250,47 @@ export function McpNodeDialog({ isOpen, onClose }: McpNodeDialogProps) {
       case WizardStep.ServerSelection:
         return (
           <div>
-            <h3
+            <div
               style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
                 margin: '0 0 12px 0',
-                fontSize: '14px',
-                fontWeight: 600,
-                color: 'var(--vscode-foreground)',
               }}
             >
-              {t('mcp.dialog.selectServer')}
-            </h3>
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('mcp.dialog.selectServer')}
+              </h3>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() => openExternalUrl(PULSE_MCP_URL)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    openExternalUrl(PULSE_MCP_URL);
+                  }
+                }}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  cursor: 'pointer',
+                  color: 'var(--vscode-textLink-foreground)',
+                  fontSize: '12px',
+                }}
+                title={PULSE_MCP_URL}
+              >
+                {t('mcp.browse.servers')} (pulsemcp.com)
+                <ExternalLink size={11} />
+              </span>
+            </div>
             <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
               <McpServerList
                 onServerSelect={(server) => {

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -597,6 +597,7 @@ export interface WebviewTranslationKeys {
   'mcp.search.noResults': string;
   'mcp.search.serverPlaceholder': string;
   'mcp.search.noServers': string;
+  'mcp.browse.servers': string;
 
   // MCP Node Dialog
   'mcp.dialog.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -662,6 +662,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'mcp.search.noResults': 'No tools found matching "{query}"',
   'mcp.search.serverPlaceholder': 'Filter servers by name...',
   'mcp.search.noServers': 'No servers found matching "{query}"',
+  'mcp.browse.servers': 'Browse MCP Servers',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool Configuration',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -659,6 +659,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'mcp.search.noResults': '"{query}" に一致するツールが見つかりません',
   'mcp.search.serverPlaceholder': 'サーバー名でフィルタ...',
   'mcp.search.noServers': '"{query}" に一致するサーバーが見つかりません',
+  'mcp.browse.servers': 'MCPサーバーを探す',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Toolの設定',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -654,6 +654,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'mcp.search.noResults': '"{query}"와 일치하는 도구를 찾을 수 없습니다',
   'mcp.search.serverPlaceholder': '서버 이름으로 필터...',
   'mcp.search.noServers': '"{query}"와 일치하는 서버를 찾을 수 없습니다',
+  'mcp.browse.servers': 'MCP 서버 찾아보기',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool 설정',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -631,6 +631,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'mcp.search.noResults': '未找到与"{query}"匹配的工具',
   'mcp.search.serverPlaceholder': '按名称筛选服务器...',
   'mcp.search.noServers': '未找到与"{query}"匹配的服务器',
+  'mcp.browse.servers': '浏览MCP服务器',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool配置',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -631,6 +631,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'mcp.search.noResults': '未找到與"{query}"匹配的工具',
   'mcp.search.serverPlaceholder': '按名稱篩選伺服器...',
   'mcp.search.noServers': '未找到與"{query}"匹配的伺服器',
+  'mcp.browse.servers': '瀏覽MCP伺服器',
 
   // MCP Node Dialog
   'mcp.dialog.title': 'MCP Tool配置',


### PR DESCRIPTION
## Summary

Add an external link to PulseMCP (pulsemcp.com/servers) in the MCP Node Dialog so users can easily discover and browse available MCP servers.

## What Changed

### Before
- No way to discover new MCP servers from within the MCP Tool Configuration dialog

### After
- "Browse MCP Servers (pulsemcp.com)" link with external link icon displayed next to the "Select MCP Server" heading
- Link text is i18n-translated, domain name shown in parentheses for clarity

## Changes

- `src/webview/src/components/dialogs/McpNodeDialog.tsx` - Added PulseMCP external link next to server selection heading
- `src/webview/src/i18n/translation-keys.ts` - Added `mcp.browse.servers` key
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Added translations

## Testing

- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clickable "Browse MCP Servers" link in the server selection interface that opens the MCP servers directory.
  * Implemented multi-language support with translations in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->