### PR TITLE
docs: fix stale --watch comments in preview server/watcher

### DIFF
--- a/.changeset/social-windows-sink.md
+++ b/.changeset/social-windows-sink.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: fix stale `--watch` references and a malformed JSDoc line in the preview server/watcher comments. Comment-only, zero behavior change — no release needed.

--- a/packages/cli/src/preview/server.ts
+++ b/packages/cli/src/preview/server.ts
@@ -1,12 +1,11 @@
 /**
- * `ccwf preview` HTTP server (+ optional Server-Sent Events for --watch).
+ * `ccwf preview` HTTP server with live-reload via Server-Sent Events.
  *
  * Unlike `ccwf canvas`, this server is read-only: there's no WebSocket and no
  * message-channel emulation. It just:
  *   - serves the bundled `overview.html` with an injected
  *     `<script>window.__CC_WF_PREVIEW__ = {...}</script>`
  *   - serves `/assets/*` from the same dist directory
-
  *   - holds long-lived `/<sessionId>/events` SSE connections that the page reloads on
  *     when the source file changes (and that drive auto-shutdown)
  *
@@ -60,7 +59,7 @@ export interface PreviewServerOptions {
 export interface PreviewBootstrap {
   workflow: unknown;
   locale: string;
-  /** Optional SSE URL for live-reload (set automatically when --watch). */
+  /** Optional SSE URL for live-reload (set automatically by `ccwf preview`). */
   sseUrl?: string;
 }
 

--- a/packages/cli/src/preview/watcher.ts
+++ b/packages/cli/src/preview/watcher.ts
@@ -1,5 +1,5 @@
 /**
- * Debounced filesystem watcher for `ccwf preview --watch`.
+ * Debounced filesystem watcher for `ccwf preview`.
  *
  * Wraps `fs.watch` (no extra dependency) with a small trailing debounce so that
  * editors that write atomically (rename-replace, write-truncate-then-fill) only


### PR DESCRIPTION
## What

Comment-only cleanup of stale `--watch` references and a malformed JSDoc line in the `ccwf preview` source. **Zero behavior change** — no executable code, signatures, CLI flags, MCP contracts, or schemas are touched.

Addresses #797, and additionally fixes one stale reference that #797 missed.

### Changes
1. **`server.ts` header** — `(+ optional Server-Sent Events for --watch)` → `with live-reload via Server-Sent Events`. The `preview` command exposes only `--port` / `--host` / `--keep-alive`; there is no `--watch` flag, and the SSE channel is unconditional.
2. **`server.ts` JSDoc block** — removed a bare blank line (no leading ` *`) that broke block alignment between the `/assets/*` and `/<sessionId>/events` bullets.
3. **`server.ts` `PreviewBootstrap.sseUrl`** — `set automatically when --watch` → `set automatically by \`ccwf preview\``. `sseUrl` is always set in the command's `.action`.
4. **`watcher.ts` header** (not in #797) — `Debounced filesystem watcher for \`ccwf preview --watch\`` → `for \`ccwf preview\``. Same stale-flag inaccuracy.

## Why it's safe

Only comment text changes. `sseUrl` and the file watcher are set/created unconditionally by `ccwf preview` (verified in `packages/cli/src/commands/preview.ts`), so the old `--watch` wording was simply inaccurate.

## Verify

- `pnpm -F @cc-wf-studio/cli run check` — passes (tsc)
- `pnpm -F @cc-wf-studio/cli run build` — passes

An empty changeset is included since this is comment-only and needs no release.

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cleaned up preview-related comments to remove stale “--watch” wording and clarify SSE/URL wording.
  * Fixed a malformed JSDoc line in preview server/watcher comments.
  * Purely comment/documentation updates — no behavior changes, no public API changes, and no release required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->