### PR TITLE
improvement: add SkillsMP discovery link to Skill Browser dialog

### DIFF
--- a/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
+++ b/src/webview/src/components/dialogs/SkillBrowserDialog.tsx
@@ -324,47 +324,16 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
             }}
           >
             {/* Header */}
-            <div
+            <Dialog.Title
               style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
                 margin: '0 0 8px 0',
+                fontSize: '18px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
               }}
             >
-              <Dialog.Title
-                style={{
-                  margin: 0,
-                  fontSize: '18px',
-                  fontWeight: 600,
-                  color: 'var(--vscode-foreground)',
-                }}
-              >
-                {t('skill.browser.title')}
-              </Dialog.Title>
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={() => openExternalUrl(SKILLS_MP_URL)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    openExternalUrl(SKILLS_MP_URL);
-                  }
-                }}
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '4px',
-                  cursor: 'pointer',
-                  color: 'var(--vscode-textLink-foreground)',
-                  fontSize: '12px',
-                }}
-                title={SKILLS_MP_URL}
-              >
-                {t('skill.browser.browseSkills')} (skillsmp.com)
-                <ExternalLink size={11} />
-              </span>
-            </div>
+              {t('skill.browser.title')}
+            </Dialog.Title>
             <Dialog.Description
               style={{
                 margin: '0 0 20px 0',
@@ -378,6 +347,49 @@ export function SkillBrowserDialog({ isOpen, onClose }: SkillBrowserDialogProps)
 
             {!showSettingsStep && (
               <>
+                {/* Select Skill label + discovery link */}
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    margin: '0 0 12px 0',
+                  }}
+                >
+                  <h3
+                    style={{
+                      margin: 0,
+                      fontSize: '14px',
+                      fontWeight: 600,
+                      color: 'var(--vscode-foreground)',
+                    }}
+                  >
+                    {t('skill.browser.selectSkill')}
+                  </h3>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => openExternalUrl(SKILLS_MP_URL)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        openExternalUrl(SKILLS_MP_URL);
+                      }
+                    }}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                      cursor: 'pointer',
+                      color: 'var(--vscode-textLink-foreground)',
+                      fontSize: '12px',
+                    }}
+                    title={SKILLS_MP_URL}
+                  >
+                    {t('skill.browser.browseSkills')} (skillsmp.com)
+                    <ExternalLink size={11} />
+                  </span>
+                </div>
+
                 {/* Filter Input + Create New Button */}
                 <div style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
                   <input

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -399,6 +399,7 @@ export interface WebviewTranslationKeys {
   // Skill Browser Dialog
   'skill.browser.title': string;
   'skill.browser.description': string;
+  'skill.browser.selectSkill': string;
   'skill.browser.browseSkills': string;
   'skill.browser.userTab': string;
   'skill.browser.projectTab': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -435,8 +435,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Skill Browser Dialog
   'skill.browser.title': 'Browse Skills',
-  'skill.browser.description':
-    'Select a Claude Code Skill to add to your workflow.\nSkills are specialized capabilities that Claude Code automatically utilizes.',
+  'skill.browser.description': 'Select an Agent Skill to add to your workflow.',
+  'skill.browser.selectSkill': 'Select Skill',
   'skill.browser.browseSkills': 'Browse Skills',
   'skill.browser.userTab': 'User',
   'skill.browser.projectTab': 'Project',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -434,8 +434,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Skill Browser Dialog
   'skill.browser.title': 'Skillを参照',
-  'skill.browser.description':
-    'ワークフローに追加するClaude Code Skillを選択してください。\nSkillはClaude Codeが自動的に活用する専門的な能力です。',
+  'skill.browser.description': 'ワークフローに追加するAgent Skillを選択してください。',
+  'skill.browser.selectSkill': 'Skillを選択',
   'skill.browser.browseSkills': 'Skillを探す',
   'skill.browser.userTab': 'ユーザー',
   'skill.browser.projectTab': 'プロジェクト',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -433,8 +433,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Skill Browser Dialog
   'skill.browser.title': 'Skill 탐색',
-  'skill.browser.description':
-    '워크플로에 추가할 Claude Code Skill을 선택하세요.\nSkill은 Claude Code가 자동으로 활용하는 전문적인 능력입니다.',
+  'skill.browser.description': '워크플로에 추가할 Agent Skill을 선택하세요.',
+  'skill.browser.selectSkill': 'Skill 선택',
   'skill.browser.browseSkills': 'Skill 찾아보기',
   'skill.browser.userTab': '사용자',
   'skill.browser.projectTab': '프로젝트',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -417,8 +417,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Skill Browser Dialog
   'skill.browser.title': '浏览Skill',
-  'skill.browser.description':
-    '选择要添加到工作流的Claude Code Skill。\nSkill是Claude Code自动利用的专业能力。',
+  'skill.browser.description': '选择要添加到工作流的Agent Skill。',
+  'skill.browser.selectSkill': '选择Skill',
   'skill.browser.browseSkills': '浏览Skill',
   'skill.browser.userTab': '用户',
   'skill.browser.projectTab': '项目',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -417,8 +417,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Skill Browser Dialog
   'skill.browser.title': '瀏覽Skill',
-  'skill.browser.description':
-    '選擇要新增到工作流的Claude Code Skill。\nSkill是Claude Code自動利用的專業能力。',
+  'skill.browser.description': '選擇要新增到工作流的Agent Skill。',
+  'skill.browser.selectSkill': '選擇Skill',
   'skill.browser.browseSkills': '瀏覽Skill',
   'skill.browser.userTab': '使用者',
   'skill.browser.projectTab': '專案',


### PR DESCRIPTION
## Summary

Add an external link to SkillsMP (skillsmp.com) and a "Select Skill" label to the Skill Browser Dialog, matching the MCP server selection pattern for consistency.

## What Changed

### Before
- No way to discover new Skills from within the Skill Browser dialog
- No "Select Skill" label (only dialog title and verbose description)

### After
- "Select Skill" label with "Browse Skills (skillsmp.com)" link, matching MCP dialog layout
- Dialog description simplified to a single purpose statement

## Changes

- `src/webview/src/components/dialogs/SkillBrowserDialog.tsx` - Added Select Skill label with SkillsMP link, simplified description
- `src/webview/src/i18n/translation-keys.ts` - Added `skill.browser.selectSkill` and `skill.browser.browseSkills` keys
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Added translations, simplified description text

## Testing

- [ ] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Browse Skills" discovery link in the Skill Browser Dialog, allowing users to explore available skills through an external marketplace.

* **Localization**
  * Updated terminology across all supported languages, replacing "Claude Code Skill" with "Agent Skill" throughout the interface.
  * Added localized labels for skill selection and discovery across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->