### PR TITLE
improvement: disable source maps in production VSIX

### DIFF
--- a/src/webview/vite.config.ts
+++ b/src/webview/vite.config.ts
@@ -10,7 +10,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
   build: {
     outDir: 'dist',
@@ -25,8 +25,8 @@ export default defineConfig({
         assetFileNames: 'assets/[name].[ext]',
       },
     },
-    // Generate sourcemaps for debugging
-    sourcemap: true,
+    // Generate sourcemaps only in development mode
+    sourcemap: mode === 'development',
     // Target modern browsers (VSCode uses Electron)
     target: 'esnext',
     minify: 'esbuild',
@@ -50,4 +50,4 @@ export default defineConfig({
     port: 5173,
     strictPort: true,
   },
-});
+}));

--- a/vite.extension.config.ts
+++ b/vite.extension.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from 'vite';
  * This bundles src/extension/** TypeScript files into a single output file
  * with all dependencies (including @modelcontextprotocol/sdk) included.
  */
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   build: {
     // Library mode for Node.js environment (Extension Host)
     lib: {
@@ -19,8 +19,8 @@ export default defineConfig({
     // Output directory
     outDir: 'dist',
 
-    // Generate source maps for debugging
-    sourcemap: true,
+    // Generate source maps only in development mode
+    sourcemap: mode === 'development',
 
     // Minification (disable for easier debugging, enable for production)
     minify: false,
@@ -99,4 +99,4 @@ export default defineConfig({
       '@': resolve(__dirname, 'src'),
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary

Disable source map generation in production builds to dramatically reduce VSIX package size.

## What Changed

Both `vite.config.ts` (webview) and `vite.extension.config.ts` (extension host) now generate source maps only when `mode === 'development'`. Production builds (`npm run build`) emit no `.js.map` files, while development builds (`npm run build:dev`) continue to emit them for local debugging.

### Before
- VSIX size: **5.26 MB** (154 files)
- `src/webview/dist/assets/` contained ~16.7 MB of `.js.map` files
- `dist/extension.js.map` was ~4.3 MB

### After
- VSIX size: **1.75 MB** (99 files) — **~67% reduction**
- No `.js.map` files in production VSIX
- Development builds still emit source maps for debugging
- F5 Extension Development Host workflow unaffected (uses `build:dev`-equivalent output via vite dev server / dev mode)

## Changes

- `vite.extension.config.ts` — wrap config in `({ mode }) => ({...})` and set `sourcemap: mode === 'development'`
- `src/webview/vite.config.ts` — same pattern for webview build

## Why Not `.vscodeignore`?

`.vscodeignore` cannot exclude files inside paths that were re-included with `!src/webview/dist/**`. The vite config approach is the cleanest root-cause fix and avoids fighting glob precedence.

## Marketplace Impact

None — actually beneficial:
- Faster downloads / installs for users
- Faster activation (smaller bundle to load)
- No leakage of internal source structure
- No source map verification is performed by the Marketplace

Trade-off: production stack traces will reference minified line numbers. To debug a user-reported issue, run `npm run build:dev` to repackage with source maps.

## Testing

- [x] `npm run build` — succeeds, no `.js.map` in `dist/` or `src/webview/dist/`
- [x] `npm run build:dev` — succeeds, 55 `.js.map` files emitted in webview + `extension.js.map`
- [x] `vsce package` — generates 1.75 MB VSIX
- [x] Manual install of generated VSIX — extension activates and core features (canvas, save, Mermaid Overview) work
- [ ] Verify GitHub Actions release workflow produces a smaller VSIX on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to conditionally generate source maps during development mode only, improving production build performance and reducing artifact file sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->