### PR TITLE
Add confirmation before disabling group highlight

### DIFF
--- a/src/webview/src/components/HighlightToggle.tsx
+++ b/src/webview/src/components/HighlightToggle.tsx
@@ -8,10 +8,12 @@
 import * as Switch from '@radix-ui/react-switch';
 import { Lightbulb, LightbulbOff } from 'lucide-react';
 import type React from 'react';
+import { useState } from 'react';
 import { useStableHover } from '../hooks/useStableHover';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
+import { ConfirmDialog } from './dialogs/ConfirmDialog';
 
 const TRANSITION_DURATION = window.matchMedia('(prefers-reduced-motion: reduce)').matches
   ? '0ms'
@@ -21,6 +23,15 @@ export const HighlightToggle: React.FC = () => {
   const { t } = useTranslation();
   const { isHighlightEnabled, toggleHighlightEnabled, highlightedGroupNodeId } = useWorkflowStore();
   const { ref, isHovered, onMouseEnter, onMouseLeave } = useStableHover();
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+  const handleDisableHighlight = () => {
+    if (isHighlightEnabled && highlightedGroupNodeId) {
+      setShowConfirmDialog(true);
+    } else {
+      toggleHighlightEnabled();
+    }
+  };
 
   const highlightBorder = isHovered
     ? '1px solid var(--vscode-focusBorder)'
@@ -34,230 +45,244 @@ export const HighlightToggle: React.FC = () => {
       : 'none';
 
   return (
-    <StyledTooltipProvider>
-      <StyledTooltipItem
-        content={
-          isHovered
-            ? ''
-            : isHighlightEnabled
-              ? t('toolbar.highlight.disable')
-              : t('toolbar.highlight.enable')
-        }
-      >
-        <div
-          ref={ref}
-          onMouseEnter={onMouseEnter}
-          onMouseLeave={onMouseLeave}
-          onClick={() => {
-            if (!isHovered) toggleHighlightEnabled();
-          }}
-          onKeyDown={(e) => {
-            if (!isHovered && (e.key === 'Enter' || e.key === ' ')) {
-              e.preventDefault();
-              toggleHighlightEnabled();
-            }
-          }}
-          role="button"
-          tabIndex={isHovered ? -1 : 0}
-          aria-label={
-            isHighlightEnabled ? t('toolbar.highlight.disable') : t('toolbar.highlight.enable')
+    <>
+      <StyledTooltipProvider>
+        <StyledTooltipItem
+          content={
+            isHovered
+              ? ''
+              : isHighlightEnabled
+                ? t('toolbar.highlight.disable')
+                : t('toolbar.highlight.enable')
           }
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: isHovered ? '6px' : '0px',
-            backgroundColor: 'var(--vscode-editor-background)',
-            border: highlightBorder,
-            borderRadius: '20px',
-            padding: isHovered ? '4px 6px' : '0px',
-            opacity: 0.85,
-            width: isHovered ? '100px' : '34px',
-            height: '34px',
-            overflow: 'hidden',
-            cursor: isHovered ? 'default' : 'pointer',
-            boxSizing: 'border-box',
-            boxShadow: highlightShadow,
-            animation: highlightAnimation,
-            transition: `width ${TRANSITION_DURATION} ease, padding ${TRANSITION_DURATION} ease, gap ${TRANSITION_DURATION} ease`,
-          }}
         >
-          {/* Off Icon (Left) */}
           <div
+            ref={ref}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onClick={() => {
+              if (!isHovered) handleDisableHighlight();
+            }}
+            onKeyDown={(e) => {
+              if (!isHovered && (e.key === 'Enter' || e.key === ' ')) {
+                e.preventDefault();
+                handleDisableHighlight();
+              }
+            }}
+            role="button"
+            tabIndex={isHovered ? -1 : 0}
+            aria-label={
+              isHighlightEnabled ? t('toolbar.highlight.disable') : t('toolbar.highlight.enable')
+            }
             style={{
-              width: isHovered || !isHighlightEnabled ? '20px' : '0px',
-              opacity: isHovered || !isHighlightEnabled ? 1 : 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: isHovered ? '6px' : '0px',
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: highlightBorder,
+              borderRadius: '20px',
+              padding: isHovered ? '4px 6px' : '0px',
+              opacity: 0.85,
+              width: isHovered ? '100px' : '34px',
+              height: '34px',
               overflow: 'hidden',
-              flexShrink: 0,
-              transition: `width ${TRANSITION_DURATION} ease, opacity ${TRANSITION_DURATION} ease`,
+              cursor: isHovered ? 'default' : 'pointer',
+              boxSizing: 'border-box',
+              boxShadow: highlightShadow,
+              animation: highlightAnimation,
+              transition: `width ${TRANSITION_DURATION} ease, padding ${TRANSITION_DURATION} ease, gap ${TRANSITION_DURATION} ease`,
             }}
           >
-            {isHovered ? (
-              <StyledTooltipItem content={t('toolbar.highlight.disable')}>
-                <div
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (isHighlightEnabled) toggleHighlightEnabled();
-                  }}
-                  onKeyDown={(e) => {
-                    if ((e.key === 'Enter' || e.key === ' ') && isHighlightEnabled) {
-                      e.preventDefault();
-                      toggleHighlightEnabled();
-                    }
-                  }}
-                  role="button"
-                  tabIndex={isHighlightEnabled ? 0 : -1}
-                  aria-label={t('toolbar.highlight.disable')}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    width: '20px',
-                    height: '20px',
-                    borderRadius: '50%',
-                    backgroundColor: !isHighlightEnabled
-                      ? 'var(--vscode-badge-background)'
-                      : 'transparent',
-                    transition: 'background-color 150ms',
-                    cursor: isHighlightEnabled ? 'pointer' : 'default',
-                  }}
-                >
-                  <LightbulbOff
-                    size={12}
-                    style={{
-                      color: !isHighlightEnabled
-                        ? 'var(--vscode-badge-foreground)'
-                        : 'var(--vscode-disabledForeground)',
-                    }}
-                  />
-                </div>
-              </StyledTooltipItem>
-            ) : (
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: '20px',
-                  height: '20px',
-                }}
-              >
-                <LightbulbOff size={14} style={{ color: 'var(--vscode-disabledForeground)' }} />
-              </div>
-            )}
-          </div>
-
-          {/* Switch */}
-          <div
-            style={{
-              width: isHovered ? '34px' : '0px',
-              opacity: isHovered ? 1 : 0,
-              overflow: 'hidden',
-              flexShrink: 0,
-              transition: `width ${TRANSITION_DURATION} ease, opacity ${TRANSITION_DURATION} ease`,
-            }}
-          >
-            <Switch.Root
-              checked={isHighlightEnabled}
-              onCheckedChange={() => {
-                toggleHighlightEnabled();
-              }}
-              onClick={(e) => e.stopPropagation()}
-              aria-label="Group node highlight"
+            {/* Off Icon (Left) */}
+            <div
               style={{
-                all: 'unset',
-                width: '32px',
-                height: '18px',
-                backgroundColor: 'var(--vscode-input-background)',
-                borderRadius: '9px',
-                position: 'relative',
-                border: '1px solid var(--vscode-input-border)',
-                cursor: 'pointer',
+                width: isHovered || !isHighlightEnabled ? '20px' : '0px',
+                opacity: isHovered || !isHighlightEnabled ? 1 : 0,
+                overflow: 'hidden',
+                flexShrink: 0,
+                transition: `width ${TRANSITION_DURATION} ease, opacity ${TRANSITION_DURATION} ease`,
               }}
             >
