### PR TITLE
feat: enhance StartMenu with version display and recent workflows

### DIFF
--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -13,6 +13,7 @@ import type {
   GetCurrentWorkflowResponsePayload,
   LaunchAiAgentPayload,
   McpConfigTarget,
+  RecentWorkflowItem,
   RunAiEditingSkillPayload,
   SetReviewBeforeApplyPayload,
   StartMcpServerPayload,
@@ -125,6 +126,48 @@ export interface ImportParameters {
   workflowId: string;
   /** Workspace name for display in error dialogs (decoded from Base64) */
   workspaceName?: string;
+}
+
+const MAX_RECENT_WORKFLOWS = 10;
+
+async function addRecentWorkflow(
+  context: vscode.ExtensionContext,
+  workflowId: string
+): Promise<void> {
+  const recent = context.globalState.get<string[]>('recentWorkflows', []);
+  const updated = [workflowId, ...recent.filter((id) => id !== workflowId)].slice(
+    0,
+    MAX_RECENT_WORKFLOWS
+  );
+  await context.globalState.update('recentWorkflows', updated);
+}
+
+async function loadRecentWorkflows(
+  context: vscode.ExtensionContext,
+  fileService: FileService
+): Promise<RecentWorkflowItem[]> {
+  const recentIds = context.globalState.get<string[]>('recentWorkflows', []);
+  const items: RecentWorkflowItem[] = [];
+  const validIds: string[] = [];
+
+  for (const id of recentIds) {
+    try {
+      const filePath = fileService.getWorkflowFilePath(id);
+      const content = await fileService.readFile(filePath);
+      const workflow = JSON.parse(content);
+      items.push({ id, name: workflow.name || id });
+      validIds.push(id);
+    } catch {
+      // File no longer exists - skip
+    }
+  }
+
+  // Clean up stale entries
+  if (validIds.length !== recentIds.length) {
+    await context.globalState.update('recentWorkflows', validIds);
+  }
+
+  return items;
 }
 
 /**
@@ -351,6 +394,7 @@ export function registerOpenEditorCommand(
               const extensionPkg = require(
                 vscode.Uri.joinPath(vscode.Uri.file(context.extensionPath), 'package.json').fsPath
               );
+              const recentWorkflows = await loadRecentWorkflows(context, fileService);
               webview.postMessage({
                 type: 'INITIAL_STATE',
                 payload: {
@@ -358,6 +402,7 @@ export function registerOpenEditorCommand(
                   unreadReleaseCount: showWhatsNewBadge ? unreadReleaseCount : 0,
                   showWhatsNewBadge,
                   extensionVersion: extensionPkg.version ?? '',
+                  recentWorkflows,
                 },
               });
 
@@ -386,6 +431,8 @@ export function registerOpenEditorCommand(
                   message.payload.workflow,
                   message.requestId
                 );
+                // Record in recent workflows
+                await addRecentWorkflow(context, message.payload.workflow.name);
                 // Update MCP server workflow cache
                 const saveManager = getMcpServerManager();
                 if (saveManager) {
@@ -961,6 +1008,8 @@ export function registerOpenEditorCommand(
                   message.payload.workflowId,
                   message.requestId
                 );
+                // Record in recent workflows
+                await addRecentWorkflow(context, message.payload.workflowId);
               } else {
                 webview.postMessage({
                   type: 'ERROR',
@@ -1056,6 +1105,11 @@ export function registerOpenEditorCommand(
                   requestId: message.requestId,
                   payload: { workflow },
                 });
+
+                // Record in recent workflows
+                if (workflow.name) {
+                  await addRecentWorkflow(context, workflow.name);
+                }
 
                 console.log(`Workflow loaded from file picker: ${filePath}`);
               } catch (error) {

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -6,6 +6,7 @@
  */
 
 import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type {
   AiEditingProvider,
@@ -1106,10 +1107,10 @@ export function registerOpenEditorCommand(
                   payload: { workflow },
                 });
 
-                // Record in recent workflows
-                if (workflow.name) {
-                  await addRecentWorkflow(context, workflow.name);
-                }
+                // Record in recent workflows (use filename as canonical ID
+                // to match getWorkflowFilePath resolution)
+                const workflowId = path.basename(filePath, '.json');
+                await addRecentWorkflow(context, workflowId);
 
                 console.log(`Workflow loaded from file picker: ${filePath}`);
               } catch (error) {

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -348,12 +348,16 @@ export function registerOpenEditorCommand(
               // Webview is fully initialized and ready to receive messages
               // This is more reliable than setTimeout (fixes Issue #396)
               const showWhatsNewBadge = context.globalState.get<boolean>('showWhatsNewBadge', true);
+              const extensionPkg = require(
+                vscode.Uri.joinPath(vscode.Uri.file(context.extensionPath), 'package.json').fsPath
+              );
               webview.postMessage({
                 type: 'INITIAL_STATE',
                 payload: {
                   isFirstTimeUser,
                   unreadReleaseCount: showWhatsNewBadge ? unreadReleaseCount : 0,
                   showWhatsNewBadge,
+                  extensionVersion: extensionPkg.version ?? '',
                 },
               });
 

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -56,6 +56,7 @@ export interface InitialStatePayload {
   isFirstTimeUser: boolean;
   unreadReleaseCount: number;
   showWhatsNewBadge: boolean;
+  extensionVersion: string;
 }
 
 // ============================================================================

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -52,11 +52,17 @@ export interface WorkflowListPayload {
   }>;
 }
 
+export interface RecentWorkflowItem {
+  id: string;
+  name: string;
+}
+
 export interface InitialStatePayload {
   isFirstTimeUser: boolean;
   unreadReleaseCount: number;
   showWhatsNewBadge: boolean;
   extensionVersion: string;
+  recentWorkflows?: RecentWorkflowItem[];
 }
 
 // ============================================================================

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -207,6 +207,7 @@ const App: React.FC = () => {
   const pendingTourAfterSampleLoadRef = useRef(false);
   const [unreadReleaseCount, setUnreadReleaseCount] = useState(0);
   const [extensionVersion, setExtensionVersion] = useState('');
+  const [recentWorkflows, setRecentWorkflows] = useState<Array<{ id: string; name: string }>>([]);
   const [showWhatsNewBadge, setShowWhatsNewBadge] = useState(true);
   const [showMcpRefreshDialog, setShowMcpRefreshDialog] = useState(false);
   const [mcpRefreshSkillName, setMcpRefreshSkillName] = useState<string>('cc-workflow-ai-editor');
@@ -383,6 +384,7 @@ const App: React.FC = () => {
         setUnreadReleaseCount(payload.unreadReleaseCount ?? 0);
         setShowWhatsNewBadge(payload.showWhatsNewBadge ?? true);
         setExtensionVersion(payload.extensionVersion ?? '');
+        setRecentWorkflows(payload.recentWorkflows ?? []);
       } else if (message.type === 'IMPORT_WORKFLOW_FROM_SLACK') {
         // Handle import workflow request from Extension Host
         // Simply forward the message back to Extension Host to trigger the import process
@@ -715,6 +717,13 @@ const App: React.FC = () => {
             onDismissEmptyState={() => setEmptyStateDismissed(true)}
             onLoadWorkflow={handleLoadWorkflowFromEmptyState}
             extensionVersion={extensionVersion}
+            recentWorkflows={recentWorkflows}
+            onLoadRecent={(id) => {
+              vscode.postMessage({
+                type: 'LOAD_WORKFLOW',
+                payload: { workflowId: id },
+              });
+            }}
           />
           {/* Processing overlay for canvas area only (with message centered in canvas) */}
           <ProcessingOverlay isVisible={isProcessing} message={t('refinement.processingOverlay')} />

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -34,6 +34,7 @@ import { SlackConnectionRequiredDialog } from './components/dialogs/SlackConnect
 import { SlackManualTokenDialog } from './components/dialogs/SlackManualTokenDialog';
 import { SlackShareDialog } from './components/dialogs/SlackShareDialog';
 import { SubAgentFlowDialog } from './components/dialogs/SubAgentFlowDialog';
+import { WhatsNewDialog } from './components/dialogs/WhatsNewDialog';
 import { ErrorNotification } from './components/ErrorNotification';
 import { NodePalette } from './components/NodePalette';
 import { PropertyOverlay } from './components/PropertyOverlay';
@@ -209,6 +210,7 @@ const App: React.FC = () => {
   const [extensionVersion, setExtensionVersion] = useState('');
   const [recentWorkflows, setRecentWorkflows] = useState<Array<{ id: string; name: string }>>([]);
   const [showWhatsNewBadge, setShowWhatsNewBadge] = useState(true);
+  const [isWhatsNewFromStartMenu, setIsWhatsNewFromStartMenu] = useState(false);
   const [showMcpRefreshDialog, setShowMcpRefreshDialog] = useState(false);
   const [mcpRefreshSkillName, setMcpRefreshSkillName] = useState<string>('cc-workflow-ai-editor');
   const [emptyStateDismissed, setEmptyStateDismissed] = useState(false);
@@ -724,6 +726,7 @@ const App: React.FC = () => {
                 payload: { workflowId: id },
               });
             }}
+            onVersionClick={() => setIsWhatsNewFromStartMenu(true)}
           />
           {/* Processing overlay for canvas area only (with message centered in canvas) */}
           <ProcessingOverlay isVisible={isProcessing} message={t('refinement.processingOverlay')} />
@@ -778,6 +781,14 @@ const App: React.FC = () => {
         isOpen={isSampleDialogOpen}
         onClose={() => setIsSampleDialogOpen(false)}
         onLoadSample={handleLoadSample}
+      />
+
+      {/* What's New Dialog triggered from StartMenu version click */}
+      <WhatsNewDialog
+        isOpen={isWhatsNewFromStartMenu}
+        onClose={() => setIsWhatsNewFromStartMenu(false)}
+        showBadge={showWhatsNewBadge}
+        onShowBadgeChange={setShowWhatsNewBadge}
       />
 
       {/* Unsaved changes confirmation before loading sample */}

--- a/src/webview/src/App.tsx
+++ b/src/webview/src/App.tsx
@@ -206,6 +206,7 @@ const App: React.FC = () => {
   const [showUnsavedConfirmForSample, setShowUnsavedConfirmForSample] = useState(false);
   const pendingTourAfterSampleLoadRef = useRef(false);
   const [unreadReleaseCount, setUnreadReleaseCount] = useState(0);
+  const [extensionVersion, setExtensionVersion] = useState('');
   const [showWhatsNewBadge, setShowWhatsNewBadge] = useState(true);
   const [showMcpRefreshDialog, setShowMcpRefreshDialog] = useState(false);
   const [mcpRefreshSkillName, setMcpRefreshSkillName] = useState<string>('cc-workflow-ai-editor');
@@ -381,6 +382,7 @@ const App: React.FC = () => {
         }
         setUnreadReleaseCount(payload.unreadReleaseCount ?? 0);
         setShowWhatsNewBadge(payload.showWhatsNewBadge ?? true);
+        setExtensionVersion(payload.extensionVersion ?? '');
       } else if (message.type === 'IMPORT_WORKFLOW_FROM_SLACK') {
         // Handle import workflow request from Extension Host
         // Simply forward the message back to Extension Host to trigger the import process
@@ -712,6 +714,7 @@ const App: React.FC = () => {
             onOpenSample={() => setIsSampleDialogOpen(true)}
             onDismissEmptyState={() => setEmptyStateDismissed(true)}
             onLoadWorkflow={handleLoadWorkflowFromEmptyState}
+            extensionVersion={extensionVersion}
           />
           {/* Processing overlay for canvas area only (with message centered in canvas) */}
           <ProcessingOverlay isVisible={isProcessing} message={t('refinement.processingOverlay')} />

--- a/src/webview/src/components/StartMenu.tsx
+++ b/src/webview/src/components/StartMenu.tsx
@@ -15,6 +15,7 @@ interface StartMenuProps {
   onOpenSample: () => void;
   onStartFromScratch: () => void;
   onLoadWorkflow: () => void;
+  extensionVersion?: string;
 }
 
 const buttonStyle: React.CSSProperties = {
@@ -38,6 +39,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   onOpenSample,
   onStartFromScratch,
   onLoadWorkflow,
+  extensionVersion,
 }) => {
   return (
     <Dialog.Root open={isOpen}>
@@ -112,7 +114,14 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               </button>
             </div>
 
-            <div style={{ marginTop: '12px', textAlign: 'center' }}>
+            <div
+              style={{
+                marginTop: '12px',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
               <button
                 type="button"
                 onClick={onOpenSample}
@@ -138,6 +147,17 @@ export const StartMenu: React.FC<StartMenuProps> = ({
                 <FolderOpen size={12} />
                 Sample Workflow
               </button>
+              {extensionVersion && (
+                <span
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--vscode-descriptionForeground)',
+                    padding: '4px',
+                  }}
+                >
+                  v{extensionVersion}
+                </span>
+              )}
             </div>
           </Dialog.Content>
         </Dialog.Overlay>

--- a/src/webview/src/components/StartMenu.tsx
+++ b/src/webview/src/components/StartMenu.tsx
@@ -16,6 +16,8 @@ interface StartMenuProps {
   onStartFromScratch: () => void;
   onLoadWorkflow: () => void;
   extensionVersion?: string;
+  recentWorkflows?: Array<{ id: string; name: string }>;
+  onLoadRecent?: (id: string) => void;
 }
 
 const buttonStyle: React.CSSProperties = {
@@ -40,7 +42,11 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   onStartFromScratch,
   onLoadWorkflow,
   extensionVersion,
+  recentWorkflows,
+  onLoadRecent,
 }) => {
+  const hasRecent = recentWorkflows && recentWorkflows.length > 0;
+
   return (
     <Dialog.Root open={isOpen}>
       <Dialog.Portal>
@@ -61,7 +67,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               border: '1px solid var(--vscode-panel-border)',
               borderRadius: '6px',
               padding: '24px',
-              width: '320px',
+              width: hasRecent ? '480px' : '320px',
               maxWidth: '90vw',
               display: 'flex',
               flexDirection: 'column',
@@ -82,36 +88,112 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               CC Workflow Studio
             </Dialog.Title>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              <button
-                type="button"
-                onClick={onStartFromScratch}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+            <div style={{ display: 'flex', gap: '16px' }}>
+              {/* Left: Primary actions */}
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '8px',
+                  flex: hasRecent ? '0 0 auto' : '1',
+                  width: hasRecent ? '180px' : undefined,
                 }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--vscode-editor-background)';
-                }}
-                style={buttonStyle}
               >
-                <Plus size={16} style={{ flexShrink: 0 }} />
-                New
-              </button>
+                <button
+                  type="button"
+                  onClick={onStartFromScratch}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--vscode-editor-background)';
+                  }}
+                  style={buttonStyle}
+                >
+                  <Plus size={16} style={{ flexShrink: 0 }} />
+                  New
+                </button>
 
-              <button
-                type="button"
-                onClick={onLoadWorkflow}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--vscode-editor-background)';
-                }}
-                style={buttonStyle}
-              >
-                <FileDown size={16} style={{ flexShrink: 0 }} />
-                Load
-              </button>
+                <button
+                  type="button"
+                  onClick={onLoadWorkflow}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = 'var(--vscode-editor-background)';
+                  }}
+                  style={buttonStyle}
+                >
+                  <FileDown size={16} style={{ flexShrink: 0 }} />
+                  Load
+                </button>
+              </div>
+
+              {/* Right: Recent workflows */}
+              {hasRecent && (
+                <div
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    border: '1px solid var(--vscode-panel-border)',
+                    borderRadius: '4px',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '11px',
+                      color: 'var(--vscode-descriptionForeground)',
+                      padding: '6px 12px 2px',
+                      flexShrink: 0,
+                    }}
+                  >
+                    Recent
+                  </div>
+                  <div
+                    style={{
+                      maxHeight: '148px',
+                      overflowY: 'auto',
+                      overflowX: 'hidden',
+                    }}
+                  >
+                    {recentWorkflows.map((wf) => (
+                      <button
+                        key={wf.id}
+                        type="button"
+                        onClick={() => onLoadRecent?.(wf.id)}
+                        onMouseEnter={(e) => {
+                          e.currentTarget.style.backgroundColor =
+                            'var(--vscode-list-hoverBackground)';
+                        }}
+                        onMouseLeave={(e) => {
+                          e.currentTarget.style.backgroundColor = 'transparent';
+                        }}
+                        style={{
+                          display: 'block',
+                          width: '100%',
+                          padding: '8px 12px',
+                          border: 'none',
+                          backgroundColor: 'transparent',
+                          color: 'var(--vscode-foreground)',
+                          cursor: 'pointer',
+                          fontSize: '13px',
+                          textAlign: 'left',
+                          transition: 'background-color 0.15s',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {wf.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
 
             <div

--- a/src/webview/src/components/StartMenu.tsx
+++ b/src/webview/src/components/StartMenu.tsx
@@ -244,6 +244,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
                   onClick={onVersionClick}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
                       onVersionClick?.();
                     }
                   }}

--- a/src/webview/src/components/StartMenu.tsx
+++ b/src/webview/src/components/StartMenu.tsx
@@ -18,6 +18,7 @@ interface StartMenuProps {
   extensionVersion?: string;
   recentWorkflows?: Array<{ id: string; name: string }>;
   onLoadRecent?: (id: string) => void;
+  onVersionClick?: () => void;
 }
 
 const buttonStyle: React.CSSProperties = {
@@ -44,6 +45,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   extensionVersion,
   recentWorkflows,
   onLoadRecent,
+  onVersionClick,
 }) => {
   const hasRecent = recentWorkflows && recentWorkflows.length > 0;
 
@@ -73,6 +75,12 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               flexDirection: 'column',
               boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)',
               outline: 'none',
+            }}
+            // Prevent auto-focus on the first button (New) to avoid unwanted highlight on open.
+            // Focus the dialog content itself so Tab key navigation still works.
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+              (e.currentTarget as HTMLElement).focus();
             }}
             onEscapeKeyDown={onStartFromScratch}
           >
