### PR TITLE
ci: guard against promoting to production with pending changesets

### DIFF
--- a/.changeset/guard-pending-changesets.md
+++ b/.changeset/guard-pending-changesets.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI only — add a guard that blocks promoting main → production while unconsumed changesets remain (plus a backstop in the publish workflow). No release needed.

--- a/.github/workflows/guard-production.yml
+++ b/.github/workflows/guard-production.yml
@@ -1,0 +1,32 @@
+name: Guard — no pending changesets on production PR
+
+# Promoting main → production is the "we are about to release" signal. By then
+# the "Version Packages" PR must already be merged into main, so all changesets
+# are consumed and versions are bumped. If unconsumed .changeset/*.md files are
+# still present, the promote happened too early: a release dispatch would
+# silently no-op (versions unchanged → npm rejects as already-published) and the
+# intended bump would never ship. This check fails the production PR in that
+# case so the mistake is caught before merge.
+
+on:
+  pull_request:
+    branches:
+      - production
+
+jobs:
+  no-pending-changesets:
+    name: No pending changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fail if pending changesets remain
+        run: |
+          PENDING=$(ls .changeset/*.md 2>/dev/null | grep -v 'README.md' || true)
+          if [ -n "$PENDING" ]; then
+            echo "::error::Pending changesets found. Merge the 'Version Packages' PR into main before promoting to production:"
+            echo "$PENDING"
+            exit 1
+          fi
+          echo "OK: no pending changesets — safe to promote to production."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Abort if pending changesets (Version PR not merged)
+        run: |
+          # Backstop for the production guard: if production was updated without
+          # merging the "Version Packages" PR first, unconsumed changesets remain
+          # and publishing would silently no-op. Fail loudly instead.
+          PENDING=$(ls .changeset/*.md 2>/dev/null | grep -v 'README.md' || true)
+          if [ -n "$PENDING" ]; then
+            echo "::error::Pending changesets on ${{ inputs.ref }} — merge the 'Version Packages' PR before releasing. Aborting:"
+            echo "$PENDING"
+            exit 1
+          fi
+          echo "OK: no pending changesets."
+
       - name: Build all packages
         run: pnpm -r run build
 


### PR DESCRIPTION
## Summary

Adds a safety net for the release flow. Promoting `main` → `production` is the "about to release" signal, and by then the **"Version Packages" PR must already be merged** (changesets consumed, versions bumped). If it wasn't, a release dispatch **silently no-ops** — `changeset publish` finds the package.json versions already on npm and skips them, so the intended bump never ships and the changesets sit unconsumed.

This catches that mistake two ways.

## Changes

- **`.github/workflows/guard-production.yml`** (new) — triggers on `pull_request` targeting `production`. Fails if any `.changeset/*.md` (excluding `README.md`) files remain. You see a red ❌ on the production PR before merging, with a message to merge the Version Packages PR first.
- **`.github/workflows/release.yml`** — adds an "Abort if pending changesets" step before the publish step. Backstop for the case where `production` is updated by a direct push that skips the PR.

## How it behaves

| Situation | guard-production (PR check) | release.yml backstop |
|---|---|---|
| Version PR merged → no pending changesets | ✅ pass | ✅ proceeds |
| Version PR skipped → changesets remain | ❌ fails the production PR | ❌ aborts the dispatch |

CI-only change; empty changeset records "no release".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for validating production branch promotions
  * Enhanced release workflow with changeset verification checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breaking-brake/cc-wf-studio/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->