### PR TITLE
chore: remove broken Snyk badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 <p align="center">
   <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
-  <a href="https://snyk.io/test/github/breaking-brake/cc-wf-studio"><img src="https://snyk.io/test/github/breaking-brake/cc-wf-studio/badge.svg" alt="Known Vulnerabilities" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
   <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>


### PR DESCRIPTION
## Problem

The Snyk vulnerability badge in README.md links to a broken/dead URL, resulting in a non-functional badge.

### Current Behavior
1. Click Snyk badge in README
2. ❌ Link is broken / badge not rendering

### Expected Behavior
1. All README badges link to valid URLs
2. ✅ No broken badges displayed

## Solution

Removed the broken Snyk badge from the README badges section.

### Changes

**File**: `README.md`

- Removed the Snyk "Known Vulnerabilities" badge and link

## Impact

- Cleaner README with no broken badges
- No functional impact

## Testing

- [x] Verified badge removal in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Snyk vulnerability badge link from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->