### PR TITLE
improvement: allow edge selection inside group nodes and animate on select

### DIFF
--- a/src/webview/src/components/NodePalette.tsx
+++ b/src/webview/src/components/NodePalette.tsx
@@ -117,6 +117,9 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       id: `group-${Date.now()}`,
       type: 'group' as const,
       position,
+      // Place group below edge SVG layer (z-index: 0) so edges inside groups remain clickable.
+      // React Flow adds +1000 to selected nodes, so -1001 keeps selected groups at -1 (still below edges).
+      zIndex: -1001,
       data: {
         label: 'Group',
       },

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -169,7 +169,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
 
     const hasHighlight = highlightedGroupNodeId != null;
     const hasSelection = isEdgeAnimationEnabled && selectedNodeId != null;
-    if (!hasHighlight && !hasSelection) return edges;
+    const hasSelectedEdge = isEdgeAnimationEnabled && edges.some((e) => e.selected);
+    if (!hasHighlight && !hasSelection && !hasSelectedEdge) return edges;
 
     return edges.map((edge) => {
       const isHighlightAnimated =
@@ -180,12 +181,12 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             (highlightChildIds.has(edge.source) || highlightChildIds.has(edge.target))));
 
       const isSelectionAnimated =
-        hasSelection &&
-        (edge.selected ||
-          edge.source === selectedNodeId ||
-          edge.target === selectedNodeId ||
-          (selectionChildIds != null &&
-            (selectionChildIds.has(edge.source) || selectionChildIds.has(edge.target))));
+        (isEdgeAnimationEnabled && edge.selected) ||
+        (hasSelection &&
+          (edge.source === selectedNodeId ||
+            edge.target === selectedNodeId ||
+            (selectionChildIds != null &&
+              (selectionChildIds.has(edge.source) || selectionChildIds.has(edge.target)))));
 
       return { ...edge, animated: isHighlightAnimated || isSelectionAnimated };
     });

--- a/src/webview/src/stores/workflow-store.ts
+++ b/src/webview/src/stores/workflow-store.ts
@@ -823,6 +823,8 @@ export const useWorkflowStore = create<WorkflowStore>()(
             data: node.type === 'mcp' ? normalizeMcpNodeData(node.data as McpNodeData) : node.data,
             ...(node.parentId && { parentId: node.parentId }),
             ...(node.style && { style: node.style }),
+            // Keep group below edge SVG layer so edges inside groups remain clickable (selected: -1001+1000=-1 < edge:0)
+            ...(node.type === 'group' && { zIndex: -1001 }),
           }))
         );
 
@@ -868,6 +870,8 @@ export const useWorkflowStore = create<WorkflowStore>()(
             data: node.type === 'mcp' ? normalizeMcpNodeData(node.data as McpNodeData) : node.data,
             ...(node.parentId && { parentId: node.parentId }),
             ...(node.style && { style: node.style }),
+            // Keep group below edge SVG layer so edges inside groups remain clickable (selected: -1001+1000=-1 < edge:0)
+            ...(node.type === 'group' && { zIndex: -1001 }),
           }))
         );
 
@@ -905,6 +909,8 @@ export const useWorkflowStore = create<WorkflowStore>()(
             data: node.data,
             ...(node.parentId && { parentId: node.parentId }),
             ...(node.style && { style: node.style }),
+            // Keep group below edge SVG layer so edges inside groups remain clickable (selected: -1001+1000=-1 < edge:0)
+            ...(node.type === 'group' && { zIndex: -1001 }),
           }))
         );
 


### PR DESCRIPTION
## Summary

Improve edge interaction inside group nodes and add selection animation for edges.

## What Changed

### Before
- Clicking an edge inside a group node selected the group instead of the edge
- Selecting an edge directly did not trigger animation

### After
- Edges inside group nodes are now clickable and selectable
- Selecting an edge directly triggers the flow animation

## Changes

- `src/webview/src/components/NodePalette.tsx` - Set group node zIndex to -1001 on creation
- `src/webview/src/stores/workflow-store.ts` - Set group node zIndex to -1001 on deserialization (3 paths)
- `src/webview/src/components/WorkflowEditor.tsx` - Move edge.selected check outside hasSelection guard for direct edge animation

## Testing

- [x] Manual E2E testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed group nodes rendering order so edges within groups remain properly interactive and clickable.
  * Improved edge animation responsiveness with more accurate selection state detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->