### PR TITLE
chore: npm audit fix for axios vulnerabilities

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,7 @@
   "mcpServers": {
     "atlassian": {
       "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.atlassian.com/v1/sse"
-      ]
+      "args": ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/sse"]
     },
     "cc-workflow-studio": {
       "type": "http",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,14 +2115,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -7104,10 +7104,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",


### PR DESCRIPTION
## Summary
- Run `npm audit fix` to resolve 2 Snyk code scanning alerts on axios
- Format `.mcp.json` (auto-formatted by biome)

## Details
| Alert | Severity | Rule |
|-------|----------|------|
| #21 | Critical | SNYK-JS-AXIOS-15965856 |
| #22 | High | SNYK-JS-AXIOS-15969258 |

- axios upgraded from 1.13.5 → 1.15.0 (transitive dependency via `@slack/web-api`)
- No direct dependency changes in `package.json`

## Test plan
- [x] `npm run check` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code formatting improvements for configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->