### PR TITLE
chore: add stale bot to auto-close inactive PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has not had recent activity. It will be closed in 7 days if
+            no further activity occurs. Thank you for your contributions.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Feel free to reopen it if you plan to continue working on it.
+          stale-pr-label: stale
+          exempt-pr-labels: "pinned,wip,do-not-close"
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to automatically close stale pull requests using [actions/stale](https://github.com/actions/stale) v9.

## What Changed

### Before
- Inactive PRs accumulated indefinitely with no automatic cleanup

### After
- PRs with no activity for 30 days are labeled `stale` with a notification
- Stale PRs are automatically closed after 7 more days of inactivity
- PRs labeled `pinned`, `wip`, or `do-not-close` are exempt
- Issues are not affected

## Changes

- `.github/workflows/stale.yml` - New workflow running daily via cron

## Testing

- [x] YAML syntax validated
- [x] Workflow uses pinned major version (`actions/stale@v9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage inactive pull requests: runs daily, marks PRs as stale after 30 days with a notice, and closes them after 7 additional days if no activity. Exempts PRs labeled "pinned", "wip", or "do-not-close" to preserve ongoing work. This automation applies only to pull requests; issues are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->