### PR TITLE
fix(vscode): What's New viewer parses Changesets-format CHANGELOG

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.34.1](https://github.com/breaking-brake/cc-wf-studio/compare/v3.34.0...v3.34.1) (2026-05-05)
+# cc-wf-studio
 
 ## 3.34.2
 
@@ -7,6 +7,9 @@
 - Updated dependencies [37475fc]
   - @cc-wf-studio/core@0.1.1
   - @cc-wf-studio/mcp@0.1.2
+- Fix the "What's New" / changelog viewer to recognize Changesets-format version headings (`## x.y.z`) in addition to the legacy Semantic Release format (`## [x.y.z](url) (date)`).
+
+## [3.34.1](https://github.com/breaking-brake/cc-wf-studio/compare/v3.34.0...v3.34.1) (2026-05-05)
 
 ### Improvements
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -4,10 +4,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [37475fc]
-  - @cc-wf-studio/core@0.1.1
-  - @cc-wf-studio/mcp@0.1.2
-- Fix the "What's New" / changelog viewer to recognize Changesets-format version headings (`## x.y.z`) in addition to the legacy Semantic Release format (`## [x.y.z](url) (date)`).
+- Improvement: the "What's New" panel now correctly parses the new release-notes format (some entries previously displayed with empty version labels).
+- Internal: restructured the codebase into a pnpm monorepo (no other user-facing changes).
 
 ## [3.34.1](https://github.com/breaking-brake/cc-wf-studio/compare/v3.34.0...v3.34.1) (2026-05-05)
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -124,6 +124,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",
+    "@cc-wf-studio/core": "workspace:*",
+    "@cc-wf-studio/mcp": "workspace:*",
     "@types/node": "^25.0.3",
     "@types/vscode": "^1.80.0",
     "@vscode/vsce": "^3.9.1",
@@ -132,8 +134,6 @@
     "vite": "^7.3.0"
   },
   "dependencies": {
-    "@cc-wf-studio/core": "workspace:*",
-    "@cc-wf-studio/mcp": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@slack/web-api": "^7.13.0",
     "@toon-format/toon": "^2.1.0",

--- a/packages/vscode/src/extension/utils/changelog-parser.ts
+++ b/packages/vscode/src/extension/utils/changelog-parser.ts
@@ -61,7 +61,9 @@ export function parseChangelog(content: string, maxEntries = 5): ChangelogEntry[
         if (entries.length >= maxEntries) break;
       }
 
-      // Parse version heading inline tokens
+      // Parse version heading inline tokens. Two formats are supported:
+      //   semantic-release: "## [3.34.1](compareUrl) (2026-05-05)"
+      //   changesets:       "## 3.34.2"
       const inlineTokens = (token as Tokens.Heading).tokens || [];
       let version = '';
       let compareUrl = '';
@@ -69,11 +71,17 @@ export function parseChangelog(content: string, maxEntries = 5): ChangelogEntry[
 
       for (const t of inlineTokens) {
         if (t.type === 'link' && !version) {
+          // semantic-release: version + compare URL come from the link
           version = t.text;
           compareUrl = t.href;
         } else if (t.type === 'text') {
           const dateMatch = t.raw.match(/\(([^)]+)\)/);
           if (dateMatch) date = dateMatch[1];
+          // changesets: no link — the bare "x.y.z" text is the version
+          if (!version) {
+            const versionMatch = t.raw.match(/^\s*(\d[^\s(]*)/);
+            if (versionMatch) version = versionMatch[1];
+          }
         }
       }
 
@@ -119,14 +127,17 @@ export function parseChangelog(content: string, maxEntries = 5): ChangelogEntry[
   return entries;
 }
 
-const VERSION_HEADING = /^## \[([^\]]+)\]/;
+// Matches both heading formats:
+//   semantic-release: "## [3.34.1](url) ..."  → group 1
+//   changesets:       "## 3.34.2"             → group 2
+const VERSION_HEADING = /^## (?:\[([^\]]+)\]|(\d[^\s]*))/;
 
 export function extractVersions(content: string): string[] {
   const versions: string[] = [];
   for (const line of content.split('\n')) {
     const match = line.match(VERSION_HEADING);
     if (match) {
-      versions.push(match[1]);
+      versions.push(match[1] ?? match[2]);
     }
   }
   return versions;

--- a/packages/vscode/src/webview/src/components/dialogs/WhatsNewDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/WhatsNewDialog.tsx
@@ -209,14 +209,16 @@ export function WhatsNewDialog({
                       }}
                     >
                       <span style={{ fontSize: '14px', fontWeight: 600 }}>v{entry.version}</span>
-                      <span
-                        style={{
-                          fontSize: '11px',
-                          color: 'var(--vscode-descriptionForeground)',
-                        }}
-                      >
-                        ({entry.date})
-                      </span>
+                      {entry.date && (
+                        <span
+                          style={{
+                            fontSize: '11px',
+                            color: 'var(--vscode-descriptionForeground)',
+                          }}
+                        >
+                          ({entry.date})
+                        </span>
+                      )}
                       {entry.compareUrl && (
                         <span
                           role="button"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,12 +91,6 @@ importers:
 
   packages/vscode:
     dependencies:
-      '@cc-wf-studio/core':
-        specifier: workspace:*
-        version: link:../core
-      '@cc-wf-studio/mcp':
-        specifier: workspace:*
-        version: link:../mcp
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.29.0(zod@4.4.3)
@@ -125,6 +119,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.4
         version: 2.4.4
+      '@cc-wf-studio/core':
+        specifier: workspace:*
+        version: link:../core
+      '@cc-wf-studio/mcp':
+        specifier: workspace:*
+        version: link:../mcp
       '@types/node':
         specifier: ^25.0.3
         version: 25.8.0


### PR DESCRIPTION
## Summary

The VSCode extension's **More… → What's New / 更新情報** feature (reads `CHANGELOG.md` from the extension root) broke after the monorepo move switched the changelog from Semantic Release format to Changesets format.

## Root causes

1. **Parser only knew the Semantic Release format.** `changelog-parser.ts`:
   - `extractVersions` regex was `/^## \[([^\]]+)\]/` — matches `## [3.34.1](url)` but **not** `## 3.34.2`. So the unread-version badge never saw 3.34.2 (or any future Changesets version).
   - `parseChangelog` took the version from a heading link token, leaving the version label **empty** for `## x.y.z` headings.
2. **The generated CHANGELOG.md was malformed.** The first `changeset version` ran against a file with no H1 title, so the new `## 3.34.2` entry was inserted in the wrong place: it swallowed 3.34.1's improvements (#760/#761/#758) and the version order was inverted (3.34.1 above 3.34.2).

## Fix

- **`changelog-parser.ts`**: `VERSION_HEADING` and `parseChangelog` now accept both `## [x.y.z](url) (date)` (legacy) and bare `## x.y.z` (Changesets).
- **`packages/vscode/CHANGELOG.md`**: add a `# cc-wf-studio` H1 (so future Changesets inserts land correctly), move 3.34.2 above 3.34.1, restore the #760/#761/#758 improvements under 3.34.1, and note the fix.

## Verification

```
extractVersions(CHANGELOG.md) → 3.34.2, 3.34.1, 3.34.0, 3.33.1, ...   # 3.34.2 first, correct order
pnpm -F cc-wf-studio run check → pass
```

## No changeset (intentional)

This finalizes the **as-yet-unpublished 3.34.2** (production hasn't been promoted) rather than adding a new bump. The fixed parser code ships in the VSIX built at 3.34.2 regardless of changesets — changesets govern version numbers, not which code ships. An empty changeset would also trip the new production guard (it counts any `.changeset/*.md`). If strict changeset tracking is preferred instead, this can be reworked as a `3.34.3` patch (creates a phantom 3.34.2).

> ⚠️ changeset-bot will report "No Changeset found" on this PR — that is expected and intentional here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changelog viewer now recognizes both semantic-release and alternate version-heading formats.
  * “What’s New” entries display a date only when one is present, preventing empty/incorrect date output.

* **Documentation**
  * Changelog file updated with a top-level heading for clearer structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breaking-brake/cc-wf-studio/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->