### PR TITLE
improvement: use fixed MCP server port with user-configurable setting

### DIFF
--- a/.github/skills/cc-workflow-ai-editor/SKILL.md
+++ b/.github/skills/cc-workflow-ai-editor/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cc-workflow-ai-editor
+description: AI workflow editor for CC Workflow Studio. Create and edit visual AI agent workflows through interactive conversation using MCP tools (get_workflow_schema, get_current_workflow, apply_workflow, update_nodes). Use when the user wants to create a new workflow, modify an existing workflow, or edit the workflow canvas in CC Workflow Studio via the built-in MCP server.
+---
+
+1. Call `get_workflow_schema` via `cc-workflow-studio` MCP server
+2. Call `get_current_workflow` via `cc-workflow-studio` MCP server
+3. Ask the user what to create or modify
+4. Generate workflow JSON: use built-in sub-agents (builtInType: explore/plan/general-purpose) by default. Only call `list_available_agents` when the user explicitly asks to use an existing custom sub-agent.
+5. Apply changes via `cc-workflow-studio` MCP server:
+   - **New workflow or structural changes** (add/remove nodes/connections): use `apply_workflow`
+   - **Partial updates to existing nodes** (change name, position, or data): use `update_nodes` (more token-efficient)
+   - Fix errors if any
+6. Ask for feedback, repeat from step 4
+
+## Group Node
+
+Group nodes are visual containers for organizing related nodes on the canvas. They do NOT affect workflow execution.
+
+### Rules
+- Group nodes have `type: "group"` and require `data.label` (display name)
+- Group nodes must have `style: { width, height }` to define their visual area
+- Group nodes CANNOT have connections (no edges to/from group nodes)
+- To place a node inside a group, set the child node's `parentId` to the group's `id`
+- Child node `position` is relative to the group's top-left corner (not the canvas origin)
+- The `name` field on group nodes is not validated (can be empty or omitted)
+
+### Example
+```json
+{
+  "nodes": [
+    {
+      "id": "group-1",
+      "type": "group",
+      "name": "",
+      "position": { "x": 100, "y": 100 },
+      "style": { "width": 400, "height": 300 },
+      "data": { "label": "Data Processing" }
+    },
+    {
+      "id": "node-1",
+      "type": "subAgent",
+      "name": "fetch-data",
+      "parentId": "group-1",
+      "position": { "x": 50, "y": 50 },
+      "data": { "description": "Fetch data from API", "outputPorts": 1 }
+    }
+  ]
+}
+```

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,15 @@
   "mcpServers": {
     "atlassian": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/sse"]
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.atlassian.com/v1/sse"
+      ]
+    },
+    "cc-workflow-studio": {
+      "type": "http",
+      "url": "http://127.0.0.1:6289/mcp"
     }
   }
 }

--- a/.roo/mcp.json
+++ b/.roo/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "cc-workflow-studio": {
+      "type": "streamable-http",
+      "url": "http://127.0.0.1:6289/mcp"
+    }
+  }
+}

--- a/.roo/skills/cc-workflow-ai-editor/SKILL.md
+++ b/.roo/skills/cc-workflow-ai-editor/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cc-workflow-ai-editor
+description: AI workflow editor for CC Workflow Studio. Create and edit visual AI agent workflows through interactive conversation using MCP tools (get_workflow_schema, get_current_workflow, apply_workflow, update_nodes). Use when the user wants to create a new workflow, modify an existing workflow, or edit the workflow canvas in CC Workflow Studio via the built-in MCP server.
+---
+
+1. Call `get_workflow_schema` via `cc-workflow-studio` MCP server
+2. Call `get_current_workflow` via `cc-workflow-studio` MCP server
+3. Ask the user what to create or modify
+4. Generate workflow JSON: use built-in sub-agents (builtInType: explore/plan/general-purpose) by default. Only call `list_available_agents` when the user explicitly asks to use an existing custom sub-agent.
+5. Apply changes via `cc-workflow-studio` MCP server:
+   - **New workflow or structural changes** (add/remove nodes/connections): use `apply_workflow`
+   - **Partial updates to existing nodes** (change name, position, or data): use `update_nodes` (more token-efficient)
+   - Fix errors if any
+6. Ask for feedback, repeat from step 4
+
+## Group Node
+
+Group nodes are visual containers for organizing related nodes on the canvas. They do NOT affect workflow execution.
+
+### Rules
+- Group nodes have `type: "group"` and require `data.label` (display name)
+- Group nodes must have `style: { width, height }` to define their visual area
+- Group nodes CANNOT have connections (no edges to/from group nodes)
+- To place a node inside a group, set the child node's `parentId` to the group's `id`
+- Child node `position` is relative to the group's top-left corner (not the canvas origin)
+- The `name` field on group nodes is not validated (can be empty or omitted)
+
+### Example
+```json
+{
+  "nodes": [
+    {
+      "id": "group-1",
+      "type": "group",
+      "name": "",
+      "position": { "x": 100, "y": 100 },
+      "style": { "width": 400, "height": 300 },
+      "data": { "label": "Data Processing" }
+    },
+    {
+      "id": "node-1",
+      "type": "subAgent",
+      "name": "fetch-data",
+      "parentId": "group-1",
+      "position": { "x": 50, "y": 50 },
+      "data": { "description": "Fetch data from API", "outputPorts": 1 }
+    }
+  ]
+}
+```

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "cc-workflow-studio": {
+      "type": "http",
+      "url": "http://127.0.0.1:6289/mcp"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,13 @@
           "minimum": 10,
           "maximum": 500,
           "description": "Maximum number of nodes allowed in a workflow."
+        },
+        "cc-wf-studio.mcp.port": {
+          "type": "number",
+          "default": 6282,
+          "minimum": 1024,
+          "maximum": 65535,
+          "description": "Port number for the built-in MCP server. Change only if the default port (6282) is already in use."
         }
       }
     }

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -31,7 +31,6 @@ import { FileService } from '../services/file-service';
 import {
   checkPortMismatch,
   getConfigTargetsForProvider,
-  removeAllAgentConfigs,
   writeAllAgentConfigs,
 } from '../services/mcp-server-config-writer';
 import { SlackApiService } from '../services/slack-api-service';
