### PR TITLE
chore: migrate OAuth server URL to api subdomain

### DIFF
--- a/src/extension/services/slack-oauth-service.ts
+++ b/src/extension/services/slack-oauth-service.ts
@@ -22,7 +22,7 @@ import { log } from '../extension';
  */
 const OAUTH_CONFIG = {
   /** OAuth server base URL */
-  serverUrl: 'https://cc-wf-studio.com',
+  serverUrl: 'https://api.cc-wf-studio.com',
   /** Slack OAuth Client ID (public) */
   slackClientId: '9964370319943.10022663519665',
   /** Bot Token scopes (empty - all operations use User Token) */

--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -317,7 +317,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/terms')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',
@@ -339,7 +339,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/privacy')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',
@@ -620,7 +620,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/terms')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',
@@ -642,7 +642,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/privacy')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',


### PR DESCRIPTION
## Summary

Move the OAuth server base URL from the apex domain (`https://cc-wf-studio.com`) to a dedicated API subdomain (`https://api.cc-wf-studio.com`) so the apex can be reused by the documentation site.

Marked as `chore:` to keep this out of user-facing release notes — it is an infrastructure migration, not a user-visible change.

## Motivation

The apex domain `cc-wf-studio.com` is currently bound to the `cc-wf-studio-connectors` Worker (Slack OAuth). To host the documentation site at the apex, the Worker is being moved to the `api.` subdomain. The extension must point to the new subdomain so Slack OAuth keeps working after the cutover.

## Changes

**Modified Files:**
- `src/extension/services/slack-oauth-service.ts` - Change OAuth `serverUrl` constant from apex to `api.` subdomain
- `src/webview/src/components/dialogs/SlackManualTokenDialog.tsx` - Update 4 legal page links (`/terms` x2, `/privacy` x2) to the `api.` subdomain

## Pre-merge checklist (infra side)

Before merging, the following Cloudflare/Slack-side prep must be completed so the new URL is reachable:

- [ ] Add `api.cc-wf-studio.com` as a Custom Domain on the `cc-wf-studio-connectors` Worker (in parallel with the existing apex binding)
- [ ] Verify `curl -I https://api.cc-wf-studio.com/health` returns 200
- [ ] Add `https://api.cc-wf-studio.com/slack/callback` to the Slack App "Redirect URLs"

## Release implication

`chore:` commits do not trigger semantic-release. After merging this PR, the new URL will only ship to users when a future `feat:` / `fix:` commit triggers a release that bundles this change.

**Until that release ships, do NOT remove the apex Custom Domain from the Worker** — users on older extension versions still call `https://cc-wf-studio.com/slack/*`. The apex Custom Domain can only be removed once a release containing this commit has reached users.

## Testing

- [ ] Manual E2E: open the extension, run Slack OAuth flow end-to-end, verify token exchange succeeds
- [ ] Manual E2E: open the manual token dialog, click Terms and Privacy links, verify both pages load from `api.cc-wf-studio.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Slack integration server endpoints so OAuth and manual token flows connect to the proper API host, improving reliability of Slack sign-in and token exchange.
  * Updated external Terms of Service and Privacy Policy links in Slack dialogs to point to the correct server for consistent documentation and support access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->