-              <Switch.Thumb
-                style={{
-                  all: 'unset',
-                  display: 'block',
-                  width: '14px',
-                  height: '14px',
-                  backgroundColor: 'var(--vscode-button-background)',
-                  borderRadius: '7px',
-                  transition: 'transform 100ms',
-                  transform: isHighlightEnabled ? 'translateX(16px)' : 'translateX(2px)',
-                  willChange: 'transform',
-                  margin: '1px',
-                }}
-              />
-            </Switch.Root>
-          </div>
-
-          {/* On Icon (Right) */}
-          <div
-            style={{
-              width: isHovered || isHighlightEnabled ? '20px' : '0px',
-              opacity: isHovered || isHighlightEnabled ? 1 : 0,
-              overflow: 'hidden',
-              flexShrink: 0,
-              transition: `width ${TRANSITION_DURATION} ease, opacity ${TRANSITION_DURATION} ease`,
-            }}
-          >
-            {isHovered ? (
-              <StyledTooltipItem content={t('toolbar.highlight.enable')}>
+              {isHovered ? (
+                <StyledTooltipItem content={t('toolbar.highlight.disable')}>
+                  <div
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (isHighlightEnabled) handleDisableHighlight();
+                    }}
+                    onKeyDown={(e) => {
+                      if ((e.key === 'Enter' || e.key === ' ') && isHighlightEnabled) {
+                        e.preventDefault();
+                        handleDisableHighlight();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={isHighlightEnabled ? 0 : -1}
+                    aria-label={t('toolbar.highlight.disable')}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '20px',
+                      height: '20px',
+                      borderRadius: '50%',
+                      backgroundColor: !isHighlightEnabled
+                        ? 'var(--vscode-badge-background)'
+                        : 'transparent',
+                      transition: 'background-color 150ms',
+                      cursor: isHighlightEnabled ? 'pointer' : 'default',
+                    }}
+                  >
+                    <LightbulbOff
+                      size={12}
+                      style={{
+                        color: !isHighlightEnabled
+                          ? 'var(--vscode-badge-foreground)'
+                          : 'var(--vscode-disabledForeground)',
+                      }}
+                    />
+                  </div>
+                </StyledTooltipItem>
+              ) : (
                 <div
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!isHighlightEnabled) toggleHighlightEnabled();
-                  }}
-                  onKeyDown={(e) => {
-                    if ((e.key === 'Enter' || e.key === ' ') && !isHighlightEnabled) {
-                      e.preventDefault();
-                      toggleHighlightEnabled();
-                    }
-                  }}
-                  role="button"
-                  tabIndex={isHighlightEnabled ? -1 : 0}
-                  aria-label={t('toolbar.highlight.enable')}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
                     width: '20px',
                     height: '20px',