@@ -1696,12 +1695,6 @@ export function registerOpenEditorCommand(
 
               try {
                 await stopManager.stop();
-
-                // Remove configs (best-effort)
-                const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-                if (workspacePath) {
-                  await removeAllAgentConfigs(workspacePath);
-                }
 
                 webview.postMessage({
                   type: 'MCP_SERVER_STATUS',

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -29,6 +29,7 @@ import { cancelGeneration } from '../services/claude-code-service';
 import { CommentarySessionManager } from '../services/commentary-session-manager';
 import { FileService } from '../services/file-service';
 import {
+  checkPortMismatch,
   getConfigTargetsForProvider,
   removeAllAgentConfigs,
   writeAllAgentConfigs,
@@ -240,6 +241,11 @@ export function registerOpenEditorCommand(
           }
           const webview = currentPanel.webview;
 
+          // Helper: get configured MCP port from VSCode settings
+          function getConfiguredMcpPort(): number {
+            return vscode.workspace.getConfiguration('cc-wf-studio').get<number>('mcp.port', 6282);
+          }
+
           // Helper: ensure MCP server is running and config written for Run operations
           async function ensureMcpServerForRun(
             provider: AiEditingProvider,
@@ -253,7 +259,7 @@ export function registerOpenEditorCommand(
             const previousPort = mcpManager.getPort();
             let serverPort = previousPort;
             if (!mcpManager.isRunning()) {
-              serverPort = await mcpManager.start(context.extensionPath);
+              serverPort = await mcpManager.start(context.extensionPath, getConfiguredMcpPort());
             }
             const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
 
@@ -272,6 +278,31 @@ export function registerOpenEditorCommand(
                 const written = await writeAllAgentConfigs(newTargets, serverUrl, workspacePath);
                 mcpManager.addWrittenConfigs(written);
                 configWritten = written.length > 0;
+              }
+
+              // Check for port mismatch in config files
+              if (serverPort !== null) {
+                const primaryTarget = requiredTargets[0];
+                const { mismatch, configPort } = await checkPortMismatch(
+                  primaryTarget,
+                  serverPort,
+                  workspacePath
+                );
+                if (mismatch) {
+                  vscode.window.showWarningMessage(
+                    `MCP port mismatch: server is running on port ${serverPort}, but ${primaryTarget} config has port ${configPort}. Rewriting config.`
+                  );
+                  for (const t of requiredTargets) {
+                    mcpManager.getWrittenConfigs().delete(t);
+                  }
+                  const rewritten = await writeAllAgentConfigs(
+                    requiredTargets,
+                    serverUrl,
+                    workspacePath
+                  );
+                  mcpManager.addWrittenConfigs(rewritten);
+                  configWritten = true;
+                }
               }
             }
 
@@ -1600,7 +1631,10 @@ export function registerOpenEditorCommand(
                   'copilot',
                 ];
 
-                const port = await startManager.start(context.extensionPath);
+                const port = await startManager.start(
+                  context.extensionPath,
+                  getConfiguredMcpPort()
+                );
                 const serverUrl = `http://127.0.0.1:${port}/mcp`;
 
                 // Write config to selected targets
@@ -1627,9 +1661,9 @@ export function registerOpenEditorCommand(
 
                 log('INFO', 'MCP Server started via UI', { port, configsWritten });
               } catch (error) {
-                log('ERROR', 'Failed to start MCP server', {
-                  error: error instanceof Error ? error.message : String(error),
-                });
+                const errMsg = error instanceof Error ? error.message : String(error);
+                log('ERROR', 'Failed to start MCP server', { error: errMsg });
+                vscode.window.showErrorMessage(errMsg);
                 webview.postMessage({
                   type: 'MCP_SERVER_STATUS',
                   requestId: message.requestId,
@@ -1782,7 +1816,10 @@ export function registerOpenEditorCommand(
                 // 1. Start server if not running
                 let serverPort = launchManager.getPort();
                 if (!launchManager.isRunning()) {
-                  serverPort = await launchManager.start(context.extensionPath);
+                  serverPort = await launchManager.start(
+                    context.extensionPath,
+                    getConfiguredMcpPort()
+                  );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
 
@@ -1796,6 +1833,30 @@ export function registerOpenEditorCommand(
                 if (newTargets.length > 0) {
                   const written = await writeAllAgentConfigs(newTargets, serverUrl, workspacePath);
                   launchManager.addWrittenConfigs(written);
+                }
+
+                // Check for port mismatch in config files
+                if (serverPort !== null) {
+                  const primaryTarget = requiredTargets[0];
+                  const { mismatch, configPort } = await checkPortMismatch(
+                    primaryTarget,
+                    serverPort,
+                    workspacePath
+                  );
+                  if (mismatch) {
+                    vscode.window.showWarningMessage(
+                      `MCP port mismatch: server is running on port ${serverPort}, but ${primaryTarget} config has port ${configPort}. Rewriting config.`
+                    );
+                    for (const t of requiredTargets) {
+                      launchManager.getWrittenConfigs().delete(t);
+                    }
+                    const rewritten = await writeAllAgentConfigs(
+                      requiredTargets,
+                      serverUrl,
+                      workspacePath
+                    );
+                    launchManager.addWrittenConfigs(rewritten);
+                  }
                 }
 
                 // 3. Send MCP_SERVER_STATUS update

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode';
 import { registerOpenEditorCommand } from './commands/open-editor';
 import { handleConnectSlackManual } from './commands/slack-connect-manual';
 import { WorkflowPreviewEditorProvider } from './editors/workflow-preview-editor-provider';
-import { removeAllAgentConfigs } from './services/mcp-server-config-writer';
 import { McpServerManager } from './services/mcp-server-service';
 import { SlackApiService } from './services/slack-api-service';
 import { SlackTokenManager } from './utils/slack-token-manager';
@@ -199,14 +198,10 @@ export function activate(context: vscode.ExtensionContext): void {
  * Called when the extension is deactivated
  */
 export async function deactivate(): Promise<void> {
-  // Stop MCP server and clean up configs if running
+  // Stop MCP server if running (configs are kept for fixed-port reuse)
   if (mcpServerManager?.isRunning()) {
     try {
       await mcpServerManager.stop();
-      const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-      if (workspacePath) {
-        await removeAllAgentConfigs(workspacePath);
-      }
     } catch (error) {
       log('ERROR', 'Failed to stop MCP server during deactivation', {
         error: error instanceof Error ? error.message : String(error),

--- a/src/extension/services/mcp-server-config-writer.ts
+++ b/src/extension/services/mcp-server-config-writer.ts
@@ -111,6 +111,17 @@ export async function writeAgentConfig(
   workspacePath: string
 ): Promise<void> {
   try {
+    // Skip write if config already has the correct port
+    const configPort = await readConfiguredPort(target, workspacePath);
+    const newPort = extractPortFromUrl(serverUrl);
+    if (configPort !== null && configPort === newPort) {
+      log(
+        'INFO',
+        `MCP Config Writer: Config for ${target} already has port ${configPort}, skipping write`
+      );
+      return;
+    }
+
     if (target === 'codex') {
       const config = await readCodexConfig();
       if (!config.mcp_servers) {
@@ -182,6 +193,56 @@ export async function writeAgentConfig(
     });
     throw error;
   }
+}
+
+/**
+ * Extract port number from a URL string
+ */
+function extractPortFromUrl(url: string): number | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.port ? Number.parseInt(parsed.port, 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the configured port for a specific target from its config file
+ */
+export async function readConfiguredPort(
+  target: McpConfigTarget,
+  workspacePath: string
+): Promise<number | null> {
+  try {
+    if (target === 'codex') {
+      const config = await readCodexConfig();
+      const url = config.mcp_servers?.[SERVER_ENTRY_NAME]?.url;
+      return url ? extractPortFromUrl(url) : null;
+    }
+    const filePath = getConfigPath(target, workspacePath);
+    const config = await readJsonConfig(filePath);
+    const entry = config.servers?.[SERVER_ENTRY_NAME] || config.mcpServers?.[SERVER_ENTRY_NAME];
+    const url = entry?.url || (entry as Record<string, unknown>)?.serverUrl;
+    return typeof url === 'string' ? extractPortFromUrl(url) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if the running server port matches the port in a config file
+ */
+export async function checkPortMismatch(
+  target: McpConfigTarget,
+  runningPort: number,
+  workspacePath: string
+): Promise<{ mismatch: boolean; configPort: number | null }> {
+  const configPort = await readConfiguredPort(target, workspacePath);
+  if (configPort === null) {
+    return { mismatch: false, configPort: null };
+  }
+  return { mismatch: configPort !== runningPort, configPort };
 }
 
 /**

--- a/src/extension/services/mcp-server-service.ts
+++ b/src/extension/services/mcp-server-service.ts
@@ -5,7 +5,7 @@
  * can connect to for workflow CRUD operations.
  *
  * Architecture:
- * - HTTP server on 127.0.0.1 (localhost only) with dynamic port
+ * - HTTP server on 127.0.0.1 (localhost only) with configurable fixed port (default: 6282)
  * - StreamableHTTPServerTransport in stateless mode (no session management)
  * - Webview communication via postMessage for workflow data
  * - lastKnownWorkflow cache for when Webview is closed
@@ -51,7 +51,7 @@ export class McpServerManager {
   >();
   private pendingApplyRequests = new Map<string, PendingRequest<boolean>>();
 
-  async start(extensionPath: string): Promise<number> {
+  async start(extensionPath: string, port?: number): Promise<number> {
     if (this.httpServer) {
       throw new Error('MCP server is already running');
     }
@@ -145,10 +145,11 @@ export class McpServerManager {
       }
     });
 
-    // Start listening on dynamic port, localhost only
+    // Start listening on configured port (default: 6282), localhost only
+    const listenPort = port ?? 0;
     const httpServer = this.httpServer;
     return new Promise<number>((resolve, reject) => {
-      httpServer.listen(0, '127.0.0.1', () => {
+      httpServer.listen(listenPort, '127.0.0.1', () => {
         const address = httpServer.address();
         if (address && typeof address !== 'string') {
           this.port = address.port;
@@ -159,11 +160,17 @@ export class McpServerManager {
         }
       });
 
-      httpServer.on('error', (error) => {
-        log('ERROR', 'MCP Server: HTTP server error', {
-          error: error.message,
-        });
-        reject(error);
+      httpServer.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code === 'EADDRINUSE') {
+          const msg = `Port ${listenPort} is already in use. Change the port in Settings (cc-wf-studio.mcp.port) or close the application using port ${listenPort}.`;
+          log('ERROR', 'MCP Server: Port in use', { port: listenPort });
+          reject(new Error(msg));
+        } else {
+          log('ERROR', 'MCP Server: HTTP server error', {
+            error: error.message,
+          });
+          reject(error);
+        }
       });
     });
   }


### PR DESCRIPTION
## Summary

Replace random ephemeral MCP server port with a fixed default port (6282), eliminating unnecessary git diff noise in `.mcp.json` and other agent config files on every server startup.

## What Changed

### Before
- MCP server used port `0` (OS-assigned random port) on every startup
- Agent config files (`.mcp.json`, `.vscode/mcp.json`, etc.) were rewritten with a new port each time
- This caused git diff noise for every developer using the project

### After
- Default fixed port `6282`, configurable via VSCode Settings (`cc-wf-studio.mcp.port`)
- Config files only rewritten when the port actually changes — no more unnecessary git diffs
- EADDRINUSE error shows actionable message guiding users to change the port in settings
- Port mismatch detection: warns when config file port differs from running server port, with both port numbers displayed, and auto-rewrites the config

## Changes

- `package.json` - Added `cc-wf-studio.mcp.port` setting (default: 6282, range: 1024-65535)
- `src/extension/services/mcp-server-service.ts` - Accept port parameter in `start()`, handle EADDRINUSE with user-friendly error
- `src/extension/services/mcp-server-config-writer.ts` - Added `readConfiguredPort()`, `checkPortMismatch()`, and skip-write optimization
- `src/extension/commands/open-editor.ts` - Pass configured port to all 3 `start()` call sites, add mismatch warning + auto-rewrite

## Testing

- [x] Default port 6282 startup
- [x] Custom port via settings
- [x] EADDRINUSE error message when port is occupied
- [x] Port mismatch warning when config file has stale port

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable MCP server port in VS Code settings (default 6282, range 1024–65535).
  * Automatic port mismatch detection and automated config rewrite when inconsistencies are found.
  * Added local MCP server entries for the workflow studio to simplify local setup.

* **Bug Fixes**
  * Improved handling and user-facing messages for port-in-use conflicts.

* **Documentation**
  * Added workflow editor documentation describing workflow editing flows and group-node rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->