### PR TITLE
chore: fix TS deprecation warnings and remove redundant activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
     }
   },
   "activationEvents": [
-    "onUri",
-    "onCustomEditor:cc-wf-studio.workflowPreview"
+    "onUri"
   ],
   "scripts": {
     "vscode:prepublish": "npm run build",

--- a/src/webview/tsconfig.json
+++ b/src/webview/tsconfig.json
@@ -15,7 +15,6 @@
     "jsx": "react-jsx",
 
     /* Path mapping */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../shared/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary

Fix TypeScript 7.0 deprecation warnings and remove a redundant VSCode activation event.

## What Changed

### Before
- `moduleResolution: "node"` (node10) triggers TS 7.0 deprecation warning
- `baseUrl: "."` in webview tsconfig triggers TS 7.0 deprecation warning
- `onCustomEditor:cc-wf-studio.workflowPreview` manually declared despite being auto-generated from `contributes.customEditors`

### After
- `moduleResolution: "bundler"` — correct for Vite-bundled projects, future-proof for TS 7.0
- `baseUrl` removed — `paths` works without it since TS 4.1
- Redundant activation event removed — VSCode auto-generates it from package.json contributions

## Changes

- `tsconfig.json` — Change `moduleResolution` from `"node"` to `"bundler"`
- `src/webview/tsconfig.json` — Remove deprecated `baseUrl` option
- `package.json` — Remove redundant `onCustomEditor` activation event

## Testing

- [x] `npm run check` passed
- [x] `npm run build` passed (extension + webview)
- [x] VSCode deprecation warnings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension activation configuration to streamline initialization flow
  * Updated TypeScript compiler settings to improve module resolution and path handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->