### PR TITLE
fix(vscode): correct README image base URL for monorepo layout

### DIFF
--- a/.changeset/marketplace-readme-image-base-url.md
+++ b/.changeset/marketplace-readme-image-base-url.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+fix: correct README image base URL for monorepo layout

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -120,7 +120,7 @@
     "format": "biome format --write .",
     "check": "biome check --write .",
     "test": "pnpm --filter cc-wf-studio-webview run test",
-    "package": "vsce package --no-dependencies"
+    "package": "vsce package --no-dependencies --baseImagesUrl https://github.com/breaking-brake/cc-wf-studio/raw/HEAD/packages/vscode --baseContentUrl https://github.com/breaking-brake/cc-wf-studio/blob/HEAD/packages/vscode"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",


### PR DESCRIPTION
## Problem

README images on the VS Code Marketplace (and Open VSX) page render as broken links.

## Cause

`vsce package` rewrites relative image paths in `README.md` into absolute GitHub raw URLs and bakes them into the README inside the `.vsix` (which is what both marketplaces display). The base URL is computed by vsce's `guessBaseUrls()`, which **ignores the `repository.directory` field** and derives the base from the repository URL alone:

`https://github.com/breaking-brake/cc-wf-studio/raw/HEAD`

After the monorepo move (`adcb8618`), the extension lives under `packages/vscode/`, so `./resources/hero.png` is rewritten to `.../raw/HEAD/resources/hero.png` — missing the `packages/vscode/` segment — and 404s.

## Fix

Pass explicit base URLs to `vsce package` so the missing `packages/vscode` segment is prepended:

```
vsce package --no-dependencies \
  --baseImagesUrl  https://github.com/breaking-brake/cc-wf-studio/raw/HEAD/packages/vscode \
  --baseContentUrl https://github.com/breaking-brake/cc-wf-studio/blob/HEAD/packages/vscode
```

README keeps clean relative paths (GitHub rendering and local preview unaffected). The rewrite is baked into the `.vsix` at package time, so this single change fixes both the Marketplace and Open VSX.

## Verification

Built the VSIX locally and inspected the rewritten README — all image `src`s now resolve correctly:

```
src="https://github.com/breaking-brake/cc-wf-studio/raw/HEAD/packages/vscode/resources/hero.png"
...
```

No `./resources/...` relative paths remain, and the rewritten URLs return HTTP 200.

## Release note

Includes a `patch` changeset for `cc-wf-studio` only — no npm packages are affected. The fix reaches the store after a new VSIX is published and the Repository Owner uploads it to the Marketplace / Open VSX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image base URL references in README documentation to display correctly in monorepo layouts
  * Improved marketplace extension packaging by correcting base URLs for images and content resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->