@@ -231,10 +239,27 @@ export const StartMenu: React.FC<StartMenuProps> = ({
               </button>
               {extensionVersion && (
                 <span
+                  role="button"
+                  tabIndex={0}
+                  onClick={onVersionClick}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      onVersionClick?.();
+                    }
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.opacity = '1';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.opacity = '0.7';
+                  }}
                   style={{
                     fontSize: '11px',
                     color: 'var(--vscode-descriptionForeground)',
                     padding: '4px',
+                    cursor: 'pointer',
+                    opacity: 0.7,
+                    transition: 'opacity 0.15s',
                   }}
                 >
                   v{extensionVersion}

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -97,6 +97,8 @@ interface WorkflowEditorProps {
   onDismissEmptyState?: () => void;
   onLoadWorkflow?: () => void;
   extensionVersion?: string;
+  recentWorkflows?: Array<{ id: string; name: string }>;
+  onLoadRecent?: (id: string) => void;
 }
 
 /**
@@ -110,6 +112,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   onDismissEmptyState,
   onLoadWorkflow,
   extensionVersion,
+  recentWorkflows,
+  onLoadRecent,
 }) => {
   const { t } = useTranslation();
   const isCompact = useIsCompactMode();
@@ -542,6 +546,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             onStartFromScratch={onDismissEmptyState}
             onLoadWorkflow={onLoadWorkflow}
             extensionVersion={extensionVersion}
+            recentWorkflows={recentWorkflows}
+            onLoadRecent={onLoadRecent}
           />
         )}
       </div>

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -99,6 +99,7 @@ interface WorkflowEditorProps {
   extensionVersion?: string;
   recentWorkflows?: Array<{ id: string; name: string }>;
   onLoadRecent?: (id: string) => void;
+  onVersionClick?: () => void;
 }
 
 /**
@@ -114,6 +115,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   extensionVersion,
   recentWorkflows,
   onLoadRecent,
+  onVersionClick,
 }) => {
   const { t } = useTranslation();
   const isCompact = useIsCompactMode();
@@ -548,6 +550,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             extensionVersion={extensionVersion}
             recentWorkflows={recentWorkflows}
             onLoadRecent={onLoadRecent}
+            onVersionClick={onVersionClick}
           />
         )}
       </div>

--- a/src/webview/src/components/WorkflowEditor.tsx
+++ b/src/webview/src/components/WorkflowEditor.tsx
@@ -96,6 +96,7 @@ interface WorkflowEditorProps {
   onOpenSample?: () => void;
   onDismissEmptyState?: () => void;
   onLoadWorkflow?: () => void;
+  extensionVersion?: string;
 }
 
 /**
@@ -108,6 +109,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   onOpenSample,
   onDismissEmptyState,
   onLoadWorkflow,
+  extensionVersion,
 }) => {
   const { t } = useTranslation();
   const isCompact = useIsCompactMode();
@@ -539,6 +541,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             onOpenSample={onOpenSample}
             onStartFromScratch={onDismissEmptyState}
             onLoadWorkflow={onLoadWorkflow}
+            extensionVersion={extensionVersion}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

Enhance the StartMenu component with version display, recent workflows quick access, and improved UX.

## Motivation

The StartMenu previously only offered New/Load/Sample actions. Users had to navigate through the file picker every time they wanted to reopen a recent workflow. Additionally, there was no way to see the current extension version or access the changelog from the start screen.

## Changes

**Modified Files:**
- `src/shared/types/messages.ts` - Add `RecentWorkflowItem` type and extend `InitialStatePayload` with `extensionVersion` and `recentWorkflows`
- `src/extension/commands/open-editor.ts` - Add recent workflow tracking in globalState (max 10), load/validate on startup, record on Save/Load
- `src/webview/src/App.tsx` - Thread version, recent workflows, and WhatsNew dialog state to WorkflowEditor
- `src/webview/src/components/WorkflowEditor.tsx` - Relay new props to StartMenu
- `src/webview/src/components/StartMenu.tsx` - 2-column layout with recent workflows, clickable version, auto-focus fix

**Key Features:**
- **Version display**: Bottom-right of StartMenu, clickable to open WhatsNew dialog
- **Recent workflows**: 2-column layout (New/Load left, Recent list right), scrollable after 5 items, max 10 entries
- **Auto-focus fix**: Dialog opens without highlighting any button; Tab key starts navigation
- **Graceful fallback**: Single-column layout when no recent workflows exist
- **Stale entry cleanup**: Deleted workflow files are automatically removed from recent list

## Testing

- [x] Manual E2E testing completed
- [x] `npm run check` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent workflows panel in the start menu — access up to 10 of your most-recent workflows (de-duplicated and persisted).
  * Extension version shown in the start menu with an accessible version button.
  * "What's New" dialog integrated into the UI, with a badge and keyboard-accessible trigger from the start menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->