### PR TITLE
chore: simplify redundant Biome commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,7 @@ fix: add missing MCP node definition to workflow schema
 **Always run these commands in the following order after code modifications:**
 
 ```bash
-npm run format  # Auto-format code with Biome
-npm run lint    # Check for linting issues
-npm run check   # Run all Biome checks (lint + format verification)
+npm run check   # Run all Biome checks (lint + format, with auto-fix)
 npm run build   # Build extension and webview (verify compilation)
 ```
 
@@ -90,11 +88,9 @@ npm run build   # Build extension and webview (verify compilation)
 #### During Development
 1. **After code modification**:
    ```bash
-   npm run format && npm run lint && npm run check
+   npm run check
    ```
-   - Fixes formatting issues automatically
-   - Identifies linting problems
-   - Verifies code quality standards
+   - Runs lint + format with auto-fix in a single command
 
 2. **Before manual E2E testing**:
    ```bash
@@ -105,7 +101,7 @@ npm run build   # Build extension and webview (verify compilation)
 
 3. **Before git commit**:
    ```bash
-   npm run format && npm run lint && npm run check
+   npm run check
    ```
    - Ensures all code quality standards are met
    - Prevents committing code with linting/formatting issues


### PR DESCRIPTION
## Summary

Simplify code quality check instructions by replacing redundant triple-command chain with a single `npm run check`.

## What Changed

### Before
- CLAUDE.md instructed running `npm run format && npm run lint && npm run check` (3 commands)
- `format` and `lint` are already included in `check`, making the first two redundant

### After
- Single `npm run check` command covers lint + format with auto-fix

## Changes

- `CLAUDE.md` - Replaced 3 occurrences of redundant command chains with `npm run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development documentation to reflect a streamlined code quality verification process using a consolidated command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->