### PR TITLE
feat: redesign onboarding tour and add empty state

### DIFF
--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -209,6 +209,7 @@ const App: React.FC = () => {
   const [showWhatsNewBadge, setShowWhatsNewBadge] = useState(true);
   const [showMcpRefreshDialog, setShowMcpRefreshDialog] = useState(false);
   const [mcpRefreshSkillName, setMcpRefreshSkillName] = useState<string>('cc-workflow-ai-editor');
+  const [emptyStateDismissed, setEmptyStateDismissed] = useState(false);
 
   // Pending MCP apply state for diff preview
   const [pendingMcpApply, setPendingMcpApply] = useState<{
@@ -229,6 +230,28 @@ const App: React.FC = () => {
     expand: expandNodePalette,
   } = useCollapsiblePanel();
   const isCompact = useIsCompactMode();
+
+  // Reset emptyStateDismissed when a workflow is loaded (so empty state reappears after reset)
+  const prevActiveWorkflowRef = useRef(activeWorkflow);
+  useEffect(() => {
+    if (prevActiveWorkflowRef.current !== null && activeWorkflow === null) {
+      setEmptyStateDismissed(false);
+    }
+    prevActiveWorkflowRef.current = activeWorkflow;
+  }, [activeWorkflow]);
+
+  // Empty state: show when canvas has only default Start/End nodes, no edges, no active workflow
+  const isCanvasEmpty =
+    nodes.length === 2 &&
+    edges.length === 0 &&
+    activeWorkflow === null &&
+    nodes.some((n) => n.id === 'start-node-default') &&
+    nodes.some((n) => n.id === 'end_node_default');
+  const showEmptyState = isCanvasEmpty && !emptyStateDismissed && !runTour;
+
+  const handleLoadWorkflowFromEmptyState = useCallback(() => {
+    vscode.postMessage({ type: 'OPEN_FILE_PICKER' });
+  }, []);
 
   const handleError = (errorData: ErrorPayload) => {
     setError(errorData);
@@ -685,6 +708,10 @@ const App: React.FC = () => {
           <WorkflowEditor
             isNodePaletteCollapsed={isNodePaletteCollapsed}
             onExpandNodePalette={expandNodePalette}
+            showEmptyState={showEmptyState}
+            onOpenSample={() => setIsSampleDialogOpen(true)}
+            onDismissEmptyState={() => setEmptyStateDismissed(true)}
+            onLoadWorkflow={handleLoadWorkflowFromEmptyState}
           />
           {/* Processing overlay for canvas area only (with message centered in canvas) */}
           <ProcessingOverlay isVisible={isProcessing} message={t('refinement.processingOverlay')} />

--- a/src/webview/src/components/EmptyState.tsx
+++ b/src/webview/src/components/EmptyState.tsx
@@ -1,0 +1,147 @@
+/**
+ * Empty State Component
+ *
+ * Displayed on the canvas when no workflow is loaded (only Start/End nodes).
+ * Provides quick actions to get started.
+ * Uses Radix UI Dialog for consistency with other dialogs.
+ */
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { FileDown, FolderOpen, Plus } from 'lucide-react';
+import type React from 'react';
+
+interface EmptyStateProps {
+  isOpen: boolean;
+  onOpenSample: () => void;
+  onStartFromScratch: () => void;
+  onLoadWorkflow: () => void;
+}
+
+const buttonStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  width: '100%',
+  padding: '10px 16px',
+  border: '1px solid var(--vscode-panel-border)',
+  borderRadius: '4px',
+  backgroundColor: 'var(--vscode-editor-background)',
+  color: 'var(--vscode-foreground)',
+  cursor: 'pointer',
+  fontSize: '13px',
+  textAlign: 'left',
+  transition: 'background-color 0.15s',
+};
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  isOpen,
+  onOpenSample,
+  onStartFromScratch,
+  onLoadWorkflow,
+}) => {
+  return (
+    <Dialog.Root open={isOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 9999,
+          }}
+        >
+          <Dialog.Content
+            style={{
+              backgroundColor: 'var(--vscode-editor-background)',
+              border: '1px solid var(--vscode-panel-border)',
+              borderRadius: '6px',
+              padding: '24px',
+              width: '320px',
+              maxWidth: '90vw',
+              display: 'flex',
+              flexDirection: 'column',
+              boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)',
+              outline: 'none',
+            }}
+            onEscapeKeyDown={onStartFromScratch}
+          >
+            <Dialog.Title
+              style={{
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--vscode-foreground)',
+                marginBottom: '16px',
+                textAlign: 'center',
+              }}
+            >
+              CC Workflow Studio
+            </Dialog.Title>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <button
+                type="button"
+                onClick={onStartFromScratch}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-editor-background)';
+                }}
+                style={buttonStyle}
+              >
+                <Plus size={16} style={{ flexShrink: 0 }} />
+                New
+              </button>
+
+              <button
+                type="button"
+                onClick={onLoadWorkflow}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = 'var(--vscode-editor-background)';
+                }}
+                style={buttonStyle}
+              >
+                <FileDown size={16} style={{ flexShrink: 0 }} />
+                Load
+              </button>
+            </div>
+
+            <div style={{ marginTop: '12px', textAlign: 'center' }}>
+              <button
+                type="button"
+                onClick={onOpenSample}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.opacity = '1';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.opacity = '0.8';
+                }}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: 'var(--vscode-textLink-foreground)',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                  padding: '4px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  opacity: 0.8,
+                }}
+              >
+                <FolderOpen size={12} />
+                Sample Workflow
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/webview/src/components/Toolbar.tsx
+++ b/src/webview/src/components/Toolbar.tsx
@@ -1360,6 +1360,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   return (
     <StyledTooltipProvider>
       <div
+        data-tour="toolbar-actions"
         style={{
           position: 'relative',
           display: 'flex',

--- a/src/webview/src/components/Tour.tsx
+++ b/src/webview/src/components/Tour.tsx
@@ -83,6 +83,7 @@ export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
       onDeselectNode: () => setSelectedNodeIdRef.current(null),
       moveNext: () => driverInstance.moveNext(),
       movePrevious: () => driverInstance.movePrevious(),
+      skipToStep: (index: number) => driverInstance.drive(index),
     }),
     []
   );

