### PR TITLE
chore: add biome-ignore for intentional !important in tour styles

### DIFF
--- a/src/webview/src/styles/main.css
+++ b/src/webview/src/styles/main.css
@@ -193,8 +193,10 @@ button {
   z-index: 10000;
 }
 
-/* Shift minimap up when tour floating button is visible */
+/* Shift minimap up when tour floating button is visible.
+   !important is required to override React Flow's inline styles on .react-flow__panel */
 body.tour-floating-visible .react-flow__panel.bottom.right {
+  /* biome-ignore lint/complexity/noImportantStyles: React Flow applies inline styles that can only be overridden with !important */
   bottom: 24px !important;
 }
 


### PR DESCRIPTION
## Summary

- Suppress `noImportantStyles` Biome warning in `npm run check` by adding a `biome-ignore` inline comment
- React Flow applies inline styles on `.react-flow__panel`, so `!important` is required to override them (intentionally introduced in PR #723)

### Changes

**File**: `src/webview/src/styles/main.css`

- Added `biome-ignore lint/complexity/noImportantStyles` with explanation
- Updated existing comment to document why `!important` is necessary

## Impact

- `npm run check` now passes with zero warnings
- No runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved styling documentation and lint configuration for better code maintainability. No visible changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->