### PR TITLE
fix(cli, mcp): patch ccwf --version + add ccwf-mcp --version (0.1.1)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @cc-wf-studio/cli
 
+## 0.1.1
+
+### Patch Changes
+
+- Fix `ccwf --version` reporting `0.0.0` instead of the actual published version, and add a `--version` / `-V` flag to `ccwf-mcp`. Both bins now read the version from their own `package.json` at startup so they stay in sync with the npm release without a build-time substitution step.
+- Updated dependencies
+  - @cc-wf-studio/mcp@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cc-wf-studio/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Command-line tool for cc-wf-studio: render, validate, and run workflows, plus a stdio MCP server entry.",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,9 @@
  *   - run <file> [--overwrite]      (commit 7)
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { registerCanvasCommand } from './commands/canvas.js';
 import { registerExportCommand } from './commands/export.js';
@@ -20,12 +23,20 @@ import { registerRunCommand } from './commands/run.js';
 import { registerUninstallSkillsCommand } from './commands/uninstall-skills.js';
 import { registerValidateCommand } from './commands/validate.js';
 
+// Read version from package.json so `ccwf --version` stays in sync with the
+// published npm version without a build-time substitution step. The compiled
+// entry sits at `<pkg>/dist/cli.js`, so package.json is one directory up.
+const pkgJsonPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+const { version: pkgVersion } = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as {
+  version: string;
+};
+
 const program = new Command();
 
 program
   .name('ccwf')
   .description('Command-line tool for cc-wf-studio workflows.')
-  .version('0.0.0');
+  .version(pkgVersion);
 
 registerRenderCommand(program);
 registerValidateCommand(program);

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cc-wf-studio/mcp
 
+## 0.1.1
+
+### Patch Changes
+
+- Fix `ccwf --version` reporting `0.0.0` instead of the actual published version, and add a `--version` / `-V` flag to `ccwf-mcp`. Both bins now read the version from their own `package.json` at startup so they stay in sync with the npm release without a build-time substitution step.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cc-wf-studio/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server toolkit for cc-wf-studio workflows. Ships tool definitions, an IO adapter contract, and a stdio bin (ccwf-mcp) for file-mode usage.",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/packages/mcp/src/mcp.ts
+++ b/packages/mcp/src/mcp.ts
@@ -9,10 +9,21 @@
  * details (sha256 revisions, no auto-create of sub-agent .md files, …).
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createWorkflowMcpServer } from './factory.js';
 import { FileWorkflowAdapter } from './file-adapter.js';
+
+// Read version from package.json so `ccwf-mcp --version` stays in sync with
+// the published npm version. The compiled entry sits at `<pkg>/dist/mcp.js`,
+// so package.json is one directory up.
+const pkgJsonPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+const { version: pkgVersion } = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as {
+  version: string;
+};
 
 const USAGE = `Usage: ccwf-mcp --file <path-to-workflow.json> [--project-root <dir>]`;
 
@@ -23,6 +34,7 @@ async function main(): Promise<void> {
       file: { type: 'string' as const },
       'project-root': { type: 'string' as const },
       help: { type: 'boolean' as const, short: 'h' },
+      version: { type: 'boolean' as const, short: 'V' },
     },
     strict: true,
   };
@@ -31,6 +43,11 @@ async function main(): Promise<void> {
   } catch (error) {
     process.stderr.write(`${(error as Error).message}\n${USAGE}\n`);
     process.exit(2);
+  }
+
+  if (parsed.values.version) {
+    process.stdout.write(`${pkgVersion}\n`);
+    return;
   }
 
   if (parsed.values.help) {


### PR DESCRIPTION
## Summary

First post-publish patch. After `@cc-wf-studio/{core,mcp,cli}@0.1.0` shipped, a quick `ccwf --version` against the npm-installed bin surfaced two issues:

- `ccwf --version` → `0.0.0` (was hardcoded in `packages/cli/src/cli.ts:28`)
- `ccwf-mcp --version` → "Unknown option" (the bin never wired one up)

Both bins now read their own `package.json` at startup, so the value tracks the published npm version without a build-time substitution step.

## Changes

- `packages/cli/src/cli.ts` — replace `.version('0.0.0')` with `pkgVersion` loaded from `<pkg>/package.json` via `import.meta.url`.
- `packages/mcp/src/mcp.ts` — add `--version` / `-V` to the parseArgs spec, short-circuit to print the version before any other work.
- `.changeset/patch-version-flag.md` (consumed by `pnpm changeset version`):
  - `@cc-wf-studio/cli`: `0.1.0` → `0.1.1` (patch)
  - `@cc-wf-studio/mcp`: `0.1.0` → `0.1.1` (patch)
  - `@cc-wf-studio/core` is untouched.

## Local verification

```sh
$ pnpm -F @cc-wf-studio/cli -F @cc-wf-studio/mcp run build
$ node packages/cli/dist/cli.js --version
0.1.1
$ node packages/mcp/dist/mcp.js --version
0.1.1
```

Plus a tarball install smoke (mcp + cli @ 0.1.1 from local tarballs, core @ 0.1.0 pulled from npmjs.com):
- `ccwf --version` → `0.1.1`
- `ccwf-mcp --version` → `0.1.1`
- Installed package.json versions match expectations.

## Post-merge publish plan

Same recipe as 0.1.0, scoped to the two bumped packages:

```sh
git checkout chore/monorepo && git pull
pnpm -F @cc-wf-studio/mcp publish --access public --no-git-checks
pnpm -F @cc-wf-studio/cli publish --access public --no-git-checks
git tag '@cc-wf-studio/mcp@0.1.1' HEAD
git tag '@cc-wf-studio/cli@0.1.1' HEAD
git push origin '@cc-wf-studio/mcp@0.1.1' '@cc-wf-studio/cli@0.1.1'
```

Order matters: mcp first because cli's `package.json` declares `@cc-wf-studio/mcp@0.1.1` as a runtime dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)