### PR TITLE
chore: relicense core/cli/mcp/webview from AGPL to MIT

### DIFF
--- a/.changeset/relicense-libs-mit.md
+++ b/.changeset/relicense-libs-mit.md
@@ -1,0 +1,7 @@
+---
+"@cc-wf-studio/core": patch
+"@cc-wf-studio/cli": patch
+"@cc-wf-studio/mcp": patch
+---
+
+Relicense from AGPL-3.0-or-later to **MIT**. The headless library and tooling packages are now permissively licensed to encourage reuse and embedding; the VSCode extension (`cc-wf-studio`) remains AGPL-3.0-or-later. Each package now ships its own `LICENSE` file in the published tarball. This is a license loosening — no code or API change — so existing usage is unaffected.

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 breaking-brake
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@cc-wf-studio/cli",
   "version": "0.1.1",
   "description": "Command-line tool for cc-wf-studio: render, validate, and run workflows, plus a stdio MCP server entry.",
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 breaking-brake
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@cc-wf-studio/core",
   "version": "0.1.0",
   "description": "Core workflow schema, parser, serializer, Mermaid generation, and Claude Code export logic for cc-wf-studio",
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/LICENSE
+++ b/packages/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 breaking-brake
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,7 +2,7 @@
   "name": "@cc-wf-studio/mcp",
   "version": "0.1.1",
   "description": "MCP server toolkit for cc-wf-studio workflows. Ships tool definitions, an IO adapter contract, and a stdio bin (ccwf-mcp) for file-mode usage.",
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/vscode/src/webview/LICENSE
+++ b/packages/vscode/src/webview/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 breaking-brake
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vscode/src/webview/package.json
+++ b/packages/vscode/src/webview/package.json
@@ -2,7 +2,7 @@
   "name": "cc-wf-studio-webview",
   "version": "3.34.1",
   "private": true,
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Relicenses the headless library + tooling packages from **AGPL-3.0-or-later → MIT** to encourage reuse and embedding. The VSCode extension (`cc-wf-studio`) **stays AGPL-3.0-or-later**.

| Package | Before | After |
|---|---|---|
| `@cc-wf-studio/core` | AGPL-3.0-or-later | **MIT** |
| `@cc-wf-studio/mcp` | AGPL-3.0-or-later | **MIT** |
| `@cc-wf-studio/cli` | AGPL-3.0-or-later | **MIT** |
| `cc-wf-studio-webview` (private) | AGPL-3.0-or-later | **MIT** |
| `cc-wf-studio` (VSCode extension) | AGPL-3.0-or-later | **unchanged (AGPL)** |

## Why

- `core` / `mcp` are libraries; `cli` is a tool. AGPL deters adoption (companies avoid AGPL deps). MIT maximizes reuse.
- The webview must be MIT for `cli` to be cleanly MIT — `cli` bundles the webview's built assets, so an AGPL webview would make the cli tarball effectively AGPL. An AGPL work (the extension) freely includes MIT code, so the VSCode extension stays AGPL.
- Monetization paths for this product (open-core premium add-ons, hosted SaaS, managed AI execution) all work under MIT; only dual-licensing would require AGPL, which is a poor fit for a small project.
- The webview stays an internal package for now; publishing it as a standalone `@cc-wf-studio/webview` is deferred until a concrete consumer (standalone web app / third-party embed) exists. MIT keeps that door open.

## Changes

- `license` field → `MIT` for `@cc-wf-studio/{core,mcp,cli}` and `cc-wf-studio-webview`.
- Add an MIT `LICENSE` file to each (the published npm tarballs previously shipped no license text; verified `pnpm pack --dry-run` now includes `LICENSE`).
- Changeset bumps `core` / `mcp` / `cli` at **patch** (license loosening, no code/API change).

## Note: cc-wf-studio gets an auto patch bump

`updateInternalDependencies: "patch"` means bumping `core` / `mcp` cascades a **dependency-update patch bump to `cc-wf-studio`** (3.34.1 → 3.34.2 on the next Version Packages PR). The extension's code is unchanged and it **remains AGPL** — only its version label + internal dependency refs update. The VSIX 3.34.2 would be functionally identical to 3.34.1.

## Relicensing feasibility

All copyright in these packages (within the `chore/monorepo` lineage) is breaking-brake's own work — no external contributors are in this lineage (the APPLO / ShayneC commits live only on unmerged PR / fork refs, never in `main` / `production` / `chore/monorepo`). So the AGPL→MIT relicense needs no third-party consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)