--- a/src/webview/src/components/Tour.tsx
+++ b/src/webview/src/components/Tour.tsx
@@ -100,9 +100,6 @@ export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
   // Minimize the tour: save step, destroy Driver.js, show floating button
   const doMinimize = useCallback(() => {
     removeClickOutsideListener();
-    if (stepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
-      setSelectedNodeIdRef.current(null);
-    }
     if (driverRef.current) {
       driverRef.current.destroy();
       driverRef.current = null;

--- a/src/webview/src/components/Tour.tsx
+++ b/src/webview/src/components/Tour.tsx
@@ -1,12 +1,17 @@
 /**
  * Claude Code Workflow Studio - Interactive Tour Component
  *
- * Provides a guided tour for first-time users using Driver.js
+ * Provides a guided tour for first-time users using Driver.js.
+ * Uses allowClose: false and self-managed close/minimize.
+ * Minimize: destroy Driver.js instance, show floating button.
+ * Resume: recreate Driver.js instance at the saved step index.
  */
 
 import { type Driver, driver } from 'driver.js';
+import { HelpCircle } from 'lucide-react';
 import type React from 'react';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import 'driver.js/dist/driver.css';
 import { getDriverConfig, getTourSteps, PROPERTY_PANEL_STEP_INDEX } from '../constants/tour-steps';
 import { useTranslation } from '../i18n/i18n-context';
@@ -17,92 +22,270 @@ interface TourProps {
   onFinish: () => void;
 }
 
-/**
- * Tour Component
- *
- * Displays an interactive overlay tour that guides users through the application
- */
+// SVG icons for injected buttons
+const CLOSE_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+const MINIMIZE_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>';
+
+const INJECTED_BTN_STYLE =
+  'background: transparent; border: none; color: var(--vscode-icon-foreground); cursor: pointer; padding: 4px; display: flex; align-items: center; transition: opacity 0.2s;';
+
 export const Tour: React.FC<TourProps> = ({ run, onFinish }) => {
   const { t } = useTranslation();
   const driverRef = useRef<Driver | null>(null);
   const onFinishRef = useRef(onFinish);
   const setSelectedNodeId = useWorkflowStore((state) => state.setSelectedNodeId);
+  const nodes = useWorkflowStore((state) => state.nodes);
   const setSelectedNodeIdRef = useRef(setSelectedNodeId);
-  const previousStepIndexRef = useRef<number | null>(null);
+  const nodesRef = useRef(nodes);
+  const stepIndexRef = useRef<number>(0);
+  const [minimized, setMinimized] = useState(false);
+  const minimizedRef = useRef(false);
 
-  // Update refs when they change
+  // Update refs
   useEffect(() => {
     onFinishRef.current = onFinish;
   }, [onFinish]);
-
   useEffect(() => {
     setSelectedNodeIdRef.current = setSelectedNodeId;
   }, [setSelectedNodeId]);
-
   useEffect(() => {
-    // Initialize driver instance
-    if (!driverRef.current) {
+    nodesRef.current = nodes;
+  }, [nodes]);
+  useEffect(() => {
+    minimizedRef.current = minimized;
+    if (minimized && run) {
+      document.body.classList.add('tour-floating-visible');
+    } else {
+      document.body.classList.remove('tour-floating-visible');
+    }
+    return () => {
+      document.body.classList.remove('tour-floating-visible');
+    };
+  }, [minimized, run]);
+
+  // Build step callbacks for Driver.js
+  const buildStepCallbacks = useCallback(
+    (driverInstance: Driver) => ({
+      onSelectSampleNode: () => {
+        const currentNodes = nodesRef.current;
+        const promptNode = currentNodes.find((n) => n.type === 'prompt');
+        const subAgentNode = currentNodes.find((n) => n.type === 'subAgent');
+        const nonDefaultNode = currentNodes.find(
+          (n) => n.type !== 'start' && n.type !== 'end' && n.type !== 'group'
+        );
+        const targetNode = promptNode || subAgentNode || nonDefaultNode || currentNodes[0];
+        if (targetNode) {
+          setSelectedNodeIdRef.current(targetNode.id);
+        }
+      },
+      onDeselectNode: () => setSelectedNodeIdRef.current(null),
+      moveNext: () => driverInstance.moveNext(),
+      movePrevious: () => driverInstance.movePrevious(),
+    }),
+    []
+  );
+
+  // Click-outside listener: minimize when clicking outside the popover
+  const clickOutsideRef = useRef<((e: MouseEvent) => void) | null>(null);
+
+  const removeClickOutsideListener = useCallback(() => {
+    if (clickOutsideRef.current) {
+      document.removeEventListener('click', clickOutsideRef.current, true);
+      clickOutsideRef.current = null;
+    }
+  }, []);
+
+  // Minimize the tour: save step, destroy Driver.js, show floating button
+  const doMinimize = useCallback(() => {
+    removeClickOutsideListener();
+    if (stepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
+      setSelectedNodeIdRef.current(null);
+    }
+    if (driverRef.current) {
+      driverRef.current.destroy();
+      driverRef.current = null;
+    }
+    setMinimized(true);
+  }, [removeClickOutsideListener]);
+
+  const addClickOutsideListener = useCallback(() => {
+    removeClickOutsideListener();
+    const handler = (e: MouseEvent) => {
+      const popover = document.querySelector('.driver-popover');
+      if (popover && !popover.contains(e.target as Node)) {
+        e.stopPropagation();
+        e.preventDefault();
+        doMinimize();
+      }
+    };
+    clickOutsideRef.current = handler;
+    // Use capture + setTimeout to avoid catching the current click
+    setTimeout(() => {
+      document.addEventListener('click', handler, true);
+    }, 0);
+  }, [doMinimize, removeClickOutsideListener]);
+
+  // Inject custom close (×) and minimize (−) buttons into Driver.js popover
+  const injectButtons = useCallback(() => {
+    const popover = document.querySelector('.driver-popover');
+    if (!popover || document.getElementById('tour-custom-btns')) return;
+
+    const container = document.createElement('div');
+    container.id = 'tour-custom-btns';
+    container.style.cssText = 'position: absolute; top: 4px; right: 4px; display: flex; gap: 2px;';
+
+    // Minimize button
+    const minimizeBtn = document.createElement('button');
+    minimizeBtn.title = t('tour.button.minimize' as keyof typeof t);
+    minimizeBtn.style.cssText = INJECTED_BTN_STYLE;
+    minimizeBtn.innerHTML = MINIMIZE_ICON;
+    minimizeBtn.addEventListener('mouseenter', () => {
+      minimizeBtn.style.opacity = '0.6';
+    });
+    minimizeBtn.addEventListener('mouseleave', () => {
+      minimizeBtn.style.opacity = '1';
+    });
+    minimizeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      doMinimize();
+    });
+
+    // Close button
+    const closeBtn = document.createElement('button');
+    closeBtn.title = t('tour.button.close' as keyof typeof t);
+    closeBtn.style.cssText = INJECTED_BTN_STYLE;
+    closeBtn.innerHTML = CLOSE_ICON;
+    closeBtn.addEventListener('mouseenter', () => {
+      closeBtn.style.opacity = '0.6';
+    });
+    closeBtn.addEventListener('mouseleave', () => {
+      closeBtn.style.opacity = '1';
+    });
+    closeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      removeClickOutsideListener();
+      if (stepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
+        setSelectedNodeIdRef.current(null);
+      }
+      if (driverRef.current) {
+        driverRef.current.destroy();
+        driverRef.current = null;
+      }
+      onFinishRef.current();
+    });
+
+    container.appendChild(minimizeBtn);
+    container.appendChild(closeBtn);
+    popover.appendChild(container);
+  }, [t, doMinimize, removeClickOutsideListener]);
+
+  // Create and start a Driver.js instance at a given step index
+  const startDriver = useCallback(
+    (startIndex: number) => {
       const config = getDriverConfig((key) => t(key as keyof typeof t));
-      driverRef.current = driver({
+      const driverInstance = driver({
         ...config,
-        onHighlightStarted: (_element, _step, options) => {
-          const currentIndex = options.state.activeIndex;
-          previousStepIndexRef.current = currentIndex ?? null;
+        overlayClickBehavior: () => {
+          doMinimize();
         },
-        onCloseClick: () => {
-          // Called when close button (X) is clicked
-          // Deselect node if we were on property panel step
-          if (previousStepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
-            setSelectedNodeIdRef.current(null);
-          }
-          if (driverRef.current) {
-            driverRef.current.destroy();
-          }
+        onHighlightStarted: (_element, _step, options) => {
+          stepIndexRef.current = options.state.activeIndex ?? 0;
+          requestAnimationFrame(() => {
+            injectButtons();
+            addClickOutsideListener();
+          });
         },
         onDestroyStarted: () => {
-          // Called when tour is about to be destroyed (completed, skipped, or closed)
-          // Deselect node if we were on property panel step
-          if (previousStepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
+          // Only called for natural completion (last step "Done" click)
+          // Close/minimize buttons handle their own cleanup
+          if (stepIndexRef.current === PROPERTY_PANEL_STEP_INDEX) {
             setSelectedNodeIdRef.current(null);
           }
-          // Destroy the driver instance
           if (driverRef.current) {
             driverRef.current.destroy();
             driverRef.current = null;
           }
-          // Reset step tracking
-          previousStepIndexRef.current = null;
-          // Call onFinish callback
+          stepIndexRef.current = 0;
           onFinishRef.current();
         },
       });
+
+      const steps = getTourSteps(
+        (key) => t(key as keyof typeof t),
+        buildStepCallbacks(driverInstance)
+      );
+      driverInstance.setSteps(steps);
+      driverInstance.drive(startIndex);
+      driverRef.current = driverInstance;
+    },
+    [t, injectButtons, buildStepCallbacks, doMinimize, addClickOutsideListener]
+  );
+
+  // Main effect: start/stop/resume tour
+  useEffect(() => {
+    if (run && !minimized && !driverRef.current) {
+      startDriver(stepIndexRef.current);
+    } else if (!run) {
+      removeClickOutsideListener();
+      if (driverRef.current) {
+        driverRef.current.destroy();
+        driverRef.current = null;
+      }
+      stepIndexRef.current = 0;
+      setMinimized(false);
     }
 
-    // Start or stop tour based on run prop
-    if (run && driverRef.current) {
-      // Create step callbacks that reference the current driver instance
-      const driverInstance = driverRef.current;
-      const steps = getTourSteps((key) => t(key as keyof typeof t), {
-        onSelectStartNode: () => setSelectedNodeIdRef.current('start-node-default'),
-        onDeselectNode: () => setSelectedNodeIdRef.current(null),
-        moveNext: () => driverInstance.moveNext(),
-        movePrevious: () => driverInstance.movePrevious(),
-      });
-      driverRef.current.setSteps(steps);
-      driverRef.current.drive();
-    } else if (!run && driverRef.current) {
-      driverRef.current.destroy();
-      driverRef.current = null;
-    }
-
-    // Cleanup on unmount
     return () => {
+      removeClickOutsideListener();
       if (driverRef.current) {
         driverRef.current.destroy();
         driverRef.current = null;
       }
     };
-  }, [run, t]);
+  }, [run, minimized, startDriver, removeClickOutsideListener]);
+
+  // Floating resume button when minimized
+  if (minimized && run) {
+    return createPortal(
+      <button
+        type="button"
+        onClick={() => setMinimized(false)}
+        title={t('tour.button.resume' as keyof typeof t)}
+        style={{
+          position: 'fixed',
+          bottom: '16px',
+          right: '16px',
+          zIndex: 10001,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          padding: '8px 14px',
+          borderRadius: '20px',
+          border: '1px solid var(--vscode-panel-border)',
+          backgroundColor: 'var(--vscode-button-background)',
+          color: 'var(--vscode-button-foreground)',
+          cursor: 'pointer',
+          fontSize: '13px',
+          fontWeight: 500,
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.2)',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+        }}
+      >
+        <HelpCircle size={16} />
+        {t('tour.button.resume' as keyof typeof t)}
+      </button>,
+      document.body
+    );
+  }
 
   return null;
 };

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -29,6 +29,7 @@ import { useWorkflowStore } from '../stores/workflow-store';
 import { CanvasToolbar } from './CanvasToolbar';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
 import { DescriptionPanel } from './DescriptionPanel';
+import { EmptyState } from './EmptyState';
 // Custom edge with delete button
 import { DeletableEdge } from './edges/DeletableEdge';
 import { MinimapContainer } from './MinimapContainer';
@@ -91,6 +92,10 @@ const edgeTypes: EdgeTypes = {
 interface WorkflowEditorProps {
   isNodePaletteCollapsed?: boolean;
   onExpandNodePalette?: () => void;
+  showEmptyState?: boolean;
+  onOpenSample?: () => void;
+  onDismissEmptyState?: () => void;
+  onLoadWorkflow?: () => void;
 }
 
 /**
@@ -99,6 +104,10 @@ interface WorkflowEditorProps {
 export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   isNodePaletteCollapsed = false,
   onExpandNodePalette,
+  showEmptyState = false,
+  onOpenSample,
+  onDismissEmptyState,
+  onLoadWorkflow,
 }) => {
   const { t } = useTranslation();
   const isCompact = useIsCompactMode();
@@ -523,6 +532,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             </Panel>
           )}
         </ReactFlow>
+        {onOpenSample && onDismissEmptyState && onLoadWorkflow && (
+          <EmptyState
+            isOpen={showEmptyState}
+            onOpenSample={onOpenSample}
+            onStartFromScratch={onDismissEmptyState}
+            onLoadWorkflow={onLoadWorkflow}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -24,6 +24,7 @@ export const getTourSteps = (
     onDeselectNode?: () => void;
     moveNext?: () => void;
     movePrevious?: () => void;
+    skipToStep?: (index: number) => void;
   }
 ): DriveStep[] => [
   // Step 1: Welcome
@@ -46,9 +47,15 @@ export const getTourSteps = (
       // Select a node before moving to property panel step
       onNextClick: () => {
         callbacks?.onSelectSampleNode?.();
+        const start = Date.now();
         const waitForPropertyPanel = () => {
           if (document.querySelector('.property-panel')) {
             callbacks?.moveNext?.();
+            return;
+          }
+          // Timeout: skip property panel step if it doesn't appear (e.g. empty canvas)
+          if (Date.now() - start > 500) {
+            callbacks?.skipToStep?.(PROPERTY_PANEL_STEP_INDEX + 1);
             return;
           }
           requestAnimationFrame(waitForPropertyPanel);

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -46,9 +46,14 @@ export const getTourSteps = (
       // Select a node before moving to property panel step
       onNextClick: () => {
         callbacks?.onSelectSampleNode?.();
-        setTimeout(() => {
-          callbacks?.moveNext?.();
-        }, 50);
+        const waitForPropertyPanel = () => {
+          if (document.querySelector('.property-panel')) {
+            callbacks?.moveNext?.();
+            return;
+          }
+          requestAnimationFrame(waitForPropertyPanel);
+        };
+        waitForPropertyPanel();
       },
     },
   },

--- a/src/webview/src/constants/tour-steps.ts
+++ b/src/webview/src/constants/tour-steps.ts
@@ -2,17 +2,17 @@
  * Claude Code Workflow Studio - Tour Steps Definition
  *
  * Defines interactive tour steps for first-time users using Driver.js
+ * Redesigned to 7 focused steps using sample workflow as teaching context
  */
 
 import type { Config as DriverConfig, DriveStep } from 'driver.js';
 
 // Tour step indices (0-based)
-export const CANVAS_STEP_INDEX = 11;
-export const PROPERTY_PANEL_STEP_INDEX = 12;
+export const PROPERTY_PANEL_STEP_INDEX = 2;
 
 /**
  * Tour steps configuration
- * Each step guides users through creating their first workflow
+ * Each step guides users through the workflow editor using a sample workflow
  *
  * @param t - Translation function
  * @param callbacks - Optional callbacks for step-specific actions
@@ -20,12 +20,13 @@ export const PROPERTY_PANEL_STEP_INDEX = 12;
 export const getTourSteps = (
   t: (key: string) => string,
   callbacks?: {
-    onSelectStartNode?: () => void;
+    onSelectSampleNode?: () => void;
     onDeselectNode?: () => void;
     moveNext?: () => void;
     movePrevious?: () => void;
   }
 ): DriveStep[] => [
+  // Step 1: Welcome
   {
     popover: {
       title: '',
@@ -34,6 +35,42 @@ export const getTourSteps = (
       align: 'center',
     },
   },
+  // Step 2: Canvas with sample workflow
+  {
+    element: '.react-flow',
+    popover: {
+      title: '',
+      description: t('tour.canvas'),
+      side: 'over',
+      align: 'center',
+      // Select a node before moving to property panel step
+      onNextClick: () => {
+        callbacks?.onSelectSampleNode?.();
+        setTimeout(() => {
+          callbacks?.moveNext?.();
+        }, 50);
+      },
+    },
+  },
+  // Step 3: Property Panel (select a node to show it)
+  {
+    element: '.property-panel',
+    popover: {
+      title: '',
+      description: t('tour.propertyPanel'),
+      side: 'left',
+      align: 'start',
+      onPrevClick: () => {
+        callbacks?.onDeselectNode?.();
+        callbacks?.movePrevious?.();
+      },
+      onNextClick: () => {
+        callbacks?.onDeselectNode?.();
+        callbacks?.moveNext?.();
+      },
+    },
+  },
+  // Step 4: Node Palette (all nodes at once)
   {
     element: '.node-palette',
     popover: {
@@ -43,175 +80,17 @@ export const getTourSteps = (
       align: 'start',
     },
   },
+  // Step 5: Toolbar (Save/Load/Export/Run grouped)
   {
-    element: '[data-tour="add-prompt-button"]',
+    element: '[data-tour="toolbar-actions"]',
     popover: {
       title: '',
-      description: t('tour.addPrompt'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-subagent-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addSubAgent'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-subagentflow-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addSubAgentFlow'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-skill-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addSkill'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-mcp-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addMcp'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-ifelse-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addIfElse'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-switch-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addSwitch'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-askuserquestion-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addAskUserQuestion'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="add-end-button"]',
-    popover: {
-      title: '',
-      description: t('tour.addEnd'),
-      side: 'right',
-      align: 'start',
-    },
-  },
-  {
-    popover: {
-      title: '',
-      description: t('tour.canvas'),
-      side: 'over',
-      align: 'center',
-      // Select Start node before moving to property panel step
-      onNextClick: () => {
-        callbacks?.onSelectStartNode?.();
-        // Small delay to allow React to render the property panel
-        setTimeout(() => {
-          callbacks?.moveNext?.();
-        }, 50);
-      },
-    },
-  },
-  {
-    element: '.property-panel',
-    popover: {
-      title: '',
-      description: t('tour.propertyPanel'),
-      side: 'left',
-      align: 'start',
-      // Deselect node when leaving property panel step (going back)
-      onPrevClick: () => {
-        callbacks?.onDeselectNode?.();
-        callbacks?.movePrevious?.();
-      },
-      // Deselect node when leaving property panel step (going forward)
-      onNextClick: () => {
-        callbacks?.onDeselectNode?.();
-        callbacks?.moveNext?.();
-      },
-    },
-  },
-  {
-    popover: {
-      title: '',
-      description: t('tour.connectNodes'),
-      side: 'over',
-      align: 'center',
-    },
-  },
-  {
-    element: '[data-tour="workflow-name-input"]',
-    popover: {
-      title: '',
-      description: t('tour.workflowName'),
+      description: t('tour.toolbarActions'),
       side: 'bottom',
       align: 'start',
     },
   },
-  {
-    element: '[data-tour="save-button"]',
-    popover: {
-      title: '',
-      description: t('tour.saveWorkflow'),
-      side: 'bottom',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="load-button"]',
-    popover: {
-      title: '',
-      description: t('tour.loadWorkflow'),
-      side: 'bottom',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="export-button"]',
-    popover: {
-      title: '',
-      description: t('tour.exportWorkflow'),
-      side: 'bottom',
-      align: 'start',
-    },
-  },
-  {
-    element: '[data-tour="run-button"]',
-    popover: {
-      title: '',
-      description: t('tour.runSlashCommand'),
-      side: 'bottom',
-      align: 'start',
-    },
-  },
+  // Step 6: AI Refine button
   {
     element: '[data-tour="ai-refine-button"]',
     popover: {
@@ -221,13 +100,13 @@ export const getTourSteps = (
       align: 'start',
     },
   },
+  // Step 7: Finish
   {
-    element: '[data-tour="more-actions-button"]',
     popover: {
       title: '',
-      description: t('tour.moreActions'),
-      side: 'bottom',
-      align: 'start',
+      description: t('tour.finish'),
+      side: 'over',
+      align: 'center',
     },
   },
 ];
@@ -240,11 +119,11 @@ export const getDriverConfig = (t: (key: string) => string): DriverConfig => ({
   animate: false,
   showProgress: true,
   progressText: 'Step {{current}}/{{total}}',
-  showButtons: ['next', 'previous', 'close'],
+  showButtons: ['next', 'previous'],
   nextBtnText: t('tour.button.next'),
   prevBtnText: t('tour.button.back'),
   doneBtnText: t('tour.button.finish'),
-  allowClose: true,
+  allowClose: false,
   allowKeyboardControl: true,
   smoothScroll: false,
   overlayColor: 'rgba(0, 0, 0, 0.5)',

--- a/src/webview/src/i18n/translation-keys.ts
+++ b/src/webview/src/i18n/translation-keys.ts
@@ -341,26 +341,12 @@ export interface WebviewTranslationKeys {
 
   // Tour
   'tour.welcome': string;
-  'tour.nodePalette': string;
-  'tour.addPrompt': string;
-  'tour.addSubAgent': string;
-  'tour.addSubAgentFlow': string;
-  'tour.addSkill': string;
-  'tour.addMcp': string;
-  'tour.addAskUserQuestion': string;
-  'tour.addEnd': string;
-  'tour.addIfElse': string;
-  'tour.addSwitch': string;
   'tour.canvas': string;
   'tour.propertyPanel': string;
-  'tour.connectNodes': string;
-  'tour.workflowName': string;
-  'tour.saveWorkflow': string;
-  'tour.loadWorkflow': string;
-  'tour.exportWorkflow': string;
-  'tour.runSlashCommand': string;
+  'tour.nodePalette': string;
+  'tour.toolbarActions': string;
   'tour.refineWithAI': string;
-  'tour.moreActions': string;
+  'tour.finish': string;
 
   // Tour buttons
   'tour.button.back': string;
@@ -368,6 +354,8 @@ export interface WebviewTranslationKeys {
   'tour.button.finish': string;
   'tour.button.next': string;
   'tour.button.skip': string;
+  'tour.button.minimize': string;
+  'tour.button.resume': string;
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': string;

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -354,10 +354,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' is met',
 
   // Tour
-  'tour.welcome':
-    'Welcome to CC Workflow Studio!\n\nLet us walk you through the basics using a sample workflow.',
+  'tour.welcome': 'Welcome to CC Workflow Studio!\n\nLet us walk you through the basics.',
   'tour.canvas':
-    'This is the workflow canvas. Nodes are connected to form a processing pipeline.\n\nDrag nodes to move them, and drag handles (⚪) to connect nodes together.',
+    'This is the workflow canvas. Place nodes and connect them to build a processing pipeline.\n\nDrag nodes to move them, and drag handles (⚪) to connect nodes together.',
   'tour.propertyPanel':
     'Click a node to open the Property Panel.\n\nHere you can configure node name, prompt, model selection, and more.',
   'tour.nodePalette':
@@ -367,7 +366,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'tour.refineWithAI':
     'Use "Edit with AI" to generate or improve workflows through an interactive chat.\n\nYou can start from an empty canvas or refine existing workflows conversationally.',
   'tour.finish':
-    "That's the end of the tour!\n\nTry editing this sample, or reset to start from scratch.\nYou can revisit this tour anytime from the Help option in the More menu.",
+    "That's the end of the tour!\n\nFeel free to start building your workflow.\nYou can revisit this tour anytime from the Help option in the More menu.",
 
   // Tour buttons
   'tour.button.back': 'Back',

--- a/src/webview/src/i18n/translations/en.ts
+++ b/src/webview/src/i18n/translations/en.ts
@@ -355,47 +355,19 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Tour
   'tour.welcome':
-    "Welcome to CC Workflow Studio!\n\nThis tour will introduce the key features and show you where everything is. Let's get familiar with the basics before creating your first workflow.",
-  'tour.nodePalette':
-    'The Node Palette contains various nodes you can use in your workflow.\n\nClick on Prompt, Sub-Agent, AskUserQuestion, If/Else, Switch, and other nodes to add them to the canvas.',
-  'tour.addPrompt':
-    'This "Prompt" button lets you add Prompt nodes to the canvas.\n\nA Prompt node is a template that supports variables and is the basic building block of workflows.',
-  'tour.addSubAgent':
-    'The "Sub-Agent" node is a specialized agent that executes specific tasks.\n\nConfigure prompts and tool restrictions to create agents with single responsibilities.',
-  'tour.addSubAgentFlow':
-    '"Sub-Agent Flow" allows you to visually define complex Sub-Agent processing flows.\n\nTo run MCP or Skills in parallel, wrap each process in a Sub-Agent Flow and create a flow that executes those Sub-Agent Flows in parallel.',
-  'tour.addSkill':
-    'The "Skill" node calls Claude Code skills.\n\nSelect and execute skills from personal (~/.claude/skills/) or project (.claude/skills/) directories.',
-  'tour.addMcp':
-    'The "MCP Tool" node executes MCP server tools.\n\nUse it for external service integration or custom tool invocation.',
-  'tour.addAskUserQuestion':
-    'The "AskUserQuestion" node lets you branch the workflow based on user selection.\n\nYou can add it to the canvas using this button.',
-  'tour.addEnd':
-    'The "End" node marks the endpoint of a workflow.\n\nYou can place multiple End nodes to set different endpoints based on outcomes.',
-  'tour.addIfElse':
-    'The "If/Else" node branches the workflow in two directions based on a condition.\n\nSet True or False conditions to control the flow of processing.',
-  'tour.addSwitch':
-    'The "Switch" node branches the workflow in multiple directions based on multiple conditions.\n\nSet multiple cases and a default case to implement complex branching logic.',
+    'Welcome to CC Workflow Studio!\n\nLet us walk you through the basics using a sample workflow.',
   'tour.canvas':
-    'This is the canvas. Drag nodes to adjust their position and drag handles to connect nodes.\n\nStart and End nodes are already placed.',
+    'This is the workflow canvas. Nodes are connected to form a processing pipeline.\n\nDrag nodes to move them, and drag handles (⚪) to connect nodes together.',
   'tour.propertyPanel':
-    'The Property Panel lets you configure the selected node.\n\nYou can edit node name, prompt, model selection, and more.',
-  'tour.connectNodes':
-    'Connect nodes to create your workflow.\n\nDrag from the output handle (⚪) on the right of a node to the input handle on the left of another node.',
-  'tour.workflowName':
-    'This is where you name your workflow.\n\nYou can use letters, numbers, hyphens, and underscores.',
-  'tour.saveWorkflow':
-    'Click the "Save" button to save your workflow as JSON in the `.vscode/workflows/` directory.\n\nYou can load and continue editing later.',
-  'tour.loadWorkflow':
-    'To load a saved workflow, select it from the dropdown menu and click the "Load" button.',
-  'tour.exportWorkflow':
-    'Click the "Convert" button to convert your workflow to a Slash Command format.\n\nThe converted files are saved to the .claude/commands/ directory.',
-  'tour.runSlashCommand':
-    'Click the "Run" button to convert your workflow to a Slash Command and immediately execute it in Claude Code.\n\nThis combines conversion and execution in a single action.',
+    'Click a node to open the Property Panel.\n\nHere you can configure node name, prompt, model selection, and more.',
+  'tour.nodePalette':
+    'Add nodes to your workflow from the Node Palette.\n\nPrompt, Sub-Agent, Skill, MCP Tool, If/Else, Switch, and more are available.',
+  'tour.toolbarActions':
+    'Save, load, convert, and run workflows from the toolbar.\n\nThe "Run" button lets you execute your workflow directly in Claude Code.',
   'tour.refineWithAI':
-    'Use the "Edit with AI" button to create or improve workflows through an interactive chat with AI.\n\nYou can start from an empty canvas or edit existing workflows conversationally.',
-  'tour.moreActions':
-    'The "More" menu provides additional actions:<br><br>• Claude API - Upload workflows to Claude API<br>• Share to Slack - Share workflows with your team<br>• Reset Workflow - Clear the canvas<br>• Focus Mode - Toggle distraction-free editing<br>• AI Agents - Open workflows in other AI agents<br>• What\'s New - View latest updates<br>• Help - View this tour again<br><br>Enjoy creating workflows!',
+    'Use "Edit with AI" to generate or improve workflows through an interactive chat.\n\nYou can start from an empty canvas or refine existing workflows conversationally.',
+  'tour.finish':
+    "That's the end of the tour!\n\nTry editing this sample, or reset to start from scratch.\nYou can revisit this tour anytime from the Help option in the More menu.",
 
   // Tour buttons
   'tour.button.back': 'Back',
@@ -403,6 +375,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.finish': 'Finish',
   'tour.button.next': 'Next',
   'tour.button.skip': 'Skip',
+  'tour.button.minimize': 'Minimize',
+  'tour.button.resume': 'Resume Tour',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': 'Delete Node',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -354,47 +354,19 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Tour
   'tour.welcome':
-    'CC Workflow Studioへようこそ！\n\nこのツアーでは、各機能の場所と役割をご紹介します。基本的な使い方を理解して、ワークフロー作成を始めましょう。',
-  'tour.nodePalette':
-    'ノードパレットには、ワークフローで使用できる様々なノードが用意されています。\n\nPrompt、Sub-Agent、AskUserQuestion、If/Else、Switchなどのノードをクリックしてキャンバスに追加できます。',
-  'tour.addPrompt':
-    'この「Prompt」ボタンから、Promptノードをキャンバスに追加できます。\n\nPromptノードは変数を使用できるテンプレートで、ワークフローの基本的な構成要素です。',
-  'tour.addSubAgent':
-    '「Sub-Agent」ノードは、特定のタスクを実行する専門のエージェントです。\n\nプロンプトとツール制限を設定して、単一の責務を持つエージェントを作成できます。',
-  'tour.addSubAgentFlow':
-    '「Sub-Agent Flow」は、複雑なSub-Agentの処理フローを視覚的に定義できます。\n\nMCPやSkillを並列実行したい場合は、各処理をSub-Agent Flowに内包し、それらのSub-Agent Flowを並列実行するフローを作成することで実現できます。',
-  'tour.addSkill':
-    '「Skill」ノードは、Claude Codeのスキルを呼び出します。\n\n個人用（~/.claude/skills/）またはプロジェクト用（.claude/skills/）のスキルを選択して実行できます。',
-  'tour.addMcp':
-    '「MCP Tool」ノードは、MCPサーバーのツールを実行します。\n\n外部サービスとの連携やカスタムツールの呼び出しに使用できます。',
-  'tour.addAskUserQuestion':
-    '「AskUserQuestion」ノードは、ユーザーの選択に応じてワークフローを分岐させるために使用します。\n\nこのボタンからキャンバスに追加できます。',
-  'tour.addEnd':
-    '「End」ノードは、ワークフローの終了点を示します。\n\n複数のEndノードを配置して、異なる結果に応じた終了点を設定できます。',
-  'tour.addIfElse':
-    '「If/Else」ノードは、条件に基づいてワークフローを2方向に分岐させます。\n\n真（True）または偽（False）の条件を設定して、処理の流れを制御できます。',
-  'tour.addSwitch':
-    '「Switch」ノードは、複数の条件に基づいてワークフローを多方向に分岐させます。\n\n複数のケースとデフォルトケースを設定して、複雑な分岐ロジックを実現できます。',
+    'CC Workflow Studioへようこそ！\n\nサンプルワークフローを使って、基本的な操作方法をご紹介します。',
   'tour.canvas':
-    'ここがキャンバスです。ノードをドラッグして配置を調整し、ハンドルをドラッグしてノード間を接続できます。\n\n既にStartノードとEndノードが配置されています。',
+    'これがワークフローのキャンバスです。ノードが接続されて処理フローを構成しています。\n\nノードをドラッグして移動、ハンドル(⚪)をドラッグしてノード間を接続できます。',
   'tour.propertyPanel':
-    'プロパティパネルでは、選択したノードの詳細設定を行います。\n\nノード名、プロンプト、モデル選択などを編集できます。',
-  'tour.connectNodes':
-    'ノードを接続してワークフローを作りましょう。\n\nノードの右側の出力ハンドル(⚪)を別のノードの左側の入力ハンドルにドラッグして接続します。',
-  'tour.workflowName':
-    'ここでワークフローに名前を付けることができます。\n\n英数字、ハイフン、アンダースコアが使用できます。',
-  'tour.saveWorkflow':
-    '「保存」ボタンをクリックすると、ワークフローが`.vscode/workflows/`ディレクトリにJSON形式で保存されます。\n\n後で読み込んで編集を続けることができます。',
-  'tour.loadWorkflow':
-    '保存したワークフローを読み込むには、ドロップダウンメニューからワークフローを選択し、「読み込み」ボタンをクリックします。',
-  'tour.exportWorkflow':
-    '「Convert」ボタンをクリックすると、ワークフローをSlash Command形式に変換できます。\n\n変換されたファイルは .claude/commands/ ディレクトリに保存されます。',
-  'tour.runSlashCommand':
-    '「Run」ボタンをクリックすると、ワークフローをSlash Commandに変換し、即座にClaude Codeで実行できます。\n\n変換と実行を一度に行えます。',
+    'ノードをクリックすると、プロパティパネルが表示されます。\n\nここでノード名、プロンプト、モデル選択などの詳細設定を行います。',
+  'tour.nodePalette':
+    'ノードパレットから、ワークフローにノードを追加できます。\n\nPrompt、Sub-Agent、Skill、MCP Tool、If/Else、Switchなど様々なノードが用意されています。',
+  'tour.toolbarActions':
+    'ツールバーからワークフローの保存・読み込み・変換・実行ができます。\n\n「Run」ボタンで、ワークフローをそのままClaude Codeで実行できます。',
   'tour.refineWithAI':
-    '「AI編集」ボタンで、AIとチャットしながらワークフローを生成・改善できます。\n\n空のキャンバスから新規作成も、既存のワークフローの修正も対話的に行えます。',
-  'tour.moreActions':
-    '「その他」メニューから追加の操作が利用できます：<br><br>• Claude API - ワークフローをClaude APIにアップロード<br>• Slackに共有 - チームとワークフローを共有<br>• リセット - キャンバスをクリア<br>• 集中モード - 集中編集モードの切り替え<br>• AIエージェント - 他のAIエージェントでワークフローを開く<br>• 最新情報 - 最新のアップデートを確認<br>• ヘルプ - このツアーを再表示<br><br>それでは、ワークフロー作成を楽しんでください！',
+    '「AI編集」ボタンで、AIにワークフローの生成や改善を依頼できます。\n\n空のキャンバスからの新規作成も、既存ワークフローの修正も対話的に行えます。',
+  'tour.finish':
+    'ツアーは以上です！\n\nこのサンプルを編集して試してみるか、リセットして新しく作成してみてください。\nツアーは「その他」メニューの「ヘルプ」からいつでも再表示できます。',
 
   // Tour buttons
   'tour.button.back': '戻る',
@@ -402,6 +374,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.finish': '完了',
   'tour.button.next': '次へ',
   'tour.button.skip': 'スキップ',
+  'tour.button.minimize': '最小化',
+  'tour.button.resume': 'ツアーを再開',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': 'ノードを削除',

--- a/src/webview/src/i18n/translations/ja.ts
+++ b/src/webview/src/i18n/translations/ja.ts
@@ -353,10 +353,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': 'の場合',
 
   // Tour
-  'tour.welcome':
-    'CC Workflow Studioへようこそ！\n\nサンプルワークフローを使って、基本的な操作方法をご紹介します。',
+  'tour.welcome': 'CC Workflow Studioへようこそ！\n\n基本的な操作方法をご紹介します。',
   'tour.canvas':
-    'これがワークフローのキャンバスです。ノードが接続されて処理フローを構成しています。\n\nノードをドラッグして移動、ハンドル(⚪)をドラッグしてノード間を接続できます。',
+    'これがワークフローのキャンバスです。ノードを配置し、接続して処理フローを作成します。\n\nノードをドラッグして移動、ハンドル(⚪)をドラッグしてノード間を接続できます。',
   'tour.propertyPanel':
     'ノードをクリックすると、プロパティパネルが表示されます。\n\nここでノード名、プロンプト、モデル選択などの詳細設定を行います。',
   'tour.nodePalette':
@@ -366,7 +365,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'tour.refineWithAI':
     '「AI編集」ボタンで、AIにワークフローの生成や改善を依頼できます。\n\n空のキャンバスからの新規作成も、既存ワークフローの修正も対話的に行えます。',
   'tour.finish':
-    'ツアーは以上です！\n\nこのサンプルを編集して試してみるか、リセットして新しく作成してみてください。\nツアーは「その他」メニューの「ヘルプ」からいつでも再表示できます。',
+    'ツアーは以上です！\n\nワークフローを自由に編集してみてください。\nツアーは「その他」メニューの「ヘルプ」からいつでも再表示できます。',
 
   // Tour buttons
   'tour.button.back': '戻る',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -353,10 +353,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': '이 충족될 때',
 
   // Tour
-  'tour.welcome':
-    'CC Workflow Studio에 오신 것을 환영합니다!\n\n샘플 워크플로우를 사용하여 기본 조작 방법을 소개합니다.',
+  'tour.welcome': 'CC Workflow Studio에 오신 것을 환영합니다!\n\n기본 조작 방법을 소개합니다.',
   'tour.canvas':
-    '워크플로우 캔버스입니다. 노드가 연결되어 처리 파이프라인을 구성합니다.\n\n노드를 드래그하여 이동하고 핸들(⚪)을 드래그하여 노드를 연결할 수 있습니다.',
+    '워크플로우 캔버스입니다. 노드를 배치하고 연결하여 처리 파이프라인을 만듭니다.\n\n노드를 드래그하여 이동하고 핸들(⚪)을 드래그하여 노드를 연결할 수 있습니다.',
   'tour.propertyPanel':
     '노드를 클릭하면 속성 패널이 표시됩니다.\n\n여기에서 노드 이름, 프롬프트, 모델 선택 등을 설정할 수 있습니다.',
   'tour.nodePalette':
@@ -366,7 +365,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'tour.refineWithAI':
     '"AI로 편집" 버튼으로 AI에게 워크플로우 생성이나 개선을 요청할 수 있습니다.\n\n빈 캔버스에서 새로 시작하거나 기존 워크플로우를 대화형으로 수정할 수 있습니다.',
   'tour.finish':
-    '투어가 끝났습니다!\n\n이 샘플을 편집하거나 초기화하여 새로 시작해 보세요.\n투어는 "더보기" 메뉴의 "도움말"에서 언제든 다시 볼 수 있습니다.',
+    '투어가 끝났습니다!\n\n워크플로우를 자유롭게 편집해 보세요.\n투어는 "더보기" 메뉴의 "도움말"에서 언제든 다시 볼 수 있습니다.',
 
   // Tour buttons
   'tour.button.back': '뒤로',

--- a/src/webview/src/i18n/translations/ko.ts
+++ b/src/webview/src/i18n/translations/ko.ts
@@ -354,47 +354,19 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Tour
   'tour.welcome':
-    'CC Workflow Studio에 오신 것을 환영합니다!\n\n이 투어에서는 주요 기능의 위치와 역할을 소개합니다. 첫 워크플로우를 만들기 전에 기본 사항을 익혀보세요.',
-  'tour.nodePalette':
-    '노드 팔레트에는 워크플로우에서 사용할 수 있는 다양한 노드가 있습니다.\n\nPrompt, Sub-Agent, AskUserQuestion, If/Else, Switch 등의 노드를 클릭하여 캔버스에 추가할 수 있습니다.',
-  'tour.addPrompt':
-    '이 "Prompt" 버튼으로 캔버스에 Prompt 노드를 추가할 수 있습니다.\n\nPrompt 노드는 변수를 지원하는 템플릿으로 워크플로우의 기본 구성 요소입니다.',
-  'tour.addSubAgent':
-    '"Sub-Agent" 노드는 특정 작업을 실행하는 전문 에이전트입니다.\n\n프롬프트와 도구 제한을 설정하여 단일 책임을 가진 에이전트를 만들 수 있습니다.',
-  'tour.addSubAgentFlow':
-    '"Sub-Agent Flow"는 복잡한 Sub-Agent 처리 흐름을 시각적으로 정의할 수 있습니다.\n\nMCP나 Skill을 병렬로 실행하려면 각 처리를 Sub-Agent Flow에 포함하고 해당 Sub-Agent Flow들을 병렬로 실행하는 흐름을 만들면 됩니다.',
-  'tour.addSkill':
-    '"Skill" 노드는 Claude Code 스킬을 호출합니다.\n\n개인용(~/.claude/skills/) 또는 프로젝트용(.claude/skills/) 스킬을 선택하여 실행할 수 있습니다.',
-  'tour.addMcp':
-    '"MCP Tool" 노드는 MCP 서버 도구를 실행합니다.\n\n외부 서비스 연동이나 커스텀 도구 호출에 사용할 수 있습니다.',
-  'tour.addAskUserQuestion':
-    '"AskUserQuestion" 노드는 사용자 선택에 따라 워크플로우를 분기하는 데 사용됩니다.\n\n이 버튼으로 캔버스에 추가할 수 있습니다.',
-  'tour.addEnd':
-    '"End" 노드는 워크플로우의 종료 지점을 나타냅니다.\n\n여러 End 노드를 배치하여 결과에 따른 다른 종료 지점을 설정할 수 있습니다.',
-  'tour.addIfElse':
-    '"If/Else" 노드는 조건에 따라 워크플로우를 두 방향으로 분기합니다.\n\n참(True) 또는 거짓(False) 조건을 설정하여 처리 흐름을 제어할 수 있습니다.',
-  'tour.addSwitch':
-    '"Switch" 노드는 여러 조건에 따라 워크플로우를 다방향으로 분기합니다.\n\n여러 케이스와 기본 케이스를 설정하여 복잡한 분기 로직을 구현할 수 있습니다.',
+    'CC Workflow Studio에 오신 것을 환영합니다!\n\n샘플 워크플로우를 사용하여 기본 조작 방법을 소개합니다.',
   'tour.canvas':
-    '여기가 캔버스입니다. 노드를 드래그하여 위치를 조정하고 핸들을 드래그하여 노드를 연결할 수 있습니다.\n\n시작 및 종료 노드가 이미 배치되어 있습니다.',
+    '워크플로우 캔버스입니다. 노드가 연결되어 처리 파이프라인을 구성합니다.\n\n노드를 드래그하여 이동하고 핸들(⚪)을 드래그하여 노드를 연결할 수 있습니다.',
   'tour.propertyPanel':
-    '속성 패널에서 선택한 노드를 구성할 수 있습니다.\n\n노드 이름, 프롬프트, 모델 선택 등을 편집할 수 있습니다.',
-  'tour.connectNodes':
-    '노드를 연결하여 워크플로우를 만드세요.\n\n노드 오른쪽의 출력 핸들(⚪)에서 다른 노드 왼쪽의 입력 핸들로 드래그하세요.',
-  'tour.workflowName':
-    '여기에서 워크플로우에 이름을 지정할 수 있습니다.\n\n문자, 숫자, 하이픈 및 밑줄을 사용할 수 있습니다.',
-  'tour.saveWorkflow':
-    '"저장" 버튼을 클릭하면 워크플로우가 `.vscode/workflows/` 디렉터리에 JSON으로 저장됩니다.\n\n나중에 로드하여 계속 편집할 수 있습니다.',
-  'tour.loadWorkflow':
-    '저장된 워크플로우를 로드하려면 드롭다운 메뉴에서 워크플로우를 선택하고 "불러오기" 버튼을 클릭하세요.',
-  'tour.exportWorkflow':
-    '"Convert" 버튼을 클릭하면 워크플로우를 Slash Command 형식으로 변환합니다.\n\n변환된 파일은 .claude/commands/ 디렉토리에 저장됩니다.',
-  'tour.runSlashCommand':
-    '"Run" 버튼을 클릭하면 워크플로우를 Slash Command로 변환하고 즉시 Claude Code에서 실행합니다.\n\n변환과 실행을 한 번에 수행합니다.',
+    '노드를 클릭하면 속성 패널이 표시됩니다.\n\n여기에서 노드 이름, 프롬프트, 모델 선택 등을 설정할 수 있습니다.',
+  'tour.nodePalette':
+    '노드 팔레트에서 워크플로우에 노드를 추가할 수 있습니다.\n\nPrompt, Sub-Agent, Skill, MCP Tool, If/Else, Switch 등 다양한 노드가 있습니다.',
+  'tour.toolbarActions':
+    '툴바에서 워크플로우의 저장, 로드, 변환, 실행이 가능합니다.\n\n"Run" 버튼으로 워크플로우를 바로 Claude Code에서 실행할 수 있습니다.',
   'tour.refineWithAI':
-    '"AI로 편집" 버튼을 사용하여 AI와 대화하며 워크플로우를 생성하거나 개선할 수 있습니다.\n\n빈 캔버스에서 시작하거나 기존 워크플로우를 대화형으로 수정할 수 있습니다.',
-  'tour.moreActions':
-    '"더보기" 메뉴에서 추가 작업을 사용할 수 있습니다:<br><br>• Claude API - 워크플로우를 Claude API에 업로드<br>• Slack에 공유 - 팀과 워크플로우 공유<br>• 초기화 - 캔버스 지우기<br>• 집중 모드 - 집중 편집 모드 전환<br>• AI 에이전트 - 다른 AI 에이전트에서 워크플로우 열기<br>• 새소식 - 최신 업데이트 확인<br>• 도움말 - 이 투어 다시 보기<br><br>워크플로우 생성을 즐기세요!',
+    '"AI로 편집" 버튼으로 AI에게 워크플로우 생성이나 개선을 요청할 수 있습니다.\n\n빈 캔버스에서 새로 시작하거나 기존 워크플로우를 대화형으로 수정할 수 있습니다.',
+  'tour.finish':
+    '투어가 끝났습니다!\n\n이 샘플을 편집하거나 초기화하여 새로 시작해 보세요.\n투어는 "더보기" 메뉴의 "도움말"에서 언제든 다시 볼 수 있습니다.',
 
   // Tour buttons
   'tour.button.back': '뒤로',
@@ -402,6 +374,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.finish': '완료',
   'tour.button.next': '다음',
   'tour.button.skip': '건너뛰기',
+  'tour.button.minimize': '최소화',
+  'tour.button.resume': '투어 재개',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '노드 삭제',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -343,43 +343,18 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' 时',
 
   // Tour
-  'tour.welcome':
-    '欢迎使用CC Workflow Studio！\n\n本导览将介绍主要功能的位置和作用。在创建第一个工作流之前，让我们先熟悉基础知识。',
+  'tour.welcome': '欢迎使用CC Workflow Studio！\n\n使用示例工作流来介绍基本操作方法。',
+  'tour.canvas':
+    '这是工作流画布。节点连接形成处理流水线。\n\n拖动节点移动位置，拖动手柄(⚪)连接节点。',
+  'tour.propertyPanel': '点击节点会显示属性面板。\n\n在这里可以设置节点名称、提示、模型选择等。',
   'tour.nodePalette':
-    '节点面板包含可在工作流中使用的各种节点。\n\n点击Prompt、Sub-Agent、AskUserQuestion、If/Else、Switch等节点将其添加到画布。',
-  'tour.addPrompt':
-    '这个"Prompt"按钮可以将Prompt节点添加到画布。\n\nPrompt节点是支持变量的模板，是工作流的基本构建块。',
-  'tour.addSubAgent':
-    '"Sub-Agent"节点是执行特定任务的专业代理。\n\n配置提示和工具限制，创建具有单一职责的代理。',
-  'tour.addSubAgentFlow':
-    '「Sub-Agent Flow」可以可视化定义复杂的Sub-Agent处理流程。\n\n如果您想并行执行MCP或Skill，可以将各处理包含在Sub-Agent Flow中，然后创建并行执行这些Sub-Agent Flow的工作流来实现。',
-  'tour.addSkill':
-    '"Skill"节点调用Claude Code技能。\n\n可以选择并执行个人用（~/.claude/skills/）或项目用（.claude/skills/）的技能。',
-  'tour.addMcp': '"MCP Tool"节点执行MCP服务器工具。\n\n可用于外部服务集成或自定义工具调用。',
-  'tour.addAskUserQuestion':
-    '"AskUserQuestion"节点用于根据用户选择分支工作流。\n\n可以使用此按钮将其添加到画布。',
-  'tour.addEnd':
-    '"End"节点表示工作流的结束点。\n\n可以放置多个End节点，根据不同结果设置不同的结束点。',
-  'tour.addIfElse':
-    '"If/Else"节点根据条件将工作流分成两个方向。\n\n设置真（True）或假（False）条件来控制处理流程。',
-  'tour.addSwitch':
-    '"Switch"节点根据多个条件将工作流分成多个方向。\n\n设置多个案例和默认案例来实现复杂的分支逻辑。',
-  'tour.canvas': '这是画布。拖动节点调整位置，拖动手柄连接节点。\n\n已经放置了开始和结束节点。',
-  'tour.propertyPanel': '属性面板可以配置所选节点。\n\n您可以编辑节点名称、提示、模型选择等。',
-  'tour.connectNodes':
-    '连接节点以创建工作流。\n\n从节点右侧的输出手柄(⚪)拖动到另一个节点左侧的输入手柄。',
-  'tour.workflowName': '在这里可以为工作流命名。\n\n可以使用字母、数字、连字符和下划线。',
-  'tour.saveWorkflow':
-    '点击"保存"按钮将工作流以JSON格式保存到`.vscode/workflows/`目录。\n\n稍后可以加载并继续编辑。',
-  'tour.loadWorkflow': '要加载已保存的工作流，请从下拉菜单中选择工作流并点击"加载"按钮。',
-  'tour.exportWorkflow':
-    '点击"Convert"按钮可将工作流转换为Slash Command格式。\n\n转换后的文件保存在.claude/commands/目录中。',
-  'tour.runSlashCommand':
-    '点击"Run"按钮可将工作流转换为Slash Command并立即在Claude Code中执行。\n\n一键完成转换和执行。',
+    '从节点面板添加节点到工作流。\n\nPrompt、Sub-Agent、Skill、MCP Tool、If/Else、Switch等多种节点可供使用。',
+  'tour.toolbarActions':
+    '从工具栏保存、加载、转换和运行工作流。\n\n"Run"按钮可直接在Claude Code中执行工作流。',
   'tour.refineWithAI':
-    '使用"AI编辑"按钮通过与AI对话创建或改进工作流。\n\n可以从空画布开始或以对话方式编辑现有工作流。',
-  'tour.moreActions':
-    '"更多"菜单提供以下功能：<br><br>• Claude API - 将工作流上传到Claude API<br>• 分享到Slack - 与团队分享工作流<br>• 重置 - 清空画布<br>• 专注模式 - 切换无干扰编辑模式<br>• AI代理 - 在其他AI代理中打开工作流<br>• 最新动态 - 查看最新更新<br>• 帮助 - 再次查看此导览<br><br>享受创建工作流的乐趣！',
+    '使用"AI编辑"按钮请求AI生成或改进工作流。\n\n可以从空画布开始或以对话方式编辑现有工作流。',
+  'tour.finish':
+    '导览结束！\n\n试着编辑此示例，或重置后从头开始。\n可以随时从"更多"菜单的"帮助"重新查看导览。',
 
   // Tour buttons
   'tour.button.back': '返回',
@@ -387,6 +362,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.finish': '完成',
   'tour.button.next': '下一步',
   'tour.button.skip': '跳过',
+  'tour.button.minimize': '最小化',
+  'tour.button.resume': '继续导览',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '删除节点',

--- a/src/webview/src/i18n/translations/zh-CN.ts
+++ b/src/webview/src/i18n/translations/zh-CN.ts
@@ -343,9 +343,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' 时',
 
   // Tour
-  'tour.welcome': '欢迎使用CC Workflow Studio！\n\n使用示例工作流来介绍基本操作方法。',
+  'tour.welcome': '欢迎使用CC Workflow Studio！\n\n为您介绍基本操作方法。',
   'tour.canvas':
-    '这是工作流画布。节点连接形成处理流水线。\n\n拖动节点移动位置，拖动手柄(⚪)连接节点。',
+    '这是工作流画布。放置节点并连接它们来构建处理流水线。\n\n拖动节点移动位置，拖动手柄(⚪)连接节点。',
   'tour.propertyPanel': '点击节点会显示属性面板。\n\n在这里可以设置节点名称、提示、模型选择等。',
   'tour.nodePalette':
     '从节点面板添加节点到工作流。\n\nPrompt、Sub-Agent、Skill、MCP Tool、If/Else、Switch等多种节点可供使用。',
@@ -353,8 +353,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
     '从工具栏保存、加载、转换和运行工作流。\n\n"Run"按钮可直接在Claude Code中执行工作流。',
   'tour.refineWithAI':
     '使用"AI编辑"按钮请求AI生成或改进工作流。\n\n可以从空画布开始或以对话方式编辑现有工作流。',
-  'tour.finish':
-    '导览结束！\n\n试着编辑此示例，或重置后从头开始。\n可以随时从"更多"菜单的"帮助"重新查看导览。',
+  'tour.finish': '导览结束！\n\n请自由编辑您的工作流。\n可以随时从"更多"菜单的"帮助"重新查看导览。',
 
   // Tour buttons
   'tour.button.back': '返回',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -343,9 +343,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' 時',
 
   // Tour
-  'tour.welcome': '歡迎使用CC Workflow Studio！\n\n使用範例工作流程來介紹基本操作方法。',
+  'tour.welcome': '歡迎使用CC Workflow Studio！\n\n為您介紹基本操作方法。',
   'tour.canvas':
-    '這是工作流程畫布。節點連接形成處理管線。\n\n拖曳節點移動位置，拖曳手柄(⚪)連接節點。',
+    '這是工作流程畫布。放置節點並連接它們來建立處理管線。\n\n拖曳節點移動位置，拖曳手柄(⚪)連接節點。',
   'tour.propertyPanel': '點擊節點會顯示屬性面板。\n\n在這裡可以設定節點名稱、提示、模型選擇等。',
   'tour.nodePalette':
     '從節點面板新增節點到工作流程。\n\nPrompt、Sub-Agent、Skill、MCP Tool、If/Else、Switch等多種節點可供使用。',
@@ -354,7 +354,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'tour.refineWithAI':
     '使用「AI編輯」按鈕請求AI生成或改善工作流程。\n\n可以從空白畫布開始或以對話方式編輯現有工作流程。',
   'tour.finish':
-    '導覽結束！\n\n試著編輯此範例，或重置後從頭開始。\n可以隨時從「更多」選單的「說明」重新查看導覽。',
+    '導覽結束！\n\n請自由編輯您的工作流程。\n可以隨時從「更多」選單的「說明」重新查看導覽。',
 
   // Tour buttons
   'tour.button.back': '返回',

--- a/src/webview/src/i18n/translations/zh-TW.ts
+++ b/src/webview/src/i18n/translations/zh-TW.ts
@@ -343,43 +343,18 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'default.conditionSuffix': ' 時',
 
   // Tour
-  'tour.welcome':
-    '歡迎使用CC Workflow Studio！\n\n本導覽將介紹主要功能的位置和作用。在建立第一個工作流程之前，讓我們先熟悉基礎知識。',
+  'tour.welcome': '歡迎使用CC Workflow Studio！\n\n使用範例工作流程來介紹基本操作方法。',
+  'tour.canvas':
+    '這是工作流程畫布。節點連接形成處理管線。\n\n拖曳節點移動位置，拖曳手柄(⚪)連接節點。',
+  'tour.propertyPanel': '點擊節點會顯示屬性面板。\n\n在這裡可以設定節點名稱、提示、模型選擇等。',
   'tour.nodePalette':
-    '節點面板包含可在工作流程中使用的各種節點。\n\n點擊Prompt、Sub-Agent、AskUserQuestion、If/Else、Switch等節點將其新增到畫布。',
-  'tour.addPrompt':
-    '這個「Prompt」按鈕可以將Prompt節點新增到畫布。\n\nPrompt節點是支援變數的範本，是工作流程的基本建置區塊。',
-  'tour.addSubAgent':
-    '「Sub-Agent」節點是執行特定任務的專業代理。\n\n配置提示和工具限制，建立具有單一職責的代理。',
-  'tour.addSubAgentFlow':
-    '「Sub-Agent Flow」可以視覺化定義複雜的Sub-Agent處理流程。\n\n如果您想並行執行MCP或Skill，可以將各處理包含在Sub-Agent Flow中，然後建立並行執行這些Sub-Agent Flow的工作流程來實現。',
-  'tour.addSkill':
-    '「Skill」節點呼叫Claude Code技能。\n\n可以選擇並執行個人用（~/.claude/skills/）或專案用（.claude/skills/）的技能。',
-  'tour.addMcp': '「MCP Tool」節點執行MCP伺服器工具。\n\n可用於外部服務整合或自訂工具呼叫。',
-  'tour.addAskUserQuestion':
-    '「AskUserQuestion」節點用於根據使用者選擇分支工作流程。\n\n可以使用此按鈕將其新增到畫布。',
-  'tour.addEnd':
-    '「End」節點表示工作流程的結束點。\n\n可以放置多個End節點，根據不同結果設定不同的結束點。',
-  'tour.addIfElse':
-    '「If/Else」節點根據條件將工作流程分成兩個方向。\n\n設定真（True）或假（False）條件來控制處理流程。',
-  'tour.addSwitch':
-    '「Switch」節點根據多個條件將工作流程分成多個方向。\n\n設定多個案例和預設案例來實現複雜的分支邏輯。',
-  'tour.canvas': '這是畫布。拖曳節點調整位置，拖曳手柄連接節點。\n\n已經放置了開始和結束節點。',
-  'tour.propertyPanel': '屬性面板可以設定所選節點。\n\n您可以編輯節點名稱、提示、模型選擇等。',
-  'tour.connectNodes':
-    '連接節點以建立工作流程。\n\n從節點右側的輸出手柄(⚪)拖曳到另一個節點左側的輸入手柄。',
-  'tour.workflowName': '在這裡可以為工作流程命名。\n\n可以使用字母、數字、連字號和底線。',
-  'tour.saveWorkflow':
-    '點擊「儲存」按鈕將工作流程以JSON格式儲存到`.vscode/workflows/`目錄。\n\n稍後可以載入並繼續編輯。',
-  'tour.loadWorkflow': '要載入已儲存的工作流程，請從下拉選單中選擇工作流程並點擊「載入」按鈕。',
-  'tour.exportWorkflow':
-    '點擊「Convert」按鈕可將工作流程轉換為Slash Command格式。\n\n轉換後的檔案儲存在.claude/commands/目錄中。',
-  'tour.runSlashCommand':
-    '點擊「Run」按鈕可將工作流程轉換為Slash Command並立即在Claude Code中執行。\n\n一鍵完成轉換和執行。',
+    '從節點面板新增節點到工作流程。\n\nPrompt、Sub-Agent、Skill、MCP Tool、If/Else、Switch等多種節點可供使用。',
+  'tour.toolbarActions':
+    '從工具列儲存、載入、轉換和執行工作流程。\n\n「Run」按鈕可直接在Claude Code中執行工作流程。',
   'tour.refineWithAI':
-    '使用「AI編輯」按鈕透過與AI對話建立或改善工作流程。\n\n可以從空白畫布開始或以對話方式編輯現有工作流程。',
-  'tour.moreActions':
-    '「更多」選單提供以下功能：<br><br>• Claude API - 將工作流程上傳到Claude API<br>• 分享到Slack - 與團隊分享工作流程<br>• 重置 - 清空畫布<br>• 專注模式 - 切換無干擾編輯模式<br>• AI代理 - 在其他AI代理中開啟工作流程<br>• 最新消息 - 檢視最新更新<br>• 說明 - 再次檢視此導覽<br><br>享受建立工作流程的樂趣！',
+    '使用「AI編輯」按鈕請求AI生成或改善工作流程。\n\n可以從空白畫布開始或以對話方式編輯現有工作流程。',
+  'tour.finish':
+    '導覽結束！\n\n試著編輯此範例，或重置後從頭開始。\n可以隨時從「更多」選單的「說明」重新查看導覽。',
 
   // Tour buttons
   'tour.button.back': '返回',
@@ -387,6 +362,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'tour.button.finish': '完成',
   'tour.button.next': '下一步',
   'tour.button.skip': '略過',
+  'tour.button.minimize': '最小化',
+  'tour.button.resume': '繼續導覽',
 
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '刪除節點',

--- a/src/webview/src/styles/main.css
+++ b/src/webview/src/styles/main.css
@@ -193,6 +193,11 @@ button {
   z-index: 10000;
 }
 
+/* Shift minimap up when tour floating button is visible */
+body.tour-floating-visible .react-flow__panel.bottom.right {
+  bottom: 24px !important;
+}
+
 /* ============================================================================
    Highlight Toggle Button Pulse Animation
    Synced with GroupNode's highlightPulse to visually connect the two


### PR DESCRIPTION
## Summary

Redesign the onboarding tour from 22 steps to 7 focused steps using the sample workflow as teaching context, and add an empty state dialog when no workflow is loaded.

## Motivation

- The existing 22-step tour was too verbose, pointing at each UI element one by one ("見ればわかる" - self-explanatory)
- The sample workflow was loaded without explanation on first launch, and subsequent launches showed an empty canvas with no guidance
- Users needed a way to interact with the UI during the tour without the popover blocking them

## Changes

**New Files:**
- `src/webview/src/components/EmptyState.tsx` - Empty state dialog with New / Load / Sample Workflow actions using Radix UI Dialog

**Modified Files:**
- `src/webview/src/constants/tour-steps.ts` - Reduced from 22 to 7 steps; `allowClose: false` for custom control
- `src/webview/src/components/Tour.tsx` - Added minimize/resume (destroy + drive(index)), custom close/minimize buttons via DOM injection, click-outside-to-minimize
- `src/webview/src/components/WorkflowEditor.tsx` - Integrated EmptyState overlay on canvas
- `src/webview/src/App.tsx` - Empty canvas detection logic, callbacks for empty state actions
- `src/webview/src/components/Toolbar.tsx` - Added `data-tour="toolbar-actions"` attribute
- `src/webview/src/styles/main.css` - Minimap shift when tour floating button is visible
- `src/webview/src/i18n/translation-keys.ts` - Updated tour keys (removed 16, added 4)
- `src/webview/src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` - Updated tour translations for all 5 languages

## Tour Steps (New)

| # | Highlight | Content |
|---|-----------|---------|
| 1 | — | Welcome with sample workflow |
| 2 | Canvas | Drag nodes, connect via handles |
| 3 | Property Panel | Click node to configure |
| 4 | Node Palette | Add nodes (all types) |
| 5 | Toolbar | Save / Load / Convert / Run |
| 6 | AI Refine | Generate or improve with AI |
| 7 | — | Finish message |

## Testing

- [x] Manual E2E testing completed
- [x] Tour: 7 steps work correctly with sample workflow
- [x] Tour minimize: click (−) or outside popover → floating resume button
- [x] Tour resume: click resume button → same step restored
- [x] Tour close: click (×) → tour ends
- [x] Empty state: shows on empty canvas with 3 actions
- [x] Empty state: dismissed on "New", reappears after workflow reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an empty-state dialog for new workflows (start from scratch, load, or open a sample) with persistence/dismiss behavior and a load action that opens the file picker.
  * Workflow editor now shows the empty-state overlay when appropriate.

* **New Features — Onboarding**
  * Redesigned tour into a condensed 7-step flow with minimize/resume controls and click-outside-to-minimize behavior; resume button floats when minimized.

* **Localization**
  * Simplified and consolidated tour copy across languages; added minimize/resume labels.

* **Style**
  * Adjusted layout to avoid the tour resume button overlapping the minimap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->