### PR TITLE
fix(vscode, core, cli): switch Roo Code to Zoo Code

### DIFF
--- a/.changeset/switch-roo-code-to-zoo-code.md
+++ b/.changeset/switch-roo-code-to-zoo-code.md
@@ -1,0 +1,7 @@
+---
+"cc-wf-studio": minor
+"@cc-wf-studio/core": patch
+"@cc-wf-studio/cli": patch
+---
+
+fix: switch the Roo Code integration to Zoo Code (#770). The sunset Roo Code extension is replaced by its maintained community fork: the extension now detects `ZooCodeOrganization.zoo-code` first (falling back to the legacy Roo Code extension if installed), launches skills with Zoo Code's `/<skill>` slash syntax, and all UI labels, generated skill instructions, and CLI hints now say "Zoo Code". The `roo-code` agent ID and `.roo/` output paths are unchanged because Zoo Code still reads `.roo/skills/` and `.roo/mcp.json`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Design workflows on a canvas. Export as Markdown your AI agent already understan
 | GitHub Copilot Chat | `.github/prompts/` | [Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) |
 | GitHub Copilot CLI | `.github/skills/` | [Copilot CLI](https://github.com/github/copilot-cli) |
 | OpenAI Codex CLI | `.codex/skills/` | [Codex CLI](https://github.com/openai/codex) |
-| Roo Code | `.roo/skills/` | [Roo Code](https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline) |
+| Zoo Code (formerly Roo Code) | `.roo/skills/` | [Zoo Code](https://marketplace.visualstudio.com/items?itemName=ZooCodeOrganization.zoo-code) |
 | Gemini CLI | `.gemini/skills/` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) |
 | Antigravity | `.agent/skills/` | [Antigravity](https://antigravity.google/) |
 | Cursor | `.cursor/agents/` `.cursor/skills/` | [Cursor](https://github.com/cursor/cursor) |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -83,7 +83,7 @@ Output layout by target agent:
 | `copilot` | `.github/skills/<workflow>/SKILL.md` |
 | `cursor` | `.cursor/skills/<workflow>/SKILL.md` + `.cursor/agents/<sub-agent>.md` |
 | `gemini` | `.gemini/skills/<workflow>/SKILL.md` |
-| `roo-code` | `.roo/skills/<workflow>/SKILL.md` |
+| `roo-code` (Zoo Code, the maintained Roo Code fork) | `.roo/skills/<workflow>/SKILL.md` |
 
 `.claude/commands/` is the previous home for the workflow entry; Claude Code is folding it into `.claude/skills/`, where each skill is a *directory* containing `SKILL.md` (see the Agent Skills format). `ccwf export --agent claude-code` writes to the new directory-based layout. Existing `.claude/commands/<workflow>.md` files are not deleted automatically.
 

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -108,7 +108,7 @@ Output by `--agent`:
 | `copilot`              | `.github/skills/<workflow>/SKILL.md`                                                         |
 | `cursor`               | `.cursor/skills/<workflow>/SKILL.md` + `.cursor/agents/<sub-agent>.md`                       |
 | `gemini`               | `.gemini/skills/<workflow>/SKILL.md`                                                         |
-| `roo-code`             | `.roo/skills/<workflow>/SKILL.md`                                                            |
+| `roo-code` (Zoo Code)  | `.roo/skills/<workflow>/SKILL.md`                                                            |
 
 Use `export` (rather than `run`) when the user wants the *files only* — e.g. checking generated content into git, inspecting before execution, or generating Skills for multiple agents in batch.
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -152,7 +152,7 @@ export function registerExportCommand(program: Command): void {
     .argument('<file>', 'Path to a workflow JSON file.')
     .option<SupportedAgent>(
       '--agent <name>',
-      `Target agent. One of: ${SUPPORTED_AGENTS.join(', ')}.`,
+      `Target agent. One of: ${SUPPORTED_AGENTS.join(', ')}. roo-code targets Zoo Code, the maintained fork of the sunset Roo Code.`,
       parseAgentOption,
       CLAUDE_CODE_AGENT
     )

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -49,7 +49,7 @@ const NEXT_STEP_HINTS: Record<string, (slash: string) => string> = {
   gemini: (slash) =>
     `run \`${slash}\` in Gemini CLI. If the skill isn't found, restart Gemini CLI to pick up the new file.`,
   'roo-code': (slash) =>
-    `run \`:${slash}\` in Roo Code. If the skill isn't found, restart Roo Code to pick up the new file.`,
+    `run \`/${slash}\` in Zoo Code. If the skill isn't found, restart Zoo Code to pick up the new file.`,
 };
 
 export function registerRunCommand(program: Command): void {
@@ -61,7 +61,7 @@ export function registerRunCommand(program: Command): void {
     .argument('<file>', 'Path to a workflow JSON file.')
     .option(
       '--agent <name>',
-      'Target agent (claude-code | antigravity | codex | copilot | cursor | gemini | roo-code).',
+      'Target agent (claude-code | antigravity | codex | copilot | cursor | gemini | roo-code). roo-code targets Zoo Code, the maintained fork of the sunset Roo Code.',
       'claude-code'
     )
     .option('--overwrite', 'Overwrite existing files instead of erroring.', false)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@ npm install @cc-wf-studio/core
 | `services/workflow-prompt-generator` | `generateMermaidFlowchart`, `generateExecutionInstructions`, `sanitizeNodeId` + the `ExportProvider` union. |
 | `services/workflow-overview-formatter` | `generateOverviewMarkdown` — the per-node Markdown the canvas Overview panel and `ccwf preview` render side-by-side with the Mermaid diagram. |
 | `services/workflow-export` | Pure `.claude/*` file generators (`generateSubAgentFile`, `generateSlashCommandFile`, `nodeNameToFileName`, `escapeYamlString`, `validateClaudeFileFormat`) and `planWorkflowExportFiles(workflow)` — the planner Claude Code's `ccwf export` walks. |
-| `services/agent-skill-export` | `AgentSkillProvider` union + `generateAgentSkillContent` and `planAgentSkillFiles(workflow, agent)` for every non-Claude agent (Antigravity / Codex / Copilot / Cursor / Gemini / Roo Code). |
+| `services/agent-skill-export` | `AgentSkillProvider` union + `generateAgentSkillContent` and `planAgentSkillFiles(workflow, agent)` for every non-Claude agent (Antigravity / Codex / Copilot / Cursor / Gemini / Zoo Code). |
 | `utils/validate-workflow` | `validateAIGeneratedWorkflow` — the schema check `ccwf validate` runs. |
 | `utils/migrate-workflow` | Forward-migration of older workflow JSON to the current schema. |
 | `utils/schema-parser` | Helpers that load the bundled workflow schema (`resources/workflow-schema.toon`). |

--- a/packages/core/src/services/agent-skill-export.ts
+++ b/packages/core/src/services/agent-skill-export.ts
@@ -36,6 +36,8 @@ export type AgentSkillProvider =
   | 'copilot'
   | 'cursor'
   | 'gemini'
+  // Targets Zoo Code, the maintained fork of the sunset Roo Code extension.
+  // The ID stays 'roo-code' because Zoo Code still reads `.roo/skills/`.
   | 'roo-code';
 
 interface AgentSkillSpec {

--- a/packages/core/src/services/workflow-prompt-generator.ts
+++ b/packages/core/src/services/workflow-prompt-generator.ts
@@ -596,7 +596,7 @@ function getAgentName(provider: ExportProvider): string {
     case 'gemini':
       return 'Gemini CLI';
     case 'roo-code':
-      return 'Roo Code';
+      return 'Zoo Code';
     case 'antigravity':
       return 'Antigravity';
     case 'cursor':

--- a/packages/core/src/types/mcp-node.ts
+++ b/packages/core/src/types/mcp-node.ts
@@ -14,6 +14,7 @@ export type McpConfigSource =
   | 'copilot'
   | 'codex'
   | 'gemini'
+  // '.roo/' directory — read by Zoo Code (formerly Roo Code)
   | 'roo'
   | 'antigravity'
   | 'cursor';

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -328,7 +328,7 @@ export interface SubAgentFlowNodeData {
 export interface McpNodeData {
   /** MCP server identifier (from 'claude mcp list') */
   serverId: string;
-  /** Source provider of the MCP server (claude, copilot, codex, gemini, roo) */
+  /** Source provider of the MCP server (claude, copilot, codex, gemini, roo — '.roo/' is read by Zoo Code, formerly Roo Code) */
   source?: 'claude' | 'copilot' | 'codex' | 'gemini' | 'roo';
   /** Tool function name from the MCP server (optional for aiToolSelection mode) */
   toolName?: string;

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -37,7 +37,7 @@ Design workflows on a canvas. Export as Markdown your AI agent already understan
 | GitHub Copilot Chat | `.github/prompts/` | [Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) |
 | GitHub Copilot CLI | `.github/skills/` | [Copilot CLI](https://github.com/github/copilot-cli) |
 | OpenAI Codex CLI | `.codex/skills/` | [Codex CLI](https://github.com/openai/codex) |
-| Roo Code | `.roo/skills/` | [Roo Code](https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline) |
+| Zoo Code (formerly Roo Code) | `.roo/skills/` | [Zoo Code](https://marketplace.visualstudio.com/items?itemName=ZooCodeOrganization.zoo-code) |
 | Gemini CLI | `.gemini/skills/` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) |
 | Antigravity | `.agent/skills/` | [Antigravity](https://antigravity.google/) |
 | Cursor | `.cursor/agents/` `.cursor/skills/` | [Cursor](https://github.com/cursor/cursor) |

--- a/packages/vscode/docs/ai-coding-tools-config-reference.md
+++ b/packages/vscode/docs/ai-coding-tools-config-reference.md
@@ -949,7 +949,7 @@ mode: mode-slug                      # Optional, mode to use when executing
 **globalStorage paths:**
 - macOS: `~/Library/Application Support/Code/User/globalStorage/zoocodeorganization.zoo-code/`
 - Linux: `~/.config/Code/User/globalStorage/zoocodeorganization.zoo-code/`
-- Windows: `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\`
+- Windows: `%APPDATA%\Code\User\globalStorage\zoocodeorganization.zoo-code\`
 
 **Schema:**
 ```yaml

--- a/packages/vscode/docs/ai-coding-tools-config-reference.md
+++ b/packages/vscode/docs/ai-coding-tools-config-reference.md
@@ -10,7 +10,7 @@ Created by referencing official documentation for each tool.
 | Claude Code | Project<br>User | Project<br>User | Project<br>User | Project<br>User | Project<br>User | Project |
 | Gemini CLI | Project<br>User | Project<br>User | Project<br>User | - | Project<br>User | Project |
 | Antigravity | Project | Project<br>User | Workflows | Agent mode | Project | - |
-| Roo Code | Project<br>Global | Project<br>Global | Project<br>Global | Project<br>Global | Project<br>Global | Project |
+| Zoo Code (formerly Roo Code) | Project<br>Global | Project<br>Global | Project<br>Global | Project<br>Global | Project<br>Global | Project |
 | VSCode Copilot Chat | Project<br>User | Project<br>User | Project<br>User | Project | Project<br>User | - |
 | Copilot CLI | Project | Project<br>Global | - | Project<br>Global | Global | - |
 | Codex CLI (OpenAI) | Project<br>Global | Project<br>User<br>Admin | - | - | Global | - |
@@ -855,17 +855,14 @@ X-Custom-Header = "value"
 
 ---
 
-## Roo Code
+## Zoo Code (formerly Roo Code)
 
-Roo Code (formerly Roo Cline) is a VSCode extension for AI-assisted coding with customizable modes.
+Zoo Code is the maintained community fork of Roo Code (which itself forked from Roo Cline), a VSCode extension for AI-assisted coding with customizable modes. The original Roo Code extension and its Router service were sunset in 2026; Zoo Code keeps the same `.roo/` configuration layout. The directory layouts below apply to both.
 
 > **Reference:**
-> - [Roo Code Documentation](https://docs.roocode.com/)
-> - [Custom Instructions](https://docs.roocode.com/features/custom-instructions)
-> - [Skills](https://docs.roocode.com/features/skills)
-> - [Slash Commands](https://docs.roocode.com/features/slash-commands)
-> - [Custom Modes](https://docs.roocode.com/features/custom-modes)
-> - [MCP in Roo Code](https://docs.roocode.com/features/mcp/using-mcp-in-roo)
+> - [Zoo Code Documentation](https://docs.zoocode.dev/)
+> - [Roo → Zoo migration guide](https://docs.zoocode.dev/roo-to-zoo-migration)
+> - Legacy Roo Code docs: [Custom Instructions](https://docs.roocode.com/features/custom-instructions), [Skills](https://docs.roocode.com/features/skills), [Slash Commands](https://docs.roocode.com/features/slash-commands), [Custom Modes](https://docs.roocode.com/features/custom-modes), [MCP](https://docs.roocode.com/features/mcp/using-mcp-in-roo)
 
 ### Rules (Instructions)
 
@@ -950,8 +947,8 @@ mode: mode-slug                      # Optional, mode to use when executing
 | **Global (legacy)** | `{globalStorage}/settings/custom_modes.json` | JSON | Global custom modes (legacy) |
 
 **globalStorage paths:**
-- macOS: `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
-- Linux: `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/`
+- macOS: `~/Library/Application Support/Code/User/globalStorage/zoocodeorganization.zoo-code/`
+- Linux: `~/.config/Code/User/globalStorage/zoocodeorganization.zoo-code/`
 - Windows: `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\`
 
 **Schema:**
@@ -1046,15 +1043,15 @@ customModes:
 Project Root/
 ├── CLAUDE.md                           # Claude Code (root rule)
 ├── GEMINI.md                           # Gemini CLI (project instructions)
-├── AGENTS.md                           # Codex CLI, Copilot CLI, VSCode Copilot Chat, Roo Code (root rule)
+├── AGENTS.md                           # Codex CLI, Copilot CLI, VSCode Copilot Chat, Zoo Code (root rule)
 ├── AGENTS.override.md                  # Codex CLI (override)
 ├── .mcp.json                           # Claude Code (MCP)
 ├── .claudeignore                       # Claude Code (ignore)
 ├── .geminiignore                       # Gemini CLI (ignore)
-├── .rooignore                          # Roo Code (ignore)
-├── .roomodes                           # Roo Code (project custom modes, YAML/JSON)
-├── .roorules                           # Roo Code (fallback rules)
-├── .roorules-{modeSlug}               # Roo Code (fallback mode-specific rules)
+├── .rooignore                          # Zoo Code (ignore)
+├── .roomodes                           # Zoo Code (project custom modes, YAML/JSON)
+├── .roorules                           # Zoo Code (fallback rules)
+├── .roorules-{modeSlug}               # Zoo Code (fallback mode-specific rules)
 │
 ├── .claude/
 │   ├── CLAUDE.local.md                 # Claude Code (local memory, gitignored)
@@ -1088,13 +1085,13 @@ Project Root/
 │   └── skills/{name}/SKILL.md          # VSCode Copilot Chat, Copilot CLI (skills)
 │
 ├── .roo/
-│   ├── rules/                          # Roo Code (project rules, all modes)
-│   ├── rules-{modeSlug}/              # Roo Code (project mode-specific rules)
-│   ├── skills/{name}/SKILL.md          # Roo Code (project skills)
-│   ├── skills-{modeSlug}/{name}/SKILL.md  # Roo Code (project mode-specific skills)
-│   ├── commands/*.md                   # Roo Code (project slash commands)
-│   ├── mcp.json                        # Roo Code (project MCP)
-│   └── system-prompt-{mode-slug}       # Roo Code (system prompt override)
+│   ├── rules/                          # Zoo Code (project rules, all modes)
+│   ├── rules-{modeSlug}/              # Zoo Code (project mode-specific rules)
+│   ├── skills/{name}/SKILL.md          # Zoo Code (project skills)
+│   ├── skills-{modeSlug}/{name}/SKILL.md  # Zoo Code (project mode-specific skills)
+│   ├── commands/*.md                   # Zoo Code (project slash commands)
+│   ├── mcp.json                        # Zoo Code (project MCP)
+│   └── system-prompt-{mode-slug}       # Zoo Code (system prompt override)
 │
 └── .vscode/
     └── mcp.json                        # VSCode Copilot Chat (MCP)
@@ -1136,21 +1133,22 @@ User Home (~)/
 │   └── session-state/                  # Copilot CLI (session storage)
 │
 └── .roo/
-    ├── rules/                          # Roo Code (global rules, all modes)
-    ├── rules-{modeSlug}/              # Roo Code (global mode-specific rules)
-    ├── skills/{name}/SKILL.md          # Roo Code (global skills)
-    ├── skills-{modeSlug}/{name}/SKILL.md  # Roo Code (global mode-specific skills)
-    └── commands/*.md                   # Roo Code (global slash commands)
+    ├── rules/                          # Zoo Code (global rules, all modes)
+    ├── rules-{modeSlug}/              # Zoo Code (global mode-specific rules)
+    ├── skills/{name}/SKILL.md          # Zoo Code (global skills)
+    ├── skills-{modeSlug}/{name}/SKILL.md  # Zoo Code (global mode-specific skills)
+    └── commands/*.md                   # Zoo Code (global slash commands)
 
-# Roo Code VS Code Extension Global Storage
-# macOS:   ~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/
-# Linux:   ~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/
-# Windows: %APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\
+# Zoo Code VS Code Extension Global Storage
+# (legacy Roo Code used rooveterinaryinc.roo-cline in the same locations)
+# macOS:   ~/Library/Application Support/Code/User/globalStorage/zoocodeorganization.zoo-code/
+# Linux:   ~/.config/Code/User/globalStorage/zoocodeorganization.zoo-code/
+# Windows: %APPDATA%\Code\User\globalStorage\zoocodeorganization.zoo-code\
 {globalStorage}/
 └── settings/
-    ├── cline_mcp_settings.json         # Roo Code (global MCP)
-    ├── custom_modes.yaml               # Roo Code (global custom modes, recommended)
-    └── custom_modes.json               # Roo Code (global custom modes, legacy)
+    ├── cline_mcp_settings.json         # Zoo Code (global MCP)
+    ├── custom_modes.yaml               # Zoo Code (global custom modes, recommended)
+    └── custom_modes.json               # Zoo Code (global custom modes, legacy)
 ```
 
 ---
@@ -1188,14 +1186,15 @@ User Home (~)/
 - [Gemini CLI MCP Servers](https://geminicli.com/docs/tools/mcp-server/)
 - [Gemini CLI .geminiignore](https://geminicli.com/docs/cli/gemini-ignore/)
 - [Gemini CLI Extensions](https://geminicli.com/docs/extensions/)
-- [Roo Code Documentation](https://docs.roocode.com/)
-- [Roo Code Custom Instructions](https://docs.roocode.com/features/custom-instructions)
-- [Roo Code Skills](https://docs.roocode.com/features/skills)
-- [Roo Code Slash Commands](https://docs.roocode.com/features/slash-commands)
-- [Roo Code Custom Modes](https://docs.roocode.com/features/custom-modes)
-- [Roo Code MCP](https://docs.roocode.com/features/mcp/using-mcp-in-roo)
-- [Roo Code .rooignore](https://docs.roocode.com/features/rooignore)
-- [Roo Code System Prompt Override](https://docs.roocode.com/advanced-usage/footgun-prompting)
+- [Zoo Code Documentation](https://docs.zoocode.dev/)
+- Legacy Roo Code docs (layout still applies to Zoo Code):
+  - [Roo Code Custom Instructions](https://docs.roocode.com/features/custom-instructions)
+  - [Roo Code Skills](https://docs.roocode.com/features/skills)
+  - [Roo Code Slash Commands](https://docs.roocode.com/features/slash-commands)
+  - [Roo Code Custom Modes](https://docs.roocode.com/features/custom-modes)
+  - [Roo Code MCP](https://docs.roocode.com/features/mcp/using-mcp-in-roo)
+  - [Roo Code .rooignore](https://docs.roocode.com/features/rooignore)
+  - [Roo Code System Prompt Override](https://docs.roocode.com/advanced-usage/footgun-prompting)
 - [Use custom instructions in VS Code](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)
 - [Use Agent Skills in VS Code](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
 - [Use prompt files in VS Code](https://code.visualstudio.com/docs/copilot/customization/prompt-files)

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -21,6 +21,8 @@
     "codex",
     "copilot",
     "roo",
+    "zoo",
+    "zoo code",
     "gemini",
     "antigravity",
     "cursor"

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -769,7 +769,7 @@ export function registerOpenEditorCommand(
               break;
 
             case 'EXPORT_FOR_ROO_CODE':
-              // Export workflow for Roo Code (Skills format)
+              // Export workflow for Zoo Code (Skills format)
               if (message.payload?.workflow) {
                 await handleExportForRooCode(
                   fileService,
@@ -791,7 +791,7 @@ export function registerOpenEditorCommand(
               break;
 
             case 'RUN_FOR_ROO_CODE':
-              // Run workflow for Roo Code (via Extension API)
+              // Run workflow for Zoo Code (via Extension API)
               if (message.payload?.workflow) {
                 try {
                   await ensureMcpServerForRun(
@@ -800,7 +800,7 @@ export function registerOpenEditorCommand(
                     fileService.getWorkspacePath()
                   );
                 } catch (mcpError) {
-                  log('WARN', 'Failed to auto-start MCP server for Roo Code run', {
+                  log('WARN', 'Failed to auto-start MCP server for Zoo Code run', {
                     error: mcpError instanceof Error ? mcpError.message : String(mcpError),
                   });
                 }

--- a/packages/vscode/src/extension/commands/roo-code-handlers.ts
+++ b/packages/vscode/src/extension/commands/roo-code-handlers.ts
@@ -1,7 +1,9 @@
 /**
- * Claude Code Workflow Studio - Roo Code Integration Handlers
+ * Claude Code Workflow Studio - Roo Code / Zoo Code Integration Handlers
  *
- * Handles Export/Run for Roo Code integration
+ * Handles Export/Run for Zoo Code (formerly Roo Code) integration.
+ * Internal identifiers keep the 'roo-code' name because Zoo Code still
+ * reads the `.roo/` project directory.
  */
 
 import { NodeType } from '@cc-wf-studio/core';
@@ -16,7 +18,11 @@ import type {
 import { extractMcpServerIdsFromWorkflow } from '../services/copilot-export-service';
 import { nodeNameToFileName } from '../services/export-service';
 import type { FileService } from '../services/file-service';
-import { isRooCodeInstalled, startRooCodeTask } from '../services/roo-code-extension-service';
+import {
+  getInstalledRooCodeFlavor,
+  skillLaunchText,
+  startRooCodeTask,
+} from '../services/roo-code-extension-service';
 import {
   previewMcpSyncForRooCode,
   syncMcpConfigForRooCode,
@@ -31,7 +37,7 @@ import {
 } from '../services/skill-normalization-service';
 
 /**
- * Handle Export for Roo Code request
+ * Handle Export for Zoo Code request
  *
  * Exports workflow to Skills format (.roo/skills/name/SKILL.md)
  *
@@ -49,13 +55,13 @@ export async function handleExportForRooCode(
   try {
     const { workflow } = payload;
 
-    // Warn about SubAgent limitations in Roo Code
+    // Warn about SubAgent limitations in Zoo Code
     const hasSubAgentNodes = workflow.nodes.some(
       (node) => node.type === NodeType.SubAgent || node.type === NodeType.SubAgentFlow
     );
     if (hasSubAgentNodes) {
       const result = await vscode.window.showWarningMessage(
-        'This workflow contains Sub-Agent nodes.\n\nRoo Code does not have a Sub-Agent feature. Sub-Agents will be substituted with child tasks (new_task), which cannot run in parallel.',
+        'This workflow contains Sub-Agent nodes.\n\nZoo Code does not have a Sub-Agent feature. Sub-Agents will be substituted with child tasks (new_task), which cannot run in parallel.',
         { modal: true },
         'Continue'
       );
@@ -118,7 +124,7 @@ export async function handleExportForRooCode(
     });
 
     vscode.window.showInformationMessage(
-      `Exported workflow as Roo Code skill: ${exportResult.skillPath}`
+      `Exported workflow as Zoo Code skill: ${exportResult.skillPath}`
     );
   } catch (error) {
     const failedPayload: RooCodeOperationFailedPayload = {
@@ -135,10 +141,10 @@ export async function handleExportForRooCode(
 }
 
 /**
- * Handle Run for Roo Code request
+ * Handle Run for Zoo Code request
  *
  * Exports workflow to Skills format, syncs MCP config,
- * and starts Roo Code with :skill command via Extension API
+ * and starts Zoo Code with the skill launch command via Extension API
  *
  * @param fileService - File service instance
  * @param webview - Webview for sending responses
@@ -172,18 +178,18 @@ export async function handleRunForRooCode(
 
       if (normalizeResult.normalizedSkills && normalizeResult.normalizedSkills.length > 0) {
         console.log(
-          `[Roo Code] Copied ${normalizeResult.normalizedSkills.length} skill(s) to .claude/skills/`
+          `[Zoo Code] Copied ${normalizeResult.normalizedSkills.length} skill(s) to .claude/skills/`
         );
       }
     }
 
-    // Step 0.75: Warn about SubAgent limitations in Roo Code
+    // Step 0.75: Warn about SubAgent limitations in Zoo Code
     const hasSubAgentNodes = workflow.nodes.some(
       (node) => node.type === NodeType.SubAgent || node.type === NodeType.SubAgentFlow
     );
     if (hasSubAgentNodes) {
       const result = await vscode.window.showWarningMessage(
-        'This workflow contains Sub-Agent nodes.\n\nRoo Code does not have a Sub-Agent feature. Sub-Agents will be substituted with child tasks (new_task), which cannot run in parallel.',
+        'This workflow contains Sub-Agent nodes.\n\nZoo Code does not have a Sub-Agent feature. Sub-Agents will be substituted with child tasks (new_task), which cannot run in parallel.',
         { modal: true },
         'Continue'
       );
@@ -206,7 +212,7 @@ export async function handleRunForRooCode(
       if (mcpSyncPreview.serversToAdd.length > 0) {
         const serverList = mcpSyncPreview.serversToAdd.map((s) => `  • ${s}`).join('\n');
         const result = await vscode.window.showInformationMessage(
-          `The following MCP servers will be added to .roo/mcp.json for Roo Code:\n\n${serverList}\n\nProceed?`,
+          `The following MCP servers will be added to .roo/mcp.json for Zoo Code:\n\n${serverList}\n\nProceed?`,
           { modal: true },
           'Yes',
           'No'
@@ -257,12 +263,13 @@ export async function handleRunForRooCode(
       syncedMcpServers = await syncMcpConfigForRooCode(mcpServerIds, workspacePath);
     }
 
-    // Step 5: Start Roo Code with :skill command via Extension API
+    // Step 5: Start Zoo Code (or legacy Roo Code) with the skill launch command via Extension API
     const skillName = nodeNameToFileName(workflow.name);
+    const flavor = getInstalledRooCodeFlavor();
     let rooCodeOpened = false;
 
-    if (isRooCodeInstalled()) {
-      rooCodeOpened = await startRooCodeTask(`:skill ${skillName}`);
+    if (flavor) {
+      rooCodeOpened = await startRooCodeTask(skillLaunchText(flavor, skillName));
     }
 
     // Send success response
@@ -283,11 +290,12 @@ export async function handleRunForRooCode(
       syncedMcpServers.length > 0
         ? ` (MCP servers: ${syncedMcpServers.join(', ')} added to .roo/mcp.json)`
         : '';
+    const agentLabel = flavor === 'roo-code-legacy' ? 'Roo Code (legacy)' : 'Zoo Code';
     const rooCodeInfo = rooCodeOpened
       ? ''
-      : ' (Roo Code extension not found - skill exported only)';
+      : ' (Zoo Code extension not found - skill exported only)';
     vscode.window.showInformationMessage(
-      `Running workflow via Roo Code: ${workflow.name}${configInfo}${rooCodeInfo}`
+      `Running workflow via ${agentLabel}: ${workflow.name}${configInfo}${rooCodeInfo}`
     );
   } catch (error) {
     const failedPayload: RooCodeOperationFailedPayload = {

--- a/packages/vscode/src/extension/services/ai-editing-skill-service.ts
+++ b/packages/vscode/src/extension/services/ai-editing-skill-service.ts
@@ -12,7 +12,11 @@ import * as vscode from 'vscode';
 import { log } from '../extension';
 import { isAntigravityInstalled } from './antigravity-extension-service';
 import { isCursorInstalled } from './cursor-extension-service';
-import { isRooCodeInstalled, startRooCodeTask } from './roo-code-extension-service';
+import {
+  getInstalledRooCodeFlavor,
+  skillLaunchText,
+  startRooCodeTask,
+} from './roo-code-extension-service';
 
 export type AiEditingProvider =
   | 'claude-code'
@@ -167,10 +171,13 @@ async function launchProvider(
     }
 
     case 'roo-code': {
-      if (isRooCodeInstalled()) {
-        await startRooCodeTask(`:skill ${skillName}`);
+      const flavor = getInstalledRooCodeFlavor();
+      if (flavor) {
+        await startRooCodeTask(skillLaunchText(flavor, skillName));
       } else {
-        throw new Error('Roo Code extension is not installed.');
+        throw new Error(
+          'Zoo Code extension is not installed. (The legacy Roo Code extension is also supported if installed.)'
+        );
       }
       break;
     }

--- a/packages/vscode/src/extension/services/mcp-config-reader.ts
+++ b/packages/vscode/src/extension/services/mcp-config-reader.ts
@@ -26,7 +26,7 @@
  * - ~/.gemini/settings.json (user-level)
  * - <workspace>/.gemini/settings.json (project-level)
  *
- * Roo Code:
+ * Zoo Code (formerly Roo Code):
  * - <workspace>/.roo/mcp.json (project-level)
  *
  * Antigravity:
@@ -127,7 +127,7 @@ function readLegacyClaudeConfig(): {
 function normalizeServerConfig(config: Partial<McpServerConfig>): McpServerConfig | null {
   // If type is already specified, normalize and use it
   if (config.type) {
-    // Normalize 'streamable-http' (used by Roo Code) to 'http'
+    // Normalize 'streamable-http' (used by Zoo Code) to 'http'
     const type = config.type === ('streamable-http' as string) ? 'http' : config.type;
     return { ...config, type } as McpServerConfig;
   }
@@ -289,7 +289,7 @@ function readGeminiMcpConfig(configPath: string): Record<string, McpServerConfig
 }
 
 /**
- * Read Roo Code MCP config (.roo/mcp.json)
+ * Read Zoo Code MCP config (.roo/mcp.json)
  *
  * Format: { "mcpServers": { ... } }
  *
@@ -304,7 +304,7 @@ function readRooMcpConfig(configPath: string): Record<string, McpServerConfig> |
     const servers = parsed.mcpServers as Record<string, McpServerConfig> | undefined;
 
     if (servers) {
-      log('INFO', 'Successfully read Roo Code mcp.json', {
+      log('INFO', 'Successfully read Zoo Code mcp.json', {
         configPath,
         serverCount: Object.keys(servers).length,
       });
@@ -318,7 +318,7 @@ function readRooMcpConfig(configPath: string): Record<string, McpServerConfig> |
       return null;
     }
 
-    log('WARN', 'Failed to read Roo Code mcp.json', {
+    log('WARN', 'Failed to read Zoo Code mcp.json', {
       configPath,
       error: error instanceof Error ? error.message : String(error),
     });
@@ -825,17 +825,17 @@ export function getMcpServerConfig(
     }
 
     // =========================================================================
-    // Roo Code source (Priority 11)
+    // Zoo Code source (Priority 11)
     // =========================================================================
 
-    // Priority 11: Roo Code project-scope (.roo/mcp.json)
+    // Priority 11: Zoo Code project-scope (.roo/mcp.json)
     const rooProjectConfigPath = getRooProjectMcpConfigPath();
     if (rooProjectConfigPath) {
       const rooProjectConfig = readRooMcpConfig(rooProjectConfigPath);
       if (rooProjectConfig?.[serverId]) {
         const serverConfig = normalizeServerConfig(rooProjectConfig[serverId]);
         if (serverConfig) {
-          log('INFO', 'Retrieved MCP server configuration from Roo Code project scope', {
+          log('INFO', 'Retrieved MCP server configuration from Zoo Code project scope', {
             serverId,
             scope: 'roo-project',
             configPath: rooProjectConfigPath,
@@ -889,7 +889,7 @@ export function getMcpServerConfig(
     // Server not found in any configuration
     log(
       'WARN',
-      'MCP server not found in any configuration (Claude, Copilot, Codex, Gemini, Roo Code, Antigravity, Cursor)',
+      'MCP server not found in any configuration (Claude, Copilot, Codex, Gemini, Zoo Code, Antigravity, Cursor)',
       {
         serverId,
         workspacePath,
@@ -909,7 +909,7 @@ export function getMcpServerConfig(
 }
 
 /**
- * Get all MCP server IDs from all configuration sources (Claude, Copilot, Codex, Gemini, Roo Code)
+ * Get all MCP server IDs from all configuration sources (Claude, Copilot, Codex, Gemini, Zoo Code)
  *
  * @param workspacePath - Optional workspace path for project-scoped servers
  * @returns Array of unique server IDs
@@ -1026,10 +1026,10 @@ export function getAllMcpServerIds(workspacePath?: string): string[] {
     }
 
     // =========================================================================
-    // Roo Code source
+    // Zoo Code source
     // =========================================================================
 
-    // Collect from Roo Code project-scope (.roo/mcp.json)
+    // Collect from Zoo Code project-scope (.roo/mcp.json)
     const rooProjectConfigPath = getRooProjectMcpConfigPath();
     if (rooProjectConfigPath) {
       const rooProjectConfig = readRooMcpConfig(rooProjectConfigPath);
@@ -1095,7 +1095,7 @@ export interface McpServerWithSource extends McpServerConfig {
  * - Copilot CLI (.copilot/mcp-config.json)
  * - Codex CLI (~/.codex/config.toml)
  * - Gemini CLI (~/.gemini/settings.json, .gemini/settings.json)
- * - Roo Code (.roo/mcp.json)
+ * - Zoo Code (.roo/mcp.json)
  * - Antigravity (~/.gemini/antigravity/mcp_config.json)
  * - Cursor (~/.cursor/mcp.json)
  *
@@ -1110,7 +1110,7 @@ export interface McpServerWithSource extends McpServerConfig {
  * 8. User-scope Codex CLI (~/.codex/config.toml)
  * 9. User-scope Gemini CLI (~/.gemini/settings.json)
  * 10. Project-scope Gemini CLI (<workspace>/.gemini/settings.json)
- * 11. Project-scope Roo Code (<workspace>/.roo/mcp.json)
+ * 11. Project-scope Zoo Code (<workspace>/.roo/mcp.json)
  * 12. User-scope Antigravity (~/.gemini/antigravity/mcp_config.json)
  * 13. User-scope Cursor (~/.cursor/mcp.json)
  *
@@ -1236,7 +1236,7 @@ export function getAllMcpServersWithSource(workspacePath?: string): McpServerWit
       }
     }
 
-    // Priority 10: Roo Code project-scope (.roo/mcp.json)
+    // Priority 10: Zoo Code project-scope (.roo/mcp.json)
     const rooProjectConfigPath = getRooProjectMcpConfigPath();
     if (rooProjectConfigPath) {
       const rooProjectConfig = readRooMcpConfig(rooProjectConfigPath);

--- a/packages/vscode/src/extension/services/mcp-server-config-writer.ts
+++ b/packages/vscode/src/extension/services/mcp-server-config-writer.ts
@@ -6,7 +6,7 @@
  *
  * Supported targets:
  * - Claude Code: {workspace}/.mcp.json
- * - Roo Code: {workspace}/.roo/mcp.json
+ * - Zoo Code: {workspace}/.roo/mcp.json
  * - VSCode Copilot: {workspace}/.vscode/mcp.json
  * - Copilot CLI: ~/.copilot/mcp-config.json (global)
  * - Codex CLI: ~/.codex/config.toml (global)
@@ -167,7 +167,7 @@ export async function writeAgentConfig(
       config.mcpServers[SERVER_ENTRY_NAME] = { type: 'http', url: serverUrl, tools: ['*'] };
       await writeJsonConfig(filePath, config);
     } else if (target === 'roo-code') {
-      // Roo Code uses "mcpServers" key with type "streamable-http"
+      // Zoo Code uses "mcpServers" key with type "streamable-http"
       const filePath = getConfigPath(target, workspacePath);
       const config = await readJsonConfig(filePath);
       if (!config.mcpServers) {

--- a/packages/vscode/src/extension/services/roo-code-extension-service.ts
+++ b/packages/vscode/src/extension/services/roo-code-extension-service.ts
@@ -1,42 +1,95 @@
 /**
- * Claude Code Workflow Studio - Roo Code Extension Service
+ * Claude Code Workflow Studio - Roo Code / Zoo Code Extension Service
  *
- * Wrapper for Roo Code VSCode Extension API.
- * Uses the extension's exported API to start new tasks with :skill command.
+ * Wrapper for the Zoo Code VSCode Extension API (community fork of the
+ * sunset Roo Code extension — see issue #770). Zoo Code keeps the `.roo/`
+ * project directory and the same `startNewTask` extension API, so the
+ * integration is unchanged except for the extension ID and launch text.
+ *
+ * Detection prefers Zoo Code and falls back to the legacy Roo Code
+ * extension, which still works if the user configured a non-Router provider.
  */
 
 import * as vscode from 'vscode';
 
-const ROO_CODE_EXTENSION_ID = 'RooVeterinaryInc.roo-cline';
+const ZOO_CODE_EXTENSION_ID = 'ZooCodeOrganization.zoo-code';
+const LEGACY_ROO_CODE_EXTENSION_ID = 'RooVeterinaryInc.roo-cline';
 
 /**
- * Check if Roo Code extension is installed
- *
- * @returns True if Roo Code extension is installed
+ * Which compatible extension is installed.
+ * 'zoo-code' = Zoo Code (preferred), 'roo-code-legacy' = the sunset Roo Code extension.
  */
-export function isRooCodeInstalled(): boolean {
-  return vscode.extensions.getExtension(ROO_CODE_EXTENSION_ID) !== undefined;
+export type RooCodeFlavor = 'zoo-code' | 'roo-code-legacy';
+
+function findInstalledExtension(): {
+  extension: vscode.Extension<unknown>;
+  flavor: RooCodeFlavor;
+} | null {
+  const zoo = vscode.extensions.getExtension(ZOO_CODE_EXTENSION_ID);
+  if (zoo) {
+    return { extension: zoo, flavor: 'zoo-code' };
+  }
+  const legacyRoo = vscode.extensions.getExtension(LEGACY_ROO_CODE_EXTENSION_ID);
+  if (legacyRoo) {
+    return { extension: legacyRoo, flavor: 'roo-code-legacy' };
+  }
+  return null;
 }
 
 /**
- * Start a new task in Roo Code
+ * Get the flavor of the installed Zoo Code / Roo Code extension
  *
- * Activates the Roo Code extension if needed and calls startNewTask API.
+ * @returns 'zoo-code' or 'roo-code-legacy', or null if neither is installed
+ */
+export function getInstalledRooCodeFlavor(): RooCodeFlavor | null {
+  return findInstalledExtension()?.flavor ?? null;
+}
+
+/**
+ * Check if a compatible extension (Zoo Code or legacy Roo Code) is installed
  *
- * @param message - Message to send (e.g., ":skill my-skill")
+ * @returns True if either extension is installed
+ */
+export function isRooCodeInstalled(): boolean {
+  return findInstalledExtension() !== null;
+}
+
+/**
+ * Build the task text that loads a skill, per extension flavor.
+ *
+ * Zoo Code parses slash-command mentions (`/<name>`) with a fallback to
+ * skills; legacy Roo Code used the `:skill <name>` syntax.
+ *
+ * @param flavor - Installed extension flavor
+ * @param skillName - Name of the exported skill
+ * @returns Task text to pass to startRooCodeTask
+ */
+export function skillLaunchText(flavor: RooCodeFlavor, skillName: string): string {
+  return flavor === 'zoo-code' ? `/${skillName}` : `:skill ${skillName}`;
+}
+
+/**
+ * Start a new task in Zoo Code (or legacy Roo Code)
+ *
+ * Activates the extension if needed and calls its startNewTask API.
+ *
+ * @param message - Message to send (e.g., "/my-skill")
  * @returns True if the task was started successfully
  */
 export async function startRooCodeTask(message: string): Promise<boolean> {
-  const extension = vscode.extensions.getExtension(ROO_CODE_EXTENSION_ID);
-  if (!extension) {
+  const installed = findInstalledExtension();
+  if (!installed) {
     return false;
   }
 
+  const { extension } = installed;
   if (!extension.isActive) {
     await extension.activate();
   }
 
-  const api = extension.exports;
+  const api = extension.exports as
+    | { startNewTask?: (options: { text: string }) => Promise<unknown> }
+    | undefined;
 
   if (api?.startNewTask) {
     await api.startNewTask({ text: message });

--- a/packages/vscode/src/extension/services/roo-code-mcp-sync-service.ts
+++ b/packages/vscode/src/extension/services/roo-code-mcp-sync-service.ts
@@ -1,10 +1,10 @@
 /**
- * Claude Code Workflow Studio - Roo Code MCP Sync Service
+ * Claude Code Workflow Studio - Zoo Code (formerly Roo Code) MCP Sync Service
  *
  * Handles MCP server configuration sync to {workspace}/.roo/mcp.json
- * for Roo Code execution.
+ * for Zoo Code execution.
  *
- * Note: Roo Code uses JSON format for MCP configuration:
+ * Note: Zoo Code uses JSON format for MCP configuration:
  * - Config path: {workspace}/.roo/mcp.json
  * - MCP servers section: mcpServers.{server_name}
  */
@@ -14,14 +14,14 @@ import * as path from 'node:path';
 import { getMcpServerConfig } from './mcp-config-reader';
 
 /**
- * Roo Code mcp.json structure
+ * Zoo Code mcp.json structure
  */
 interface RooCodeMcpConfig {
   mcpServers?: Record<string, RooCodeMcpServerEntry>;
 }
 
 /**
- * MCP server configuration entry for Roo Code
+ * MCP server configuration entry for Zoo Code
  */
 interface RooCodeMcpServerEntry {
   command?: string;
@@ -43,14 +43,14 @@ export interface RooCodeMcpSyncPreviewResult {
 }
 
 /**
- * Get the Roo Code MCP config file path
+ * Get the Zoo Code MCP config file path
  */
 function getRooCodeMcpConfigPath(workspacePath: string): string {
   return path.join(workspacePath, '.roo', 'mcp.json');
 }
 
 /**
- * Read existing Roo Code MCP config
+ * Read existing Zoo Code MCP config
  */
 async function readRooCodeMcpConfig(workspacePath: string): Promise<RooCodeMcpConfig> {
   const configPath = getRooCodeMcpConfigPath(workspacePath);
@@ -65,7 +65,7 @@ async function readRooCodeMcpConfig(workspacePath: string): Promise<RooCodeMcpCo
 }
 
 /**
- * Write Roo Code MCP config to file
+ * Write Zoo Code MCP config to file
  *
  * @param workspacePath - Workspace path
  * @param config - Config to write
@@ -127,7 +127,7 @@ export async function previewMcpSyncForRooCode(
 }
 
 /**
- * Sync MCP server configurations to .roo/mcp.json for Roo Code
+ * Sync MCP server configurations to .roo/mcp.json for Zoo Code
  *
  * Reads MCP server configs from all Claude Code scopes (project, local, user)
  * and writes them to .roo/mcp.json in JSON format.
@@ -179,7 +179,7 @@ export async function syncMcpConfigForRooCode(
       continue;
     }
 
-    // Convert to Roo Code format
+    // Convert to Zoo Code format
     const rooCodeEntry: RooCodeMcpServerEntry = {};
 
     if (serverConfig.command) {

--- a/packages/vscode/src/extension/services/roo-code-skill-export-service.ts
+++ b/packages/vscode/src/extension/services/roo-code-skill-export-service.ts
@@ -1,5 +1,5 @@
 /**
- * Roo Code Skill Export — facade over the core planner.
+ * Zoo Code (formerly Roo Code) Skill Export — facade over the core planner.
  * See `agent-skill-export-helper.ts` for the I/O implementation.
  */
 

--- a/packages/vscode/src/extension/services/skill-normalization-service.ts
+++ b/packages/vscode/src/extension/services/skill-normalization-service.ts
@@ -31,7 +31,7 @@ const NON_STANDARD_SKILL_PATTERNS = [
   '.github/skills/', // GitHub Copilot CLI
   '.copilot/skills/', // GitHub Copilot CLI (alternative)
   '.codex/skills/', // OpenAI Codex CLI
-  '.roo/skills/', // Roo Code
+  '.roo/skills/', // Zoo Code
   '.gemini/skills/', // Google Gemini CLI
   '.agent/skills/', // Google Antigravity
   '.cursor/skills/', // Cursor (Anysphere)
@@ -79,7 +79,7 @@ function getStandardSkillPatterns(targetCli: TargetCli): string[] {
       patterns.push('.codex/skills/');
       break;
     case 'roo-code':
-      // Roo Code considers .roo/skills/ as native
+      // Zoo Code considers .roo/skills/ as native
       patterns.push('.roo/skills/');
       break;
     case 'gemini':

--- a/packages/vscode/src/extension/utils/path-utils.ts
+++ b/packages/vscode/src/extension/utils/path-utils.ts
@@ -122,7 +122,7 @@ export function getCodexProjectSkillsDir(): string | null {
 }
 
 /**
- * Get the Roo Code user-scope Skills directory path
+ * Get the Zoo Code (formerly Roo Code) user-scope Skills directory path
  *
  * @returns Absolute path to ~/.roo/skills/
  *
@@ -135,7 +135,7 @@ export function getRooUserSkillsDir(): string {
 }
 
 /**
- * Get the Roo Code project-scope Skills directory path
+ * Get the Zoo Code (formerly Roo Code) project-scope Skills directory path
  *
  * @returns Absolute path to .roo/skills/ in workspace root, or null if no workspace
  *
@@ -376,7 +376,7 @@ export function getCursorUserMcpConfigPath(): string {
 }
 
 /**
- * Get the Roo Code project-scope MCP config path (.roo/mcp.json)
+ * Get the Zoo Code (formerly Roo Code) project-scope MCP config path (.roo/mcp.json)
  *
  * @returns Absolute path to project MCP config, or null if no workspace
  *

--- a/packages/vscode/src/shared/types/messages.ts
+++ b/packages/vscode/src/shared/types/messages.ts
@@ -1837,11 +1837,11 @@ export interface CodexOperationFailedPayload {
 }
 
 // ============================================================================
-// Roo Code Integration Payloads (Beta)
+// Zoo Code (formerly Roo Code) Integration Payloads (Beta)
 // ============================================================================
 
 /**
- * Export workflow for Roo Code payload (Skills format)
+ * Export workflow for Zoo Code payload (Skills format)
  * Exports to .roo/skills/{name}/SKILL.md
  */
 export interface ExportForRooCodePayload {
@@ -1852,7 +1852,7 @@ export interface ExportForRooCodePayload {
 }
 
 /**
- * Export for Roo Code success payload
+ * Export for Zoo Code success payload
  */
 export interface ExportForRooCodeSuccessPayload {
   /** Skill name */
@@ -1864,8 +1864,8 @@ export interface ExportForRooCodeSuccessPayload {
 }
 
 /**
- * Run workflow for Roo Code payload
- * Exports and runs via Roo Code Extension API
+ * Run workflow for Zoo Code payload
+ * Exports and runs via Zoo Code Extension API
  */
 export interface RunForRooCodePayload {
   /** Workflow to run */
@@ -1875,19 +1875,19 @@ export interface RunForRooCodePayload {
 }
 
 /**
- * Run for Roo Code success payload
+ * Run for Zoo Code success payload
  */
 export interface RunForRooCodeSuccessPayload {
   /** Workflow name */
   workflowName: string;
-  /** Whether Roo Code was opened */
+  /** Whether Zoo Code was opened */
   rooCodeOpened: boolean;
   /** Timestamp */
   timestamp: string; // ISO 8601
 }
 
 /**
- * Roo Code operation failed payload
+ * Zoo Code operation failed payload
  */
 export interface RooCodeOperationFailedPayload {
   /** Error code */

--- a/packages/vscode/src/webview/src/components/Toolbar.tsx
+++ b/packages/vscode/src/webview/src/components/Toolbar.tsx
@@ -195,7 +195,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   // Codex integration
   const [isCodexExporting, setIsCodexExporting] = useState(false);
   const [isCodexRunning, setIsCodexRunning] = useState(false);
-  // Roo Code integration
+  // Zoo Code integration
   const [isRooCodeExporting, setIsRooCodeExporting] = useState(false);
   const [isRooCodeRunning, setIsRooCodeRunning] = useState(false);
   // Gemini CLI integration
@@ -799,7 +799,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   };
 
   // ============================================================================
-  // Roo Code Integration Handlers
+  // Zoo Code Integration Handlers
   // ============================================================================
 
   const handleRooCodeExport = async () => {
@@ -838,11 +838,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
       const { isHighlightEnabled } = useWorkflowStore.getState();
       const result = await exportForRooCode(workflow, { highlightEnabled: isHighlightEnabled });
-      console.log('Workflow exported as skill for Roo Code:', result.skillPath);
+      console.log('Workflow exported as skill for Zoo Code:', result.skillPath);
     } catch (error) {
       onError({
         code: 'EXPORT_FAILED',
-        message: error instanceof Error ? error.message : 'Failed to export for Roo Code',
+        message: error instanceof Error ? error.message : 'Failed to export for Zoo Code',
         details: error,
       });
     } finally {
@@ -886,11 +886,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
       const { isHighlightEnabled } = useWorkflowStore.getState();
       const result = await runForRooCode(workflow, { highlightEnabled: isHighlightEnabled });
-      console.log('Workflow run for Roo Code:', result.workflowName);
+      console.log('Workflow run for Zoo Code:', result.workflowName);
     } catch (error) {
       onError({
         code: 'RUN_FAILED',
-        message: error instanceof Error ? error.message : 'Failed to run for Roo Code',
+        message: error instanceof Error ? error.message : 'Failed to run for Zoo Code',
         details: error,
       });
     } finally {
@@ -1964,7 +1964,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                 </div>
               )}
 
-              {/* Vertical Divider - shown when Roo Code is enabled */}
+              {/* Vertical Divider - shown when Zoo Code is enabled */}
               {isRooCodeEnabled && (
                 <div
                   style={{
@@ -1976,7 +1976,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                 />
               )}
 
-              {/* Roo Code Column - shown when Roo Code is enabled */}
+              {/* Zoo Code Column - shown when Zoo Code is enabled */}
               {isRooCodeEnabled && (
                 <div
                   style={{
@@ -1992,7 +1992,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       whiteSpace: 'nowrap',
                     }}
                   >
-                    Roo Code
+                    Zoo Code
                   </span>
                   <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
                     <div style={{ display: 'flex' }}>

--- a/packages/vscode/src/webview/src/components/common/AIProviderBadge.tsx
+++ b/packages/vscode/src/webview/src/components/common/AIProviderBadge.tsx
@@ -55,7 +55,7 @@ const PROVIDER_CONFIG: Record<
     },
   },
   roo: {
-    label: 'Roo Code',
+    label: 'Zoo Code',
     colors: {
       light: '#FFFFFF', // White background (light theme)
       dark: '#1E1E1E', // Black background (dark theme)

--- a/packages/vscode/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/packages/vscode/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -362,7 +362,7 @@ export function MoreActionsDropdown({
                   {isCodexEnabled && <Check size={14} />}
                 </DropdownMenu.Item>
 
-                {/* Roo Code Toggle */}
+                {/* Zoo Code Toggle */}
                 <DropdownMenu.Item
                   onSelect={(event) => {
                     event.preventDefault();
@@ -381,7 +381,7 @@ export function MoreActionsDropdown({
                   }}
                 >
                   <Bot size={14} />
-                  <span style={{ flex: 1 }}>Roo Code</span>
+                  <span style={{ flex: 1 }}>Zoo Code</span>
                   {isRooCodeEnabled && <Check size={14} />}
                 </DropdownMenu.Item>
 

--- a/packages/vscode/src/webview/src/hooks/useEnabledAiProviders.ts
+++ b/packages/vscode/src/webview/src/hooks/useEnabledAiProviders.ts
@@ -21,7 +21,7 @@ export const AI_PROVIDER_OPTIONS: AiProviderOption[] = [
   { provider: 'copilot-chat', label: 'Copilot Chat' },
   { provider: 'copilot-cli', label: 'Copilot CLI' },
   { provider: 'codex', label: 'Codex CLI' },
-  { provider: 'roo-code', label: 'Roo Code' },
+  { provider: 'roo-code', label: 'Zoo Code' },
   { provider: 'gemini', label: 'Gemini CLI' },
   { provider: 'antigravity', label: 'Antigravity' },
   { provider: 'cursor', label: 'Cursor' },

--- a/packages/vscode/src/webview/src/services/vscode-bridge.ts
+++ b/packages/vscode/src/webview/src/services/vscode-bridge.ts
@@ -645,11 +645,11 @@ export function runForCodexCli(
 }
 
 // ============================================================================
-// Roo Code Integration Functions (Beta)
+// Zoo Code Integration Functions (Beta)
 // ============================================================================
 
 /**
- * Export workflow for Roo Code (Beta)
+ * Export workflow for Zoo Code (Beta)
  *
  * Exports the workflow to Skills format (.roo/skills/name/SKILL.md)
  *
@@ -679,7 +679,7 @@ export function exportForRooCode(
             timestamp: new Date().toISOString(),
           });
         } else if (message.type === 'EXPORT_FOR_ROO_CODE_FAILED') {
-          reject(new Error(message.payload?.errorMessage || 'Failed to export for Roo Code'));
+          reject(new Error(message.payload?.errorMessage || 'Failed to export for Zoo Code'));
         }
       }
     };
@@ -705,10 +705,10 @@ export function exportForRooCode(
 }
 
 /**
- * Run workflow for Roo Code (Beta)
+ * Run workflow for Zoo Code (Beta)
  *
- * Exports the workflow to Roo Code Skills format and starts
- * Roo Code with :skill command via Extension API
+ * Exports the workflow to Zoo Code Skills format and starts
+ * Zoo Code with the skill launch command via Extension API
  *
  * @param workflow - Workflow to run
  * @returns Promise that resolves with run result
@@ -736,7 +736,7 @@ export function runForRooCode(
             timestamp: new Date().toISOString(),
           });
         } else if (message.type === 'RUN_FOR_ROO_CODE_FAILED') {
-          reject(new Error(message.payload?.errorMessage || 'Failed to run for Roo Code'));
+          reject(new Error(message.payload?.errorMessage || 'Failed to run for Zoo Code'));
         }
       }
     };

--- a/packages/vscode/src/webview/src/stores/refinement-store.ts
+++ b/packages/vscode/src/webview/src/stores/refinement-store.ts
@@ -31,7 +31,7 @@ const COPILOT_CHAT_ENABLED_STORAGE_KEY = 'cc-wf-studio:copilot-chat-enabled';
 const COPILOT_CLI_ENABLED_STORAGE_KEY = 'cc-wf-studio:copilot-cli-enabled';
 // Note: This key is shared with Toolbar.tsx for the "Codex (Beta)" toggle
 const CODEX_ENABLED_STORAGE_KEY = 'cc-wf-studio:codex-beta-enabled';
-// Note: This key is shared with Toolbar.tsx for the "Roo Code (Beta)" toggle
+// Note: This key is shared with Toolbar.tsx for the "Zoo Code (Beta)" toggle
 const ROO_CODE_ENABLED_STORAGE_KEY = 'cc-wf-studio:roo-code-beta-enabled';
 // Note: This key is shared with Toolbar.tsx for the "Gemini CLI (Beta)" toggle
 const GEMINI_ENABLED_STORAGE_KEY = 'cc-wf-studio:gemini-beta-enabled';
@@ -384,7 +384,7 @@ function saveCodexEnabledToStorage(enabled: boolean): void {
 }
 
 /**
- * Load Roo Code enabled state from localStorage
+ * Load Zoo Code enabled state from localStorage
  */
 function loadRooCodeEnabledFromStorage(): boolean {
   try {
@@ -396,7 +396,7 @@ function loadRooCodeEnabledFromStorage(): boolean {
 }
 
 /**
- * Save Roo Code enabled state to localStorage
+ * Save Zoo Code enabled state to localStorage
  */
 function saveRooCodeEnabledToStorage(enabled: boolean): void {
   try {


### PR DESCRIPTION
## Problem

Fixes #770.

The Roo Code extension has been sunset and its default API relay (Roo Code Router) was shut down, so the Roo Code integration no longer works end-to-end.

### Current Behavior
1. Export/Run a workflow for Roo Code from the canvas (or `ccwf export --agent roo-code`)
2. ❌ The skill files are written, but launching the workflow fails on the Roo Code side with a "Roo Code Router has been sunset" error; users on the defunct Router cannot run anything

### Expected Behavior
1. Export/Run a workflow for the agent
2. ✅ The workflow launches in **Zoo Code** (`ZooCodeOrganization.zoo-code`), the maintained community fork of Roo Code, which has no Router dependency

## Solution

Switch the integration target to Zoo Code with a minimal-churn approach. Zoo Code keeps the `.roo/` project layout (`.roo/skills/`, `.roo/mcp.json`, verified in its `SkillsManager.ts` / `McpHub.ts`) and the same `startNewTask({text})` extension API, so the `roo-code` agent ID, message types, and all output paths stay unchanged — only extension detection, launch text, and user-facing labels change.

### Changes

**File**: `packages/vscode/src/extension/services/roo-code-extension-service.ts`
- Detect `ZooCodeOrganization.zoo-code` first, fall back to the legacy `RooVeterinaryInc.roo-cline` (still usable with a non-Router provider)
- New `RooCodeFlavor` type and `skillLaunchText()` — Zoo Code uses slash syntax (`/<skill>`), legacy Roo Code keeps `:skill <skill>`

**File**: `packages/vscode/src/extension/commands/roo-code-handlers.ts`, `packages/vscode/src/extension/services/ai-editing-skill-service.ts`
- Both launch sites (Run flow; AI Edit / Import Skill / Generate Tour flows) now use the flavor-aware launch text
- Notifications say "Zoo Code" (or "Roo Code (legacy)" when the fallback was used)

**File**: `packages/core/src/services/workflow-prompt-generator.ts`
- `getAgentName('roo-code')` now returns "Zoo Code" (generated SKILL.md instructions); tool names (`ask_followup_question`, `execute_command`, `new_task`) are unchanged since Zoo Code is a fork

**File**: `packages/cli/src/commands/run.ts`, `packages/cli/src/commands/export.ts`
- Next-step hint switched to `` run `/<skill>` in Zoo Code ``; `--agent` help notes that `roo-code` targets Zoo Code

**Files**: `packages/vscode/src/webview/src/...` (Toolbar, MoreActionsDropdown, AIProviderBadge, useEnabledAiProviders, vscode-bridge, refinement-store)
- UI labels renamed to "Zoo Code"; provider IDs, storage keys, and wire message types untouched

**Docs**: root/vscode/cli/core READMEs, `packages/vscode/docs/ai-coding-tools-config-reference.md`, `packages/vscode/package.json` keywords
- Marketplace link now points to `ZooCodeOrganization.zoo-code`; config reference section retitled "Zoo Code (formerly Roo Code)"

## Release

- Changeset: `minor` for `cc-wf-studio`, `patch` for `@cc-wf-studio/core` and `@cc-wf-studio/cli` (`.changeset/switch-roo-code-to-zoo-code.md`)

## Impact

- Users with Zoo Code installed get a working Run-for-Zoo-Code path again
- Users still on the legacy Roo Code extension keep working via the fallback (with their own provider configured)
- No data migration: `.roo/skills/`, `.roo/mcp.json`, workflow JSON `source: 'roo'`, and the `--agent roo-code` CLI flag are all unchanged

## Testing

- [x] `pnpm check` and `pnpm build` pass across all packages
- [x] CLI smoke test: `ccwf export --agent roo-code` writes `.roo/skills/<name>/SKILL.md` with "Zoo Code" in the generated instructions; `ccwf run` prints the new `/<skill>` hint
- [x] Pending: E2E in Extension Development Host with Zoo Code v3.58.1 — verify the `/<skillName>` task text actually loads the skill (isolated in `skillLaunchText()`, one-line change if the syntax needs adjusting)
- [ ] Pending: legacy fallback E2E with only Roo Code installed (`:skill` syntax)

## Notes

- The `/<skillName>` launch syntax is inferred from Zoo Code's source (`command-mentions.spec.ts`: slash-command mentions fall back to skills) but not yet verified live — hence the pending E2E item above
- A full `zoo-code` agent ID rename was considered and deliberately skipped: Zoo Code still reads `.roo/`, so the rename would be cosmetic churn (discussed during planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Zoo Code (community fork), with automatic detection and legacy Roo Code fallback and updated skill invocation syntax.

* **Documentation**
  * Updated UI labels, CLI hints, README entries, VS Code UI text, and config/docs to reflect Zoo Code branding and supported agent information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->