### PR TITLE
fix: use non-localized labels for built-in sub-agent names and badge

### DIFF
--- a/src/shared/constants/built-in-sub-agents.ts
+++ b/src/shared/constants/built-in-sub-agents.ts
@@ -9,15 +9,12 @@ import type { BuiltInSubAgentType } from '../types/workflow-definition';
 
 /** i18n keys for built-in sub-agent presets (must match WebviewTranslationKeys) */
 type BuiltInI18nKey =
-  | 'subAgent.builtIn.generalPurpose.name'
   | 'subAgent.builtIn.generalPurpose.description'
   | 'subAgent.builtIn.generalPurpose.defaultAgentDefinition'
   | 'subAgent.builtIn.generalPurpose.defaultPrompt'
-  | 'subAgent.builtIn.explore.name'
   | 'subAgent.builtIn.explore.description'
   | 'subAgent.builtIn.explore.defaultAgentDefinition'
   | 'subAgent.builtIn.explore.defaultPrompt'
-  | 'subAgent.builtIn.plan.name'
   | 'subAgent.builtIn.plan.description'
   | 'subAgent.builtIn.plan.defaultAgentDefinition'
   | 'subAgent.builtIn.plan.defaultPrompt';
@@ -25,8 +22,8 @@ type BuiltInI18nKey =
 export interface BuiltInSubAgentPreset {
   /** The built-in sub-agent type identifier */
   type: BuiltInSubAgentType;
-  /** i18n key for the display name */
-  nameKey: BuiltInI18nKey;
+  /** Display name (not localized — kept in English across all languages) */
+  displayName: string;
   /** i18n key for the description */
   descriptionKey: BuiltInI18nKey;
   /** i18n key for the default agent definition (what this agent IS) */
@@ -46,7 +43,7 @@ export interface BuiltInSubAgentPreset {
 export const BUILT_IN_SUB_AGENTS: readonly BuiltInSubAgentPreset[] = [
   {
     type: 'general-purpose',
-    nameKey: 'subAgent.builtIn.generalPurpose.name',
+    displayName: 'General Purpose',
     descriptionKey: 'subAgent.builtIn.generalPurpose.description',
     defaultAgentDefinitionKey: 'subAgent.builtIn.generalPurpose.defaultAgentDefinition',
     defaultPromptKey: 'subAgent.builtIn.generalPurpose.defaultPrompt',
@@ -55,7 +52,7 @@ export const BUILT_IN_SUB_AGENTS: readonly BuiltInSubAgentPreset[] = [
   },
   {
     type: 'explore',
-    nameKey: 'subAgent.builtIn.explore.name',
+    displayName: 'Explore',
     descriptionKey: 'subAgent.builtIn.explore.description',
     defaultAgentDefinitionKey: 'subAgent.builtIn.explore.defaultAgentDefinition',
     defaultPromptKey: 'subAgent.builtIn.explore.defaultPrompt',
@@ -66,7 +63,7 @@ export const BUILT_IN_SUB_AGENTS: readonly BuiltInSubAgentPreset[] = [
   },
   {
     type: 'plan',
-    nameKey: 'subAgent.builtIn.plan.name',
+    displayName: 'Plan',
     descriptionKey: 'subAgent.builtIn.plan.description',
     defaultAgentDefinitionKey: 'subAgent.builtIn.plan.defaultAgentDefinition',
     defaultPromptKey: 'subAgent.builtIn.plan.defaultPrompt',

--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -177,7 +177,7 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
     const newNode = {
       id: `agent-${Date.now()}`,
       type: 'subAgent' as const,
-      name: t(preset.nameKey),
+      name: preset.displayName,
       position,
       data: {
         description: formData.description,

--- a/src/webview/src/components/PropertyOverlay.tsx
+++ b/src/webview/src/components/PropertyOverlay.tsx
@@ -424,10 +424,10 @@ const SubAgentProperties: React.FC<{
                   fontWeight: 600,
                 }}
               >
-                {t('subAgent.builtIn.badge')}
+                Built-in
               </span>
               <span style={{ fontWeight: 600 }}>
-                {builtInPreset ? t(builtInPreset.nameKey) : data.builtInType}
+                {builtInPreset ? builtInPreset.displayName : data.builtInType}
               </span>
             </div>
           );

--- a/src/webview/src/components/dialogs/SubAgentCreationDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentCreationDialog.tsx
@@ -428,7 +428,7 @@ export const SubAgentCreationDialog: React.FC<SubAgentCreationDialogProps> = ({
                               : 'var(--vscode-foreground)',
                           }}
                         >
-                          {t(preset.nameKey)}
+                          {preset.displayName}
                         </span>
                         <span
                           style={{
@@ -440,7 +440,7 @@ export const SubAgentCreationDialog: React.FC<SubAgentCreationDialogProps> = ({
                             fontWeight: 500,
                           }}
                         >
-                          {t('subAgent.builtIn.badge')}
+                          Built-in
                         </span>
                       </div>
                       <div

--- a/src/webview/src/components/dialogs/SubAgentFormDialog.tsx
+++ b/src/webview/src/components/dialogs/SubAgentFormDialog.tsx
@@ -271,9 +271,9 @@ export function SubAgentFormDialog({
                       fontWeight: 500,
                     }}
                   >
-                    {t('subAgent.builtIn.badge')}
+                    Built-in
                   </span>
-                  <span style={{ fontWeight: 600 }}>{t(builtInPreset.nameKey)}</span>
+                  <span style={{ fontWeight: 600 }}>{builtInPreset.displayName}</span>
                 </div>
               )}
 

--- a/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -11,7 +11,6 @@ import { SUB_AGENT_COLORS } from '@shared/types/workflow-definition';
 import { Bot } from 'lucide-react';
 import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
-import { useTranslation } from '../../i18n/i18n-context';
 import { AIProviderBadge } from '../common/AIProviderBadge';
 import { DeleteButton } from './DeleteButton';
 
@@ -20,7 +19,6 @@ import { DeleteButton } from './DeleteButton';
  */
 export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.memo(
   ({ id, data, selected }) => {
-    const { t } = useTranslation();
     const builtInPreset = data.builtInType
       ? BUILT_IN_SUB_AGENTS.find((p) => p.type === data.builtInType)
       : undefined;
@@ -67,7 +65,7 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
           }}
         >
           {builtInPreset
-            ? t(builtInPreset.nameKey)
+            ? builtInPreset.displayName
             : data.pluginName
               ? `${data.pluginName}:${data.description || 'Untitled Sub-Agent'}`
               : data.description || 'Untitled Sub-Agent'}
@@ -107,7 +105,7 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
                 fontWeight: 600,
               }}
             >
-              {t('subAgent.builtIn.badge')}
+              Built-in
             </div>
           )}
 

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -911,17 +911,13 @@ export interface WebviewTranslationKeys {
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': string;
   'subAgent.dialog.builtInDescription': string;
-  'subAgent.builtIn.badge': string;
   'subAgent.builtIn.controlledByPreset': string;
-  'subAgent.builtIn.generalPurpose.name': string;
   'subAgent.builtIn.generalPurpose.description': string;
   'subAgent.builtIn.generalPurpose.defaultAgentDefinition': string;
   'subAgent.builtIn.generalPurpose.defaultPrompt': string;
-  'subAgent.builtIn.explore.name': string;
   'subAgent.builtIn.explore.description': string;
   'subAgent.builtIn.explore.defaultAgentDefinition': string;
   'subAgent.builtIn.explore.defaultPrompt': string;
-  'subAgent.builtIn.plan.name': string;
   'subAgent.builtIn.plan.description': string;
   'subAgent.builtIn.plan.defaultAgentDefinition': string;
   'subAgent.builtIn.plan.defaultPrompt': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -1000,22 +1000,18 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.builtInTab': 'Built-in',
   'subAgent.dialog.builtInDescription':
     'Built-in sub-agents optimized for Claude Code.\nFor other AI Agents, these presets are exported as regular sub-agents that emulate similar behavior.',
-  'subAgent.builtIn.badge': 'Built-in',
   'subAgent.builtIn.controlledByPreset': 'Controlled by preset',
-  'subAgent.builtIn.generalPurpose.name': 'General Purpose',
   'subAgent.builtIn.generalPurpose.description':
     'General-purpose agent for researching complex questions, searching code, and executing multi-step tasks.',
   'subAgent.builtIn.generalPurpose.defaultAgentDefinition':
     'General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. Has access to all tools.',
   'subAgent.builtIn.generalPurpose.defaultPrompt': 'Research and complete the following task:',
-  'subAgent.builtIn.explore.name': 'Explore',
   'subAgent.builtIn.explore.description':
     'Fast read-only agent for exploring codebases — find files, search code, and answer codebase questions.',
   'subAgent.builtIn.explore.defaultAgentDefinition':
     'Fast agent specialized for exploring codebases. Use for quick file searches, keyword searches, and answering questions about the codebase. Read-only — no Write/Edit tools.',
   'subAgent.builtIn.explore.defaultPrompt':
     'Explore the codebase and answer the following question:',
-  'subAgent.builtIn.plan.name': 'Plan',
   'subAgent.builtIn.plan.description':
     'Software architect agent for designing implementation plans and identifying critical files.',
   'subAgent.builtIn.plan.defaultAgentDefinition':

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -993,22 +993,18 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.builtInTab': 'ビルトイン',
   'subAgent.dialog.builtInDescription':
     'Claude Codeのビルトインサブエージェントを選択します。\n他のAIエージェントでは、同様の振る舞いを再現するようにエクスポートされます。',
-  'subAgent.builtIn.badge': 'ビルトイン',
   'subAgent.builtIn.controlledByPreset': 'プリセットが制御',
-  'subAgent.builtIn.generalPurpose.name': '汎用',
   'subAgent.builtIn.generalPurpose.description':
     '複雑な調査、コード検索、マルチステップタスクの実行に対応する汎用エージェント。',
   'subAgent.builtIn.generalPurpose.defaultAgentDefinition':
     '複雑な調査、コード検索、マルチステップタスクの実行に対応する汎用エージェント。全ツールへのアクセス権を持つ。',
   'subAgent.builtIn.generalPurpose.defaultPrompt': '以下のタスクを調査して完了してください：',
-  'subAgent.builtIn.explore.name': 'Explore',
   'subAgent.builtIn.explore.description':
     'コードベース探索に特化した高速読み取り専用エージェント。ファイル検索、コード検索、質問回答が可能。',
   'subAgent.builtIn.explore.defaultAgentDefinition':
     'コードベース探索に特化した高速エージェント。ファイル検索、キーワード検索、コードベースに関する質問回答に使用。読み取り専用 — Write/Editツール不可。',
   'subAgent.builtIn.explore.defaultPrompt':
     'コードベースを探索して、以下の質問に回答してください：',
-  'subAgent.builtIn.plan.name': 'Plan',
   'subAgent.builtIn.plan.description':
     '実装計画の設計と重要ファイルの特定を行うソフトウェアアーキテクトエージェント。',
   'subAgent.builtIn.plan.defaultAgentDefinition':

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -987,21 +987,17 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.builtInTab': '내장',
   'subAgent.dialog.builtInDescription':
     'Claude Code의 내장 서브 에이전트를 선택합니다.\n다른 AI 에이전트에서는 유사한 동작을 재현하도록 내보내집니다.',
-  'subAgent.builtIn.badge': '내장',
   'subAgent.builtIn.controlledByPreset': '프리셋에서 제어',
-  'subAgent.builtIn.generalPurpose.name': '범용',
   'subAgent.builtIn.generalPurpose.description':
     '복잡한 조사, 코드 검색, 멀티스텝 작업 실행을 위한 범용 에이전트.',
   'subAgent.builtIn.generalPurpose.defaultAgentDefinition':
     '복잡한 조사, 코드 검색, 멀티 스텝 작업 실행에 대응하는 범용 에이전트. 모든 도구에 대한 접근 권한을 가짐.',
   'subAgent.builtIn.generalPurpose.defaultPrompt': '다음 작업을 조사하고 완료하세요:',
-  'subAgent.builtIn.explore.name': 'Explore',
   'subAgent.builtIn.explore.description':
     '코드베이스 탐색에 특화된 빠른 읽기 전용 에이전트. 파일 검색, 코드 검색, 질문 응답 가능.',
   'subAgent.builtIn.explore.defaultAgentDefinition':
     '코드베이스 탐색에 특화된 고속 에이전트. 파일 검색, 키워드 검색, 코드베이스 관련 질문 답변에 사용. 읽기 전용 — Write/Edit 도구 불가.',
   'subAgent.builtIn.explore.defaultPrompt': '코드베이스를 탐색하고 다음 질문에 답하세요:',
-  'subAgent.builtIn.plan.name': 'Plan',
   'subAgent.builtIn.plan.description':
     '구현 계획 설계 및 중요 파일 식별을 위한 소프트웨어 아키텍트 에이전트.',
   'subAgent.builtIn.plan.defaultAgentDefinition':

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -954,21 +954,17 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.builtInTab': '内置',
   'subAgent.dialog.builtInDescription':
     '选择 Claude Code 的内置子代理。\n导出到其他 AI 代理时，将以模拟类似行为的方式导出。',
-  'subAgent.builtIn.badge': '内置',
   'subAgent.builtIn.controlledByPreset': '由预设控制',
-  'subAgent.builtIn.generalPurpose.name': '通用',
   'subAgent.builtIn.generalPurpose.description':
     '用于复杂研究、代码搜索和执行多步骤任务的通用代理。',
   'subAgent.builtIn.generalPurpose.defaultAgentDefinition':
     '用于研究复杂问题、搜索代码和执行多步骤任务的通用代理。拥有所有工具的访问权限。',
   'subAgent.builtIn.generalPurpose.defaultPrompt': '研究并完成以下任务：',
-  'subAgent.builtIn.explore.name': 'Explore',
   'subAgent.builtIn.explore.description':
     '专用于代码库探索的快速只读代理。可进行文件搜索、代码搜索和问题回答。',
   'subAgent.builtIn.explore.defaultAgentDefinition':
     '专门用于探索代码库的快速代理。用于快速文件搜索、关键词搜索和回答代码库相关问题。只读 — 无Write/Edit工具。',
   'subAgent.builtIn.explore.defaultPrompt': '探索代码库并回答以下问题：',
-  'subAgent.builtIn.plan.name': 'Plan',
   'subAgent.builtIn.plan.description': '用于设计实现计划和识别关键文件的软件架构师代理。',
   'subAgent.builtIn.plan.defaultAgentDefinition':
     '用于设计实施计划的软件架构师代理。返回分步计划，识别关键文件，并考虑架构权衡。只读 — 无Write/Edit工具。',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -955,21 +955,17 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.dialog.builtInTab': '內建',
   'subAgent.dialog.builtInDescription':
     '選擇 Claude Code 的內建子代理。\n匯出到其他 AI 代理時，將以模擬類似行為的方式匯出。',
-  'subAgent.builtIn.badge': '內建',
   'subAgent.builtIn.controlledByPreset': '由預設控制',
-  'subAgent.builtIn.generalPurpose.name': '通用',
   'subAgent.builtIn.generalPurpose.description':
     '用於複雜研究、程式碼搜尋和執行多步驟任務的通用代理。',
   'subAgent.builtIn.generalPurpose.defaultAgentDefinition':
     '用於研究複雜問題、搜尋程式碼和執行多步驟任務的通用代理。擁有所有工具的存取權限。',
   'subAgent.builtIn.generalPurpose.defaultPrompt': '研究並完成以下任務：',
-  'subAgent.builtIn.explore.name': 'Explore',
   'subAgent.builtIn.explore.description':
     '專用於程式碼庫探索的快速唯讀代理。可進行檔案搜尋、程式碼搜尋和問題回答。',
   'subAgent.builtIn.explore.defaultAgentDefinition':
     '專門用於探索程式碼庫的快速代理。用於快速檔案搜尋、關鍵字搜尋和回答程式碼庫相關問題。唯讀 — 無Write/Edit工具。',
   'subAgent.builtIn.explore.defaultPrompt': '探索程式碼庫並回答以下問題：',
-  'subAgent.builtIn.plan.name': 'Plan',
   'subAgent.builtIn.plan.description': '用於設計實作計畫和識別關鍵檔案的軟體架構師代理。',
   'subAgent.builtIn.plan.defaultAgentDefinition':
     '用於設計實施計畫的軟體架構師代理。返回分步計畫，識別關鍵檔案，並考慮架構權衡。唯讀 — 無Write/Edit工具。',


### PR DESCRIPTION
## Problem

Built-in sub-agent labels (name and badge) were inconsistently localized across languages.

### Current Behavior
1. Open a workflow with built-in sub-agent nodes (locale: ja/ko/zh)
2. ❌ "General Purpose" displays as "汎用" / "범용" / "通用", while "Explore" and "Plan" stay in English
3. ❌ Badge shows localized text ("ビルトイン" / "내장" / "内置") which looks awkward for technical terms

### Expected Behavior
1. Open a workflow with built-in sub-agent nodes (any locale)
2. ✅ All preset names display consistently in English: "General Purpose", "Explore", "Plan"
3. ✅ Badge always shows "Built-in"

## Solution

Replace i18n-based labels with non-localized constants for built-in sub-agent names and badge text, since these are technical identifiers that should remain in English across all languages.

### Changes

**`src/shared/constants/built-in-sub-agents.ts`**
- Replace `nameKey` (i18n key) with `displayName` (direct string constant)

**`SubAgentNode.tsx`, `NodePalette.tsx`, `PropertyOverlay.tsx`, `SubAgentCreationDialog.tsx`, `SubAgentFormDialog.tsx`**
- Replace `t(preset.nameKey)` → `preset.displayName`
- Replace `t('subAgent.builtIn.badge')` → literal `"Built-in"`

**`translation-keys.ts`, `en.ts`, `ja.ts`, `ko.ts`, `zh-CN.ts`, `zh-TW.ts`**
- Remove unused i18n keys: `badge`, `generalPurpose.name`, `explore.name`, `plan.name`

## Impact

- Canvas nodes, property overlay, creation/form dialogs all display consistent English labels
- No behavioral change — only display text affected
- Localized `description`, `defaultAgentDefinition`, `defaultPrompt` are preserved (these are user-facing dialog content)

## Testing

- [x] Build passes (`npm run format && npm run lint && npm run build`)
- [x] Manual E2E testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated built-in sub-agent preset naming: replaced localization keys with direct display names for General Purpose, Explore, and Plan presets.
  * Hardcoded "Built-in" badge label across dialogs and node displays.
  * Streamlined preset display logic in node palette, property overlays, and creation dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->