### PR TITLE
chore: fix npm audit vulnerabilities via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3753,9 +3753,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -8514,9 +8514,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Problem

`npm audit` reports 5 vulnerabilities (2 high, 3 moderate) in project dependencies.

### Vulnerabilities Fixed

| Package | Version Change | Severity | Issue |
|---------|---------------|----------|-------|
| `@hono/node-server` | 1.19.11 → 1.19.13 | moderate | Middleware bypass via repeated slashes in serveStatic |
| `hono` | 4.12.7 → 4.12.12 | moderate | Cookie validation, IP matching, path traversal, middleware bypass |
| `vite` | 7.3.1 → 7.3.2 | high | Path traversal, `server.fs.deny` bypass, WebSocket arbitrary file read |

### Not Fixed (npm bundled dependencies)

- `brace-expansion` 5.0.4 — bundled in npm itself, awaiting npm update
- `picomatch` 4.0.3 — bundled in npm itself, awaiting npm update

## Solution

Run `npm audit fix` to update vulnerable packages to patched versions.

### Changes

**File**: `package-lock.json`

- Updated 3 packages to patched versions

## Impact

- Resolves 3 of 5 reported vulnerabilities (remaining 2 are in npm's bundled deps)
- No breaking changes — only patch/minor version bumps

## Testing

- [x] `npm run check` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)