### PR TITLE
docs: restore npm references now that 0.1.x is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
   <a href="https://github.com/breaking-brake/cc-wf-studio/stargazers"><img src="https://img.shields.io/github/stars/breaking-brake/cc-wf-studio" alt="GitHub Stars" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio"><img src="https://vsmarketplacebadges.dev/version-short/breaking-brake.cc-wf-studio.svg?label=VS%20Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://open-vsx.org/extension/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/open-vsx/v/breaking-brake/cc-wf-studio?label=OpenVSX" alt="OpenVSX" /></a>
+  <a href="https://www.npmjs.com/package/@cc-wf-studio/cli"><img src="https://img.shields.io/npm/v/@cc-wf-studio/cli?label=npm%20%2F%20cli" alt="npm @cc-wf-studio/cli" /></a>
+  <a href="https://www.npmjs.com/package/@cc-wf-studio/mcp"><img src="https://img.shields.io/npm/v/@cc-wf-studio/mcp?label=npm%20%2F%20mcp" alt="npm @cc-wf-studio/mcp" /></a>
   <a href="https://deepwiki.com/breaking-brake/cc-wf-studio"><img src="https://img.shields.io/badge/Ask-DeepWiki-009485" alt="Ask DeepWiki" /></a>
 </p>
 
@@ -44,8 +46,46 @@ Design workflows on a canvas. Export as Markdown your AI agent already understan
 
 > **Note:** Agents other than Claude Code require activation from Toolbar's **More** menu.
 
