### PR TITLE
chore: remove noExplicitAny warnings in mcp-server-tools

### DIFF
--- a/src/extension/services/mcp-server-tools.ts
+++ b/src/extension/services/mcp-server-tools.ts
@@ -17,7 +17,12 @@ import * as path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { PlannedSubAgentFile } from '../../shared/types/messages';
-import { NodeType, type Workflow, type WorkflowNode } from '../../shared/types/workflow-definition';
+import {
+  type BaseNode,
+  NodeType,
+  type Workflow,
+  type WorkflowNode,
+} from '../../shared/types/workflow-definition';
 import { getProjectCommandsDir } from '../utils/path-utils';
 import { validateAIGeneratedWorkflow } from '../utils/validate-workflow';
 import { scanAllCommands } from './command-service';
@@ -428,7 +433,7 @@ export function registerMcpTools(server: McpServer, manager: McpServerManager): 
 
           // type更新
           if (update.type !== undefined) {
-            (node as any).type = update.type;
+            (node as BaseNode).type = update.type;
           }
 
           if (update.name !== undefined) {
@@ -456,15 +461,15 @@ export function registerMcpTools(server: McpServer, manager: McpServerManager): 
           // parentId (null = 解除、undefined = 変更なし)
           if ('parentId' in update) {
             if (update.parentId === null || update.parentId === undefined) {
-              delete (node as any).parentId;
+              delete node.parentId;
             } else {
-              (node as any).parentId = update.parentId;
+              node.parentId = update.parentId;
             }
           }
 
           // style
           if (update.style !== undefined) {
-            (node as any).style = update.style;
+            node.style = update.style;
           }
         }
 


### PR DESCRIPTION
## Summary

Remove 4 Biome `noExplicitAny` warnings from `mcp-server-tools.ts` by using proper type assertions.

## What Changed

### Before
- `(node as any).type`, `(node as any).parentId`, `(node as any).style` used to bypass TypeScript type checks

### After
- `(node as BaseNode).type` for discriminated union discriminant assignment (type-safe within `NodeType` enum)
- Direct property access for `parentId` and `style` (already defined on `BaseNode`, no cast needed)

## Changes

- `src/extension/services/mcp-server-tools.ts` - Replace `as any` with `as BaseNode` or remove cast entirely

## Testing

- [x] `npm run check` — zero warnings
- [x] `npm run build` — build successful
- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety for node property handling in the MCP server tools layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->