### PR TITLE
docs(skills): make pr-to-main / pr-to-production monorepo-aware

### DIFF
--- a/.claude/skills/pr-to-main/SKILL.md
+++ b/.claude/skills/pr-to-main/SKILL.md
@@ -51,7 +51,7 @@ So the job here is not just "open a PR" — it's "open a PR that the release pip
 - **Title** — `main` merges via **squash**, so the PR title *becomes* the squash commit subject. It must therefore follow the commit convention: `<type>(<scope>): <description>`.
   - `<type>`: matches the change type from step 2 — `fix` / `feat` / `improvement` / `docs` / `refactor` / `chore` / `ci`.
   - `<scope>`: the affected package/area from step 2 — `vscode`, `cli`, `mcp`, `core` (use the directory name, not the npm name). List several as `(cli, mcp)`. **Omit the scope** for repo-wide changes (root config, `.github/`, top-level docs), e.g. `ci: guard against pending changesets`.
-  - `<description>`: imperative mood, no trailing period, concise (aim ≤50 chars per the commit guideline; GitHub appends ` (#NN)` on squash, so don't pad it).
+  - `<description>`: imperative mood, no trailing period, concise (aim ≤50 chars per the commit guideline; GitHub appends a `(#NN)` suffix, with a leading space, on squash — so don't pad it).
   - Examples (from this repo's history): `fix(vscode): parse Changesets-format CHANGELOG`, `feat(cli): ccwf install-skills subcommand`, `docs: add root README for the monorepo`.
 - **Body**: in the **Changes** section, write real monorepo paths (`packages/vscode/src/...`, `packages/core/...`), not generic placeholders.
 - Mention the changeset in the body so reviewers can see the intended release effect — e.g. "Adds a `patch` changeset for `cc-wf-studio`" or "No release needed (empty changeset)".

--- a/.claude/skills/pr-to-main/SKILL.md
+++ b/.claude/skills/pr-to-main/SKILL.md
@@ -1,46 +1,59 @@
 ---
 name: pr-to-main
-description: Create a PR to main branch for feature/fix changes. Use when the user says "PRを作成", "mainにPR", or wants to submit changes for review.
+description: Create a PR to the main branch for feature/fix changes in this pnpm + Changesets monorepo. Use when the user says "PRを作成", "mainにPR", or wants to submit changes for review. Always run this in the monorepo-aware way — identify the affected package(s) and make sure a changeset exists, because the release pipeline is Changesets-driven.
 ---
 
 # PR to Main Branch
 
-Create PR for feature branches targeting main.
+Create a PR for a feature/fix branch targeting `main` in the cc-wf-studio monorepo.
+
+This is a **pnpm monorepo with four packages** (`packages/core`, `packages/mcp`, `packages/cli`, `packages/vscode`) and versioning is driven by **Changesets**, not commit messages. Two monorepo facts shape this workflow:
+
+- A release-worthy change must ship with a `.changeset/*.md` file in the same PR. Without it, the change merges but **never gets released** — and pending changesets later block promotion to production.
+- Knowing *which package(s)* changed drives the changeset target, the PR scope, and the commit scope (e.g. `fix(vscode):`).
+
+So the job here is not just "open a PR" — it's "open a PR that the release pipeline can actually act on."
 
 ## Workflow
 
-1. **Gather context** (parallel):
-   - `git status` (no -uall flag)
-   - `git diff` for staged/unstaged changes
-   - `git log` for commit history on current branch
-   - Check if branch tracks remote and needs push
+1. **Gather context** (run in parallel):
+   - `git status` (no `-uall`)
+   - `git diff` (staged + unstaged) and `git diff origin/main...HEAD` for the full branch delta
+   - `git log origin/main..HEAD --oneline` for every commit on the branch
+   - Check whether the branch tracks a remote and needs pushing
+   - `ls .changeset/*.md` to see whether a changeset already exists
 
-2. **Analyze changes**:
-   - Review ALL commits in the branch (not just latest)
-   - Identify the type from commit prefix: `fix:`, `feat:`, `improvement:`
+2. **Identify scope and type**:
+   - **Affected package(s)**: map changed paths to packages — `packages/core` → `@cc-wf-studio/core`, `packages/mcp` → `@cc-wf-studio/mcp`, `packages/cli` → `@cc-wf-studio/cli`, `packages/vscode` → `cc-wf-studio` (the VSCode extension). Changes outside `packages/` (root config, `.github/`, docs) usually need no release.
+   - **Type**: read the commit prefix, allowing an optional scope — `fix:` / `fix(vscode):` → fix, `feat:` / `feat(core):` → feat, `improvement:` → improvement. Review **all** commits on the branch, not just the latest.
 
-3. **Select template** based on commit prefix:
-   - `fix:` → Use `assets/fix-template.md`
-   - `feat:` → Use `assets/feat-template.md`
-   - `improvement:` → Use `assets/improvement-template.md`
+3. **Ensure a changeset exists** (the monorepo-critical step):
+   - If a `.changeset/*.md` already covers this change, confirm it names the right package(s) and bump level, and move on.
+   - If the change should be released and no changeset exists, create one with `pnpm changeset` — select the affected package(s) from step 2, choose patch/minor/major, and write a one-line summary (this becomes the CHANGELOG entry). Note: bumping `@cc-wf-studio/core` auto-bumps its dependents, so you don't author separate changesets for `cli`/`mcp`.
+   - If the change genuinely needs no release (CI-only, tooling, docs), record that intent explicitly with `pnpm changeset add --empty` so the pipeline isn't left guessing.
+   - Why this matters: the release flow (`release-version-pr.yml` → "Version Packages" PR → production → publish) only acts on consumed changesets, and a guard fails the promote if changesets are still pending. A PR without the right changeset is a silent no-op for releases.
 
-4. **Create PR** (parallel if needed):
-   - Push branch with `-u` flag if needed
-   - Create PR using `gh pr create`
+4. **Verify the build is green** before opening the PR:
+   - Run `pnpm check && pnpm build` from the repo root (Biome + type-checks, then full compilation). Reviewers and CI expect a clean tree, and catching breakage now is cheaper than after review.
+
+5. **Select the PR template** based on type (from step 2):
+   - `fix:` → `assets/fix-template.md`
+   - `feat:` → `assets/feat-template.md`
+   - `improvement:` → `assets/improvement-template.md`
+
+6. **Create the PR**:
+   - Push the branch with `git push -u` if it has no upstream.
+   - Open it with `gh pr create --base main`, filling the chosen template.
 
 ## PR Format
 
-**Language**: Always write PR title and body in English
-
-**Title**: Under 70 characters, descriptive
+- **Language**: always write the PR title and body in English (repo rule).
+- **Title**: under 70 characters, descriptive. Prefer a package scope when the change is package-specific, e.g. `fix(vscode): ...`.
+- **Body**: in the **Changes** section, write real monorepo paths (`packages/vscode/src/...`, `packages/core/...`), not generic placeholders.
+- Mention the changeset in the body so reviewers can see the intended release effect — e.g. "Adds a `patch` changeset for `cc-wf-studio`" or "No release needed (empty changeset)".
 
 ## Templates
 
-### fix: (Bug fixes)
-Use `assets/fix-template.md` - Problem/Solution format with Current/Expected behavior
-
-### feat: (New features)
-Use `assets/feat-template.md` - Summary/Motivation/Changes format
-
-### improvement: (Enhancements)
-Use `assets/improvement-template.md` - Before/After comparison format
+- **fix:** `assets/fix-template.md` — Problem/Solution with Current vs Expected behavior.
+- **feat:** `assets/feat-template.md` — Summary/Motivation/Changes.
+- **improvement:** `assets/improvement-template.md` — Before/After comparison.

--- a/.claude/skills/pr-to-main/SKILL.md
+++ b/.claude/skills/pr-to-main/SKILL.md
@@ -48,7 +48,11 @@ So the job here is not just "open a PR" — it's "open a PR that the release pip
 ## PR Format
 
 - **Language**: always write the PR title and body in English (repo rule).
-- **Title**: under 70 characters, descriptive. Prefer a package scope when the change is package-specific, e.g. `fix(vscode): ...`.
+- **Title** — `main` merges via **squash**, so the PR title *becomes* the squash commit subject. It must therefore follow the commit convention: `<type>(<scope>): <description>`.
+  - `<type>`: matches the change type from step 2 — `fix` / `feat` / `improvement` / `docs` / `refactor` / `chore` / `ci`.
+  - `<scope>`: the affected package/area from step 2 — `vscode`, `cli`, `mcp`, `core` (use the directory name, not the npm name). List several as `(cli, mcp)`. **Omit the scope** for repo-wide changes (root config, `.github/`, top-level docs), e.g. `ci: guard against pending changesets`.
+  - `<description>`: imperative mood, no trailing period, concise (aim ≤50 chars per the commit guideline; GitHub appends ` (#NN)` on squash, so don't pad it).
+  - Examples (from this repo's history): `fix(vscode): parse Changesets-format CHANGELOG`, `feat(cli): ccwf install-skills subcommand`, `docs: add root README for the monorepo`.
 - **Body**: in the **Changes** section, write real monorepo paths (`packages/vscode/src/...`, `packages/core/...`), not generic placeholders.
 - Mention the changeset in the body so reviewers can see the intended release effect — e.g. "Adds a `patch` changeset for `cc-wf-studio`" or "No release needed (empty changeset)".
 

--- a/.claude/skills/pr-to-main/assets/feat-template.md
+++ b/.claude/skills/pr-to-main/assets/feat-template.md
@@ -11,10 +11,14 @@ Closes #[issue-number]
 ## Changes
 
 **New Files:**
-- `path/to/file.ts` - [Purpose]
+- `packages/<pkg>/src/...` - [Purpose]
 
 **Modified Files:**
-- `path/to/file.ts` - [Changes]
+- `packages/<pkg>/src/...` - [Changes]
+
+## Release
+
+- Changeset: [e.g. `minor` for `@cc-wf-studio/core` / no release needed (empty)]
 
 ## Screenshots / Demo
 

--- a/.claude/skills/pr-to-main/assets/fix-template.md
+++ b/.claude/skills/pr-to-main/assets/fix-template.md
@@ -16,9 +16,13 @@
 
 ### Changes
 
-**File**: `path/to/file.ts`
+**File**: `packages/<pkg>/src/...`
 
 [List of changes]
+
+## Release
+
+- Changeset: [e.g. `patch` for `cc-wf-studio` / no release needed (empty)]
 
 ## Impact
 

--- a/.claude/skills/pr-to-main/assets/improvement-template.md
+++ b/.claude/skills/pr-to-main/assets/improvement-template.md
@@ -16,7 +16,11 @@ Closes #[issue-number]
 
 ## Changes
 
-- `path/to/file.ts` - [Changes]
+- `packages/<pkg>/src/...` - [Changes]
+
+## Release
+
+- Changeset: [e.g. `patch` for `cc-wf-studio` / no release needed (empty)]
 
 ## Testing
 

--- a/.claude/skills/pr-to-production/SKILL.md
+++ b/.claude/skills/pr-to-production/SKILL.md
@@ -9,7 +9,7 @@ Promote `main` to `production` so the publish workflow can release the pending p
 
 **Important: this repo uses Changesets, not semantic-release.** Versions are NOT computed from commit messages. The bump already happened earlier in the flow:
 
-```
+```text
 1. feature PR + .changeset/*.md            → merged to main
 2. release-version-pr.yml opens/updates the
    "Version Packages" PR (bumps + CHANGELOG) → merged to main

--- a/.claude/skills/pr-to-production/SKILL.md
+++ b/.claude/skills/pr-to-production/SKILL.md
@@ -1,94 +1,70 @@
 ---
 name: pr-to-production
-description: Create a release PR from main to production branch. Use when the user says "リリースPR", "productionにPR", "リリース準備", or wants to trigger a release.
+description: Create a release PR promoting main to the production branch in this pnpm + Changesets monorepo. Use when the user says "リリースPR", "productionにPR", "リリース準備", or wants to trigger a release. This promotes already-bumped versions to production so the manual "Release — Publish" workflow can publish them.
 ---
 
 # PR to Production Branch (Release)
 
-Create release PR from main to production for semantic-release.
+Promote `main` to `production` so the publish workflow can release the pending packages.
+
+**Important: this repo uses Changesets, not semantic-release.** Versions are NOT computed from commit messages. The bump already happened earlier in the flow:
+
+```
+1. feature PR + .changeset/*.md            → merged to main
+2. release-version-pr.yml opens/updates the
+   "Version Packages" PR (bumps + CHANGELOG) → merged to main
+3. main now carries bumped versions and consumed changesets
+4. promote main → production               ← THIS SKILL creates that PR
+5. Actions → "Release — Publish" (ref: production, manual workflow_dispatch)
+   → publishes npm packages + uploads the VSIX if cc-wf-studio was bumped
+```
+
+So this skill's job is step 4: open a PR from `main` to `production` that mirrors the current state of main. It does **not** bump versions or write CHANGELOGs — those are already on main.
+
+## Precondition: no pending changesets on main
+
+The release will silently no-op (and a CI guard fails the promote) if unconsumed changesets are still on main — that means the "Version Packages" PR has not been merged yet. Check first:
+
+```bash
+git fetch origin production main --quiet
+git ls-tree -r --name-only origin/main -- .changeset | grep -E '\.changeset/.+\.md$' | grep -v 'README.md'
+```
+
+If that lists any `.changeset/*.md` besides `README.md`, **stop** and tell the user to merge the "Version Packages" PR first. Only proceed when there are none.
 
 ## Workflow
 
-1. **Fetch latest from remote** (required first):
-   - `git fetch origin production main --quiet`
-   - **IMPORTANT**: Always use remote refs (`origin/production`, `origin/main`) for comparison. Local branches may be stale.
+1. **Fetch latest** (required first): `git fetch origin production main --quiet`. Always compare against remote refs (`origin/main`, `origin/production`) — local branches may be stale.
 
-2. **Gather context** (parallel):
-   - `git log origin/production..origin/main --oneline` for commits to release
-   - `git ls-remote --tags origin | grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/.*refs\/tags\///' | sort -V | tail -1` for latest release version from remote
-   - `git rev-list --count origin/production..origin/main` to check if main is ahead of production
+2. **Check the precondition** above (pending changesets). Abort if any remain.
 
-3. **Analyze commits**:
-   - Categorize by type: feat, fix, chore, etc.
-   - Calculate expected version bump
+3. **Gather context** (parallel):
+   - `git log origin/production..origin/main --oneline` — commits to be released.
+   - `git rev-list --count origin/production..origin/main` — confirm main is ahead. If `0`, there is nothing to release.
+   - Read each `packages/*/package.json` `version` on `origin/main` to report the versions that will publish, and compare against `origin/production` to see which packages actually changed:
+     ```bash
+     for p in core mcp cli vscode; do
+       echo "$p -> main: $(git show origin/main:packages/$p/package.json | grep '"version"' | head -1) | prod: $(git show origin/production:packages/$p/package.json | grep '"version"' | head -1)"
+     done
+     ```
 
-4. **Create PR**:
-   - Use `gh pr create` with base `production`
-   - Use template from `assets/pr-template.md`
+4. **Create the PR**:
+   - `gh pr create --base production --head main` using `assets/pr-template.md`.
+   - Title: `Release: <summary>` (e.g. `Release: cc-wf-studio@3.34.3` for a single-package release, or `Release: core/cli/mcp + extension` when several bump together).
 
-## Version Bump Rules
+## What publishing does (for the PR body)
 
-- `feat:` → **minor** (1.0.0 → 1.1.0)
-- `fix:`, `perf:`, `revert:` → **patch** (1.0.0 → 1.0.1)
-- `BREAKING CHANGE` → **major** (1.0.0 → 2.0.0)
-- `docs:`, `chore:`, `ci:` → no bump
+After this PR merges to production, the **manual** "Release — Publish" workflow (`workflow_dispatch`, ref `production`) runs `pnpm changeset publish`, which:
+
+- Publishes to npm any of `@cc-wf-studio/{core,mcp,cli}` whose version is ahead of the registry (OIDC Trusted Publishing, no token).
+- Creates the git tags (including `cc-wf-studio@x.y.z` for the private extension, since `privatePackages.tag` is on).
+- If `cc-wf-studio` was bumped, builds the VSIX and attaches it to its GitHub Release. **The store upload to VS Marketplace / Open VSX is then a manual step by the Repository Owner** — CI does not run `vsce publish`.
+
+## Merge strategy
+
+Use a **merge commit** (not squash) so `production` mirrors `main` exactly — the publish step reads versions from the production tree, and the histories should stay aligned.
 
 ## PR Format
 
-**Language**: Always write PR title and body in English
-
-**Title**: `Release: vX.Y.Z`
-
-**Body**: Use template at `assets/pr-template.md`
-
-## Example
-
-```bash
-gh pr create --base production --title "Release: v0.2.0" --body "$(cat <<'EOF'
-## Summary
-
-Merge latest changes from `main` to `production` for automated release v0.2.0.
-
-## Included Changes
-
-### Features
-- feat: add chunk-based translation for large documents (#5)
-
-### Enhancements
-- chore: setup semantic-release (#4)
-
-## Release Version Calculation
-
-**v0.2.0** (minor bump)
-
-Semantic Release will analyze commits since v0.1.1:
-- ✅ `feat: add chunk-based translation` (#5) → **minor bump**
-- ❌ `chore: setup semantic-release` (#4) → no version bump
-
-Result: **0.1.1 + minor = 0.2.0**
-
-## CHANGELOG.md Contents
-
-The following features will be included:
-- Add chunk-based translation for large documents (#5)
-
-Setup semantic-release (#4) will not appear in CHANGELOG.
-
-## Release Automation
-
-This merge will trigger:
-1. Analyze commit messages (0.1.1 → 0.2.0)
-2. Update version in package.json files
-3. Generate CHANGELOG.md with features
-4. Create GitHub release
-5. Build and upload VSIX package
-6. Sync version changes back to main
-
-## Merge Strategy
-
-**Use merge commit** (not squash) to preserve commit history for Semantic Release.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
+- **Language**: always write the PR title and body in English (repo rule).
+- **Body**: use `assets/pr-template.md`.

--- a/.claude/skills/pr-to-production/assets/pr-template.md
+++ b/.claude/skills/pr-to-production/assets/pr-template.md
@@ -1,48 +1,38 @@
 ## Summary
 
-Merge latest changes from `main` to `production` for automated release vX.Y.Z.
+Promote `main` to `production` to release the pending package version bumps. Versions and CHANGELOGs were already produced by the merged "Version Packages" PR (Changesets) — this PR only moves them to `production` for publishing.
+
+## Packages to Release
+
+| Package | production | → main (this release) |
+|---|---|---|
+| `@cc-wf-studio/core` | A.B.C | A.B.C |
+| `@cc-wf-studio/mcp` | A.B.C | A.B.C |
+| `@cc-wf-studio/cli` | A.B.C | A.B.C |
+| `cc-wf-studio` (extension) | A.B.C | X.Y.Z |
+
+(List only the rows that change; leave others as-is for context.)
 
 ## Included Changes
 
-### Features
-- feat: [description] (#PR)
+- [type: short description] (#PR)
 
-### Bug Fixes
-- fix: [description] (#PR)
+## What Publishing Will Do
 
-### Enhancements
-- chore: [description] (#PR)
+After this PR merges, manually run **Actions → "Release — Publish"** (`workflow_dispatch`, ref `production`). It will:
 
-## Release Version Calculation
+1. `pnpm changeset publish` — publish npm packages whose version is ahead of the registry (`@cc-wf-studio/{core,mcp,cli}`, via OIDC Trusted Publishing).
+2. Create git tags, including `cc-wf-studio@X.Y.Z` for the extension.
+3. If `cc-wf-studio` was bumped: build the VSIX and attach it to the GitHub Release.
 
-**vX.Y.Z** (minor/patch/major bump)
+**Note:** The VS Marketplace / Open VSX store upload is a separate manual step by the Repository Owner (downloads the VSIX from the GitHub Release) — CI does not publish to the stores.
 
-Semantic Release will analyze commits since the last release (vA.B.C):
-- ✅ `feat: [desc]` (#PR) → **minor bump**
-- ✅ `fix: [desc]` (#PR) → **patch bump**
-- ❌ `chore: [desc]` (#PR) → no version bump
+## Preconditions
 
-Result: **A.B.C + [bump type] = X.Y.Z**
-
-## CHANGELOG.md Contents
-
-The following will be included:
-- [Feature/Fix descriptions]
-
-Chore commits will not appear in CHANGELOG.
-
-## Release Automation
-
-This merge will trigger:
-1. Analyze commit messages for version bump
-2. Update version in package.json files
-3. Generate CHANGELOG.md
-4. Create GitHub release
-5. Build and upload VSIX package
-6. Sync version changes back to main
+- [x] No pending `.changeset/*.md` on `main` (the "Version Packages" PR is merged).
 
 ## Merge Strategy
 
-**Use merge commit** (not squash) to preserve commit history for Semantic Release.
+**Use a merge commit** (not squash) so `production` mirrors `main` exactly.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Problem

The `pr-to-main` and `pr-to-production` skills predate the monorepo + Changesets migration and no longer match how this repo releases:

- **`pr-to-main`** never adds or checks a `.changeset/*.md`. Since releases are Changesets-driven, a PR created via this skill would merge without a changeset and the change would silently never be released (and pending changesets later block promotion to production). It also didn't identify which `packages/*` changed or run `pnpm check && pnpm build`.
- **`pr-to-production`** was written for **semantic-release** — it computed version bumps from commit prefixes and described generating CHANGELOGs from commits. The repo actually uses Changesets + a manual `workflow_dispatch` publish, so the skill was actively misleading.

## Changes

**`.claude/skills/pr-to-main/`**
- Add workflow steps: identify affected package(s) → ensure a changeset exists (`pnpm changeset`, or `--empty` when no release is needed) → `pnpm check && pnpm build` before opening the PR.
- Handle scoped commit prefixes (`fix(vscode):`).
- Templates: replace `path/to/file.ts` with `packages/<pkg>/...` and add a **Release** section noting the changeset.

**`.claude/skills/pr-to-production/`**
- Rewrite around the real flow: feature PR + changeset → "Version Packages" PR → promote main → production → manual "Release — Publish".
- Add a precondition check that no `.changeset/*.md` remain on main before promoting.
- Report per-package versions (main vs production) instead of computing bumps from commits.
- Template rewritten to describe `pnpm changeset publish`, npm OIDC publishing, VSIX upload, and the manual store step.

## Testing

- Verified the new bash snippets (pending-changeset check, per-package version compare) run correctly against the current repo.
- `pnpm changeset status` confirms this PR needs no changeset (`.claude/` is outside all packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote monorepo PR workflows to use a Changesets-driven flow and clarified release gating and verification steps.
  * Added mandatory pre-PR checks and explicit rules for when a release entry or an empty no-release intent is required.
  * Standardized PR title/body conventions (commit-convention pattern, scope guidance, concise descriptions) and selection of templates by change type.
  * Updated feature/fix/improvement and production-release PR templates to reflect the new process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->