-                    borderRadius: '50%',
-                    backgroundColor: isHighlightEnabled
-                      ? 'var(--vscode-badge-background)'
-                      : 'transparent',
-                    transition: 'background-color 150ms',
-                    cursor: isHighlightEnabled ? 'default' : 'pointer',
                   }}
                 >
-                  <Lightbulb
-                    size={12}
-                    style={{
-                      color: isHighlightEnabled
-                        ? 'var(--vscode-badge-foreground)'
-                        : 'var(--vscode-disabledForeground)',
-                    }}
-                  />
+                  <LightbulbOff size={14} style={{ color: 'var(--vscode-disabledForeground)' }} />
                 </div>
-              </StyledTooltipItem>
-            ) : (
-              <div
+              )}
+            </div>
+
+            {/* Switch */}
+            <div
+              style={{
+                width: isHovered ? '34px' : '0px',
+                opacity: isHovered ? 1 : 0,
+                overflow: 'hidden',
+                flexShrink: 0,
+                transition: `width ${TRANSITION_DURATION} ease, opacity ${TRANSITION_DURATION} ease`,
+              }}
+            >
+              <Switch.Root
+                checked={isHighlightEnabled}
+                onCheckedChange={() => {
+                  handleDisableHighlight();
+                }}
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Group node highlight"
                 style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  width: '20px',
-                  height: '20px',
+                  all: 'unset',
+                  width: '32px',
+                  height: '18px',
+                  backgroundColor: 'var(--vscode-input-background)',
+                  borderRadius: '9px',
+                  position: 'relative',
+                  border: '1px solid var(--vscode-input-border)',
+                  cursor: 'pointer',
                 }}
               >
