### PR TITLE
improvement: add sub-agent discovery link to Sub-Agent dialog

### DIFF
--- a/src/webview/src/components/dialogs/SubAgentCreationDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentCreationDialog.tsx
@@ -7,11 +7,15 @@
 
 import * as Dialog from '@radix-ui/react-dialog';
 import type { CommandReference } from '@shared/types/messages';
+import { ExternalLink } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from '../../i18n/i18n-context';
 import { browseCommands } from '../../services/command-browser-service';
+import { openExternalUrl } from '../../services/vscode-bridge';
 import { type SubAgentFormData, SubAgentFormDialog } from './SubAgentFormDialog';
+
+const AWESOME_SUBAGENTS_URL = 'https://github.com/VoltAgent/awesome-claude-code-subagents';
 
 const Z_INDEX = {
   DIALOG_BASE: 9999,
@@ -162,6 +166,49 @@ export const SubAgentCreationDialog: React.FC<SubAgentCreationDialogProps> = ({
             >
               {t('subAgent.dialog.description')}
             </Dialog.Description>
+
+            {/* Select Sub-Agent label + discovery link */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                margin: '0 0 12px 0',
+              }}
+            >
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  color: 'var(--vscode-foreground)',
+                }}
+              >
+                {t('subAgent.dialog.selectSubAgent')}
+              </h3>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() => openExternalUrl(AWESOME_SUBAGENTS_URL)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    openExternalUrl(AWESOME_SUBAGENTS_URL);
+                  }
+                }}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  cursor: 'pointer',
+                  color: 'var(--vscode-textLink-foreground)',
+                  fontSize: '12px',
+                }}
+                title={AWESOME_SUBAGENTS_URL}
+              >
+                {t('subAgent.dialog.browseSubAgents')} (awesome list by VoltAgent)
+                <ExternalLink size={11} />
+              </span>
+            </div>
 
             {/* Filter Input + Create New Button */}
             <div style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -870,6 +870,8 @@ export interface WebviewTranslationKeys {
   'subAgent.dialog.backButton': string;
   'subAgent.dialog.loadFailed': string;
   'subAgent.dialog.description': string;
+  'subAgent.dialog.selectSubAgent': string;
+  'subAgent.dialog.browseSubAgents': string;
   'subAgent.dialog.userDescription': string;
   'subAgent.dialog.projectDescription': string;
   'subAgent.dialog.localDescription': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -953,8 +953,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.cancelButton': 'Cancel',
   'subAgent.dialog.backButton': 'Back',
   'subAgent.dialog.loadFailed': 'Failed to load commands. Please check the commands directory.',
-  'subAgent.dialog.description':
-    'Browse and select an existing command file to use as a Sub-Agent node.',
+  'subAgent.dialog.description': 'Select a Sub-Agent to add to your workflow.',
+  'subAgent.dialog.selectSubAgent': 'Select Sub-Agent',
+  'subAgent.dialog.browseSubAgents': 'Browse Sub-Agents',
   'subAgent.dialog.userDescription':
     'Commands from ~/.claude/agents/ — available across all projects.',
   'subAgent.dialog.projectDescription': 'Commands from .claude/agents/ — specific to this project.',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -947,8 +947,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.backButton': '戻る',
   'subAgent.dialog.loadFailed':
     'コマンドの読み込みに失敗しました。コマンドディレクトリを確認してください。',
-  'subAgent.dialog.description':
-    '既存のコマンドファイルを選択して、Sub-Agentノードとして使用します。',
+  'subAgent.dialog.description': 'ワークフローに追加するSub-Agentを選択してください。',
+  'subAgent.dialog.selectSubAgent': 'Sub-Agentを選択',
+  'subAgent.dialog.browseSubAgents': 'Sub-Agentを探す',
   'subAgent.dialog.userDescription':
     '~/.claude/agents/ のコマンド — すべてのプロジェクトで利用可能。',
   'subAgent.dialog.projectDescription': '.claude/agents/ のコマンド — このプロジェクト固有。',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -942,7 +942,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.cancelButton': '취소',
   'subAgent.dialog.backButton': '뒤로',
   'subAgent.dialog.loadFailed': '커맨드를 로드하지 못했습니다. 커맨드 디렉토리를 확인하세요.',
-  'subAgent.dialog.description': '기존 커맨드 파일을 선택하여 Sub-Agent 노드로 사용합니다.',
+  'subAgent.dialog.description': '워크플로에 추가할 Sub-Agent를 선택하세요.',
+  'subAgent.dialog.selectSubAgent': 'Sub-Agent 선택',
+  'subAgent.dialog.browseSubAgents': 'Sub-Agent 찾아보기',
   'subAgent.dialog.userDescription': '~/.claude/agents/의 커맨드 — 모든 프로젝트에서 사용 가능.',
   'subAgent.dialog.projectDescription': '.claude/agents/의 커맨드 — 이 프로젝트에만 해당.',
   'subAgent.dialog.localDescription':

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -910,7 +910,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.cancelButton': '取消',
   'subAgent.dialog.backButton': '返回',
   'subAgent.dialog.loadFailed': '加载命令失败。请检查命令目录。',
-  'subAgent.dialog.description': '浏览并选择现有命令文件作为 Sub-Agent 节点使用。',
+  'subAgent.dialog.description': '选择要添加到工作流的 Sub-Agent。',
+  'subAgent.dialog.selectSubAgent': '选择 Sub-Agent',
+  'subAgent.dialog.browseSubAgents': '浏览 Sub-Agent',
   'subAgent.dialog.userDescription': '~/.claude/agents/ 中的命令 — 所有项目可用。',
   'subAgent.dialog.projectDescription': '.claude/agents/ 中的命令 — 仅限此项目。',
   'subAgent.dialog.localDescription':

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -911,7 +911,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.cancelButton': '取消',
   'subAgent.dialog.backButton': '返回',
   'subAgent.dialog.loadFailed': '載入命令失敗。請檢查命令目錄。',
-  'subAgent.dialog.description': '瀏覽並選擇現有命令檔案作為 Sub-Agent 節點使用。',
+  'subAgent.dialog.description': '選擇要新增到工作流的 Sub-Agent。',
+  'subAgent.dialog.selectSubAgent': '選擇 Sub-Agent',
+  'subAgent.dialog.browseSubAgents': '瀏覽 Sub-Agent',
   'subAgent.dialog.userDescription': '~/.claude/agents/ 中的命令 — 所有專案可用。',
   'subAgent.dialog.projectDescription': '.claude/agents/ 中的命令 — 僅限此專案。',
   'subAgent.dialog.localDescription':


### PR DESCRIPTION
## Summary

Add an external link to awesome-claude-code-subagents and a "Select Sub-Agent" label to the Sub-Agent Creation Dialog, matching the MCP/Skill dialog pattern for consistency.

## What Changed

### Before
- No way to discover new Sub-Agents from within the Sub-Agent Creation dialog
- No "Select Sub-Agent" label (only dialog title and verbose description)

### After
- "Select Sub-Agent" label with "Browse Sub-Agents (awesome list by VoltAgent)" link
- Dialog description simplified to a single purpose statement

## Changes

- `src/webview/src/components/dialogs/SubAgentCreationDialog.tsx` - Added Select Sub-Agent label with discovery link, simplified description
- `src/webview/src/i18n/translation-keys.ts` - Added `subAgent.dialog.selectSubAgent` and `subAgent.dialog.browseSubAgents` keys
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Added translations, simplified description text

## Testing

- [ ] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Select Sub-Agent" section with a link to browse a curated external list of sub-agents in the Sub-Agent Creation Dialog.
  * Updated translations across multiple languages to support the new UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->