### PR TITLE
Release: v3.33.1

### DIFF
--- a/.claude/skills/workflow-schema-tuning/SKILL.md
+++ b/.claude/skills/workflow-schema-tuning/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: workflow-schema-tuning
+description: Use when modifying `resources/workflow-schema.json` in cc-wf-studio to influence how AI agents generate workflows via the cc-workflow-ai-editor skill. Triggers include "AIが特定のノードタイプを選んでくれない", "ワークフロー生成のバイアスを調整したい", "スキーマの description を変えたい", "新しいノードタイプを追加したい", "嘘の制約がスキーマに混じっていないか確認したい". Covers what the schema actually does (instructions to AI, not runtime constraints), the design philosophy (align direction, do not prescribe rules), the build pipeline (.json → .toon auto-generated), and known bias sources to audit.
+---
+
+# Workflow Schema Tuning
+
+The schema (`resources/workflow-schema.json`) is the primary spec **delivered to the AI editor at runtime** via the `get_workflow_schema` MCP tool. It is not a runtime validator — the runtime barely validates anything. **Whatever the schema says, the AI believes.** Treat schema edits as prompt engineering, not type definitions.
+
+## Core principle: align direction, do not prescribe rules
+
+AI agents already know how to choose between node types intuitively (e.g., when to delegate to a sub-agent vs. handle in-context). The fix for bad output is almost never "add more rules" — it is "remove what is biasing the AI in the wrong direction."
+
+**Defaults**:
+- Prefer minimal description text that states each node's *positional role* (立ち位置). Example: "A step executed by the main orchestrating agent" vs. "A step executed by an isolated sub-agent." The contrast does the work.
+- Avoid `aiGenerationGuidance` lists of "when to use / when not to use / anti-patterns." They treat the AI as a rules engine, bloat tokens, and fail on unanticipated cases.
+- **Test minimal first.** Only add guidance after a concrete failure where the minimal change is provably insufficient.
+
+**Anti-pattern**: writing detailed `upgradeToSubAgentWhen` / `stayInPromptWhen` lists. If you find yourself writing 3+ bullets explaining when to use a node, the description itself is probably wrong.
+
+## Schema architecture
+
+| File | Role | Editable? |
+|---|---|---|
+| `resources/workflow-schema.json` | Single source of truth | YES |
+| `resources/workflow-schema.toon` | Token-efficient format consumed by AI via MCP | NO — auto-generated |
+| `resources/ai-editing-skill-template.md` | Skill template loaded at AI editor launch | YES |
+| `scripts/generate-toon-schema.ts` | TOON generator | YES (rare) |
+
+After editing `.json`, regenerate `.toon`:
+
+```bash
+npm run generate:toon
+```
+
+The full build (`npm run build`) does this automatically as the first step.
+
+## Where biases hide (audit checklist)
+
+When the AI consistently picks the wrong node type, look here in priority order:
+
+1. **`ai-editing-skill-template.md` step 4** — strongest pull. A line like "use built-in sub-agents by default" overrides every other signal in the schema. Keep this neutral.
+2. **`nodeTypes.<type>.description`** — the AI's first impression of what each node *means*. Keep terse, contrastive, role-focused.
+3. **`nodeTypes.<type>.aiGenerationGuidance`** — when present, this is read closely. Audit for stale "default" framings or anti-patterns that no longer apply.
+4. **`examples[]`** — the AI learns strongly from examples. If every example uses one node type, expect that node to dominate output.
+5. **Top-level constraints** (`connections.overview.forbidden`, `exportValidationRules`, `postGenerationChecklist`) — these can encode false constraints (e.g., "no cycles allowed" when the runtime allows them, since the runtime is an AI that uses judgment, not a deterministic executor). **Removing false constraints is itself a valid improvement.**
+
+## Workflow for making changes
+
+1. **Diagnose**: identify the symptom (wrong node type chosen, false constraint cited in AI's reasoning, etc.).
+2. **Locate the bias**: walk the audit checklist above. Look for a single source pulling the AI in the wrong direction before adding new content.
+3. **Minimal edit**: prefer removing biased text or fixing one description over adding new sections.
+4. **Regenerate TOON**: `npm run generate:toon`.
+5. **Validate**: `npm run check && npm run build`.
+6. **Test**: `npm run debug` launches a fresh Extension Development Host. Trigger the AI editor with a node-type-agnostic prompt (no hints like "use a sub-agent for X") and inspect the generated workflow.
+7. **Iterate**: if the minimal change is insufficient, add the smallest additional signal — not a guidance section.
+
+## Important constraints
+
+- The framework is **multi-agent** (Claude Code, Codex, "other"). Schema text must be agent-agnostic. Avoid Claude-specific phrasing like "isolated Claude session" — use "isolated AI agent session" or "isolated sub-agent."
+- The runtime is an AI agent making judgments, **not a deterministic program**. Constraints that make sense in code (no cycles, no infinite loops) often do not apply here. Verify before transcribing programming-style constraints.
+- After `generate:toon`, confirm the change took effect by grepping the relevant string in `workflow-schema.toon`. The MCP delivers TOON, not JSON.
+
+## Commit conventions for schema changes
+
+Per the project's conventional commit policy:
+- Description fixes / bias removal → `improvement:` (patch bump)
+- Build/tooling-only changes → `chore:` (no release)
+- Keep subjects ≤50 chars, body 3–5 bullets, "what changed" only
+- Split unrelated concerns into separate commits to make diffs reviewable

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 <p align="center">
   <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
-  <a href="https://snyk.io/test/github/breaking-brake/cc-wf-studio"><img src="https://snyk.io/test/github/breaking-brake/cc-wf-studio/badge.svg" alt="Known Vulnerabilities" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
   <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/breaking-brake.cc-wf-studio?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://vsmarketplacebadges.dev/version-short/breaking-brake.cc-wf-studio.svg?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
   <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>
 </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3410,9 +3410,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3753,9 +3753,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7032,9 +7032,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,12 +2115,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "compile": "tsc -p ./",
     "watch": "vite build --config vite.extension.config.ts --watch",
     "watch:webview": "cd src/webview && npm run dev",
+    "debug": "npm run build && code --extensionDevelopmentPath=. --new-window",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check --write .",

--- a/resources/ai-editing-skill-template.md
+++ b/resources/ai-editing-skill-template.md
@@ -6,7 +6,7 @@ description: AI workflow editor for CC Workflow Studio. Create and edit visual A
 1. Call `get_workflow_schema` via `cc-workflow-studio` MCP server
 2. Call `get_current_workflow` via `cc-workflow-studio` MCP server
 3. Ask the user what to create or modify
-4. Generate workflow JSON: use built-in sub-agents (builtInType: explore/plan/general-purpose) by default. Only call `list_available_agents` when the user explicitly asks to use an existing custom sub-agent.
+4. Generate workflow JSON: choose each node type based on its role description in the schema. When a `subAgent` is the right choice, use a built-in `builtInType` (explore/plan/general-purpose). Only call `list_available_agents` when the user explicitly asks to use an existing custom sub-agent.
 5. Apply changes via `cc-workflow-studio` MCP server:
    - **New workflow or structural changes** (add/remove nodes/connections): use `apply_workflow`
    - **Partial updates to existing nodes** (change name, position, or data): use `update_nodes` (more token-efficient)

--- a/resources/workflow-schema.json
+++ b/resources/workflow-schema.json
@@ -36,7 +36,7 @@
       "outputPorts": 0
     },
     "prompt": {
-      "description": "Display a message/instructions to user",
+      "description": "A step executed by the main orchestrator (your current session, where you can talk to the user).",
       "fields": {
         "label": { "type": "string", "required": false },
         "prompt": { "type": "string", "required": true, "maxLength": 10000 },
@@ -46,7 +46,7 @@
       "outputPorts": 1
     },
     "subAgent": {
-      "description": "AI sub-agent with separate agent definition and task prompt",
+      "description": "An isolated sub-agent invocation (e.g., Claude Code's Task tool).",
       "fields": {
         "description": { "type": "string", "required": true, "maxLength": 200 },
         "agentDefinition": { "type": "string", "required": true, "maxLength": 10000 },
@@ -608,7 +608,6 @@
       "forbidden": [
         "Start node cannot have input connections",
         "End node cannot have output connections",
-        "No cycles allowed",
         "No self-connections"
       ],
       "required": [
@@ -823,11 +822,6 @@
             "failureMessage": "Dead-end paths found - ensure all branches converge to an End node"
           },
           {
-            "id": "NO_CYCLES",
-            "rule": "Workflow MUST NOT contain cycles",
-            "failureMessage": "Circular reference detected - workflows must be acyclic (DAG)"
-          },
-          {
             "id": "NODE_ID_REFERENCES_VALID",
             "rule": "All node IDs in connections must reference existing nodes",
             "failureMessage": "Connection references non-existent node"
@@ -850,7 +844,6 @@
           "✓ Switch nodes: all branches connected",
           "✓ AskUserQuestion nodes (single-select): all options connected",
           "✓ No dangling nodes",
-          "✓ No circular references",
           "✓ All node IDs in connections exist in nodes array"
         ]
       }

--- a/resources/workflow-schema.toon
+++ b/resources/workflow-schema.toon
@@ -23,7 +23,7 @@ nodeTypes:
     inputPorts: unlimited
     outputPorts: 0
   prompt:
-    description: Display a message/instructions to user
+    description: "A step executed by the main orchestrator (your current session, where you can talk to the user)."
     fields:
       label:
         type: string
@@ -38,7 +38,7 @@ nodeTypes:
     inputPorts: 1
     outputPorts: 1
   subAgent:
-    description: AI sub-agent with separate agent definition and task prompt
+    description: "An isolated sub-agent invocation (e.g., Claude Code's Task tool)."
     fields:
       description:
         type: string
@@ -523,7 +523,7 @@ connections:
   description: "Comprehensive specification for workflow connections. Defines connection object structure, port naming conventions, and completeness rules for AI-generated workflows."
   overview:
     description: High-level connection constraints that apply to all workflows
-    forbidden[4]: Start node cannot have input connections,End node cannot have output connections,No cycles allowed,No self-connections
+    forbidden[3]: Start node cannot have input connections,End node cannot have output connections,No self-connections
     required[5]: At least one connection per output port,Exactly one Start node per workflow,At least one End node per workflow,All non-Start nodes must have input connection,All non-End nodes must have output connection
   format:
     description: Connection object structure in connections array
@@ -654,19 +654,18 @@ connections:
           validation: "For each connection: verify 'from' node exists, verify 'to' node exists"
     exportValidationRules:
       description: Mandatory validation rules checked when exporting or executing a workflow. These rules apply to both manually-edited and AI-generated workflows. Workflows must pass these validations before execution.
-      rules[9]{id,rule,failureMessage}:
+      rules[8]{id,rule,failureMessage}:
         EXACTLY_ONE_START,Workflow MUST have exactly one Start node,Workflow must have exactly one Start node
         AT_LEAST_ONE_END,Workflow MUST have at least one End node,Workflow must have at least one End node
         START_OUTPUT_CONNECTED,Start node's 'output' port MUST be connected,Start node output must be connected to downstream node
         END_INPUT_CONNECTED,At least one End node's 'input' port MUST be connected,At least one End node must have incoming connection
         ALL_NODES_REACHABLE,All nodes MUST be reachable from Start node,Unreachable nodes found - ensure all nodes form a connected path from Start
         ALL_PATHS_LEAD_TO_END,All execution paths MUST lead to at least one End node,Dead-end paths found - ensure all branches converge to an End node
-        NO_CYCLES,Workflow MUST NOT contain cycles,Circular reference detected - workflows must be acyclic (DAG)
         NODE_ID_REFERENCES_VALID,All node IDs in connections must reference existing nodes,Connection references non-existent node
         CONDITIONAL_BRANCHES_CONNECTED,"All conditional node branches (IfElse, Switch, AskUserQuestion single-select) MUST have outgoing connections",Conditional node has disconnected branch
     postGenerationChecklist:
       description: Quick checklist for verifying AI-generated workflows before returning to user
-      items[10]: ✓ Exactly 1 Start node with output connected,✓ At least 1 End node with input(s) connected,✓ All non-Start nodes have input connected,✓ All non-End nodes have output(s) connected,"✓ IfElse nodes: both branches connected","✓ Switch nodes: all branches connected","✓ AskUserQuestion nodes (single-select): all options connected",✓ No dangling nodes,✓ No circular references,✓ All node IDs in connections exist in nodes array
+      items[9]: ✓ Exactly 1 Start node with output connected,✓ At least 1 End node with input(s) connected,✓ All non-Start nodes have input connected,✓ All non-End nodes have output(s) connected,"✓ IfElse nodes: both branches connected","✓ Switch nodes: all branches connected","✓ AskUserQuestion nodes (single-select): all options connected",✓ No dangling nodes,✓ All node IDs in connections exist in nodes array
 validationRules:
   workflow:
     maxNodes: 100

--- a/src/extension/services/slack-oauth-service.ts
+++ b/src/extension/services/slack-oauth-service.ts
@@ -22,7 +22,7 @@ import { log } from '../extension';
  */
 const OAUTH_CONFIG = {
   /** OAuth server base URL */
-  serverUrl: 'https://cc-wf-studio.com',
+  serverUrl: 'https://api.cc-wf-studio.com',
   /** Slack OAuth Client ID (public) */
   slackClientId: '9964370319943.10022663519665',
   /** Bot Token scopes (empty - all operations use User Token) */

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2663,6 +2664,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2673,6 +2675,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2802,6 +2805,7 @@
       "integrity": "sha512-/irhyeAcKS2u6Zokagf9tqZJ0t8S6kMZq4ZG9BHZv7I+fkRrYfQX4w7geYeC2r6obThz39PDxvXQzZX+qXqGeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.2",
         "fflate": "^0.8.2",
@@ -2885,6 +2889,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3007,6 +3012,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3373,6 +3379,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3414,6 +3421,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3423,6 +3431,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3792,11 +3801,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3872,6 +3882,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -3995,6 +4006,7 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
       "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/src/webview/package-lock.json
+++ b/src/webview/package-lock.json
@@ -3388,9 +3388,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
+++ b/src/webview/src/components/dialogs/SlackManualTokenDialog.tsx
@@ -317,7 +317,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/terms')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',
@@ -339,7 +339,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/privacy')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',
@@ -620,7 +620,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/terms')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/terms')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',
@@ -642,7 +642,7 @@ export function SlackManualTokenDialog({
                   <li>
                     <button
                       type="button"
-                      onClick={() => openExternalUrl('https://cc-wf-studio.com/privacy')}
+                      onClick={() => openExternalUrl('https://api.cc-wf-studio.com/privacy')}
                       style={{
                         fontSize: '12px',
                         color: 'var(--vscode-textLink-foreground)',


### PR DESCRIPTION
## Summary

Merge latest changes from `main` to `production` for automated release v3.33.1.

This release bundles a security/dependency hygiene sweep plus one AI workflow generation improvement.

## Included Changes

### Improvements
- improvement: align AI workflow generation by removing schema biases (#751)

### Chores (no version bump, but shipped)
- chore: bump axios 1.15.0 -> 1.16.0 to fix Snyk advisories (#753)
- chore: apply npm audit fix for safe vulnerability patches (#752)
- chore: migrate OAuth server URL to api subdomain (#750)
- chore: replace retired VS Marketplace badge (#743)
- chore: remove broken Snyk badge from README (#741)
- chore: update vite to 7.3.2 to fix CVE-2026-39364 (#740)

## Release Version Calculation

**v3.33.1** (patch bump)

Semantic Release will analyze commits since v3.33.0:
- ✅ `improvement: align AI workflow generation` (#751) → **patch bump**
- ❌ All `chore:` commits (#753, #752, #750, #743, #741, #740) → no version bump

Result: **3.33.0 + patch = 3.33.1**

## CHANGELOG.md Contents

The following entry will be added under **Improvements**:
- Align AI workflow generation by removing schema biases (#751)

The `chore:` commits are hidden from CHANGELOG per `.releaserc.json` configuration, but their changes are still merged into production.

## Notable Behavioral Changes

- **#750**: OAuth server URL migrated to `api` subdomain — verify OAuth flows post-release.
- **#751**: AI workflow generation prompt no longer biases toward specific schema shapes.
- **#753 / #752 / #740**: Dependency security patches (axios, npm audit, vite CVE-2026-39364).

## Release Automation

This merge will trigger:
1. Analyze commit messages (3.33.0 → 3.33.1)
2. Update version in `package.json` and `src/webview/package.json`
3. Generate CHANGELOG.md entry
4. Create GitHub release v3.33.1
5. Build and upload VSIX package
6. Sync version changes back to `main`

## Merge Strategy

**Use merge commit** (not squash) to preserve commit history for Semantic Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)