### PR TITLE
chore: apply npm audit fix for safe vulnerability patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3410,9 +3410,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3753,9 +3753,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7032,9 +7032,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -3388,9 +3388,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Apply `npm audit fix` for safely resolvable vulnerabilities in both root and `src/webview` package locks.
- Three advisories patched via minor/patch version bumps; no source code changes required.

## Vulnerabilities Fixed

| Package | From | To | Severity | Advisory |
|---------|------|----|----|----------|
| follow-redirects | 1.15.11 | 1.16.0 | moderate | GHSA-r4q5-vmmm-2653 |
| hono | 4.12.12 | 4.12.16 | moderate | GHSA-458j-xx4x-4375 |
| postcss (root + webview) | 8.5.6 | 8.5.13 | moderate | GHSA-qx2v-qp2m-jg93 |

## Vulnerabilities NOT Fixed (out of scope)

These are bundled dependencies of the `npm` package itself and cannot be patched via `npm audit fix`. They require an upstream `npm` release:

- `brace-expansion` 4.0.0 - 5.0.4 (moderate, GHSA-f886-m6hf-6m8v)
- `picomatch` 4.0.0 - 4.0.3 (high, GHSA-3v7f-55p6-f55p / GHSA-c2c7-rcm5-vvqj)

## Test plan

- [x] `npm run check` passes
- [x] `npm run build` succeeds (extension + webview)
- [x] `npm audit` (webview): 0 vulnerabilities
- [x] `npm audit` (root): only the 2 unfixable `npm`-bundled advisories remain
- [ ] Manual smoke test in VSCode Extension Development Host