### PR TITLE
refactor: rename EmptyState component to StartMenu

### DIFF
--- a/src/webview/src/components/StartMenu.tsx
+++ b/src/webview/src/components/StartMenu.tsx
@@ -1,5 +1,5 @@
 /**
- * Empty State Component
+ * Start Menu Component
  *
  * Displayed on the canvas when no workflow is loaded (only Start/End nodes).
  * Provides quick actions to get started.
@@ -10,7 +10,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { FileDown, FolderOpen, Plus } from 'lucide-react';
 import type React from 'react';
 
-interface EmptyStateProps {
+interface StartMenuProps {
   isOpen: boolean;
   onOpenSample: () => void;
   onStartFromScratch: () => void;
@@ -33,7 +33,7 @@ const buttonStyle: React.CSSProperties = {
   transition: 'background-color 0.15s',
 };
 
-export const EmptyState: React.FC<EmptyStateProps> = ({
+export const StartMenu: React.FC<StartMenuProps> = ({
   isOpen,
   onOpenSample,
   onStartFromScratch,

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -29,7 +29,6 @@ import { useWorkflowStore } from '../stores/workflow-store';
 import { CanvasToolbar } from './CanvasToolbar';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
 import { DescriptionPanel } from './DescriptionPanel';
-import { EmptyState } from './EmptyState';
 // Custom edge with delete button
 import { DeletableEdge } from './edges/DeletableEdge';
 import { MinimapContainer } from './MinimapContainer';
@@ -47,6 +46,7 @@ import { StartNode } from './nodes/StartNode';
 import { SubAgentFlowNodeComponent } from './nodes/SubAgentFlowNode';
 import { SubAgentNodeComponent } from './nodes/SubAgentNode';
 import { SwitchNodeComponent } from './nodes/SwitchNode';
+import { StartMenu } from './StartMenu';
 
 /**
  * Node types registration (memoized outside component for performance)
@@ -534,7 +534,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           )}
         </ReactFlow>
         {onOpenSample && onDismissEmptyState && onLoadWorkflow && (
-          <EmptyState
+          <StartMenu
             isOpen={showEmptyState}
             onOpenSample={onOpenSample}
             onStartFromScratch={onDismissEmptyState}


### PR DESCRIPTION
## Summary

Rename the `EmptyState` component to `StartMenu` for clarity — it's the startup menu, not an empty state indicator.

## What Changed

### Before
- Component named `EmptyState` — unclear purpose from the name alone

### After
- Component named `StartMenu` — directly describes its role as the startup action menu

## Changes

- `src/webview/src/components/EmptyState.tsx` → `StartMenu.tsx` - File rename, component name, props type, JSDoc
- `src/webview/src/components/WorkflowEditor.tsx` - Updated import and JSX reference

## Testing

- [x] `npm run check` passed
- [x] `npm run build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal component structure reorganized for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->