### PR TITLE
improvement: add preview button to sample workflow list

### DIFF
--- a/src/extension/commands/load-sample-workflow.ts
+++ b/src/extension/commands/load-sample-workflow.ts
@@ -14,6 +14,7 @@ import * as vscode from 'vscode';
 import type {
   SampleWorkflowListPayload,
   SampleWorkflowLoadedPayload,
+  SampleWorkflowPreviewLoadedPayload,
 } from '../../shared/types/messages';
 import type { SampleWorkflowFile } from '../../shared/types/sample-workflow';
 
@@ -155,6 +156,39 @@ export async function listSampleWorkflows(
   }
 }
 
+type ResolveResult =
+  | { ok: true; parsed: SampleWorkflowFile; selected: ParsedFilename }
+  | { ok: false; message: string };
+
+async function resolveAndReadSample(
+  extensionPath: string,
+  sampleId: string
+): Promise<ResolveResult> {
+  if (!SAMPLE_ID_PATTERN.test(sampleId)) {
+    return { ok: false, message: `Invalid sample workflow ID: "${sampleId}"` };
+  }
+  const baseDir = path.resolve(extensionPath, 'resources', 'samples');
+  const parsedFiles = await readParsedFilesIn(baseDir);
+  const groups = groupBySampleId(parsedFiles);
+  const groupFiles = groups.get(sampleId);
+  if (!groupFiles) {
+    return { ok: false, message: `Sample workflow "${sampleId}" not found` };
+  }
+  const preferredLocale = vscode.env.language || 'en';
+  const selected = selectFileForLocale(groupFiles, preferredLocale);
+  if (!selected) {
+    return { ok: false, message: `Sample workflow "${sampleId}" not found` };
+  }
+  const filename = buildFilename(selected);
+  const filePath = path.resolve(baseDir, filename);
+  if (!filePath.startsWith(baseDir + path.sep)) {
+    return { ok: false, message: `Invalid sample workflow ID: "${sampleId}"` };
+  }
+  const content = await fs.readFile(filePath, 'utf-8');
+  const parsed: SampleWorkflowFile = JSON.parse(content);
+  return { ok: true, parsed, selected };
+}
+
 /**
  * Load a specific sample workflow and send it to webview.
  * Picks the locale variant matching VSCode's display language, with fallback chain.
@@ -166,73 +200,27 @@ export async function loadSampleWorkflow(
   requestId?: string
 ): Promise<void> {
   try {
-    if (!SAMPLE_ID_PATTERN.test(sampleId)) {
+    const result = await resolveAndReadSample(extensionPath, sampleId);
+    if (!result.ok) {
       webview.postMessage({
         type: 'ERROR',
         requestId,
         payload: {
           code: 'LOAD_FAILED',
-          message: `Invalid sample workflow ID: "${sampleId}"`,
+          message: result.message,
         },
       });
       return;
     }
 
-    const baseDir = path.resolve(extensionPath, 'resources', 'samples');
-    const parsedFiles = await readParsedFilesIn(baseDir);
-    const groups = groupBySampleId(parsedFiles);
-    const groupFiles = groups.get(sampleId);
-    if (!groupFiles) {
-      webview.postMessage({
-        type: 'ERROR',
-        requestId,
-        payload: {
-          code: 'LOAD_FAILED',
-          message: `Sample workflow "${sampleId}" not found`,
-        },
-      });
-      return;
-    }
-
-    const preferredLocale = vscode.env.language || 'en';
-    const selected = selectFileForLocale(groupFiles, preferredLocale);
-    if (!selected) {
-      webview.postMessage({
-        type: 'ERROR',
-        requestId,
-        payload: {
-          code: 'LOAD_FAILED',
-          message: `Sample workflow "${sampleId}" not found`,
-        },
-      });
-      return;
-    }
-
-    const filename = buildFilename(selected);
-    const filePath = path.resolve(baseDir, filename);
-    if (!filePath.startsWith(baseDir + path.sep)) {
-      webview.postMessage({
-        type: 'ERROR',
-        requestId,
-        payload: {
-          code: 'LOAD_FAILED',
-          message: `Invalid sample workflow ID: "${sampleId}"`,
-        },
-      });
-      return;
-    }
-
-    const content = await fs.readFile(filePath, 'utf-8');
-    const parsed: SampleWorkflowFile = JSON.parse(content);
-
-    const payload: SampleWorkflowLoadedPayload = { workflow: parsed.workflow };
+    const payload: SampleWorkflowLoadedPayload = { workflow: result.parsed.workflow };
     webview.postMessage({
       type: 'SAMPLE_WORKFLOW_LOADED',
       requestId,
       payload,
     });
 
-    console.log(`Sample workflow loaded: ${sampleId} (${selected.locale ?? 'no-locale'})`);
+    console.log(`Sample workflow loaded: ${sampleId} (${result.selected.locale ?? 'no-locale'})`);
   } catch (error) {
     webview.postMessage({
       type: 'ERROR',
@@ -240,6 +228,53 @@ export async function loadSampleWorkflow(
       payload: {
         code: 'LOAD_FAILED',
         message: error instanceof Error ? error.message : 'Failed to load sample workflow',
+        details: error,
+      },
+    });
+  }
+}
+
+/**
+ * Load a specific sample workflow for preview only (does not apply to canvas).
+ */
+export async function previewSampleWorkflow(
+  extensionPath: string,
+  webview: vscode.Webview,
+  sampleId: string,
+  requestId?: string
+): Promise<void> {
+  try {
+    const result = await resolveAndReadSample(extensionPath, sampleId);
+    if (!result.ok) {
+      webview.postMessage({
+        type: 'ERROR',
+        requestId,
+        payload: {
+          code: 'LOAD_FAILED',
+          message: result.message,
+        },
+      });
+      return;
+    }
+
+    const payload: SampleWorkflowPreviewLoadedPayload = {
+      sampleId,
+      workflow: result.parsed.workflow,
+    };
+    webview.postMessage({
+      type: 'SAMPLE_WORKFLOW_PREVIEW_LOADED',
+      requestId,
+      payload,
+    });
+
+    console.log(`Sample workflow previewed: ${sampleId}`);
+  } catch (error) {
+    webview.postMessage({
+      type: 'ERROR',
+      requestId,
+      payload: {
+        code: 'LOAD_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to preview sample workflow',
         details: error,
       },
     });

--- a/src/extension/commands/open-editor.ts
+++ b/src/extension/commands/open-editor.ts
@@ -71,7 +71,11 @@ import {
 import { handleExportForCursor, handleRunForCursor } from './cursor-handlers';
 import { handleExportWorkflow, handleExportWorkflowForExecution } from './export-workflow';
 import { handleExportForGeminiCli, handleRunForGeminiCli } from './gemini-handlers';
-import { listSampleWorkflows, loadSampleWorkflow } from './load-sample-workflow';
+import {
+  listSampleWorkflows,
+  loadSampleWorkflow,
+  previewSampleWorkflow,
+} from './load-sample-workflow';
 import { loadWorkflow } from './load-workflow';
 import { loadWorkflowList } from './load-workflow-list';
 import {
@@ -1030,6 +1034,26 @@ export function registerOpenEditorCommand(
             case 'LOAD_SAMPLE_WORKFLOW':
               if (message.payload?.sampleId) {
                 await loadSampleWorkflow(
+                  context.extensionPath,
+                  webview,
+                  message.payload.sampleId,
+                  message.requestId
+                );
+              } else {
+                webview.postMessage({
+                  type: 'ERROR',
+                  requestId: message.requestId,
+                  payload: {
+                    code: 'VALIDATION_ERROR',
+                    message: 'Sample workflow ID is required',
+                  },
+                });
+              }
+              break;
+
+            case 'PREVIEW_SAMPLE_WORKFLOW':
+              if (message.payload?.sampleId) {
+                await previewSampleWorkflow(
                   context.extensionPath,
                   webview,
                   message.payload.sampleId,

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -7,7 +7,7 @@
 import type { Connection, Workflow, WorkflowNode } from './workflow-definition';
 
 // Re-export Workflow for convenience
-export type { Workflow, WorkflowNode, Connection };
+export type { Connection, Workflow, WorkflowNode };
 
 // ============================================================================
 // Base Message
@@ -1114,6 +1114,15 @@ export interface SampleWorkflowLoadedPayload {
   workflow: Workflow;
 }
 
+export interface PreviewSampleWorkflowRequestPayload {
+  sampleId: string;
+}
+
+export interface SampleWorkflowPreviewLoadedPayload {
+  sampleId: string;
+  workflow: Workflow;
+}
+
 // ============================================================================
 // Extension → Webview Messages
 // ============================================================================
@@ -1265,7 +1274,8 @@ export type ExtensionMessage =
   | Message<void, 'COMMENTARY_SESSION_ENDED'>
   | Message<CommentaryErrorPayload, 'COMMENTARY_ERROR'>
   | Message<SampleWorkflowListPayload, 'SAMPLE_WORKFLOW_LIST'>
-  | Message<SampleWorkflowLoadedPayload, 'SAMPLE_WORKFLOW_LOADED'>;
+  | Message<SampleWorkflowLoadedPayload, 'SAMPLE_WORKFLOW_LOADED'>
+  | Message<SampleWorkflowPreviewLoadedPayload, 'SAMPLE_WORKFLOW_PREVIEW_LOADED'>;
 
 // ============================================================================
 // AI Slack Description Generation Payloads
@@ -2439,7 +2449,8 @@ export type WebviewMessage =
     >
   | Message<void, 'STOP_COMMENTARY'>
   | Message<void, 'LIST_SAMPLE_WORKFLOWS'>
-  | Message<LoadSampleWorkflowRequestPayload, 'LOAD_SAMPLE_WORKFLOW'>;
+  | Message<LoadSampleWorkflowRequestPayload, 'LOAD_SAMPLE_WORKFLOW'>
+  | Message<PreviewSampleWorkflowRequestPayload, 'PREVIEW_SAMPLE_WORKFLOW'>;
 
 // ============================================================================
 // Error Codes

--- a/src/webview/src/components/dialogs/SampleWorkflowDialog.tsx
+++ b/src/webview/src/components/dialogs/SampleWorkflowDialog.tsx
@@ -6,12 +6,15 @@
  */
 
 import * as Dialog from '@radix-ui/react-dialog';
+import type { Workflow } from '@shared/types/messages';
+import { X } from 'lucide-react';
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { SampleWorkflowMeta } from '../../../../shared/types/sample-workflow';
 import { useTranslation } from '../../i18n/i18n-context';
 import type { WebviewTranslationKeys } from '../../i18n/translation-keys';
 import { vscode } from '../../main';
+import { WorkflowOverview } from '../overview/WorkflowOverview';
 
 interface SampleWorkflowDialogProps {
   isOpen: boolean;
@@ -30,6 +33,13 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
   const { t } = useTranslation();
   const [samples, setSamples] = useState<SampleWorkflowMeta[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [previewWorkflow, setPreviewWorkflow] = useState<Workflow | null>(null);
+  const [previewLoadingId, setPreviewLoadingId] = useState<string | null>(null);
+  const previewLoadingIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    previewLoadingIdRef.current = previewLoadingId;
+  }, [previewLoadingId]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -38,12 +48,18 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
 
     setIsLoading(true);
 
-    // Listen for sample workflow list response
+    // Listen for sample workflow list / preview response
     const handler = (event: MessageEvent) => {
       const message = event.data;
       if (message.type === 'SAMPLE_WORKFLOW_LIST') {
         setSamples(message.payload?.samples ?? []);
         setIsLoading(false);
+      } else if (message.type === 'SAMPLE_WORKFLOW_PREVIEW_LOADED') {
+        const payload = message.payload;
+        if (payload?.sampleId === previewLoadingIdRef.current) {
+          setPreviewWorkflow(payload.workflow);
+          setPreviewLoadingId(null);
+        }
       }
     };
 
@@ -62,11 +78,18 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
     if (!isOpen) {
       setSamples([]);
       setIsLoading(true);
+      setPreviewWorkflow(null);
+      setPreviewLoadingId(null);
     }
   }, [isOpen]);
 
   const getNodeCountLabel = (count: number): string => {
     return t('sample.dialog.nodeCount').replace('{{count}}', String(count));
+  };
+
+  const handlePreview = (sampleId: string) => {
+    setPreviewLoadingId(sampleId);
+    vscode.postMessage({ type: 'PREVIEW_SAMPLE_WORKFLOW', payload: { sampleId } });
   };
 
   return (
@@ -237,8 +260,38 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
                         {t(sample.descriptionKey as keyof WebviewTranslationKeys)}
                       </p>
 
-                      {/* Load button */}
-                      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                      {/* Preview + Load buttons */}
+                      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handlePreview(sample.id);
+                          }}
+                          disabled={previewLoadingId === sample.id}
+                          style={{
+                            padding: '4px 14px',
+                            backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                            color: 'var(--vscode-button-secondaryForeground)',
+                            border: 'none',
+                            borderRadius: '2px',
+                            cursor: previewLoadingId === sample.id ? 'wait' : 'pointer',
+                            fontSize: '12px',
+                            fontWeight: 500,
+                            opacity: previewLoadingId === sample.id ? 0.7 : 1,
+                          }}
+                          onMouseEnter={(e) => {
+                            if (previewLoadingId === sample.id) return;
+                            e.currentTarget.style.backgroundColor =
+                              'var(--vscode-button-secondaryHoverBackground)';
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor =
+                              'var(--vscode-button-secondaryBackground)';
+                          }}
+                        >
+                          Preview
+                        </button>
                         <button
                           type="button"
                           onClick={(e) => {
@@ -275,6 +328,98 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
           </Dialog.Content>
         </Dialog.Overlay>
       </Dialog.Portal>
+      {/* Preview overlay (rendered above the sample list dialog) */}
+      <Dialog.Root
+        open={previewWorkflow !== null}
+        onOpenChange={(open) => {
+          if (!open) setPreviewWorkflow(null);
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay
+            style={{
+              position: 'fixed',
+              inset: 0,
+              backgroundColor: 'rgba(0, 0, 0, 0.6)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 10002,
+            }}
+          >
+            <Dialog.Content
+              onEscapeKeyDown={() => setPreviewWorkflow(null)}
+              style={{
+                position: 'relative',
+                width: '92vw',
+                height: '88vh',
+                maxWidth: '1400px',
+                display: 'flex',
+                flexDirection: 'column',
+                backgroundColor: 'var(--vscode-editor-background)',
+                border: '1px solid var(--vscode-panel-border)',
+                borderRadius: '4px',
+                boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
+                outline: 'none',
+                overflow: 'hidden',
+              }}
+            >
+              <Dialog.Title
+                style={{
+                  position: 'absolute',
+                  width: 1,
+                  height: 1,
+                  padding: 0,
+                  margin: -1,
+                  overflow: 'hidden',
+                  clip: 'rect(0,0,0,0)',
+                  whiteSpace: 'nowrap',
+                  border: 0,
+                }}
+              >
+                {t('dialog.diffPreview.previewOverview')}
+              </Dialog.Title>
+              <button
+                type="button"
+                onClick={() => setPreviewWorkflow(null)}
+                aria-label={t('dialog.diffPreview.closeOverview')}
+                title={t('dialog.diffPreview.closeOverview')}
+                style={{
+                  position: 'absolute',
+                  top: '10px',
+                  right: '10px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 4,
+                  backgroundColor: 'transparent',
+                  color: 'var(--vscode-foreground)',
+                  border: 'none',
+                  borderRadius: 0,
+                  cursor: 'pointer',
+                  opacity: 0.85,
+                  transition: 'opacity 0.15s ease',
+                  zIndex: 2,
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.opacity = '0.55';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.opacity = '0.85';
+                }}
+              >
+                <X size={20} />
+              </button>
+              <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+                <WorkflowOverview
+                  workflow={previewWorkflow}
+                  splitRatioStorageKey="cc-wf-studio.overviewMermaidPanelRatio.samplePreview"
+                />
+              </div>
+            </Dialog.Content>
+          </Dialog.Overlay>
+        </Dialog.Portal>
+      </Dialog.Root>
     </Dialog.Root>
   );
 };


### PR DESCRIPTION
## Summary

Add a "Preview" button to the left of the "Load" button on each sample workflow card so users can inspect a sample without applying it to the canvas.

## What Changed

Each sample card in the Sample Workflow dialog previously offered only a "Load" action that immediately applied the sample to the active canvas. Users had no way to review what a sample contained before committing to it. A new "Preview" button now opens the sample in a full-size `WorkflowOverview` overlay (the same pattern used for AI editing previews) so users can inspect the workflow before deciding to load.

### Before
- Sample card showed a single "Load" button (and full-card click) that applied the sample directly to the canvas.
- No way to see node graph / instructions for a sample before loading.

### After
- Sample card shows "Preview" + "Load" buttons (Preview on the left).
- Clicking Preview fetches the sample without applying it and renders `WorkflowOverview` in a nested overlay (z-index 10002).
- Closing the overlay (ESC / X / overlay click) returns to the sample list; the parent dialog stays open.
- "Load" and full-card click keep their existing behavior.

## Changes

- `src/shared/types/messages.ts` - Add `PreviewSampleWorkflowRequestPayload` / `SampleWorkflowPreviewLoadedPayload` and wire `PREVIEW_SAMPLE_WORKFLOW` / `SAMPLE_WORKFLOW_PREVIEW_LOADED` into the message unions.
- `src/extension/commands/load-sample-workflow.ts` - Extract sample-file resolution into `resolveAndReadSample` helper; refactor `loadSampleWorkflow` to use it; add new `previewSampleWorkflow` that returns the workflow without applying it.
- `src/extension/commands/open-editor.ts` - Import `previewSampleWorkflow` and handle the `PREVIEW_SAMPLE_WORKFLOW` message.
- `src/webview/src/components/dialogs/SampleWorkflowDialog.tsx` - Add Preview button (secondary style) left of Load, request preview via the new message, render `WorkflowOverview` in a nested z-index 10002 Radix Dialog overlay, reset preview state on parent close. Reuses `dialog.diffPreview.closeOverview` translation; "Preview" is hardcoded (no new i18n keys).

## Testing

- [x] `npm run check` passes (pre-existing `WorkflowEditor.tsx` lint warnings unrelated to this change)
- [x] `npm run build` passes (webview + extension)
- [x] Manual E2E in VSCode Extension Development Host: Preview + Load buttons render with Preview on the left
- [x] Manual E2E: Click Preview on each sample; Overview opens with the workflow rendered
- [x] Manual E2E: ESC / X / overlay click closes the Overview and returns to the sample list (parent dialog stays open)
- [x] Manual E2E: Load button still applies the sample to the canvas; full-card click unchanged
- [x] Manual E2E: Closing the parent dialog while previewing resets state cleanly
- [x] Manual E2E: All 5 locales (en/ja/ko/zh-CN/zh-TW) show locale-matched sample content in Preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow preview functionality. Users can now preview sample workflows before loading them via a new "Preview" button on each sample card, displaying the workflow structure in a dedicated overlay dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->