### PR TITLE
docs: update release-flow.md for the Changesets + dispatch + OIDC flow

### DIFF
--- a/.changeset/docs-update-release-flow.md
+++ b/.changeset/docs-update-release-flow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs only — bring docs/release-flow.md in line with the current Changesets + production-dispatch + OIDC flow. No release needed.

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -6,9 +6,10 @@ This repository uses **[Changesets](https://github.com/changesets/changesets)** 
 
 1. Open a feature/fix PR against `main`.
 2. If your change affects a published package, run `pnpm changeset` locally and commit the generated `.changeset/<name>.md`. (Docs/chore-only PRs: `pnpm changeset add --empty`.)
-3. Merge your PR. The `release-version-pr.yml` workflow opens / updates a `chore(release): version packages` PR collecting all pending changesets (this is a **preview** — version bumps + CHANGELOG diff; nothing is published yet).
-4. When ready to release, merge that "Version Packages" PR into `main`, then promote `main` → `production`.
-5. A maintainer runs the **"Release — Publish"** workflow from the Actions UI (ref defaults to `production`). It publishes the npm packages and uploads the VSIX for `cc-wf-studio`.
+3. Check the **changeset-bot** comment on your PR — 🦋 means a changeset was detected, ⚠️ means none was found. If you see ⚠️ and the PR should release something, add the missing changeset; if it intentionally has no release, add an empty one to clear the warning.
+4. Merge your PR. The `release-version-pr.yml` workflow opens / updates a `chore(release): version packages` PR collecting all pending changesets (this is a **preview** — version bumps + CHANGELOG diff; nothing is published yet).
+5. When ready to release, merge that "Version Packages" PR into `main`, then promote `main` → `production`.
+6. A maintainer runs the **"Release — Publish"** workflow from the Actions UI (ref defaults to `production`). It publishes the npm packages and uploads the VSIX for `cc-wf-studio`.
 
 ## Branch model
 

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -112,6 +112,15 @@ pnpm changeset
 
 The interactive prompt asks: which packages changed, the bump level (`patch` / `minor` / `major`), and a summary used for the CHANGELOG entry. Commit the generated file alongside your code. You never hand-edit `CHANGELOG.md` — Changesets generates it.
 
+### Changeset bot
+
+The [changeset-bot](https://github.com/apps/changeset-bot) GitHub App is installed on this repository. It comments on every PR to show whether a changeset is present:
+
+- **🦋 Changeset detected** — the PR adds a `.changeset/*.md` file (a real bump or an empty one).
+- **⚠️ No Changeset found** — the PR adds none. This is a *reminder, not a blocker* — merging is still allowed. If the PR genuinely needs no release, add an empty changeset (`pnpm changeset add --empty`) to make the intent explicit and clear the warning.
+
+There is no hard CI gate that fails the build on a missing changeset; the bot comment plus the human review at the "Version Packages" PR are the safety net.
+
 ## What doesn't trigger a release
 
 - Pushes to branches other than `main` (the version-PR workflow only watches `main`).

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -1,69 +1,82 @@
 # Release Flow
 
-This repository uses **[Changesets](https://github.com/changesets/changesets)** to manage versioning and publishing across the pnpm workspace. There is a **single release branch (`main`)** — all releases originate from PRs merged into `main`.
+This repository uses **[Changesets](https://github.com/changesets/changesets)** for versioning across the pnpm workspace. Publishing is a **manual GitHub Actions dispatch** that runs from the **`production`** branch.
 
 ## TL;DR for contributors
 
 1. Open a feature/fix PR against `main`.
-2. If your change affects a published package, run `pnpm changeset` locally and commit the generated `.changeset/<name>.md` file.
-3. Merge your PR. A bot will open or update a `chore(release): version packages` PR collecting all pending changesets.
-4. Merging that bot PR cuts the actual release: tags, npm publish for `@cc-wf-studio/*`, and a GitHub Release with the VSIX attached for `cc-wf-studio`.
+2. If your change affects a published package, run `pnpm changeset` locally and commit the generated `.changeset/<name>.md`. (Docs/chore-only PRs: `pnpm changeset add --empty`.)
+3. Merge your PR. The `release-version-pr.yml` workflow opens / updates a `chore(release): version packages` PR collecting all pending changesets (this is a **preview** — version bumps + CHANGELOG diff; nothing is published yet).
+4. When ready to release, merge that "Version Packages" PR into `main`, then promote `main` → `production`.
+5. A maintainer runs the **"Release — Publish"** workflow from the Actions UI (ref defaults to `production`). It publishes the npm packages and uploads the VSIX for `cc-wf-studio`.
 
 ## Branch model
 
-- `main` is the only long-lived release branch. Feature work branches off `main` and merges back via PR.
-- There is no `production` branch. (Removed in the monorepo restructure.)
+- `main` — the development + version-staging branch. Feature work branches off `main` and merges back via PR. The "Version Packages" PR also lands here.
+- `production` — the release source. `main` is promoted to `production` (push or PR) when a release is intended. Publishing always reads from `production`, so `production` is a snapshot of "what is released".
+
+## Two workflows
+
+| Workflow | Trigger | Does |
+|---|---|---|
+| `.github/workflows/release-version-pr.yml` | push to `main` | Runs `changesets/action` **version step only** — opens / updates the "Version Packages" PR. No publish. |
+| `.github/workflows/release.yml` | **`workflow_dispatch`** (input `ref`, default `production`) | Builds, runs `changesets/action` **publish step** (`pnpm changeset publish`) over npm OIDC, then detects the `cc-wf-studio@*` tag and uploads the VSIX. |
 
 ## What each package looks like at release
 
-| Package | npm | GitHub Release tag | VSIX attached |
+| Package | npm | Tag | VSIX attached |
 |---|---|---|---|
 | `@cc-wf-studio/core` | ✅ public | `@cc-wf-studio/core@x.y.z` | — |
 | `@cc-wf-studio/cli` | ✅ public | `@cc-wf-studio/cli@x.y.z` | — |
 | `@cc-wf-studio/mcp` | ✅ public | `@cc-wf-studio/mcp@x.y.z` | — |
 | `cc-wf-studio` (VSCode extension) | ❌ private | `cc-wf-studio@x.y.z` | ✅ `cc-wf-studio-x.y.z.vsix` |
 
-`cc-wf-studio` is marked `"private": true` so Changesets versions and tags it but does not push it to npm. The VSIX is built and uploaded to the corresponding GitHub Release by the workflow.
+`cc-wf-studio` is `"private": true`, so Changesets versions and tags it but does not push it to npm. The workflow detects the tag, builds the VSIX, and attaches it to the GitHub Release.
 
-> **Marketplace / Open VSX** auto-publish is **not** wired up in this Phase 1 setup. Publishing the VSIX to the VSCode Marketplace and Open VSX is currently a manual step performed by a maintainer after the VSIX has been generated.
+`cc-wf-studio-webview` is in the Changesets `ignore` list — it is bundled into `@cc-wf-studio/cli` and the extension at build time, never published on its own.
 
 ## End-to-end flow
 
 ```mermaid
 sequenceDiagram
     actor Dev as Developer
-    participant Branch as feature branch
     participant Main as main
-    participant CSBot as changesets/action
     participant VPR as "Version Packages" PR
+    participant Prod as production
+    actor Maint as Maintainer
+    participant CI as release.yml (dispatch)
     participant NPM as npm registry
     participant GH as GitHub Release
 
-    Dev->>Branch: Implement change
-    Dev->>Branch: pnpm changeset (adds .changeset/xxx.md)
-    Dev->>Main: PR merge
-
-    Main->>CSBot: workflow runs
-    alt unreleased .changeset/*.md exist
-        CSBot->>VPR: Open/update "Version Packages" PR<br/>(bumps versions, updates CHANGELOG.md)
-    end
-
-    Note over Dev,VPR: maintainer reviews bot PR
-
-    Dev->>VPR: review → merge
-    VPR->>Main: version bump commit lands
-
-    Main->>CSBot: workflow runs again
-    CSBot->>CSBot: consumes changesets (no pending left)
-    CSBot->>NPM: publishes public packages<br/>(@cc-wf-studio/*)
-    CSBot->>GH: tags + Releases per package
-    CSBot->>GH: cc-wf-studio (private) gets tag + Release
-    Note over GH: workflow detects cc-wf-studio@x.y.z tag,<br/>builds VSIX, uploads to its Release
+    Dev->>Main: feature PR + .changeset/xxx.md (merge)
+    Main->>VPR: release-version-pr.yml opens / updates Version PR
+    Note over VPR: preview of version bumps + CHANGELOG
+    Maint->>VPR: review + merge
+    VPR->>Main: version bump commit lands (changesets consumed)
+    Maint->>Prod: promote main to production
+    Maint->>CI: Actions UI "Run workflow" (ref: production)
+    CI->>NPM: pnpm changeset publish (OIDC + provenance)
+    CI->>GH: tags + Releases per package
+    CI->>GH: cc-wf-studio tag + Release, VSIX uploaded
 ```
 
-## Independent versions
+## npm authentication: OIDC Trusted Publishing
 
-Each workspace package is versioned independently — there is no `fixed` or `linked` group in `.changeset/config.json`. The intent:
+npm publishes use **OIDC Trusted Publishing** — there is **no `NPM_TOKEN` secret**. Each of `@cc-wf-studio/{core,mcp,cli}` has a Trusted Publisher configured on npmjs.com pointing at `breaking-brake/cc-wf-studio` → `release.yml`. The publish workflow sets `NPM_CONFIG_PROVENANCE: 'true'`, so each release carries a provenance attestation visible on npmjs.com.
+
+## VS Marketplace / Open VSX (manual)
+
+The workflow does **not** push the extension to the Marketplace. It only builds the `.vsix` and attaches it to the `cc-wf-studio@x.y.z` GitHub Release. The store publish is manual:
+
+1. "Release — Publish" uploads `packages/vscode/*.vsix` to the GitHub Release.
+2. The Repository Owner downloads that `.vsix`.
+3. The Repository Owner uploads it to the VS Marketplace (and Open VSX) via the publisher portal.
+
+So the GitHub Release `.vsix` is the source artifact for the store listing — there is no `vsce publish` / `ovsx publish` in CI.
+
+## Independent versions + internal dependency propagation
+
+Each workspace package is versioned independently — there is no `fixed` or `linked` group in `.changeset/config.json`.
 
 ```mermaid
 flowchart LR
@@ -72,28 +85,24 @@ flowchart LR
     MCP["@cc-wf-studio/mcp<br/>0.x.y"]
     VSCode["cc-wf-studio<br/>3.x.y (continued)"]
 
-    Core -.->|workspace:* dep| CLI
-    Core -.->|workspace:* dep| MCP
-    Core -.->|workspace:* dep| VSCode
-
-    note["・New packages start at 0.x<br/>・cc-wf-studio continues from 3.34.x<br/>・workspace:* resolves to real versions on publish"]
+    Core -->|workspace dep| CLI
+    Core -->|workspace dep| MCP
+    Core -->|workspace dep| VSCode
 ```
 
-Notes:
-
-- `cc-wf-studio` keeps its existing 3.34.x version stream so the Marketplace listing remains continuous.
-- New packages start at low pre-1.0 versions until their APIs settle (the [Changesets docs](https://github.com/changesets/changesets/blob/main/docs/decisions.md) cover when to graduate).
-- `workspace:*` dependencies between local packages are replaced with the actual published versions when `changeset publish` runs.
+- `cc-wf-studio` keeps its existing 3.34.x stream so the Marketplace listing stays continuous. A `cc-wf-studio@3.34.1` tag seeds that history.
+- New packages start at pre-1.0 (`core@0.1.0`, `mcp@0.1.1`, `cli@0.1.1` as of writing).
+- `updateInternalDependencies: "patch"` is set, so bumping `@cc-wf-studio/core` automatically bumps `cli` / `mcp` (patch) and updates their dependency ranges — no separate changeset needed for the dependents.
+- `workspace:*` dependencies are replaced with the actual published versions when `changeset publish` runs.
 
 ## Required secrets
 
-The release workflow requires these repository secrets:
-
 | Secret | Purpose |
 |---|---|
-| `RELEASE_BOT_APP_ID` | GitHub App ID used to author release commits/PRs as a bot (so subsequent workflows can be triggered). |
+| `RELEASE_BOT_APP_ID` | GitHub App ID used to author release commits / PRs as a bot. |
 | `RELEASE_BOT_PRIVATE_KEY` | Private key for the above GitHub App. |
-| `NPM_TOKEN` | Token for publishing `@cc-wf-studio/*` to npm. **Required even though Phase 1 ships only skeletons** — Changesets will silently skip the publish step if all bumped packages are private, but the token is still validated when `changeset publish` runs. |
+
+No `NPM_TOKEN` — npm publishing is via OIDC Trusted Publishing.
 
 ## Authoring a changeset
 
@@ -101,39 +110,18 @@ The release workflow requires these repository secrets:
 pnpm changeset
 ```
 
-The interactive prompt asks:
-
-1. Which packages changed? (Use space to select.)
-2. What bump level? (`patch` / `minor` / `major`).
-3. A summary used for the changelog entry.
-
-Commit the generated file alongside your code change. CI will pick it up on merge.
+The interactive prompt asks: which packages changed, the bump level (`patch` / `minor` / `major`), and a summary used for the CHANGELOG entry. Commit the generated file alongside your code. You never hand-edit `CHANGELOG.md` — Changesets generates it.
 
 ## What doesn't trigger a release
 
-- Pushes to branches other than `main`.
-- Merges that contain no `.changeset/*.md` (no version bump → no PR opened).
-- Pure docs / chore PRs where you intentionally omit a changeset.
+- Pushes to branches other than `main` (the version-PR workflow only watches `main`).
+- A "Version Packages" PR merge **does not publish** on its own — publishing is the separate manual dispatch from `production`.
+- Merges with no `.changeset/*.md` (no version bump → no Version PR).
+- Pure docs / chore PRs where you intentionally add an empty changeset.
 
-## Previous release flow (for reference)
+## Prior release flows (for reference)
 
-Before the monorepo restructure, releases were driven by **`semantic-release`** on push to a separate `production` branch:
+- **Original**: `semantic-release` on push to `production` (commit-message driven), with auto-sync `production` → `main`.
+- **Brief interlude**: per-package `semantic-release` with `semantic-release-monorepo` on a `workflow_dispatch` (Phase 8). Reverted because Changesets handles internal dependency propagation and CHANGELOG generation more cleanly for this monorepo.
 
-```mermaid
-sequenceDiagram
-    actor Dev as Developer
-    participant Main as main
-    participant Prod as production
-    participant SR as semantic-release
-    participant GH as GitHub Release
-
-    Dev->>Main: feature/fix PR merge<br/>(conventional commit prefix)
-    Dev->>Prod: PR main → production
-    Prod->>SR: push trigger
-    SR->>SR: parse commit messages → next version
-    SR->>Prod: commit chore(release): X.Y.Z [skip ci]
-    SR->>GH: create Release vX.Y.Z + attach VSIX
-    Prod->>Main: auto-sync production → main
-```
-
-Both the `production` branch and `semantic-release` are removed; the equivalent capability is now provided by Changesets on `main`.
+The current flow (Changesets + manual publish dispatch from `production` + OIDC) supersedes both.


### PR DESCRIPTION
## Summary

`docs/release-flow.md` still described the pre-Phase-9 design (Changesets on `main` only, no `production` branch, auto-publish when the "Version Packages" PR merges, `NPM_TOKEN` required). This brings it in line with the flow that actually exists now.

## What changed in the doc

- **Branch model**: `main` (dev + version-staging) **and** `production` (release source). Publishing reads from `production`.
- **Two workflows** documented: `release-version-pr.yml` (push to `main` → "Version Packages" PR, preview only) and `release.yml` (`workflow_dispatch` from `production` → `pnpm changeset publish` + VSIX).
- **npm auth**: OIDC Trusted Publishing, no `NPM_TOKEN`, with provenance. Removed `NPM_TOKEN` from the required-secrets table.
- **VSIX → Marketplace**: documented the manual download-from-GitHub-Release + upload-by-Repository-Owner step.
- **Internal dependency propagation**: noted `updateInternalDependencies: "patch"` (core bump cascades to cli/mcp).
- **Prior flows**: refreshed to mention both the original semantic-release era and the brief Phase 8 semantic-release-monorepo interlude.

Mermaid diagrams use safe pipe-label syntax (no inline-text dotted arrows that trip the GitHub renderer).

Docs-only; an empty changeset records "no release needed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)