### PR TITLE
chore: replace retired VS Marketplace badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://vsmarketplacebadges.dev/version-short/breaking-brake.cc-wf-studio.svg?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
   <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>
 </p>


### PR DESCRIPTION
## Problem

The VS Marketplace badge in README.md now renders as "retired badge" instead of the extension version.

### Current Behavior
1. Open README.md
2. ❌ VS Marketplace badge shows "retired badge" text

### Expected Behavior
1. Open README.md
2. ✅ VS Marketplace badge shows the current version (e.g. `v3.33.0`)

### Root Cause

shields.io retired all `visual-studio-marketplace/*` badge endpoints on 2026-04-09. The service file marks every route with `deprecatedService()`, so requests now return a retired placeholder instead of the version.

## Solution

Swap the badge source to `vsmarketplacebadges.dev`, which is the de-facto successor and returns a working version badge for VS Code Marketplace extensions.

### Changes

**File**: `README.md`

- Replaced `https://img.shields.io/visual-studio-marketplace/v/...` with `https://vsmarketplacebadges.dev/version-short/breaking-brake.cc-wf-studio.svg`
- Link target and `label=VS%20Marketplace` preserved

## Impact

- Restores a functional version badge in the README
- No functional impact on the extension

## Testing

- [x] Verified `vsmarketplacebadges.dev` endpoint renders `v3.33.0`
- [x] Marketplace link target unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the VS Code Marketplace badge image in the README for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->