### PR TITLE
chore: bump axios 1.15.0 -> 1.16.0 to fix Snyk advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,12 +2115,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }


### PR DESCRIPTION
## Summary

- Bump transitive `axios` (via `@slack/web-api`) from 1.15.0 to 1.16.0 to resolve 12 open Snyk code-scanning alerts.
- Lockfile-only change. No source code or runtime API changes.

## Alerts Resolved

All 12 alerts have remediation "Upgrade `axios` to version 1.15.2 or higher":

| Snyk # | Severity | Issue |
|--------|----------|-------|
| #33 | critical | Prototype Pollution |
| #27 | critical | HTTP Response Splitting |
| #34 | high | Improperly Controlled Modification of Dynamically-Determined Object Attributes |
| #35 | high | Uncontrolled Recursion |
| #25 | medium | Incomplete List of Disallowed Inputs |
| #26 | medium | Improper Encoding or Escaping of Output |
| #28 | medium | Server-side Request Forgery (SSRF) |
| #29 | medium | Allocation of Resources Without Limits or Throttling |
| #30 | medium | Allocation of Resources Without Limits or Throttling |
| #31 | medium | Insertion of Sensitive Information Into Sent Data |
| #32 | medium | CRLF Injection |
| #36 | medium | Prototype Pollution |

## Test plan

- [x] `npm run check` passes
- [x] `npm run build` succeeds (extension + webview)
- [x] `npm audit` shows axios is no longer vulnerable
- [ ] Manual smoke test: Slack share/import flow in VSCode Extension Development Host