-<!-- Hero image placeholder - recommended size: 1600x900px or 16:9 aspect ratio -->
-<!-- Place image at: /resources/hero.png -->
+---
+
+## Use it without VSCode, too
+
+The VSCode extension is the most ergonomic editor, but it isn't the only entry point. The same `workflow.json` drives a CLI and an MCP server — pick whichever interface fits the situation.
+
+```mermaid
+flowchart LR
+    Wf(["workflow.json"])
+
+    subgraph IDE["🪟 VSCode Extension"]
+        Canvas["React Flow canvas<br/>+ editor + Slack share"]
+    end
+
+    subgraph Mcp["🔌 MCP Server"]
+        AIClient["Claude Code,<br/>MCP Inspector, ..."]
+        McpServer["@cc-wf-studio/mcp<br/>(stdio: <code>ccwf-mcp</code>)"]
+        AIClient --> McpServer
+    end
+
+    subgraph Cli["💻 CLI"]
+        CliBin["@cc-wf-studio/cli<br/>(<code>ccwf render | validate | export | run | preview | canvas | mcp</code>)"]
+    end
+
+    Wf <-->|edit| Canvas
+    Wf <-->|read / write| McpServer
+    Wf <-->|read / write| CliBin
+
+    Canvas -.->|writes skills + agents| Output["Agent skills on disk<br/>(.claude/, .codex/, .cursor/, ...)"]
+    McpServer -.-> Output
+    CliBin -.-> Output
+```
+
+| Interface | Try it | Best for | Docs |
+|---|---|---|---|
+| **VSCode extension** | `code --install-extension breaking-brake.cc-wf-studio` | Designing workflows visually | [`packages/vscode`](./packages/vscode/README.md) |
+| **CLI (`ccwf`)** | `npx @cc-wf-studio/cli --help` | Terminal / CI / SSH / Codespaces — render, validate, preview, export, run a workflow without VSCode | [`packages/cli`](./packages/cli/README.md) |
+| **MCP server (`ccwf-mcp`)** | Add to your MCP client's `.mcp.json` so Claude Code (or any MCP client) can read and edit workflows over stdio | Letting an external AI client read and edit your workflows through MCP tools | [`packages/mcp`](./packages/mcp/README.md) |
+
+There is no "VSCode-only" path: a workflow you draw in the canvas is the same file `ccwf preview` will render in a browser, and the same file an external Claude Code can edit through MCP.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 Command-line tool (`ccwf`) for [cc-wf-studio](https://github.com/breaking-brake/cc-wf-studio) workflows. Renders, validates, materialises, and serves a workflow JSON from a terminal — no VSCode required.
 
-> One of the three interfaces sharing a workflow file: this CLI, the `@cc-wf-studio/mcp` stdio server, and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
+> One of the three interfaces sharing a workflow file: this CLI, the [`@cc-wf-studio/mcp`](https://www.npmjs.com/package/@cc-wf-studio/mcp) stdio server, and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,6 +4,12 @@ Pure logic shared by every cc-wf-studio interface — the VSCode extension, the 
 
 This is the "brain" of the monorepo. See the [root README](../../README.md) for how the three interfaces compose around it.
 
+## Install
+
+```sh
+npm install @cc-wf-studio/core
+```
+
 ## What's inside
 
 | Module | Purpose |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server toolkit for [cc-wf-studio](https://github.com/breaking-brake/cc-wf-studio) workflows. Ships tool definitions, an IO adapter contract, and a standalone stdio bin (`ccwf-mcp`) that AI clients can use to edit workflow JSON files without the VSCode canvas.
 
-> One of the three interfaces sharing a workflow file: this MCP server, the `@cc-wf-studio/cli`, and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
+> One of the three interfaces sharing a workflow file: this MCP server, the [`@cc-wf-studio/cli`](https://www.npmjs.com/package/@cc-wf-studio/cli), and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
 
 The package is the deduplicated home of the 6 cc-wf-studio MCP tools. Both the VSCode extension (canvas mode, HTTP transport) and the standalone bin (file mode, stdio transport) configure the same tool registrations through a shared factory.
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -132,6 +132,15 @@ sequenceDiagram
 
 Coming soon - Sample workflows and tutorials are under development.
 
+## Use without VSCode
+
+The extension is one of three entry points to the same workflow JSON. Outside VSCode you can drive the canvas through:
+
+- **[`@cc-wf-studio/cli`](https://www.npmjs.com/package/@cc-wf-studio/cli)** — `ccwf preview` opens a read-only browser viewer for any workflow file, `ccwf export` / `ccwf run` materialise it as Agent Skills, `ccwf canvas` runs the full editor in a localhost browser.
+- **[`@cc-wf-studio/mcp`](https://www.npmjs.com/package/@cc-wf-studio/mcp)** — the same MCP tools this extension exposes to in-canvas AI editing, available standalone via `npx @cc-wf-studio/mcp --file <workflow.json>` so an external Claude Code (or any MCP client) can read and edit your workflows.
+
+Same `workflow.json`, three interfaces. See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the full story.
+
 ## License
 
 This project is licensed under the **GNU Affero General Public License v3.0** (AGPL-3.0-or-later).


### PR DESCRIPTION
## Summary

Lands the documentation that Phase 5 deferred. The cli / mcp / core packages are now live on npm (`@cc-wf-studio/core@0.1.0`, `@cc-wf-studio/mcp@0.1.1`, `@cc-wf-studio/cli@0.1.1`), so the npm hrefs / install examples / three-interface overview can finally show up without 404-ing.

## What's added back

| File | Change |
|---|---|
| `README.md` | npm version badges for `cli` and `mcp` in the header; new "Use it without VSCode, too" section with the three-interface Mermaid flowchart and a "Try it / Best for / Docs" table. |
| `packages/cli/README.md` | The cross-link mention of `@cc-wf-studio/mcp` is now an npm href. |
| `packages/mcp/README.md` | Same — `@cc-wf-studio/cli` is now an npm href. |
| `packages/core/README.md` | New `## Install` section with `npm install @cc-wf-studio/core`. |
| `packages/vscode/README.md` | Restored "Use without VSCode" section so Marketplace visitors see the npm-published CLI / MCP siblings. |

No source / build changes; no version bumps; no changeset (documentation only — no release needed).

## Sanity

- All npm links resolve to real packages (checked via `curl https://registry.npmjs.org/@cc-wf-studio/<pkg>` earlier in the publish flow).
- The Mermaid flowchart's dotted-arrow syntax uses pipe-label form (`A -.->|text| B`); no inline-text variant that previously triggered a lexer error on github.com.
- Root README image paths stay at `./packages/vscode/resources/*` per the Phase 5 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)