### PR TITLE
Phase 5: monorepo README pass

### DIFF
--- a/.changeset/phase-5-readme-pass.md
+++ b/.changeset/phase-5-readme-pass.md
@@ -1,0 +1,10 @@
+---
+---
+
+Documentation-only pass introducing per-package READMEs and the monorepo's root README. No package code changes; no version bumps.
+
+- Adds the monorepo's root `README.md`, mirroring the published VSCode extension README so visitors landing from external links (X, blog posts, etc.) keep the existing marketing hero. Image paths point at `packages/vscode/resources/` since the monorepo restructure relocated the assets.
+- Adds a `packages/core/README.md` that documents every module under `@cc-wf-studio/core` and the canonical "validate → migrate → render → plan" usage flow.
+- Cross-links `packages/cli/README.md` and `packages/mcp/README.md` to the monorepo README so anyone landing on either npm page (once published) can discover the sibling interfaces.
+
+The full three-interface overview (Mermaid data-flow diagram + per-interface quick start) will land alongside the first `@cc-wf-studio/cli` and `@cc-wf-studio/mcp` npm publish — until those packages exist, the README intentionally keeps the VSCode extension as the only install path.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,161 @@
+<p align="center">
+  <img src="./packages/vscode/resources/icon-large.png" alt="CC Workflow Studio Icon" width="128">
+</p>
+
+# CC Workflow Studio
+
+<p align="center">
+  <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://vsmarketplacebadges.dev/version-short/breaking-brake.cc-wf-studio.svg?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
+  <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
+  <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>
+</p>
+
+<p align="center">
+  <img src="./packages/vscode/resources/hero.png" alt="CC Workflow Studio" width="800">
+</p>
+
+**You think visually. AI thinks in `.md`. CC Workflow Studio speaks both.**
+
+Design workflows on a canvas. Export as Markdown your AI agent already understands. No more prompt-guessing.
+
+<p align="center">
+  <a href="https://speakerdeck.com/seiyakobayashi/cc-workflow-studio">
+    <img src="./packages/vscode/resources/deck-preview.png" alt="Learn more: Why CC Workflow Studio?" width="600">
+  </a>
+  <br>
+  <em>Why CC Workflow Studio? - Speaker Deck Link</em>
+</p>
+
+---
+
+## Supported Agents
+
+| Agent | Export Format | Requires |
+|-------|--------------|----------|
+| Claude Code | `.claude/agents/` `.claude/commands/` | [Claude Code](https://github.com/anthropics/claude-code) |
+| GitHub Copilot Chat | `.github/prompts/` | [Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) |
+| GitHub Copilot CLI | `.github/skills/` | [Copilot CLI](https://github.com/github/copilot-cli) |
+| OpenAI Codex CLI | `.codex/skills/` | [Codex CLI](https://github.com/openai/codex) |
+| Roo Code | `.roo/skills/` | [Roo Code](https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline) |
+| Gemini CLI | `.gemini/skills/` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) |
+| Antigravity | `.agent/skills/` | [Antigravity](https://antigravity.google/) |
+| Cursor | `.cursor/agents/` `.cursor/skills/` | [Cursor](https://github.com/cursor/cursor) |
+
+> **Note:** Agents other than Claude Code require activation from Toolbar's **More** menu.
+
+<!-- Hero image placeholder - recommended size: 1600x900px or 16:9 aspect ratio -->
+<!-- Place image at: /resources/hero.png -->
+
+---
+
+<!-- AI Edit Demo GIF: MCP Server-based Workflow Editing -->
+<p align="center">
+  <img src="./packages/vscode/resources/demo_edit_with_ai.gif" alt="AI-Assisted Workflow Creation Demo - MCP Server-based Editing" width="800">
+</p>
+
+<p align="center">
+  <em>✨ Edit with AI: AI agents (Claude Code, GitHub Copilot, etc.) create workflows through natural language via MCP Server</em>
+</p>
+
+---
+
+<!-- Run Workflow Demo GIF -->
+<p align="center">
+  <img src="./packages/vscode/resources/demo_run_workflow.gif" alt="Run Workflow Demo - Execute workflows directly from the editor" width="800">
+</p>
+
+<p align="center">
+  <em>▶️ Run workflows directly from the editor – See your AI automation in action instantly</em>
+</p>
+
+---
+
+## Key Features
+
+🔀 **Visual Workflow Editor** - Intuitive drag-and-drop canvas for designing AI agent orchestrations without code
+
+🤖 **Agentic Engineering** - Design multi-agent workflows with Sub-Agent orchestration, Agent Skills, and MCP tool integration — the building blocks of agentic engineering
+
+✨ **Edit with AI** - Iteratively improve workflows through conversational AI - ask for changes, add features, or refine logic with natural language feedback
+
+⚡ **One-Click Export & Run** - Export workflows to ready-to-use formats and run directly from the editor
+
+## How to Use
+
+### Launch the Extension
+
+- Click the <img src="./packages/vscode/resources/icon.png" alt="icon" height="16" style="vertical-align: middle"> icon in the top-right corner of the editor
+- Or: Command Palette (`Cmd+Shift+P`) → **"CC Workflow Studio: Open Editor"**
+
+### Create a Workflow
+
+- Add nodes from the palette and configure their settings, or use [Edit with AI](#edit-with-ai).
+
+### Save & Load
+
+- Click Save <img src="./packages/vscode/resources/icon-save.png" alt="save" height="16" style="vertical-align: middle"> button in the toolbar to store your workflow as `.vscode/workflows/*.json`
+- Click Load <img src="./packages/vscode/resources/icon-file-down.png" alt="load" height="16" style="vertical-align: middle"> button in the toolbar to open a saved `.json` workflow
+
+### Export & Run
+
+- Click Export <img src="./packages/vscode/resources/icon-export.png" alt="export" height="16" style="vertical-align: middle"> button in the toolbar to create a `.md` slash command or agent skill (use `/workflow-name` in AI coding agents)
+- Click Run <img src="./packages/vscode/resources/icon-play.png" alt="run" height="16" style="vertical-align: middle"> button in the toolbar to run your workflow directly in AI coding agents
+
+### Edit with AI
+
+- Click Edit with AI <img src="./packages/vscode/resources/icon-sparkles.png" alt="sparkles" height="16" style="vertical-align: middle"> button in the toolbar to generate or refine workflows with natural language
+- **Native with MCP Server**: Click an AI agent button in the Edit with AI panel to launch native AI editing. The MCP server starts automatically behind the scenes.
+
+```mermaid
+sequenceDiagram
+    actor User
+    box VS Code (CC Workflow Studio)
+        participant UI as Editor UI
+        participant MCP as MCP Server
+    end
+    participant Agent as AI Agent
+
+    User->>UI: Click agent button
+    UI->>MCP: Auto start server
+    UI->>Agent: Launch with editing skill
+
+    loop AI edits workflow
+        Agent->>MCP: get_workflow
+        MCP-->>Agent: workflow JSON
+        Agent->>MCP: apply_workflow
+        MCP->>UI: Update canvas
+    end
+```
+
+## Usage Examples
+
+Coming soon - Sample workflows and tutorials are under development.
+
+## License
+
+This project is licensed under the **GNU Affero General Public License v3.0** (AGPL-3.0-or-later).
+
+See the [LICENSE](./LICENSE) file for the full license text.
+
+### What this means
+
+- You can use, modify, and distribute this software
+- If you modify and deploy this software (including as a network service), you must:
+  - Make your modified source code available under AGPL-3.0
+  - Provide access to the source code for users interacting with the service
+- Commercial use is allowed, but proprietary modifications are not
+
+Copyright (c) 2025 breaking-brake
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=breaking-brake/cc-wf-studio&type=Date)](https://star-history.com/#breaking-brake/cc-wf-studio&Date)
+
+## Acknowledgments
+
+Built with [React Flow](https://reactflow.dev/) • Powered by [Claude Code](https://claude.com/claude-code) • Inspired by [Dify](https://dify.ai/)
+
+---
+
+**Made with CC Workflow Studio**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,8 @@
 
 Command-line tool (`ccwf`) for [cc-wf-studio](https://github.com/breaking-brake/cc-wf-studio) workflows. Renders, validates, materialises, and serves a workflow JSON from a terminal — no VSCode required.
 
+> One of the three interfaces sharing a workflow file: this CLI, the `@cc-wf-studio/mcp` stdio server, and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
+
 ## Install
 
 ```sh

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,71 @@
+# @cc-wf-studio/core
+
+Pure logic shared by every cc-wf-studio interface — the VSCode extension, the MCP server, and the `ccwf` CLI all reach for the same workflow types, validators, and Markdown/Mermaid generators that live here. No file system, no UI, no network: a node-side dependency you can pull into your own automation without inheriting an editor.
+
+This is the "brain" of the monorepo. See the [root README](../../README.md) for how the three interfaces compose around it.
+
+## What's inside
+
+| Module | Purpose |
+|---|---|
+| `types/workflow-definition` | `Workflow`, every `*Node` shape, `Connection`, `WorkflowMetadata`, `SlashCommandOptions`, hook types, `VALIDATION_RULES`. |
+| `types/sample-workflow` / `types/ai-metrics` | Sample-workflow JSON shape used by the editor, lightweight metrics types for the AI-editing flow. |
+| `constants/built-in-sub-agents` | Catalogue of the agents Claude Code ships out of the box (`general-purpose`, `explore`, `plan`). |
+| `services/workflow-prompt-generator` | `generateMermaidFlowchart`, `generateExecutionInstructions`, `sanitizeNodeId` + the `ExportProvider` union. |
+| `services/workflow-overview-formatter` | `generateOverviewMarkdown` — the per-node Markdown the canvas Overview panel and `ccwf preview` render side-by-side with the Mermaid diagram. |
+| `services/workflow-export` | Pure `.claude/*` file generators (`generateSubAgentFile`, `generateSlashCommandFile`, `nodeNameToFileName`, `escapeYamlString`, `validateClaudeFileFormat`) and `planWorkflowExportFiles(workflow)` — the planner Claude Code's `ccwf export` walks. |
+| `services/agent-skill-export` | `AgentSkillProvider` union + `generateAgentSkillContent` and `planAgentSkillFiles(workflow, agent)` for every non-Claude agent (Antigravity / Codex / Copilot / Cursor / Gemini / Roo Code). |
+| `utils/validate-workflow` | `validateAIGeneratedWorkflow` — the schema check `ccwf validate` runs. |
+| `utils/migrate-workflow` | Forward-migration of older workflow JSON to the current schema. |
+| `utils/schema-parser` | Helpers that load the bundled workflow schema (`resources/workflow-schema.toon`). |
+| `utils/workflow-validator` | Slack-share specific validator (`validateWorkflowFile`, re-exported as `SlackValidationResult`). |
+
+Anything tied to a side-effect (`fs.writeFile`, `vscode.window.*`, `postMessage`, ...) lives in the **caller** — `core` only computes.
+
+## Usage
+
+```ts
+import {
+  generateMermaidFlowchart,
+  generateExecutionInstructions,
+  planWorkflowExportFiles,
+  planAgentSkillFiles,
+  validateAIGeneratedWorkflow,
+  migrateWorkflow,
+  type Workflow,
+} from '@cc-wf-studio/core';
+
+// 1. Validate before doing anything else.
+const result = validateAIGeneratedWorkflow(rawJson);
+if (!result.valid) {
+  throw new Error(`Bad workflow:\n${result.errors.map((e) => e.message).join('\n')}`);
+}
+
+const workflow = migrateWorkflow(rawJson) as Workflow;
+
+// 2. Render the canvas-equivalent Markdown.
+const mermaid = generateMermaidFlowchart(workflow);
+const guide = generateExecutionInstructions(workflow, { provider: 'claude-code' });
+
+// 3. Decide what files to emit (without writing them).
+const claudePlan = planWorkflowExportFiles(workflow);
+// → [{ relativePath: '.claude/skills/<workflow>/SKILL.md', contents: ... }, ...]
+
+const cursorPlan = planAgentSkillFiles(workflow, 'cursor');
+// → [{ relativePath: '.cursor/skills/<workflow>/SKILL.md', ... },
+//    { relativePath: '.cursor/agents/<sub-agent>.md', ... }]
+```
+
+## Subpath imports
+
+`@cc-wf-studio/core/mcp` exposes a few `McpNode`-specific types (`McpNodeData`, `ToolParameter`) that pre-date the unified `workflow-definition` schema and still drift in shape. Reach for them only when working with MCP nodes specifically.
+
+```ts
+import { type McpNodeData } from '@cc-wf-studio/core/mcp';
+```
+
+`@cc-wf-studio/core/resources/workflow-schema.json` and `…/workflow-schema.toon` expose the raw schema files so a host can hand them to an LLM verbatim — the MCP server's `get_workflow_schema` tool does exactly that.
+
+## License
+
+[AGPL-3.0-or-later](../../LICENSE)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,6 +2,8 @@
 
 MCP (Model Context Protocol) server toolkit for [cc-wf-studio](https://github.com/breaking-brake/cc-wf-studio) workflows. Ships tool definitions, an IO adapter contract, and a standalone stdio bin (`ccwf-mcp`) that AI clients can use to edit workflow JSON files without the VSCode canvas.
 
+> One of the three interfaces sharing a workflow file: this MCP server, the `@cc-wf-studio/cli`, and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
+
 The package is the deduplicated home of the 6 cc-wf-studio MCP tools. Both the VSCode extension (canvas mode, HTTP transport) and the standalone bin (file mode, stdio transport) configure the same tool registrations through a shared factory.
 
 ## Install


### PR DESCRIPTION
## Summary

Documentation-only pass filling the README gaps the monorepo restructure (Phase 1–4) left behind. No source / build changes, no version bump (empty changeset).

The repo had two visible holes:

- **No root `README.md`** — visitors landing on the GitHub repo (X / blog links, etc.) saw a directory listing instead of the marketing hero `main` has been carrying for months.
- **No `packages/core/README.md`** and no cross-links between `packages/{cli,mcp}` READMEs, so anyone landing on a sibling package from npm couldn't discover the others.

## What's in this PR

| File | Change |
|---|---|
| `README.md` | New. Mirror of `main`'s published VSCode-extension README. Image paths point at `packages/vscode/resources/` (the monorepo restructure relocated those assets out of the repo root). |
| `packages/core/README.md` | New. Module catalogue (`services/`, `utils/`, `types/`), subpath imports, canonical "validate → migrate → render → plan" usage sketch. |
| `packages/cli/README.md` | One-line cross-link blockquote near the top pointing at the sibling MCP server and the VSCode extension. |
| `packages/mcp/README.md` | Same one-line cross-link blockquote pointing at the sibling CLI and the VSCode extension. |
| `.changeset/phase-5-readme-pass.md` | Empty changeset — documentation-only, no release. |

## Things intentionally deferred

The draft of this pass originally added a monorepo overview (three-interface Mermaid data-flow diagram, `npx @cc-wf-studio/cli` / `npx @cc-wf-studio/mcp` "Try it" commands, a "Use without VSCode" addendum on the VSCode extension README linking at npm pages, and a `npm install @cc-wf-studio/core` example). These all assumed the CLI and MCP packages were already on npm — they aren't. Surfacing `npx ...` and npmjs.com links that 404 would erode trust more than the omission does, so:

- The cross-link blockquotes name `@cc-wf-studio/cli` and `@cc-wf-studio/mcp` as plain text, not as npm hrefs.
- `packages/core/README.md` ships without an `## Install` section.
- The "three interchangeable interfaces" overview (flowchart + per-interface quick start) will land alongside the first `@cc-wf-studio/cli` / `@cc-wf-studio/mcp` publish.

The root `README.md` keeps the VSCode extension as the only install path until then.

## Rebase note

Branch was rebased onto `origin/chore/monorepo` (post Phase 6 merge) and rewritten to 4 commits. The earlier draft's `ccwf install-skills` removal and `Reachability` → `Security` regression on `packages/cli/README.md` are no longer present; both Phase 6 outcomes are preserved.

## Test plan

- [x] `pnpm -r run check` passes.
- [x] `pnpm -r run build` passes.
- [x] All 11 image references in the root README resolve to `packages/vscode/resources/*`.
- [x] No `npmjs.com/package/@cc-wf-studio` or `npm install @cc-wf-studio` strings in any Phase-5-added content.
- [ ] Render the new READMEs on github.com once pushed and confirm hero + GIFs display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)