### PR TITLE
improvement: increase max node limit to 100 with user-configurable setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,13 @@
           "type": "boolean",
           "default": false,
           "description": "Collect and log metrics for A/B comparison of schema formats. Note: Prompt format is always 'toon'."
+        },
+        "cc-wf-studio.workflow.maxNodes": {
+          "type": "number",
+          "default": 100,
+          "minimum": 10,
+          "maximum": 500,
+          "description": "Maximum number of nodes allowed in a workflow."
         }
       }
     }

--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -2,7 +2,7 @@
   "schemaVersion": "1.0.0",
   "metadata": {
     "description": "Workflow schema for CC Workflow Studio",
-    "maxNodes": 50,
+    "maxNodes": 100,
     "supportedNodeTypes": [
       "start",
       "end",
@@ -465,7 +465,7 @@
         "constraints": [
           "SubAgentFlow nodes array can only contain: start, end, prompt, ifElse, switch, skill, mcp",
           "SubAgentFlow nodes array CANNOT contain: subAgent, subAgentFlow, askUserQuestion",
-          "Maximum 30 nodes per SubAgentFlow"
+          "Maximum 100 nodes per SubAgentFlow"
         ],
         "example": {
           "nodeInWorkflow": {
@@ -837,7 +837,7 @@
   },
   "validationRules": {
     "workflow": {
-      "maxNodes": 50,
+      "maxNodes": 100,
       "nameMaxLength": 100,
       "namePattern": "^[a-z0-9_-]+$",
       "versionPattern": "^\\d+\\.\\d+\\.\\d+$"
@@ -850,7 +850,7 @@
   },
   "subAgentFlowConstraints": {
     "description": "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed.",
-    "maxNodes": 30,
+    "maxNodes": 100,
     "supportedNodeTypes": ["start", "end", "prompt", "ifElse", "switch", "skill", "mcp", "codex"],
     "prohibitedNodeTypes": ["subAgent", "subAgentFlow", "askUserQuestion"],
     "rules": [
@@ -858,7 +858,7 @@
       "Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP)",
       "Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context)",
       "Sub-Agent Flows must have exactly one Start node and at least one End node",
-      "Maximum 30 nodes per Sub-Agent Flow"
+      "Maximum 100 nodes per Sub-Agent Flow"
     ]
   },
   "workflowStructure": {

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -1,7 +1,7 @@
 schemaVersion: 1.0.0
 metadata:
   description: Workflow schema for CC Workflow Studio
-  maxNodes: 50
+  maxNodes: 100
   supportedNodeTypes[12]: start,end,prompt,subAgent,askUserQuestion,ifElse,switch,skill,mcp,subAgentFlow,codex,group
 nodeTypes:
   start:
@@ -415,7 +415,7 @@ nodeTypes:
         description: Optional description
         nodes: MUST include at least Start and End nodes
         connections: Connect Start to End (minimum structure)
-      constraints[3]: "SubAgentFlow nodes array can only contain: start, end, prompt, ifElse, switch, skill, mcp","SubAgentFlow nodes array CANNOT contain: subAgent, subAgentFlow, askUserQuestion",Maximum 30 nodes per SubAgentFlow
+      constraints[3]: "SubAgentFlow nodes array can only contain: start, end, prompt, ifElse, switch, skill, mcp","SubAgentFlow nodes array CANNOT contain: subAgent, subAgentFlow, askUserQuestion",Maximum 100 nodes per SubAgentFlow
       example:
         nodeInWorkflow:
           id: subflow-ref-1
@@ -659,7 +659,7 @@ connections:
       items[10]: ✓ Exactly 1 Start node with output connected,✓ At least 1 End node with input(s) connected,✓ All non-Start nodes have input connected,✓ All non-End nodes have output(s) connected,"✓ IfElse nodes: both branches connected","✓ Switch nodes: all branches connected","✓ AskUserQuestion nodes (single-select): all options connected",✓ No dangling nodes,✓ No circular references,✓ All node IDs in connections exist in nodes array
 validationRules:
   workflow:
-    maxNodes: 50
+    maxNodes: 100
     nameMaxLength: 100
     namePattern: "^[a-z0-9_-]+$"
     versionPattern: "^\\d+\\.\\d+\\.\\d+$"
@@ -669,10 +669,10 @@ validationRules:
     namePatternDescription: "IMPORTANT: Node names must use ASCII alphanumeric characters, hyphens, and underscores only. NO spaces or non-ASCII characters allowed."
 subAgentFlowConstraints:
   description: "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed."
-  maxNodes: 30
+  maxNodes: 100
   supportedNodeTypes[8]: start,end,prompt,ifElse,switch,skill,mcp,codex
   prohibitedNodeTypes[3]: subAgent,subAgentFlow,askUserQuestion
-  rules[5]: Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution),Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP),Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context),Sub-Agent Flows must have exactly one Start node and at least one End node,Maximum 30 nodes per Sub-Agent Flow
+  rules[5]: Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution),Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP),Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context),Sub-Agent Flows must have exactly one Start node and at least one End node,Maximum 100 nodes per Sub-Agent Flow
 workflowStructure:
   description: Top-level workflow structure fields
   fields:

--- a/src/extension/commands/save-workflow.ts
+++ b/src/extension/commands/save-workflow.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import type { SaveSuccessPayload } from '../../shared/types/messages';
 import type { Workflow } from '../../shared/types/workflow-definition';
 import type { FileService } from '../services/file-service';
+import { getMaxNodes } from '../services/workflow-settings-service';
 
 /**
  * Save workflow to file
@@ -130,8 +131,9 @@ function validateWorkflow(workflow: Workflow): void {
     throw new Error('Workflow version must follow semantic versioning (e.g., 1.0.0)');
   }
 
-  // Check max nodes (50)
-  if (workflow.nodes.length > 50) {
-    throw new Error('Workflow cannot have more than 50 nodes');
+  // Check max nodes (configurable via settings)
+  const maxNodes = getMaxNodes();
+  if (workflow.nodes.length > maxNodes) {
+    throw new Error(`Workflow cannot have more than ${maxNodes} nodes`);
   }
 }

--- a/src/extension/services/refinement-service.ts
+++ b/src/extension/services/refinement-service.ts
@@ -35,6 +35,7 @@ import { RefinementPromptBuilder } from './refinement-prompt-builder';
 import { loadWorkflowSchemaByFormat, type SchemaLoadResult } from './schema-loader-service';
 import { filterSkillsByRelevance, type SkillRelevanceScore } from './skill-relevance-matcher';
 import { scanAllSkills } from './skill-service';
+import { getMaxNodes } from './workflow-settings-service';
 
 /** Validation error structure */
 export interface ValidationErrorInfo {
@@ -976,9 +977,8 @@ export interface SubAgentFlowRefinementResult {
 const SUBAGENTFLOW_PROHIBITED_NODE_TYPES = ['subAgent', 'subAgentFlow', 'askUserQuestion'];
 
 /**
- * Maximum nodes allowed in SubAgentFlow
+ * Maximum nodes allowed in SubAgentFlow (reads from user settings)
  */
-const SUBAGENTFLOW_MAX_NODES = 30;
 
 /**
  * Construct refinement prompt for SubAgentFlow
@@ -1091,7 +1091,7 @@ Sub-Agent Flows have strict constraints that MUST be followed:
    - subAgentFlow (no nesting allowed)
    - askUserQuestion (user interaction not supported in sub-agent context)
 2. **Allowed Node Types**: start, end, prompt, ifElse, switch, skill, mcp, codex
-3. **Maximum Nodes**: ${SUBAGENTFLOW_MAX_NODES} nodes maximum
+3. **Maximum Nodes**: ${getMaxNodes()} nodes maximum
 4. **Must have exactly one Start node and at least one End node**
 
 **Current Sub-Agent Flow**:
@@ -1488,11 +1488,11 @@ export async function refineSubAgentFlow(
     }
 
     // Step 7: Validate node count
-    if (refinedInnerWorkflow.nodes.length > SUBAGENTFLOW_MAX_NODES) {
+    if (refinedInnerWorkflow.nodes.length > getMaxNodes()) {
       log('ERROR', 'SubAgentFlow exceeds maximum node count', {
         requestId,
         nodeCount: refinedInnerWorkflow.nodes.length,
-        maxNodes: SUBAGENTFLOW_MAX_NODES,
+        maxNodes: getMaxNodes(),
         executionTimeMs: cliResult.executionTimeMs,
       });
 
@@ -1500,7 +1500,7 @@ export async function refineSubAgentFlow(
         success: false,
         error: {
           code: 'VALIDATION_ERROR',
-          message: `Sub-Agent Flow cannot exceed ${SUBAGENTFLOW_MAX_NODES} nodes`,
+          message: `Sub-Agent Flow cannot exceed ${getMaxNodes()} nodes`,
           details: `Current count: ${refinedInnerWorkflow.nodes.length}`,
         },
         executionTimeMs: cliResult.executionTimeMs,

--- a/src/extension/services/workflow-settings-service.ts
+++ b/src/extension/services/workflow-settings-service.ts
@@ -1,0 +1,17 @@
+/**
+ * Workflow Settings Service
+ *
+ * Reads workflow-related settings from VSCode configuration.
+ */
+
+import * as vscode from 'vscode';
+import { VALIDATION_RULES } from '../../shared/types/workflow-definition';
+
+/**
+ * Get the maximum number of nodes allowed in a workflow.
+ * Reads from `cc-wf-studio.workflow.maxNodes` setting.
+ */
+export function getMaxNodes(): number {
+  const config = vscode.workspace.getConfiguration('cc-wf-studio');
+  return config.get<number>('workflow.maxNodes', VALIDATION_RULES.WORKFLOW.MAX_NODES);
+}

--- a/src/extension/utils/validate-workflow.ts
+++ b/src/extension/utils/validate-workflow.ts
@@ -19,6 +19,7 @@ import {
   type WorkflowHooks,
   type WorkflowNode,
 } from '../../shared/types/workflow-definition';
+import { getMaxNodes } from '../services/workflow-settings-service';
 
 export interface ValidationError {
   code: string;
@@ -99,10 +100,11 @@ export function validateAIGeneratedWorkflow(workflow: unknown): ValidationResult
   }
 
   // Node count validation
-  if (wf.nodes.length > VALIDATION_RULES.WORKFLOW.MAX_NODES) {
+  const maxNodes = getMaxNodes();
+  if (wf.nodes.length > maxNodes) {
     errors.push({
       code: 'MAX_NODES_EXCEEDED',
-      message: `Generated workflow exceeds maximum node limit (${VALIDATION_RULES.WORKFLOW.MAX_NODES}). Please simplify your description.`,
+      message: `Generated workflow exceeds maximum node limit (${maxNodes}). Please simplify your description.`,
       field: 'nodes',
     });
   }

--- a/src/shared/types/workflow-definition.ts
+++ b/src/shared/types/workflow-definition.ts
@@ -599,7 +599,7 @@ export interface Workflow {
 
 export const VALIDATION_RULES = {
   WORKFLOW: {
-    MAX_NODES: 50,
+    MAX_NODES: 100,
     NAME_MIN_LENGTH: 1,
     NAME_MAX_LENGTH: 100,
     NAME_PATTERN: /^[a-z0-9_-]+$/, // Lowercase only (for cross-platform file system compatibility)
@@ -676,7 +676,7 @@ export const VALIDATION_RULES = {
     NAME_MAX_LENGTH: 50,
     NAME_PATTERN: /^[a-z0-9_-]+$/, // Lowercase only (for cross-platform file system compatibility)
     DESCRIPTION_MAX_LENGTH: 200,
-    MAX_NODES: 30, // Smaller than main workflow
+    MAX_NODES: 100,
     // Node-specific validation (for SubAgentFlow reference nodes)
     LABEL_MIN_LENGTH: 1,
     LABEL_MAX_LENGTH: 50,

--- a/src/webview/src/services/workflow-service.ts
+++ b/src/webview/src/services/workflow-service.ts
@@ -5,13 +5,14 @@
  * Based on: /specs/001-cc-wf-studio/data-model.md
  */
 
-import type {
-  Connection,
-  ConversationHistory,
-  SlashCommandOptions,
-  SubAgentFlow,
-  Workflow,
-  WorkflowNode,
+import {
+  type Connection,
+  type ConversationHistory,
+  type SlashCommandOptions,
+  type SubAgentFlow,
+  VALIDATION_RULES,
+  type Workflow,
+  type WorkflowNode,
 } from '@shared/types/workflow-definition';
 import type { Edge, Node } from 'reactflow';
 
@@ -188,9 +189,9 @@ export function validateWorkflow(workflow: Workflow): void {
     throw new Error('Workflow version must follow semantic versioning (e.g., 1.0.0)');
   }
 
-  // Check max nodes (50)
-  if (workflow.nodes.length > 50) {
-    throw new Error('Workflow cannot have more than 50 nodes');
+  // Check max nodes
+  if (workflow.nodes.length > VALIDATION_RULES.WORKFLOW.MAX_NODES) {
+    throw new Error(`Workflow cannot have more than ${VALIDATION_RULES.WORKFLOW.MAX_NODES} nodes`);
   }
 
   // Validate nodes


### PR DESCRIPTION
## Summary

Increase the workflow node limit from 50 to 100 (default) and expose it as a user-configurable VSCode setting (`cc-wf-studio.workflow.maxNodes`).

## What Changed

### Before
- Workflow node limit was hardcoded to 50 in multiple places
- Sub-Agent Flow node limit was hardcoded to 30
- Users could not adjust the limit

### After
- Default node limit increased to 100 for both workflows and Sub-Agent Flows
- New VSCode setting `cc-wf-studio.workflow.maxNodes` (range: 10-500, default: 100)
- All hardcoded limits replaced with centralized `getMaxNodes()` utility function

## Changes

- `package.json` - Add `cc-wf-studio.workflow.maxNodes` configuration property
- `src/extension/services/workflow-settings-service.ts` - New settings service with `getMaxNodes()`
- `src/shared/types/workflow-definition.ts` - Update default constants to 100
- `src/extension/commands/save-workflow.ts` - Use `getMaxNodes()` instead of hardcoded 50
- `src/extension/utils/validate-workflow.ts` - Use `getMaxNodes()` instead of constant
- `src/extension/services/refinement-service.ts` - Use `getMaxNodes()` instead of hardcoded 30
- `src/webview/src/services/workflow-service.ts` - Use `VALIDATION_RULES` constant instead of hardcoded 50
- `resources/workflow-schema.json` & `.toon` - Update all maxNodes values to 100

## Testing

- [x] Manual E2E testing completed (boundary values: 99, 100, 101)
- [x] Build passes (`npm run format && npm run lint && npm run check && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration property to customize the maximum number of nodes allowed in workflows, with a default limit of 100 nodes.

* **Improvements**
  * Increased the default maximum workflow nodes from 50 to 100.
  * Increased the default maximum sub-agent flow nodes from 30 to 100.
  * Workflow validation now dynamically enforces configured node limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->