### PR TITLE
fix: canvas toolbar toggles getting stuck open on rapid hover

### DIFF
--- a/src/webview/src/components/EdgeAnimationToggle.tsx
+++ b/src/webview/src/components/EdgeAnimationToggle.tsx
@@ -8,7 +8,7 @@
 import * as Switch from '@radix-ui/react-switch';
 import { ChevronsLeftRightEllipsis } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useStableHover } from '../hooks/useStableHover';
 import { useTranslation } from '../i18n/i18n-context';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
 
@@ -26,7 +26,7 @@ export const EdgeAnimationToggle: React.FC<EdgeAnimationToggleProps> = ({
   onToggle,
 }) => {
   const { t } = useTranslation();
-  const [isHovered, setIsHovered] = useState(false);
+  const { ref, isHovered, onMouseEnter, onMouseLeave } = useStableHover();
 
   return (
     <StyledTooltipProvider>
@@ -40,8 +40,9 @@ export const EdgeAnimationToggle: React.FC<EdgeAnimationToggleProps> = ({
         }
       >
         <div
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          ref={ref}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
           onClick={() => {
             if (!isHovered) onToggle();
           }}

--- a/src/webview/src/components/HighlightToggle.tsx
+++ b/src/webview/src/components/HighlightToggle.tsx
@@ -8,7 +8,7 @@
 import * as Switch from '@radix-ui/react-switch';
 import { Lightbulb, LightbulbOff } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useStableHover } from '../hooks/useStableHover';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
@@ -20,7 +20,7 @@ const TRANSITION_DURATION = window.matchMedia('(prefers-reduced-motion: reduce)'
 export const HighlightToggle: React.FC = () => {
   const { t } = useTranslation();
   const { isHighlightEnabled, toggleHighlightEnabled, highlightedGroupNodeId } = useWorkflowStore();
-  const [isHovered, setIsHovered] = useState(false);
+  const { ref, isHovered, onMouseEnter, onMouseLeave } = useStableHover();
 
   const highlightBorder = isHovered
     ? '1px solid var(--vscode-focusBorder)'
@@ -45,8 +45,9 @@ export const HighlightToggle: React.FC = () => {
         }
       >
         <div
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          ref={ref}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
           onClick={() => {
             if (!isHovered) toggleHighlightEnabled();
           }}

--- a/src/webview/src/components/InteractionModeToggle.tsx
+++ b/src/webview/src/components/InteractionModeToggle.tsx
@@ -8,7 +8,7 @@
 import * as Switch from '@radix-ui/react-switch';
 import { Hand, MousePointerClick } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useStableHover } from '../hooks/useStableHover';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
@@ -26,7 +26,7 @@ const TRANSITION_DURATION = window.matchMedia('(prefers-reduced-motion: reduce)'
 export const InteractionModeToggle: React.FC = () => {
   const { t } = useTranslation();
   const { interactionMode, toggleInteractionMode } = useWorkflowStore();
-  const [isHovered, setIsHovered] = useState(false);
+  const { ref, isHovered, onMouseEnter, onMouseLeave } = useStableHover();
 
   return (
     <StyledTooltipProvider>
@@ -40,8 +40,9 @@ export const InteractionModeToggle: React.FC = () => {
         }
       >
         <div
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          ref={ref}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
           onClick={() => {
             if (!isHovered) toggleInteractionMode();
           }}

--- a/src/webview/src/components/MinimapToggle.tsx
+++ b/src/webview/src/components/MinimapToggle.tsx
@@ -11,7 +11,7 @@
 
 import { Map as MapIcon, MapPinned } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useStableHover } from '../hooks/useStableHover';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
@@ -25,7 +25,7 @@ type MinimapDisplayMode = 'hidden' | 'auto' | 'always';
 export const MinimapToggle: React.FC = () => {
   const { t } = useTranslation();
   const { minimapDisplayMode, setMinimapDisplayMode } = useWorkflowStore();
-  const [isHovered, setIsHovered] = useState(false);
+  const { ref, isHovered, onMouseEnter, onMouseLeave } = useStableHover();
 
   const tooltipForMode = (mode: MinimapDisplayMode) => {
     switch (mode) {
@@ -171,8 +171,9 @@ export const MinimapToggle: React.FC = () => {
     <StyledTooltipProvider>
       <StyledTooltipItem content={isHovered ? '' : tooltipForMode(minimapDisplayMode)}>
         <div
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          ref={ref}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
           onClick={() => {
             if (!isHovered) cycleMode();
           }}

--- a/src/webview/src/components/ScrollModeToggle.tsx
+++ b/src/webview/src/components/ScrollModeToggle.tsx
@@ -8,7 +8,7 @@
 import * as Switch from '@radix-ui/react-switch';
 import { Move, ZoomIn } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useStableHover } from '../hooks/useStableHover';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
@@ -26,7 +26,7 @@ const TRANSITION_DURATION = window.matchMedia('(prefers-reduced-motion: reduce)'
 export const ScrollModeToggle: React.FC = () => {
   const { t } = useTranslation();
   const { scrollMode, toggleScrollMode } = useWorkflowStore();
-  const [isHovered, setIsHovered] = useState(false);
+  const { ref, isHovered, onMouseEnter, onMouseLeave } = useStableHover();
 
   return (
     <StyledTooltipProvider>
@@ -40,8 +40,9 @@ export const ScrollModeToggle: React.FC = () => {
         }
       >
         <div
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          ref={ref}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
           onClick={() => {
             if (!isHovered) toggleScrollMode();
           }}

--- a/src/webview/src/hooks/useStableHover.ts
+++ b/src/webview/src/hooks/useStableHover.ts
@@ -1,0 +1,100 @@
+/**
+ * useStableHover - Robust hover detection for animated expand/collapse toggles.
+ *
+ * Problem: When a CSS width transition is in progress, the element boundary
+ * moves under the cursor. The browser may never fire a mouseleave event
+ * because, from its perspective, the cursor never crossed the element edge
+ * — the edge moved away from the cursor instead.
+ *
+ * Solution: Instead of relying on mouseleave, we attach a document-level
+ * pointermove listener while hovered. On every move we hit-test the cursor
+ * against the element's current bounding rect. If the cursor is outside,
+ * we unhover — regardless of whether mouseleave fired.
+ *
+ * A small margin (default 4px) prevents flicker at exact boundaries.
+ * Polling is throttled via requestAnimationFrame to avoid layout thrash.
+ */
+
+import { type RefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseStableHoverReturn {
+  /** Attach this ref to the hoverable element */
+  ref: RefObject<HTMLDivElement | null>;
+  isHovered: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+/** Margin in px — cursor must be this far outside before we unhover */
+const LEAVE_MARGIN = 4;
+
+export function useStableHover(): UseStableHoverReturn {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
+  const isHoveredRef = useRef(false);
+  const rafRef = useRef<number | null>(null);
+
+  // Track the latest pointer position so we can check it on transitionend too
+  const pointerPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  const checkBounds = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const { x, y } = pointerPos.current;
+    const outside =
+      x < rect.left - LEAVE_MARGIN ||
+      x > rect.right + LEAVE_MARGIN ||
+      y < rect.top - LEAVE_MARGIN ||
+      y > rect.bottom + LEAVE_MARGIN;
+    if (outside && isHoveredRef.current) {
+      isHoveredRef.current = false;
+      setIsHovered(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isHovered) return;
+
+    const handlePointerMove = (e: PointerEvent) => {
+      pointerPos.current = { x: e.clientX, y: e.clientY };
+      if (rafRef.current !== null) return; // already scheduled
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        checkBounds();
+      });
+    };
+
+    // Also check on transitionend — the element may have shrunk away from
+    // a stationary cursor without any pointer movement.
+    const handleTransitionEnd = () => {
+      checkBounds();
+    };
+
+    document.addEventListener('pointermove', handlePointerMove);
+    const el = ref.current;
+    el?.addEventListener('transitionend', handleTransitionEnd);
+
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      el?.removeEventListener('transitionend', handleTransitionEnd);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [isHovered, checkBounds]);
+
+  const onMouseEnter = useCallback(() => {
+    isHoveredRef.current = true;
+    setIsHovered(true);
+  }, []);
+
+  // Still listen for mouseleave as the fast path — works in the common case
+  const onMouseLeave = useCallback(() => {
+    isHoveredRef.current = false;
+    setIsHovered(false);
+  }, []);
+
+  return { ref, isHovered, onMouseEnter, onMouseLeave };
+}


### PR DESCRIPTION
## Problem

Canvas toolbar toggles (ScrollMode, InteractionMode, EdgeAnimation, Highlight, Minimap) use a hover-expand UX where the toggle expands from a compact 28px icon to a full 100px control on hover. When rapidly moving the mouse in and out, the CSS width transition (200ms) causes the element boundary to shift under the cursor, preventing the browser from firing `mouseleave`. This leaves `isHovered` stuck as `true`, keeping the toggle permanently expanded.

### Current Behavior
1. Hover over a canvas toolbar toggle → it expands
2. Rapidly move mouse in and out during the CSS transition
3. ❌ Toggle stays expanded (stuck open) because `mouseleave` never fires

### Expected Behavior
1. Hover over a canvas toolbar toggle → it expands
2. Move mouse away
3. ✅ Toggle always collapses back to compact state

## Solution

Introduced `useStableHover` hook that does not rely solely on `mouseleave`. Instead, it attaches a document-level `pointermove` listener while hovered and hit-tests the cursor against the element's current bounding rect. If the cursor is outside (with a 4px margin), it forces `isHovered=false`. It also listens for `transitionend` to catch the case where the cursor is stationary while the element shrinks away.

### Changes

**New file**: `src/webview/src/hooks/useStableHover.ts`
- Document-level `pointermove` listener (only active while hovered)
- `transitionend` listener for stationary cursor during CSS transitions
- rAF-throttled bounds checking to avoid layout thrash
- Proper cleanup on unhover and unmount

**Modified files**: All 5 canvas toolbar toggles
- `ScrollModeToggle.tsx`
- `InteractionModeToggle.tsx`
- `EdgeAnimationToggle.tsx`
- `HighlightToggle.tsx`
- `MinimapToggle.tsx`
- Replaced `useState(false)` with `useStableHover()` hook
- Added `ref` to hoverable div for bounds checking

## Impact

- Zero overhead when toggles are collapsed (no listeners registered)
- No memory leak risk — all listeners cleaned up on unhover/unmount
- No behavior change for normal hover interactions (`mouseleave` still works as fast path)

## Testing

- [x] Manual E2E testing — rapid hover toggle no longer gets stuck
- [x] Build passes (`npm run format && npm run lint && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced improved hover detection for animated controls with enhanced boundary tracking during expand/collapse transitions.

* **Refactor**
  * Unified hover state management across multiple toggle components for consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->