-                <Lightbulb size={14} style={{ color: 'var(--vscode-foreground)' }} />
-              </div>
-            )}
+                <Switch.Thumb
+                  style={{
+                    all: 'unset',
+                    display: 'block',
+                    width: '14px',
+                    height: '14px',
+                    backgroundColor: 'var(--vscode-button-background)',
+                    borderRadius: '7px',
+                    transition: 'transform 100ms',
+                    transform: isHighlightEnabled ? 'translateX(16px)' : 'translateX(2px)',
+                    willChange: 'transform',
+                    margin: '1px',
+                  }}
+                />
+              </Switch.Root>
+            </div>
+
+            {/* On Icon (Right) */}
+            <div
+              style={{
+                width: isHovered || isHighlightEnabled ? '20px' : '0px',
+                opacity: isHovered || isHighlightEnabled ? 1 : 0,
+                overflow: 'hidden',
+                flexShrink: 0,
+                transition: `width ${TRANSITION_DURATION} ease, opacity ${TRANSITION_DURATION} ease`,
+              }}
+            >
+              {isHovered ? (
+                <StyledTooltipItem content={t('toolbar.highlight.enable')}>
+                  <div
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!isHighlightEnabled) toggleHighlightEnabled();
+                    }}
+                    onKeyDown={(e) => {
+                      if ((e.key === 'Enter' || e.key === ' ') && !isHighlightEnabled) {
+                        e.preventDefault();
+                        toggleHighlightEnabled();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={isHighlightEnabled ? -1 : 0}
+                    aria-label={t('toolbar.highlight.enable')}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '20px',
+                      height: '20px',
+                      borderRadius: '50%',
+                      backgroundColor: isHighlightEnabled
+                        ? 'var(--vscode-badge-background)'
+                        : 'transparent',
+                      transition: 'background-color 150ms',
+                      cursor: isHighlightEnabled ? 'default' : 'pointer',
+                    }}
+                  >
+                    <Lightbulb
+                      size={12}
+                      style={{
+                        color: isHighlightEnabled
+                          ? 'var(--vscode-badge-foreground)'
+                          : 'var(--vscode-disabledForeground)',
+                      }}
+                    />
+                  </div>
+                </StyledTooltipItem>
+              ) : (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '20px',
+                    height: '20px',
+                  }}
+                >
+                  <Lightbulb size={14} style={{ color: 'var(--vscode-foreground)' }} />
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      </StyledTooltipItem>
-    </StyledTooltipProvider>
+        </StyledTooltipItem>
+      </StyledTooltipProvider>
+      <ConfirmDialog
+        isOpen={showConfirmDialog}
+        title={t('toolbar.highlight.confirmDisable.title')}
+        message={t('toolbar.highlight.confirmDisable.message')}
+        confirmLabel={t('toolbar.highlight.confirmDisable.confirm')}
+        cancelLabel={t('toolbar.highlight.confirmDisable.cancel')}
+        onConfirm={() => {
+          setShowConfirmDialog(false);
+          toggleHighlightEnabled();
+        }}
+        onCancel={() => setShowConfirmDialog(false)}
+      />
+    </>
   );
 };

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -43,6 +43,10 @@ export interface WebviewTranslationKeys {
   'toolbar.edgeAnimation.disable': string;
   'toolbar.highlight.enable': string;
   'toolbar.highlight.disable': string;
+  'toolbar.highlight.confirmDisable.title': string;
+  'toolbar.highlight.confirmDisable.message': string;
+  'toolbar.highlight.confirmDisable.confirm': string;
+  'toolbar.highlight.confirmDisable.cancel': string;
   'toolbar.scrollMode.switchToClassic': string;
   'toolbar.scrollMode.switchToFreehand': string;
 

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -45,6 +45,11 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': 'Disable edge animation',
   'toolbar.highlight.enable': 'Enable group node highlight',
   'toolbar.highlight.disable': 'Disable group node highlight',
+  'toolbar.highlight.confirmDisable.title': 'Disable Group Node Highlight',
+  'toolbar.highlight.confirmDisable.message':
+    'A group node is currently highlighted. Are you sure you want to disable the highlight?',
+  'toolbar.highlight.confirmDisable.confirm': 'Disable',
+  'toolbar.highlight.confirmDisable.cancel': 'Cancel',
   'toolbar.scrollMode.switchToClassic': 'Switch to Classic mode (scroll = zoom)',
   'toolbar.scrollMode.switchToFreehand': 'Switch to Freehand mode (scroll = pan)',
 

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -45,6 +45,11 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': 'エッジアニメーションを無効化',
   'toolbar.highlight.enable': 'グループノードハイライトを有効化',
   'toolbar.highlight.disable': 'グループノードハイライトを無効化',
+  'toolbar.highlight.confirmDisable.title': 'グループノードハイライトを無効化',
+  'toolbar.highlight.confirmDisable.message':
+    '現在グループノードがハイライトされています。ハイライトを無効化しますか？',
+  'toolbar.highlight.confirmDisable.confirm': '無効化',
+  'toolbar.highlight.confirmDisable.cancel': 'キャンセル',
   'toolbar.scrollMode.switchToClassic': 'Classicモードに切り替え（スクロール=ズーム）',
   'toolbar.scrollMode.switchToFreehand': 'Freehandモードに切り替え（スクロール=パン）',
 

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -45,6 +45,11 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': '엣지 애니메이션 비활성화',
   'toolbar.highlight.enable': '그룹 노드 하이라이트 활성화',
   'toolbar.highlight.disable': '그룹 노드 하이라이트 비활성화',
+  'toolbar.highlight.confirmDisable.title': '그룹 노드 하이라이트 비활성화',
+  'toolbar.highlight.confirmDisable.message':
+    '현재 그룹 노드가 하이라이트되어 있습니다. 하이라이트를 비활성화하시겠습니까?',
+  'toolbar.highlight.confirmDisable.confirm': '비활성화',
+  'toolbar.highlight.confirmDisable.cancel': '취소',
   'toolbar.scrollMode.switchToClassic': 'Classic 모드로 전환 (스크롤 = 줌)',
   'toolbar.scrollMode.switchToFreehand': 'Freehand 모드로 전환 (스크롤 = 팬)',
 

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -45,6 +45,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': '禁用边动画',
   'toolbar.highlight.enable': '启用组节点高亮',
   'toolbar.highlight.disable': '禁用组节点高亮',
+  'toolbar.highlight.confirmDisable.title': '禁用组节点高亮',
+  'toolbar.highlight.confirmDisable.message': '当前有组节点正在高亮显示。确定要禁用高亮吗？',
+  'toolbar.highlight.confirmDisable.confirm': '禁用',
+  'toolbar.highlight.confirmDisable.cancel': '取消',
   'toolbar.scrollMode.switchToClassic': '切换到Classic模式（滚动=缩放）',
   'toolbar.scrollMode.switchToFreehand': '切换到Freehand模式（滚动=平移）',
 

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -45,6 +45,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.edgeAnimation.disable': '停用邊動畫',
   'toolbar.highlight.enable': '啟用群組節點高亮',
   'toolbar.highlight.disable': '停用群組節點高亮',
+  'toolbar.highlight.confirmDisable.title': '停用群組節點高亮',
+  'toolbar.highlight.confirmDisable.message': '目前有群組節點正在高亮顯示。確定要停用高亮嗎？',
+  'toolbar.highlight.confirmDisable.confirm': '停用',
+  'toolbar.highlight.confirmDisable.cancel': '取消',
   'toolbar.scrollMode.switchToClassic': '切換到Classic模式（滾動=縮放）',
   'toolbar.scrollMode.switchToFreehand': '切換到Freehand模式（滾動=平移）',
 


### PR DESCRIPTION
## Summary

Add a confirmation dialog before disabling group node highlight while a group is actively highlighted.

## What Changed

Enhanced the highlight toggle so turning highlight off asks for confirmation only when an active group highlight would be cleared.

### Before
- Disabling group highlight immediately cleared the current highlighted group.
- Users could accidentally lose the current highlight state with a single toggle action.

### After
- Disabling group highlight opens a confirmation dialog when a group is currently highlighted.
- Enabling highlight still works immediately without extra confirmation.
- Confirmation dialog text is localized for supported webview languages.

## Changes

- `src/webview/src/components/HighlightToggle.tsx` - Added conditional confirmation flow before disabling highlight.
- `src/webview/src/i18n/translation-keys.ts` - Added translation keys for the confirmation dialog.
- `src/webview/src/i18n/translations/en.ts` - Added English confirmation copy.
- `src/webview/src/i18n/translations/ja.ts` - Added Japanese confirmation copy.
- `src/webview/src/i18n/translations/ko.ts` - Added Korean confirmation copy.
- `src/webview/src/i18n/translations/zh-CN.ts` - Added Simplified Chinese confirmation copy.
- `src/webview/src/i18n/translations/zh-TW.ts` - Added Traditional Chinese confirmation copy.

## Testing

- [x] Manual E2E testing completed
- [x] `npm run lint`
- [ ] `npm run format`
- [ ] `npm run check`
- [ ] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when disabling highlight to prevent accidental changes. When users attempt to disable an active highlight, they will now see a confirmation prompt with clear messaging before the change takes effect. The dialog is fully localized in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->