### PR TITLE
feat(core, vscode, cli): add branchSession node type

### DIFF
--- a/.changeset/brave-planes-shake.md
+++ b/.changeset/brave-planes-shake.md
@@ -1,0 +1,6 @@
+---
+'@cc-wf-studio/core': minor
+'cc-wf-studio': minor
+---
+
+feat: add branchSession node type — a Claude Code-only human-in-the-loop checkpoint where the user works interactively with the AI in a branch session (/branch) and hands results back to the parent session (/resume). Exporting/running workflows containing this node for non-Claude-Code targets shows a confirmation dialog (webview) or a warning (CLI). Includes a new "Daily Dev with Branch Session" sample workflow (5 locales) and a fix for the MCP server manager getting stuck in "already running" after a failed start.

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -18,6 +18,7 @@ import {
   nodeNameToFileName,
   planAgentSkillFiles,
   planWorkflowExportFiles,
+  workflowContainsClaudeCodeOnlyNodes,
 } from '@cc-wf-studio/core';
 import { Command, InvalidArgumentError } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
@@ -87,6 +88,12 @@ async function pathExists(target: string): Promise<boolean> {
 export async function runExport(options: ExportRunOptions): Promise<ExportRunResult> {
   const { workflow } = await loadWorkflowFromFile(options.file);
   const rootDir = path.resolve(options.cwd ?? process.cwd());
+
+  if (options.agent !== CLAUDE_CODE_AGENT && workflowContainsClaudeCodeOnlyNodes(workflow)) {
+    process.stderr.write(
+      `warning: this workflow contains Claude Code-only node(s) (e.g. branchSession); ${options.agent} cannot execute those steps.\n`
+    );
+  }
 
   const plan =
     options.agent === CLAUDE_CODE_AGENT

--- a/packages/core/resources/workflow-schema.json
+++ b/packages/core/resources/workflow-schema.json
@@ -677,7 +677,17 @@
     "portNamingRules": {
       "description": "Port identifier conventions for each node type. Linear nodes: single output. Conditional nodes: multiple outputs (one per branch).",
       "linearNodes": {
-        "types": ["start", "end", "prompt", "subAgent", "skill", "mcp", "subAgentFlow", "codex"],
+        "types": [
+          "start",
+          "end",
+          "prompt",
+          "subAgent",
+          "skill",
+          "mcp",
+          "subAgentFlow",
+          "codex",
+          "branchSession"
+        ],
         "inputPortId": "input",
         "outputPortId": "output",
         "connectionExample": {

--- a/packages/core/resources/workflow-schema.json
+++ b/packages/core/resources/workflow-schema.json
@@ -15,6 +15,7 @@
       "mcp",
       "subAgentFlow",
       "codex",
+      "branchSession",
       "group"
     ]
   },
@@ -592,6 +593,21 @@
       "inputPorts": 1,
       "outputPorts": 1
     },
+    "branchSession": {
+      "description": "Human-in-the-loop checkpoint (Claude Code ONLY). The workflow pauses and the user opens a Claude Code branch session (/branch) to work interactively TOGETHER WITH the AI (code understanding, review, edits), then hands the results back to the parent session (/resume) and the workflow continues. Use when a step needs joint human+AI work — unlike subAgent (autonomous delegation) or askUserQuestion (a single question). Do NOT use for workflows targeting agents other than Claude Code.",
+      "fields": {
+        "label": { "type": "string", "required": true, "minLength": 1, "maxLength": 50 },
+        "workDescription": {
+          "type": "string",
+          "required": false,
+          "maxLength": 2000,
+          "description": "Scope of the joint human+AI work performed in the branch session (e.g. 'Review the generated code and adjust naming'). Injected into the generated instructions."
+        },
+        "outputPorts": { "type": "number", "required": true, "value": 1 }
+      },
+      "inputPorts": 1,
+      "outputPorts": 1
+    },
     "group": {
       "description": "Visual grouping container for organizing nodes. Does not affect execution flow.",
       "fields": {
@@ -866,11 +882,12 @@
     "description": "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed.",
     "maxNodes": 100,
     "supportedNodeTypes": ["start", "end", "prompt", "ifElse", "switch", "skill", "mcp", "codex"],
-    "prohibitedNodeTypes": ["subAgent", "subAgentFlow", "askUserQuestion"],
+    "prohibitedNodeTypes": ["subAgent", "subAgentFlow", "askUserQuestion", "branchSession"],
     "rules": [
       "Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution)",
       "Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP)",
       "Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context)",
+      "Sub-Agent Flows cannot contain BranchSession nodes (user interaction not supported in sub-agent context)",
       "Sub-Agent Flows must have exactly one Start node and at least one End node",
       "Maximum 100 nodes per Sub-Agent Flow"
     ]

--- a/packages/core/resources/workflow-schema.toon
+++ b/packages/core/resources/workflow-schema.toon
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0
 metadata:
   description: Workflow schema for CC Workflow Studio
   maxNodes: 100
-  supportedNodeTypes[12]: start,end,prompt,subAgent,askUserQuestion,ifElse,switch,skill,mcp,subAgentFlow,codex,group
+  supportedNodeTypes[13]: start,end,prompt,subAgent,askUserQuestion,ifElse,switch,skill,mcp,subAgentFlow,codex,branchSession,group
 nodeTypes:
   start:
     description: Workflow entry point. Exactly one required per workflow.
@@ -510,6 +510,25 @@ nodeTypes:
         description: "Skip Git repository trust check. When true, allows execution outside trusted Git repositories. Use with caution."
     inputPorts: 1
     outputPorts: 1
+  branchSession:
+    description: "Human-in-the-loop checkpoint (Claude Code ONLY). The workflow pauses and the user opens a Claude Code branch session (/branch) to work interactively TOGETHER WITH the AI (code understanding, review, edits), then hands the results back to the parent session (/resume) and the workflow continues. Use when a step needs joint human+AI work — unlike subAgent (autonomous delegation) or askUserQuestion (a single question). Do NOT use for workflows targeting agents other than Claude Code."
+    fields:
+      label:
+        type: string
+        required: true
+        minLength: 1
+        maxLength: 50
+      workDescription:
+        type: string
+        required: false
+        maxLength: 2000
+        description: Scope of the joint human+AI work performed in the branch session (e.g. 'Review the generated code and adjust naming'). Injected into the generated instructions.
+      outputPorts:
+        type: number
+        required: true
+        value: 1
+    inputPorts: 1
+    outputPorts: 1
   group:
     description: Visual grouping container for organizing nodes. Does not affect execution flow.
     fields:
@@ -680,8 +699,8 @@ subAgentFlowConstraints:
   description: "Constraints specific to Sub-Agent Flow editing. When refining a Sub-Agent Flow, these rules MUST be followed."
   maxNodes: 100
   supportedNodeTypes[8]: start,end,prompt,ifElse,switch,skill,mcp,codex
-  prohibitedNodeTypes[3]: subAgent,subAgentFlow,askUserQuestion
-  rules[5]: Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution),Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP),Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context),Sub-Agent Flows must have exactly one Start node and at least one End node,Maximum 100 nodes per Sub-Agent Flow
+  prohibitedNodeTypes[4]: subAgent,subAgentFlow,askUserQuestion,branchSession
+  rules[6]: Sub-Agent Flows cannot contain SubAgent nodes (Claude Code constraint for sequential execution),Sub-Agent Flows cannot contain SubAgentFlow nodes (no nesting allowed in Phase 1 MVP),Sub-Agent Flows cannot contain AskUserQuestion nodes (user interaction not supported in sub-agent context),Sub-Agent Flows cannot contain BranchSession nodes (user interaction not supported in sub-agent context),Sub-Agent Flows must have exactly one Start node and at least one End node,Maximum 100 nodes per Sub-Agent Flow
 workflowStructure:
   description: Top-level workflow structure fields
   fields:

--- a/packages/core/resources/workflow-schema.toon
+++ b/packages/core/resources/workflow-schema.toon
@@ -579,7 +579,7 @@ connections:
   portNamingRules:
     description: "Port identifier conventions for each node type. Linear nodes: single output. Conditional nodes: multiple outputs (one per branch)."
     linearNodes:
-      types[8]: start,end,prompt,subAgent,skill,mcp,subAgentFlow,codex
+      types[9]: start,end,prompt,subAgent,skill,mcp,subAgentFlow,codex,branchSession
       inputPortId: input
       outputPortId: output
       connectionExample:

--- a/packages/core/src/schema/claude-code-only.ts
+++ b/packages/core/src/schema/claude-code-only.ts
@@ -1,0 +1,24 @@
+/**
+ * Node-level Claude Code exclusivity.
+ *
+ * Some node types rely on Claude Code-specific runtime features and have no
+ * equivalent on other export targets. Exporters and UIs use these helpers to
+ * warn before exporting such workflows for non-Claude-Code targets.
+ */
+
+import { NodeType, type Workflow, type WorkflowNode } from '../types/workflow-definition.js';
+
+/** Node types that only execute on Claude Code (no equivalent on other targets). */
+export const CLAUDE_CODE_ONLY_NODE_TYPES: ReadonlySet<NodeType> = new Set([
+  NodeType.BranchSession,
+]);
+
+/** Returns the nodes in the list that only work on Claude Code. */
+export function getClaudeCodeOnlyNodes(nodes: readonly WorkflowNode[]): WorkflowNode[] {
+  return nodes.filter((node) => CLAUDE_CODE_ONLY_NODE_TYPES.has(node.type));
+}
+
+/** Returns true when the workflow contains at least one Claude Code-only node. */
+export function workflowContainsClaudeCodeOnlyNodes(workflow: Workflow): boolean {
+  return getClaudeCodeOnlyNodes(workflow.nodes).length > 0;
+}

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -12,3 +12,4 @@ export * from './field.js';
 export * from './sub-agent-schema.js';
 export * from './queries.js';
 export * from './warnings.js';
+export * from './claude-code-only.js';

--- a/packages/core/src/services/workflow-overview-formatter.ts
+++ b/packages/core/src/services/workflow-overview-formatter.ts
@@ -17,6 +17,7 @@
 import type {
   AskUserQuestionNode,
   BranchNode,
+  BranchSessionNode,
   CodexNode,
   Connection,
   IfElseNode,
@@ -214,6 +215,9 @@ function formatNode(
       break;
     case 'codex':
       lines.push(formatCodex(node as CodexNode));
+      break;
+    case 'branchSession':
+      lines.push(formatBranchSession(node as BranchSessionNode));
       break;
     case 'subAgentFlow':
       lines.push(formatSubAgentFlow(node as SubAgentFlowNode, workflow));
@@ -459,6 +463,18 @@ function formatCodex(node: CodexNode): string {
   if (d.sandbox) meta.push(`Sandbox: \`${d.sandbox}\``);
   out.push('');
   out.push(meta.join(' · '));
+  return out.join('\n');
+}
+
+// ----- branchSession ------------------------------------------------------
+
+function formatBranchSession(node: BranchSessionNode): string {
+  const out: string[] = ['**Type**: BRANCH SESSION (human-in-the-loop checkpoint, Claude Code only)'];
+  const d = node.data;
+  if (d.workDescription?.trim()) {
+    out.push('');
+    out.push(quote(d.workDescription.trim()));
+  }
   return out.join('\n');
 }
 

--- a/packages/core/src/services/workflow-prompt-generator.ts
+++ b/packages/core/src/services/workflow-prompt-generator.ts
@@ -10,6 +10,7 @@
 import type {
   AskUserQuestionNode,
   BranchNode,
+  BranchSessionNode,
   CodexNode,
   IfElseNode,
   McpNode,
@@ -227,6 +228,11 @@ export function generateMermaidFlowchart(source: MermaidSource): string {
       const codexNode = node as CodexNode;
       const codexName = codexNode.data.label || 'Codex Agent';
       return `${indent}${nodeId}[[${escapeLabel(`${upperType('Codex')}: ${codexName}`)}]]`;
+    }
+    if (nodeType === 'branchSession') {
+      const title = titleOf(node, 'Branch Session');
+      // Hyphenated like `Sub-Agent` so concise mode reads `BRANCH-SESSION`.
+      return `${indent}${nodeId}[${escapeLabel(`${upperType('Branch-Session')}: ${title}`)}]`;
     }
     return null;
   };
@@ -680,6 +686,9 @@ export function generateExecutionInstructions(
   sections.push(
     '- **Rectangle nodes (Prompt nodes)**: Execute the prompts described in the details section below'
   );
+  sections.push(
+    '- **Rectangle nodes (Branch-Session: ...)**: Human-in-the-loop checkpoints — pause the workflow and guide the user into a Claude Code branch session (see Branch Session Node Details)'
+  );
   sections.push('');
 
   // Group Node Execution Tracking (skipped when highlight is disabled)
@@ -717,6 +726,9 @@ export function generateExecutionInstructions(
   const skillNodes = nodes.filter((n) => n.type === 'skill') as SkillNode[];
   const mcpNodes = nodes.filter((n) => n.type === 'mcp') as McpNode[];
   const codexNodes = nodes.filter((n) => n.type === 'codex') as CodexNode[];
+  const branchSessionNodes = nodes.filter(
+    (n) => n.type === 'branchSession'
+  ) as BranchSessionNode[];
   const askUserQuestionNodes = nodes.filter(
     (n) => n.type === 'askUserQuestion'
   ) as AskUserQuestionNode[];
@@ -927,6 +939,65 @@ export function generateExecutionInstructions(
         }
         sections.push('');
       }
+    }
+  }
+
+  // Branch Session node details (Claude Code only)
+  if (branchSessionNodes.length > 0) {
+    sections.push('### Branch Session Node Details');
+    sections.push('');
+    sections.push(
+      'These nodes are human-in-the-loop checkpoints: the workflow pauses and the user works INTERACTIVELY together with the AI in a Claude Code branch session. This is NOT a sub-agent delegation. This node type only works on Claude Code.'
+    );
+    sections.push('');
+    for (const node of branchSessionNodes) {
+      const nodeId = sanitizeNodeId(node.id);
+      sections.push(`#### ${nodeId}(${node.data.label || 'Branch Session'})`);
+      sections.push('');
+      if (node.data.workDescription?.trim()) {
+        sections.push(`**Work scope**: ${node.data.workDescription.trim()}`);
+        sections.push('');
+      }
+      sections.push('Follow these steps exactly when execution reaches this node:');
+      sections.push('');
+      sections.push('**Step 1 — Guide the user into a branch session, then END YOUR TURN:**');
+      sections.push('');
+      sections.push(
+        '1. Compose a short branch-session name from the task context (alphanumeric and hyphens, e.g. `review-auth-refactor`). Naming the session makes it identifiable later.'
+      );
+      sections.push(
+        "2. Output a message that contains the literal command `/branch <session-name>` so Claude Code's suggestion UI surfaces it and the user can select it directly."
+      );
+      sections.push(
+        '3. State the work scope above (if provided) so the user knows what to do in the branch session.'
+      );
+      sections.push(
+        '4. Tell the user to work freely with the AI in the branch session and, when done, ask the AI to hand off (e.g. say 「引き継いで」/ "hand off").'
+      );
+      sections.push(
+        "5. Do NOT output the parent session ID (the branch session inherently knows its parent's ID). End your turn and wait."
+      );
+      sections.push('');
+      sections.push(
+        '**Step 2 — Handoff (applies when YOU are the branch session and the user asks to hand off):**'
+      );
+      sections.push('');
+      sections.push(
+        '1. Write a handoff markdown file (temporary file under the OS temp directory; decide the path at runtime) summarizing conclusions, decisions, edits made, and next actions.'
+      );
+      sections.push(
+        '2. Copy its content to the clipboard using a command suited to the runtime OS (`pbcopy` on macOS, `Set-Clipboard` on Windows PowerShell, `clip.exe` on cmd/Git Bash, `powershell.exe -c Set-Clipboard` on WSL, `xclip`/`wl-copy` on Linux). Prefer a method that passes UTF-8 safely.'
+      );
+      sections.push(
+        '3. Tell the user to run `/resume <parent-session-id>` and paste the clipboard content. ALWAYS also show the handoff file path as a fallback: in the parent session the user can simply ask the AI to read that file. You know your parent session\'s ID; if it is unknown (e.g. after /compact), ask the user.'
+      );
+      sections.push('');
+      sections.push('**Step 3 — Resume (applies when YOU are the parent session):**');
+      sections.push('');
+      sections.push(
+        "When the user pastes handoff content (or points you at the handoff file) after this checkpoint, treat it as the branch session's handoff result and proceed to the next node in the workflow."
+      );
+      sections.push('');
     }
   }
 

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -21,6 +21,7 @@ export enum NodeType {
   Mcp = 'mcp', // New: MCP (Model Context Protocol) tool integration
   SubAgentFlow = 'subAgentFlow', // New: Sub-Agent Flow reference node
   Codex = 'codex', // New: OpenAI Codex CLI integration
+  BranchSession = 'branchSession', // New: human-in-the-loop branch-session checkpoint (Claude Code only)
   Group = 'group', // New: Visual grouping container
 }
 
@@ -396,6 +397,22 @@ export interface CodexNodeData {
   skipGitRepoCheck?: boolean;
 }
 
+/**
+ * Branch Session node data (Claude Code only)
+ *
+ * Human-in-the-loop checkpoint: the workflow pauses and the user works
+ * interactively together with the AI in a Claude Code branch session
+ * (/branch), then hands the results back to the parent session (/resume).
+ */
+export interface BranchSessionNodeData {
+  /** Display label for the branch-session checkpoint */
+  label: string;
+  /** Optional scope of the joint human+AI work, injected into generated instructions */
+  workDescription?: string;
+  /** Number of output ports (fixed at 1) */
+  outputPorts: 1;
+}
+
 // ============================================================================
 // Node Types
 // ============================================================================
@@ -469,6 +486,11 @@ export interface CodexNode extends BaseNode {
   data: CodexNodeData;
 }
 
+export interface BranchSessionNode extends BaseNode {
+  type: NodeType.BranchSession;
+  data: BranchSessionNodeData;
+}
+
 export interface GroupNodeData {
   label: string;
 }
@@ -491,6 +513,7 @@ export type WorkflowNode =
   | McpNode
   | SubAgentFlowNode
   | CodexNode
+  | BranchSessionNode
   | GroupNode;
 
 // ============================================================================
@@ -727,6 +750,12 @@ export const VALIDATION_RULES = {
     NAME_MAX_LENGTH: 64,
     PROMPT_MIN_LENGTH: 1,
     PROMPT_MAX_LENGTH: 10000,
+    OUTPUT_PORTS: 1, // Fixed: 1 output port
+  },
+  BRANCH_SESSION: {
+    LABEL_MIN_LENGTH: 1,
+    LABEL_MAX_LENGTH: 50,
+    WORK_DESCRIPTION_MAX_LENGTH: 2000,
     OUTPUT_PORTS: 1, // Fixed: 1 output port
   },
 } as const;

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.en.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.en.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "id": "daily-dev-with-branch-sample",
+    "nameKey": "sample.dailyDevWithBranch.name",
+    "descriptionKey": "sample.dailyDevWithBranch.description",
+    "difficulty": "intermediate",
+    "tags": [
+      "development",
+      "branch-session",
+      "human-in-the-loop"
+    ],
+    "nodeCount": 8
+  },
+  "workflow": {
+    "id": "workflow-daily-dev-with-branch",
+    "name": "daily-dev-with-branch",
+    "version": "1.0.0",
+    "nodes": [
+      {
+        "id": "start-1",
+        "type": "start",
+        "name": "start-1",
+        "position": {
+          "x": 120,
+          "y": 315
+        },
+        "data": {
+          "label": "Start"
+        }
+      },
+      {
+        "id": "hearing-1",
+        "type": "prompt",
+        "name": "hearing-1",
+        "position": {
+          "x": 300,
+          "y": 300
+        },
+        "data": {
+          "label": "Hearing",
+          "prompt": "Interview the user about what they want to accomplish today. Clarify the following:\n- What they want to achieve (the goal)\n- Background and motivation\n- Scope (target repositories, directories, features)\n- Constraints (time, areas that must not be touched, dependencies, etc.)\n- Completion criteria (what counts as done)\n\nAsk follow-up questions about anything ambiguous, then summarize the interview results as a bulleted list and get the user's confirmation."
+        }
+      },
+      {
+        "id": "planning-1",
+        "type": "subAgent",
+        "name": "planning-1",
+        "position": {
+          "x": 645,
+          "y": 300
+        },
+        "data": {
+          "description": "Create an implementation plan based on the interview results",
+          "agentDefinition": "A planning agent specialized in designing implementation plans. Investigates the codebase and creates a step-by-step implementation plan that weighs architectural trade-offs.",
+          "prompt": "Based on the interview results from the previous step, create an implementation plan.\n- Investigate the relevant codebase and identify the files that need changes\n- List the implementation steps in order\n- Note risks, caveats, and how to verify the changes\nFinally, output a step-by-step implementation plan.",
+          "builtInType": "plan",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "development-1",
+        "type": "subAgent",
+        "name": "development-1",
+        "position": {
+          "x": 975,
+          "y": 300
+        },
+        "data": {
+          "description": "Execute development according to the implementation plan",
+          "agentDefinition": "A general-purpose development agent that implements, edits code, and runs tests. Follows the implementation plan faithfully and reports the changes and verification results.",
+          "prompt": "Execute development according to the implementation plan created in the previous step.\n- Implement in the order of the planned steps\n- Match the existing code style and conventions\n- Verify the work with tests or builds where possible\nWhen finished, report the list of changed files, what was implemented, and the verification results.",
+          "builtInType": "general-purpose",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "branch-session-1",
+        "type": "branchSession",
+        "name": "branch-session-1",
+        "position": {
+          "x": 1305,
+          "y": 300
+        },
+        "data": {
+          "label": "Branch Session Work",
+          "workDescription": "The user and the AI work together on answering questions about the development results, reviewing the code, and making fixes. Interactively confirm the implementation, adjust naming and design, resolve open questions, and hand the results back to the parent session.",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "completion-check-1",
+        "type": "askUserQuestion",
+        "name": "completion-check-1",
+        "position": {
+          "x": 1665,
+          "y": 285
+        },
+        "data": {
+          "questionText": "Received the report from the branch session. Is this work complete?",
+          "options": [
+            {
+              "id": "opt-done",
+              "label": "Done",
+              "description": "The work is complete. Proceed to the retrospective phase"
+            },
+            {
+              "id": "opt-continue",
+              "label": "Continue",
+              "description": "Work remains. Return to the branch session for more questions and fixes"
+            }
+          ],
+          "multiSelect": false,
+          "useAiSuggestions": false,
+          "outputPorts": 2
+        }
+      },
+      {
+        "id": "retrospective-1",
+        "type": "prompt",
+        "name": "retrospective-1",
+        "position": {
+          "x": 2010,
+          "y": 300
+        },
+        "data": {
+          "label": "Retrospective",
+          "prompt": "Look back on this session and identify improvements to carry forward.\n\n1. List the learnings, stumbling points, and repeatedly raised issues from this session\n2. For each item, decide where it should be recorded:\n   - Update CLAUDE.md (permanent project-wide rules and conventions)\n   - Update or add .claude/rules/ (detailed rules for a specific topic)\n   - Record in MEMORY.md (facts and context to remember across sessions)\n   - No record needed (a one-off event)\n3. Present the decisions to the user for confirmation, and for approved items actually update or add the files\n\nWhen the updates are complete, report a list of what was recorded."
+        }
+      },
+      {
+        "id": "end-1",
+        "type": "end",
+        "name": "end-1",
+        "position": {
+          "x": 2325,
+          "y": 315
+        },
+        "data": {
+          "label": "End"
+        }
+      }
+    ],
+    "connections": [
+      {
+        "id": "c1",
+        "from": "start-1",
+        "to": "hearing-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c2",
+        "from": "hearing-1",
+        "to": "planning-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c3",
+        "from": "planning-1",
+        "to": "development-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c4",
+        "from": "development-1",
+        "to": "branch-session-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c5",
+        "from": "branch-session-1",
+        "to": "completion-check-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c6",
+        "from": "completion-check-1",
+        "to": "retrospective-1",
+        "fromPort": "branch-0",
+        "toPort": "input"
+      },
+      {
+        "id": "c7",
+        "from": "completion-check-1",
+        "to": "branch-session-1",
+        "fromPort": "branch-1",
+        "toPort": "input"
+      },
+      {
+        "id": "c8",
+        "from": "retrospective-1",
+        "to": "end-1",
+        "fromPort": "output",
+        "toPort": "input"
+      }
+    ],
+    "createdAt": "2026-07-11T00:00:00.000Z",
+    "updatedAt": "2026-07-11T00:00:00.000Z",
+    "subAgentFlows": []
+  }
+}

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.en.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.en.json
@@ -4,11 +4,7 @@
     "nameKey": "sample.dailyDevWithBranch.name",
     "descriptionKey": "sample.dailyDevWithBranch.description",
     "difficulty": "intermediate",
-    "tags": [
-      "development",
-      "branch-session",
-      "human-in-the-loop"
-    ],
+    "tags": ["development", "branch-session", "human-in-the-loop"],
     "nodeCount": 8
   },
   "workflow": {

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.ja.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.ja.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "id": "daily-dev-with-branch-sample",
+    "nameKey": "sample.dailyDevWithBranch.name",
+    "descriptionKey": "sample.dailyDevWithBranch.description",
+    "difficulty": "intermediate",
+    "tags": [
+      "development",
+      "branch-session",
+      "human-in-the-loop"
+    ],
+    "nodeCount": 8
+  },
+  "workflow": {
+    "id": "workflow-daily-dev-with-branch",
+    "name": "daily-dev-with-branch",
+    "version": "1.0.0",
+    "nodes": [
+      {
+        "id": "start-1",
+        "type": "start",
+        "name": "start-1",
+        "position": {
+          "x": 120,
+          "y": 315
+        },
+        "data": {
+          "label": "Start"
+        }
+      },
+      {
+        "id": "hearing-1",
+        "type": "prompt",
+        "name": "hearing-1",
+        "position": {
+          "x": 300,
+          "y": 300
+        },
+        "data": {
+          "label": "Hearing",
+          "prompt": "今日実現したいことをユーザーにヒアリングしてください。以下を明確にします:\n- 実現したいこと（ゴール）\n- 背景・動機\n- 対象範囲（対象リポジトリ・ディレクトリ・機能）\n- 制約条件（時間、触ってはいけない箇所、依存関係など)\n- 完了条件（何をもって完了とするか）\n\n曖昧な点があれば追加で質問し、最後にヒアリング結果を箇条書きで要約してユーザーに確認を取ってください。"
+        }
+      },
+      {
+        "id": "planning-1",
+        "type": "subAgent",
+        "name": "planning-1",
+        "position": {
+          "x": 645,
+          "y": 300
+        },
+        "data": {
+          "description": "ヒアリング結果に基づいて実装プランを策定する",
+          "agentDefinition": "実装計画の設計を専門とするプランニングエージェント。コードベースを調査し、アーキテクチャ上のトレードオフを考慮した段階的な実装計画を作成する。",
+          "prompt": "前段のヒアリング結果を基に、実装プランを策定してください。\n- 関連するコードベースを調査し、変更が必要なファイルを特定する\n- 実装ステップを順序立てて列挙する\n- リスクや注意点、検証方法を明記する\n最終的にステップバイステップの実装計画を出力してください。",
+          "builtInType": "plan",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "development-1",
+        "type": "subAgent",
+        "name": "development-1",
+        "position": {
+          "x": 975,
+          "y": 300
+        },
+        "data": {
+          "description": "実装プランに従って開発を実行する",
+          "agentDefinition": "コードの実装・編集・テスト実行まで行う汎用開発エージェント。実装計画に忠実に従い、変更内容と検証結果を報告する。",
+          "prompt": "前段で策定された実装プランに従って開発を実行してください。\n- 計画のステップ順に実装する\n- 既存コードのスタイル・規約に合わせる\n- 可能であればテストやビルドで動作を検証する\n完了後、変更したファイル一覧・実装内容・検証結果を報告してください。",
+          "builtInType": "general-purpose",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "branch-session-1",
+        "type": "branchSession",
+        "name": "branch-session-1",
+        "position": {
+          "x": 1305,
+          "y": 300
+        },
+        "data": {
+          "label": "Branch Session Work",
+          "workDescription": "開発結果に対する質問への回答、コードレビュー、修正作業を人間とAIが共同で行う。実装内容の確認、命名や設計の調整、不明点の解消などを対話的に実施し、結果を親セッションに引き継ぐ。",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "completion-check-1",
+        "type": "askUserQuestion",
+        "name": "completion-check-1",
+        "position": {
+          "x": 1665,
+          "y": 285
+        },
+        "data": {
+          "questionText": "ブランチセッションからの報告を受けました。今回の作業は完了としてよいですか？",
+          "options": [
+            {
+              "id": "opt-done",
+              "label": "完了",
+              "description": "作業は完了。振り返りフェーズに進む"
+            },
+            {
+              "id": "opt-continue",
+              "label": "継続",
+              "description": "まだ作業が残っている。再度ブランチセッションで質問・修正を続ける"
+            }
+          ],
+          "multiSelect": false,
+          "useAiSuggestions": false,
+          "outputPorts": 2
+        }
+      },
+      {
+        "id": "retrospective-1",
+        "type": "prompt",
+        "name": "retrospective-1",
+        "position": {
+          "x": 2010,
+          "y": 300
+        },
+        "data": {
+          "label": "Retrospective",
+          "prompt": "今回の作業を振り返り、今後に引き継ぎたい改善点を洗い出してください。\n\n1. 今回のセッションで得られた学び・つまずいた点・繰り返し発生した指摘を列挙する\n2. それぞれについて、以下のどこに記録すべきか判断する:\n   - CLAUDE.md の更新（プロジェクト全体の恒久的なルール・規約）\n   - .claude/rules/ の更新または新規追加（特定トピックの詳細ルール）\n   - MEMORY.md への記録（セッションをまたいで覚えておきたい事実・コンテキスト）\n   - 記録不要（今回限りの事象）\n3. 判断結果をユーザーに提示して確認を取り、承認された項目について実際にファイルを更新・追加する\n\n更新が完了したら、記録した内容の一覧を報告してください。"
+        }
+      },
+      {
+        "id": "end-1",
+        "type": "end",
+        "name": "end-1",
+        "position": {
+          "x": 2325,
+          "y": 315
+        },
+        "data": {
+          "label": "End"
+        }
+      }
+    ],
+    "connections": [
+      {
+        "id": "c1",
+        "from": "start-1",
+        "to": "hearing-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c2",
+        "from": "hearing-1",
+        "to": "planning-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c3",
+        "from": "planning-1",
+        "to": "development-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c4",
+        "from": "development-1",
+        "to": "branch-session-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c5",
+        "from": "branch-session-1",
+        "to": "completion-check-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c6",
+        "from": "completion-check-1",
+        "to": "retrospective-1",
+        "fromPort": "branch-0",
+        "toPort": "input"
+      },
+      {
+        "id": "c7",
+        "from": "completion-check-1",
+        "to": "branch-session-1",
+        "fromPort": "branch-1",
+        "toPort": "input"
+      },
+      {
+        "id": "c8",
+        "from": "retrospective-1",
+        "to": "end-1",
+        "fromPort": "output",
+        "toPort": "input"
+      }
+    ],
+    "createdAt": "2026-07-11T00:00:00.000Z",
+    "updatedAt": "2026-07-11T00:00:00.000Z",
+    "subAgentFlows": []
+  }
+}

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.ja.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.ja.json
@@ -4,11 +4,7 @@
     "nameKey": "sample.dailyDevWithBranch.name",
     "descriptionKey": "sample.dailyDevWithBranch.description",
     "difficulty": "intermediate",
-    "tags": [
-      "development",
-      "branch-session",
-      "human-in-the-loop"
-    ],
+    "tags": ["development", "branch-session", "human-in-the-loop"],
     "nodeCount": 8
   },
   "workflow": {

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.ko.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.ko.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "id": "daily-dev-with-branch-sample",
+    "nameKey": "sample.dailyDevWithBranch.name",
+    "descriptionKey": "sample.dailyDevWithBranch.description",
+    "difficulty": "intermediate",
+    "tags": [
+      "development",
+      "branch-session",
+      "human-in-the-loop"
+    ],
+    "nodeCount": 8
+  },
+  "workflow": {
+    "id": "workflow-daily-dev-with-branch",
+    "name": "daily-dev-with-branch",
+    "version": "1.0.0",
+    "nodes": [
+      {
+        "id": "start-1",
+        "type": "start",
+        "name": "start-1",
+        "position": {
+          "x": 120,
+          "y": 315
+        },
+        "data": {
+          "label": "Start"
+        }
+      },
+      {
+        "id": "hearing-1",
+        "type": "prompt",
+        "name": "hearing-1",
+        "position": {
+          "x": 300,
+          "y": 300
+        },
+        "data": {
+          "label": "Hearing",
+          "prompt": "오늘 실현하고 싶은 것을 사용자에게 인터뷰하세요. 다음을 명확히 합니다:\n- 실현하고 싶은 것(목표)\n- 배경·동기\n- 대상 범위(대상 저장소·디렉터리·기능)\n- 제약 조건(시간, 건드리면 안 되는 부분, 의존 관계 등)\n- 완료 조건(무엇으로 완료로 볼 것인가)\n\n모호한 점이 있으면 추가로 질문하고, 마지막에 인터뷰 결과를 목록으로 요약하여 사용자에게 확인을 받으세요."
+        }
+      },
+      {
+        "id": "planning-1",
+        "type": "subAgent",
+        "name": "planning-1",
+        "position": {
+          "x": 645,
+          "y": 300
+        },
+        "data": {
+          "description": "인터뷰 결과를 바탕으로 구현 계획을 수립한다",
+          "agentDefinition": "구현 계획 설계를 전문으로 하는 플래닝 에이전트. 코드베이스를 조사하고 아키텍처상의 트레이드오프를 고려한 단계별 구현 계획을 작성한다.",
+          "prompt": "이전 단계의 인터뷰 결과를 바탕으로 구현 계획을 수립하세요.\n- 관련 코드베이스를 조사하여 변경이 필요한 파일을 식별한다\n- 구현 단계를 순서대로 나열한다\n- 리스크와 주의점, 검증 방법을 명기한다\n최종적으로 단계별 구현 계획을 출력하세요.",
+          "builtInType": "plan",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "development-1",
+        "type": "subAgent",
+        "name": "development-1",
+        "position": {
+          "x": 975,
+          "y": 300
+        },
+        "data": {
+          "description": "구현 계획에 따라 개발을 실행한다",
+          "agentDefinition": "코드 구현·편집·테스트 실행까지 수행하는 범용 개발 에이전트. 구현 계획을 충실히 따르고 변경 내용과 검증 결과를 보고한다.",
+          "prompt": "이전 단계에서 수립된 구현 계획에 따라 개발을 실행하세요.\n- 계획의 단계 순서대로 구현한다\n- 기존 코드의 스타일·규약에 맞춘다\n- 가능하면 테스트나 빌드로 동작을 검증한다\n완료 후 변경한 파일 목록·구현 내용·검증 결과를 보고하세요.",
+          "builtInType": "general-purpose",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "branch-session-1",
+        "type": "branchSession",
+        "name": "branch-session-1",
+        "position": {
+          "x": 1305,
+          "y": 300
+        },
+        "data": {
+          "label": "Branch Session Work",
+          "workDescription": "개발 결과에 대한 질문 응답, 코드 리뷰, 수정 작업을 사람과 AI가 공동으로 수행한다. 구현 내용 확인, 네이밍·설계 조정, 불명확한 점 해소 등을 대화형으로 진행하고 결과를 부모 세션에 인계한다.",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "completion-check-1",
+        "type": "askUserQuestion",
+        "name": "completion-check-1",
+        "position": {
+          "x": 1665,
+          "y": 285
+        },
+        "data": {
+          "questionText": "브랜치 세션의 보고를 받았습니다. 이번 작업을 완료로 해도 될까요?",
+          "options": [
+            {
+              "id": "opt-done",
+              "label": "완료",
+              "description": "작업 완료. 회고 단계로 진행"
+            },
+            {
+              "id": "opt-continue",
+              "label": "계속",
+              "description": "아직 작업이 남아 있음. 다시 브랜치 세션에서 질문·수정을 계속"
+            }
+          ],
+          "multiSelect": false,
+          "useAiSuggestions": false,
+          "outputPorts": 2
+        }
+      },
+      {
+        "id": "retrospective-1",
+        "type": "prompt",
+        "name": "retrospective-1",
+        "position": {
+          "x": 2010,
+          "y": 300
+        },
+        "data": {
+          "label": "Retrospective",
+          "prompt": "이번 작업을 돌아보고 앞으로 이어가고 싶은 개선점을 정리하세요.\n\n1. 이번 세션에서 얻은 배움·막혔던 점·반복적으로 발생한 지적을 나열한다\n2. 각각에 대해 다음 중 어디에 기록할지 판단한다:\n   - CLAUDE.md 업데이트(프로젝트 전체의 영구적인 규칙·규약)\n   - .claude/rules/ 업데이트 또는 신규 추가(특정 주제의 상세 규칙)\n   - MEMORY.md에 기록(세션을 넘어 기억하고 싶은 사실·컨텍스트)\n   - 기록 불필요(이번 한정 사건)\n3. 판단 결과를 사용자에게 제시하여 확인을 받고, 승인된 항목에 대해 실제로 파일을 업데이트·추가한다\n\n업데이트가 완료되면 기록한 내용의 목록을 보고하세요."
+        }
+      },
+      {
+        "id": "end-1",
+        "type": "end",
+        "name": "end-1",
+        "position": {
+          "x": 2325,
+          "y": 315
+        },
+        "data": {
+          "label": "End"
+        }
+      }
+    ],
+    "connections": [
+      {
+        "id": "c1",
+        "from": "start-1",
+        "to": "hearing-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c2",
+        "from": "hearing-1",
+        "to": "planning-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c3",
+        "from": "planning-1",
+        "to": "development-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c4",
+        "from": "development-1",
+        "to": "branch-session-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c5",
+        "from": "branch-session-1",
+        "to": "completion-check-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c6",
+        "from": "completion-check-1",
+        "to": "retrospective-1",
+        "fromPort": "branch-0",
+        "toPort": "input"
+      },
+      {
+        "id": "c7",
+        "from": "completion-check-1",
+        "to": "branch-session-1",
+        "fromPort": "branch-1",
+        "toPort": "input"
+      },
+      {
+        "id": "c8",
+        "from": "retrospective-1",
+        "to": "end-1",
+        "fromPort": "output",
+        "toPort": "input"
+      }
+    ],
+    "createdAt": "2026-07-11T00:00:00.000Z",
+    "updatedAt": "2026-07-11T00:00:00.000Z",
+    "subAgentFlows": []
+  }
+}

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.ko.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.ko.json
@@ -4,11 +4,7 @@
     "nameKey": "sample.dailyDevWithBranch.name",
     "descriptionKey": "sample.dailyDevWithBranch.description",
     "difficulty": "intermediate",
-    "tags": [
-      "development",
-      "branch-session",
-      "human-in-the-loop"
-    ],
+    "tags": ["development", "branch-session", "human-in-the-loop"],
     "nodeCount": 8
   },
   "workflow": {

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-CN.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-CN.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "id": "daily-dev-with-branch-sample",
+    "nameKey": "sample.dailyDevWithBranch.name",
+    "descriptionKey": "sample.dailyDevWithBranch.description",
+    "difficulty": "intermediate",
+    "tags": [
+      "development",
+      "branch-session",
+      "human-in-the-loop"
+    ],
+    "nodeCount": 8
+  },
+  "workflow": {
+    "id": "workflow-daily-dev-with-branch",
+    "name": "daily-dev-with-branch",
+    "version": "1.0.0",
+    "nodes": [
+      {
+        "id": "start-1",
+        "type": "start",
+        "name": "start-1",
+        "position": {
+          "x": 120,
+          "y": 315
+        },
+        "data": {
+          "label": "Start"
+        }
+      },
+      {
+        "id": "hearing-1",
+        "type": "prompt",
+        "name": "hearing-1",
+        "position": {
+          "x": 300,
+          "y": 300
+        },
+        "data": {
+          "label": "Hearing",
+          "prompt": "向用户了解今天想要实现的目标。明确以下内容:\n- 想要实现的事情（目标）\n- 背景与动机\n- 涉及范围（目标仓库、目录、功能）\n- 约束条件（时间、不可改动的部分、依赖关系等）\n- 完成条件（以什么作为完成的标准）\n\n如有不明确之处请追加提问，最后将访谈结果以列表形式总结并请用户确认。"
+        }
+      },
+      {
+        "id": "planning-1",
+        "type": "subAgent",
+        "name": "planning-1",
+        "position": {
+          "x": 645,
+          "y": 300
+        },
+        "data": {
+          "description": "基于访谈结果制定实现计划",
+          "agentDefinition": "专门设计实现计划的规划代理。调查代码库，制定考虑架构权衡的分步实现计划。",
+          "prompt": "基于上一步的访谈结果制定实现计划。\n- 调查相关代码库，确定需要修改的文件\n- 按顺序列出实现步骤\n- 写明风险、注意事项和验证方法\n最终输出分步的实现计划。",
+          "builtInType": "plan",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "development-1",
+        "type": "subAgent",
+        "name": "development-1",
+        "position": {
+          "x": 975,
+          "y": 300
+        },
+        "data": {
+          "description": "按照实现计划执行开发",
+          "agentDefinition": "负责代码实现、编辑和测试执行的通用开发代理。忠实遵循实现计划，并报告变更内容和验证结果。",
+          "prompt": "按照上一步制定的实现计划执行开发。\n- 按计划的步骤顺序实现\n- 遵循现有代码的风格与规范\n- 尽可能通过测试或构建验证\n完成后，报告修改的文件列表、实现内容和验证结果。",
+          "builtInType": "general-purpose",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "branch-session-1",
+        "type": "branchSession",
+        "name": "branch-session-1",
+        "position": {
+          "x": 1305,
+          "y": 300
+        },
+        "data": {
+          "label": "Branch Session Work",
+          "workDescription": "由人与AI共同完成对开发结果的答疑、代码评审和修改工作。以对话方式确认实现内容、调整命名与设计、解决疑问，并将结果交接回父会话。",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "completion-check-1",
+        "type": "askUserQuestion",
+        "name": "completion-check-1",
+        "position": {
+          "x": 1665,
+          "y": 285
+        },
+        "data": {
+          "questionText": "已收到分支会话的报告。本次工作可以视为完成吗？",
+          "options": [
+            {
+              "id": "opt-done",
+              "label": "完成",
+              "description": "工作已完成。进入回顾阶段"
+            },
+            {
+              "id": "opt-continue",
+              "label": "继续",
+              "description": "仍有剩余工作。再次进入分支会话继续提问和修改"
+            }
+          ],
+          "multiSelect": false,
+          "useAiSuggestions": false,
+          "outputPorts": 2
+        }
+      },
+      {
+        "id": "retrospective-1",
+        "type": "prompt",
+        "name": "retrospective-1",
+        "position": {
+          "x": 2010,
+          "y": 300
+        },
+        "data": {
+          "label": "Retrospective",
+          "prompt": "回顾本次工作，梳理希望延续到今后的改进点。\n\n1. 列出本次会话中获得的经验、遇到的问题、反复出现的指摘\n2. 针对每一项，判断应记录到哪里:\n   - 更新 CLAUDE.md（项目整体的永久规则与规范）\n   - 更新或新增 .claude/rules/（特定主题的详细规则）\n   - 记录到 MEMORY.md（跨会话需要记住的事实与上下文）\n   - 无需记录（仅限本次的事件）\n3. 将判断结果提交给用户确认，对已批准的项目实际更新或添加文件\n\n更新完成后，报告所记录内容的列表。"
+        }
+      },
+      {
+        "id": "end-1",
+        "type": "end",
+        "name": "end-1",
+        "position": {
+          "x": 2325,
+          "y": 315
+        },
+        "data": {
+          "label": "End"
+        }
+      }
+    ],
+    "connections": [
+      {
+        "id": "c1",
+        "from": "start-1",
+        "to": "hearing-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c2",
+        "from": "hearing-1",
+        "to": "planning-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c3",
+        "from": "planning-1",
+        "to": "development-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c4",
+        "from": "development-1",
+        "to": "branch-session-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c5",
+        "from": "branch-session-1",
+        "to": "completion-check-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c6",
+        "from": "completion-check-1",
+        "to": "retrospective-1",
+        "fromPort": "branch-0",
+        "toPort": "input"
+      },
+      {
+        "id": "c7",
+        "from": "completion-check-1",
+        "to": "branch-session-1",
+        "fromPort": "branch-1",
+        "toPort": "input"
+      },
+      {
+        "id": "c8",
+        "from": "retrospective-1",
+        "to": "end-1",
+        "fromPort": "output",
+        "toPort": "input"
+      }
+    ],
+    "createdAt": "2026-07-11T00:00:00.000Z",
+    "updatedAt": "2026-07-11T00:00:00.000Z",
+    "subAgentFlows": []
+  }
+}

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-CN.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-CN.json
@@ -4,11 +4,7 @@
     "nameKey": "sample.dailyDevWithBranch.name",
     "descriptionKey": "sample.dailyDevWithBranch.description",
     "difficulty": "intermediate",
-    "tags": [
-      "development",
-      "branch-session",
-      "human-in-the-loop"
-    ],
+    "tags": ["development", "branch-session", "human-in-the-loop"],
     "nodeCount": 8
   },
   "workflow": {

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-TW.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-TW.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "id": "daily-dev-with-branch-sample",
+    "nameKey": "sample.dailyDevWithBranch.name",
+    "descriptionKey": "sample.dailyDevWithBranch.description",
+    "difficulty": "intermediate",
+    "tags": [
+      "development",
+      "branch-session",
+      "human-in-the-loop"
+    ],
+    "nodeCount": 8
+  },
+  "workflow": {
+    "id": "workflow-daily-dev-with-branch",
+    "name": "daily-dev-with-branch",
+    "version": "1.0.0",
+    "nodes": [
+      {
+        "id": "start-1",
+        "type": "start",
+        "name": "start-1",
+        "position": {
+          "x": 120,
+          "y": 315
+        },
+        "data": {
+          "label": "Start"
+        }
+      },
+      {
+        "id": "hearing-1",
+        "type": "prompt",
+        "name": "hearing-1",
+        "position": {
+          "x": 300,
+          "y": 300
+        },
+        "data": {
+          "label": "Hearing",
+          "prompt": "向使用者了解今天想要實現的目標。明確以下內容:\n- 想要實現的事情（目標）\n- 背景與動機\n- 涉及範圍（目標儲存庫、目錄、功能）\n- 約束條件（時間、不可改動的部分、依賴關係等）\n- 完成條件（以什麼作為完成的標準）\n\n如有不明確之處請追加提問，最後將訪談結果以列表形式總結並請使用者確認。"
+        }
+      },
+      {
+        "id": "planning-1",
+        "type": "subAgent",
+        "name": "planning-1",
+        "position": {
+          "x": 645,
+          "y": 300
+        },
+        "data": {
+          "description": "基於訪談結果制定實作計畫",
+          "agentDefinition": "專門設計實作計畫的規劃代理。調查程式碼庫，制定考慮架構權衡的分步實作計畫。",
+          "prompt": "基於上一步的訪談結果制定實作計畫。\n- 調查相關程式碼庫，確定需要修改的檔案\n- 按順序列出實作步驟\n- 寫明風險、注意事項和驗證方法\n最終輸出分步的實作計畫。",
+          "builtInType": "plan",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "development-1",
+        "type": "subAgent",
+        "name": "development-1",
+        "position": {
+          "x": 975,
+          "y": 300
+        },
+        "data": {
+          "description": "按照實作計畫執行開發",
+          "agentDefinition": "負責程式碼實作、編輯和測試執行的通用開發代理。忠實遵循實作計畫，並報告變更內容和驗證結果。",
+          "prompt": "按照上一步制定的實作計畫執行開發。\n- 按計畫的步驟順序實作\n- 遵循現有程式碼的風格與規範\n- 盡可能透過測試或建置驗證\n完成後，報告修改的檔案列表、實作內容和驗證結果。",
+          "builtInType": "general-purpose",
+          "agentType": "claudeCode",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "branch-session-1",
+        "type": "branchSession",
+        "name": "branch-session-1",
+        "position": {
+          "x": 1305,
+          "y": 300
+        },
+        "data": {
+          "label": "Branch Session Work",
+          "workDescription": "由人與AI共同完成對開發結果的答疑、程式碼審查和修改工作。以對話方式確認實作內容、調整命名與設計、解決疑問，並將結果交接回父工作階段。",
+          "outputPorts": 1
+        }
+      },
+      {
+        "id": "completion-check-1",
+        "type": "askUserQuestion",
+        "name": "completion-check-1",
+        "position": {
+          "x": 1665,
+          "y": 285
+        },
+        "data": {
+          "questionText": "已收到分支工作階段的報告。本次工作可以視為完成嗎？",
+          "options": [
+            {
+              "id": "opt-done",
+              "label": "完成",
+              "description": "工作已完成。進入回顧階段"
+            },
+            {
+              "id": "opt-continue",
+              "label": "繼續",
+              "description": "仍有剩餘工作。再次進入分支工作階段繼續提問和修改"
+            }
+          ],
+          "multiSelect": false,
+          "useAiSuggestions": false,
+          "outputPorts": 2
+        }
+      },
+      {
+        "id": "retrospective-1",
+        "type": "prompt",
+        "name": "retrospective-1",
+        "position": {
+          "x": 2010,
+          "y": 300
+        },
+        "data": {
+          "label": "Retrospective",
+          "prompt": "回顧本次工作，梳理希望延續到今後的改進點。\n\n1. 列出本次工作階段中獲得的經驗、遇到的問題、反覆出現的指摘\n2. 針對每一項，判斷應記錄到哪裡:\n   - 更新 CLAUDE.md（專案整體的永久規則與規範）\n   - 更新或新增 .claude/rules/（特定主題的詳細規則）\n   - 記錄到 MEMORY.md（跨工作階段需要記住的事實與脈絡）\n   - 無需記錄（僅限本次的事件）\n3. 將判斷結果提交給使用者確認，對已核准的項目實際更新或新增檔案\n\n更新完成後，報告所記錄內容的列表。"
+        }
+      },
+      {
+        "id": "end-1",
+        "type": "end",
+        "name": "end-1",
+        "position": {
+          "x": 2325,
+          "y": 315
+        },
+        "data": {
+          "label": "End"
+        }
+      }
+    ],
+    "connections": [
+      {
+        "id": "c1",
+        "from": "start-1",
+        "to": "hearing-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c2",
+        "from": "hearing-1",
+        "to": "planning-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c3",
+        "from": "planning-1",
+        "to": "development-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c4",
+        "from": "development-1",
+        "to": "branch-session-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c5",
+        "from": "branch-session-1",
+        "to": "completion-check-1",
+        "fromPort": "output",
+        "toPort": "input"
+      },
+      {
+        "id": "c6",
+        "from": "completion-check-1",
+        "to": "retrospective-1",
+        "fromPort": "branch-0",
+        "toPort": "input"
+      },
+      {
+        "id": "c7",
+        "from": "completion-check-1",
+        "to": "branch-session-1",
+        "fromPort": "branch-1",
+        "toPort": "input"
+      },
+      {
+        "id": "c8",
+        "from": "retrospective-1",
+        "to": "end-1",
+        "fromPort": "output",
+        "toPort": "input"
+      }
+    ],
+    "createdAt": "2026-07-11T00:00:00.000Z",
+    "updatedAt": "2026-07-11T00:00:00.000Z",
+    "subAgentFlows": []
+  }
+}

--- a/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-TW.json
+++ b/packages/vscode/resources/samples/daily-dev-with-branch-sample.zh-TW.json
@@ -4,11 +4,7 @@
     "nameKey": "sample.dailyDevWithBranch.name",
     "descriptionKey": "sample.dailyDevWithBranch.description",
     "difficulty": "intermediate",
-    "tags": [
-      "development",
-      "branch-session",
-      "human-in-the-loop"
-    ],
+    "tags": ["development", "branch-session", "human-in-the-loop"],
     "nodeCount": 8
   },
   "workflow": {

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -1988,15 +1988,15 @@ export function registerOpenEditorCommand(
                   port: serverPort,
                 });
               } catch (error) {
-                log('ERROR', 'Failed to launch AI agent', {
-                  error: error instanceof Error ? error.message : String(error),
-                });
+                const launchErrMsg =
+                  error instanceof Error ? error.message : 'Failed to launch AI agent';
+                log('ERROR', 'Failed to launch AI agent', { error: launchErrMsg });
+                vscode.window.showErrorMessage(`Failed to launch AI agent: ${launchErrMsg}`);
                 webview.postMessage({
                   type: 'LAUNCH_AI_AGENT_FAILED',
                   requestId: message.requestId,
                   payload: {
-                    errorMessage:
-                      error instanceof Error ? error.message : 'Failed to launch AI agent',
+                    errorMessage: launchErrMsg,
                     timestamp: new Date().toISOString(),
                   },
                 });

--- a/packages/vscode/src/extension/services/mcp-server-service.ts
+++ b/packages/vscode/src/extension/services/mcp-server-service.ts
@@ -67,7 +67,15 @@ export class McpServerManager implements WorkflowIoAdapter {
 
   async start(extensionPath: string, port?: number): Promise<number> {
     if (this.httpServer) {
-      throw new Error('MCP server is already running');
+      // Idempotent: a listening server is reused instead of erroring.
+      if (this.httpServer.listening && this.port !== null) {
+        return this.port;
+      }
+      // A non-listening server is a leftover from a failed start (e.g.
+      // EADDRINUSE) — dispose it and start fresh.
+      this.httpServer.close();
+      this.httpServer = null;
+      this.port = null;
     }
 
     this.extensionPath = extensionPath;
@@ -149,6 +157,17 @@ export class McpServerManager implements WorkflowIoAdapter {
     const listenPort = port ?? 0;
     const httpServer = this.httpServer;
     return new Promise<number>((resolve, reject) => {
+      // Failed startup must not leave a half-initialized server behind —
+      // otherwise every later start() would wrongly see "already running".
+      const rejectAndCleanup = (error: Error) => {
+        if (this.httpServer === httpServer) {
+          this.httpServer = null;
+          this.port = null;
+        }
+        httpServer.close();
+        reject(error);
+      };
+
       httpServer.listen(listenPort, '127.0.0.1', () => {
         const address = httpServer.address();
         if (address && typeof address !== 'string') {
@@ -156,7 +175,7 @@ export class McpServerManager implements WorkflowIoAdapter {
           log('INFO', `MCP Server: Started on port ${this.port}`);
           resolve(this.port);
         } else {
-          reject(new Error('Failed to get server address'));
+          rejectAndCleanup(new Error('Failed to get server address'));
         }
       });
 
@@ -164,10 +183,10 @@ export class McpServerManager implements WorkflowIoAdapter {
         if (error.code === 'EADDRINUSE') {
           const msg = `Port ${listenPort} is already in use. Change the port in Settings (cc-wf-studio.mcp.port) or close the application using port ${listenPort}.`;
           log('ERROR', 'MCP Server: Port in use', { port: listenPort });
-          reject(new Error(msg));
+          rejectAndCleanup(new Error(msg));
         } else {
           log('ERROR', 'MCP Server: HTTP server error', { error: error.message });
-          reject(error);
+          rejectAndCleanup(error);
         }
       });
     });

--- a/packages/vscode/src/webview/src/components/NodePalette.tsx
+++ b/packages/vscode/src/webview/src/components/NodePalette.tsx
@@ -11,6 +11,7 @@ import type { CommandReference } from '@shared/types/messages';
 import {
   Bot,
   GitBranch,
+  GitBranchPlus,
   GitFork,
   MessageSquare,
   PanelLeftClose,
@@ -248,6 +249,21 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
         label: t('default.newPrompt'),
         prompt: t('default.prompt'),
         variables: {},
+      },
+    };
+    addNode(newNode);
+  };
+
+  const handleAddBranchSessionNode = () => {
+    const position = calculateNonOverlappingPosition(350, 200);
+    const newNode = {
+      id: `branch-session-${Date.now()}`,
+      type: 'branchSession' as const,
+      position,
+      data: {
+        label: t('default.newBranchSession'),
+        workDescription: '',
+        outputPorts: 1 as const,
       },
     };
     addNode(newNode);
@@ -946,6 +962,53 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
               }}
             >
               {t('node.askUserQuestion.description')}
+            </div>
+          )}
+        </button>
+      )}
+
+      {/* Branch Session Node Button - hidden in SubAgentFlow edit mode (Claude Code only) */}
+      {!isEditingSubAgentFlow && (
+        <button
+          type="button"
+          onClick={handleAddBranchSessionNode}
+          data-tour="add-branch-session-button"
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <GitBranchPlus size={14} />
+            {t('node.branchSession.title')}
+          </div>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.branchSession.description')}
             </div>
           )}
         </button>

--- a/packages/vscode/src/webview/src/components/PropertyOverlay.tsx
+++ b/packages/vscode/src/webview/src/components/PropertyOverlay.tsx
@@ -187,8 +187,8 @@ export const PropertyOverlay: React.FC<PropertyOverlayProps> = ({
             {getNodeTypeLabel(selectedNode.type)}
           </div>
 
-          {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, mcp, branchSession types) */}
-          {/* Note: codex uses label field instead of name, handled in CodexProperties */}
+          {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, mcp types) */}
+          {/* Note: codex and branchSession use the label field instead of name, handled in their own property editors */}
           {(selectedNode.type === 'subAgent' ||
             selectedNode.type === 'askUserQuestion' ||
             selectedNode.type === 'branch' ||
@@ -196,8 +196,7 @@ export const PropertyOverlay: React.FC<PropertyOverlayProps> = ({
             selectedNode.type === 'switch' ||
             selectedNode.type === 'prompt' ||
             selectedNode.type === 'skill' ||
-            selectedNode.type === 'mcp' ||
-            selectedNode.type === 'branchSession') && (
+            selectedNode.type === 'mcp') && (
             <div style={{ marginBottom: '16px' }}>
               <label
                 htmlFor="node-name-input"

--- a/packages/vscode/src/webview/src/components/PropertyOverlay.tsx
+++ b/packages/vscode/src/webview/src/components/PropertyOverlay.tsx
@@ -31,7 +31,7 @@ import { useTranslation } from '../i18n/i18n-context';
 import { createSubAgent } from '../services/command-browser-service';
 import { openExternalUrl } from '../services/vscode-bridge';
 import { useWorkflowStore } from '../stores/workflow-store';
-import type { PromptNodeData } from '../types/node-types';
+import type { BranchSessionNodeData, PromptNodeData } from '../types/node-types';
 import { extractVariables } from '../utils/template-utils';
 import { CollapsibleSection } from './common/CollapsibleSection';
 import { ColorPicker } from './common/ColorPicker';
@@ -187,7 +187,7 @@ export const PropertyOverlay: React.FC<PropertyOverlayProps> = ({
             {getNodeTypeLabel(selectedNode.type)}
           </div>
 
-          {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, mcp types) */}
+          {/* Node Name (only for subAgent, askUserQuestion, branch, ifElse, switch, prompt, skill, mcp, branchSession types) */}
           {/* Note: codex uses label field instead of name, handled in CodexProperties */}
           {(selectedNode.type === 'subAgent' ||
             selectedNode.type === 'askUserQuestion' ||
@@ -196,7 +196,8 @@ export const PropertyOverlay: React.FC<PropertyOverlayProps> = ({
             selectedNode.type === 'switch' ||
             selectedNode.type === 'prompt' ||
             selectedNode.type === 'skill' ||
-            selectedNode.type === 'mcp') && (
+            selectedNode.type === 'mcp' ||
+            selectedNode.type === 'branchSession') && (
             <div style={{ marginBottom: '16px' }}>
               <label
                 htmlFor="node-name-input"
@@ -367,6 +368,11 @@ export const PropertyOverlay: React.FC<PropertyOverlayProps> = ({
           ) : selectedNode.type === 'codex' ? (
             <CodexProperties
               node={selectedNode as Node<CodexNodeData>}
+              updateNodeData={updateNodeData}
+            />
+          ) : selectedNode.type === 'branchSession' ? (
+            <BranchSessionProperties
+              node={selectedNode as Node<BranchSessionNodeData>}
               updateNodeData={updateNodeData}
             />
           ) : selectedNode.type === 'group' ? (
@@ -1158,6 +1164,133 @@ const PromptProperties: React.FC<{
           </div>
         </div>
       )}
+    </div>
+  );
+};
+
+/**
+ * Branch Session Properties Editor (Claude Code only)
+ */
+const BranchSessionProperties: React.FC<{
+  node: Node<BranchSessionNodeData>;
+  updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
+}> = ({ node, updateNodeData }) => {
+  const { t } = useTranslation();
+  const data = node.data;
+  const [isEditingWorkDescription, setIsEditingWorkDescription] = useState(false);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      {/* Label */}
+      <div>
+        <label
+          htmlFor="branch-session-label-input"
+          style={{
+            display: 'block',
+            fontSize: '12px',
+            fontWeight: 600,
+            color: 'var(--vscode-foreground)',
+            marginBottom: '6px',
+          }}
+        >
+          {t('property.label')}
+        </label>
+        <input
+          id="branch-session-label-input"
+          type="text"
+          value={data.label || ''}
+          onChange={(e) => updateNodeData(node.id, { label: e.target.value })}
+          className="nodrag"
+          placeholder={t('property.label.placeholder')}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+          }}
+        />
+      </div>
+
+      {/* Work Description */}
+      <div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '6px',
+          }}
+        >
+          <label
+            htmlFor="branch-session-work-description-textarea"
+            style={{
+              display: 'block',
+              fontSize: '12px',
+              fontWeight: 600,
+              color: 'var(--vscode-foreground)',
+            }}
+          >
+            {t('property.branchSession.workDescription')}
+          </label>
+          <EditInEditorButton
+            content={data.workDescription || ''}
+            onContentUpdated={(newContent) =>
+              updateNodeData(node.id, { workDescription: newContent })
+            }
+            label={t('property.branchSession.workDescription')}
+            language="markdown"
+            onEditingStateChange={setIsEditingWorkDescription}
+          />
+        </div>
+        <textarea
+          id="branch-session-work-description-textarea"
+          value={data.workDescription || ''}
+          onChange={(e) => updateNodeData(node.id, { workDescription: e.target.value })}
+          className="nodrag"
+          rows={6}
+          placeholder={t('property.branchSession.workDescriptionPlaceholder')}
+          readOnly={isEditingWorkDescription}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border)',
+            borderRadius: '2px',
+            fontSize: '13px',
+            fontFamily: 'var(--vscode-editor-font-family)',
+            resize: 'vertical',
+            opacity: isEditingWorkDescription ? 0.5 : 1,
+            cursor: isEditingWorkDescription ? 'not-allowed' : 'text',
+          }}
+        />
+        <div
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+            marginTop: '4px',
+          }}
+        >
+          {t('property.branchSession.workDescription.help')}
+        </div>
+      </div>
+
+      {/* Claude Code Only Notice */}
+      <div
+        style={{
+          padding: '12px',
+          backgroundColor: 'var(--vscode-textBlockQuote-background)',
+          border: '1px solid var(--vscode-textBlockQuote-border)',
+          borderRadius: '4px',
+          fontSize: '12px',
+          color: 'var(--vscode-descriptionForeground)',
+        }}
+      >
+        {t('property.branchSession.claudeCodeOnlyNotice')}
+      </div>
     </div>
   );
 };

--- a/packages/vscode/src/webview/src/components/Toolbar.tsx
+++ b/packages/vscode/src/webview/src/components/Toolbar.tsx
@@ -2657,9 +2657,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         {/* Claude Code-only Node Export Confirmation Dialog */}
         <ConfirmDialog
           isOpen={showClaudeOnlyConfirm}
-          title={t('dialog.claudeOnlyExport.title')}
-          message={t('dialog.claudeOnlyExport.message')}
-          confirmLabel={t('dialog.claudeOnlyExport.confirm')}
+          title={t('dialog.claudeOnlyWarning.title')}
+          message={t('dialog.claudeOnlyWarning.message')}
+          confirmLabel={t('dialog.claudeOnlyWarning.confirm')}
           cancelLabel={t('common.cancel')}
           onConfirm={() => {
             setShowClaudeOnlyConfirm(false);

--- a/packages/vscode/src/webview/src/components/Toolbar.tsx
+++ b/packages/vscode/src/webview/src/components/Toolbar.tsx
@@ -4,6 +4,7 @@
  * Provides Save and Load functionality for workflows
  */
 
+import { CLAUDE_CODE_ONLY_NODE_TYPES, type NodeType } from '@cc-wf-studio/core';
 import type { Workflow } from '@shared/types/messages';
 import {
   BookOpen,
@@ -164,6 +165,25 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   // Copilot Chat integration
   const [isCopilotChatExporting, setIsCopilotChatExporting] = useState(false);
   const [isCopilotChatRunning, setIsCopilotChatRunning] = useState(false);
+  // Claude Code-only node warning (shown before exporting/running for non-Claude targets)
+  const [showClaudeOnlyConfirm, setShowClaudeOnlyConfirm] = useState(false);
+  const pendingClaudeOnlyActionRef = useRef<(() => Promise<void>) | null>(null);
+
+  /**
+   * Gate non-Claude-Code export/run actions: if the canvas contains
+   * Claude Code-only nodes (e.g. branchSession), ask for confirmation first.
+   */
+  const guardClaudeCodeOnly = (action: () => Promise<void>) => {
+    const hasClaudeOnlyNodes = nodes.some(
+      (n) => n.type && CLAUDE_CODE_ONLY_NODE_TYPES.has(n.type as NodeType)
+    );
+    if (hasClaudeOnlyNodes) {
+      pendingClaudeOnlyActionRef.current = action;
+      setShowClaudeOnlyConfirm(true);
+    } else {
+      void action();
+    }
+  };
 
   // Sync commentary state to Extension Host on mount (restores localStorage state after reload)
   const commentarySyncedRef = useRef(false);
@@ -1722,7 +1742,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleCopilotChatExport}
+                        onClick={() => guardClaudeCodeOnly(handleCopilotChatExport)}
                         disabled={isCopilotChatExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -1750,7 +1770,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleCopilotChatRun}
+                        onClick={() => guardClaudeCodeOnly(handleCopilotChatRun)}
                         disabled={isCopilotChatRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -1814,7 +1834,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleCopilotCliExport}
+                        onClick={() => guardClaudeCodeOnly(handleCopilotCliExport)}
                         disabled={isCopilotCliExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -1842,7 +1862,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleCopilotCliRun}
+                        onClick={() => guardClaudeCodeOnly(handleCopilotCliRun)}
                         disabled={isCopilotCliRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -1906,7 +1926,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleCodexExport}
+                        onClick={() => guardClaudeCodeOnly(handleCodexExport)}
                         disabled={isCodexExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -1934,7 +1954,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleCodexRun}
+                        onClick={() => guardClaudeCodeOnly(handleCodexRun)}
                         disabled={isCodexRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -1998,7 +2018,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleRooCodeExport}
+                        onClick={() => guardClaudeCodeOnly(handleRooCodeExport)}
                         disabled={isRooCodeExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2026,7 +2046,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleRooCodeRun}
+                        onClick={() => guardClaudeCodeOnly(handleRooCodeRun)}
                         disabled={isRooCodeRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2090,7 +2110,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleGeminiExport}
+                        onClick={() => guardClaudeCodeOnly(handleGeminiExport)}
                         disabled={isGeminiExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2118,7 +2138,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleGeminiRun}
+                        onClick={() => guardClaudeCodeOnly(handleGeminiRun)}
                         disabled={isGeminiRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2182,7 +2202,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleAntigravityExport}
+                        onClick={() => guardClaudeCodeOnly(handleAntigravityExport)}
                         disabled={isAntigravityExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2210,7 +2230,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleAntigravityRun}
+                        onClick={() => guardClaudeCodeOnly(handleAntigravityRun)}
                         disabled={isAntigravityRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2274,7 +2294,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                     <div style={{ display: 'flex' }}>
                       <button
                         type="button"
-                        onClick={handleCursorExport}
+                        onClick={() => guardClaudeCodeOnly(handleCursorExport)}
                         disabled={isCursorExporting}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2302,7 +2322,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                       </button>
                       <button
                         type="button"
-                        onClick={handleCursorRun}
+                        onClick={() => guardClaudeCodeOnly(handleCursorRun)}
                         disabled={isCursorRunning}
                         style={{
                           padding: isCompact ? '4px 8px' : '4px 12px',
@@ -2632,6 +2652,25 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           cancelLabel={t('common.cancel')}
           onConfirm={handleResetWorkflow}
           onCancel={() => setShowResetConfirm(false)}
+        />
+
+        {/* Claude Code-only Node Export Confirmation Dialog */}
+        <ConfirmDialog
+          isOpen={showClaudeOnlyConfirm}
+          title={t('dialog.claudeOnlyExport.title')}
+          message={t('dialog.claudeOnlyExport.message')}
+          confirmLabel={t('dialog.claudeOnlyExport.confirm')}
+          cancelLabel={t('common.cancel')}
+          onConfirm={() => {
+            setShowClaudeOnlyConfirm(false);
+            const action = pendingClaudeOnlyActionRef.current;
+            pendingClaudeOnlyActionRef.current = null;
+            if (action) void action();
+          }}
+          onCancel={() => {
+            setShowClaudeOnlyConfirm(false);
+            pendingClaudeOnlyActionRef.current = null;
+          }}
         />
 
         {/* What's New Dialog */}

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -34,6 +34,7 @@ import { DeletableEdge } from './edges/DeletableEdge';
 import { MinimapContainer } from './MinimapContainer';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from './nodes/BranchNode';
+import { BranchSessionNode } from './nodes/BranchSessionNode';
 // 新規ノードタイプのインポート
 import { CodexNodeComponent } from './nodes/CodexNode';
 import { EndNode } from './nodes/EndNode';
@@ -68,6 +69,7 @@ const nodeTypes: NodeTypes = {
   mcp: McpNodeComponent, // Feature: 001-mcp-node
   subAgentFlow: SubAgentFlowNodeComponent, // Feature: 089-subworkflow
   codex: CodexNodeComponent, // Feature: 518-codex-agent-node
+  branchSession: BranchSessionNode, // Feature: branch-session-node (Claude Code only)
   group: GroupNodeComponent, // Feature: group-node
 };
 
@@ -483,6 +485,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                           return 'var(--vscode-charts-purple)';
                         case 'codex':
                           return 'var(--vscode-charts-orange)';
+                        case 'branchSession':
+                          return 'var(--vscode-charts-cyan)';
                         case 'group':
                           return 'var(--vscode-panel-border)';
                         default:

--- a/packages/vscode/src/webview/src/components/nodes/BranchSessionNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/BranchSessionNode.tsx
@@ -1,0 +1,143 @@
+/**
+ * BranchSessionNode Component
+ *
+ * ブランチセッション・チェックポイントを表すノードコンポーネント (Claude Code 限定)
+ *
+ * 特徴:
+ * - 入力・出力の両方の接続を持つ
+ * - ワークフローを一時停止し、ユーザーが /branch で AI と共同作業する
+ * - 作業内容 (workDescription) のプレビュー表示
+ */
+
+import { GitBranchPlus } from 'lucide-react';
+import React from 'react';
+import { Handle, type NodeProps, Position } from 'reactflow';
+import type { BranchSessionNodeData } from '../../types/node-types';
+import { DeleteButton } from './DeleteButton';
+
+/**
+ * BranchSessionNodeコンポーネント
+ *
+ * @param data - ノードデータ（label, workDescription）
+ * @param selected - ノードが選択されているかどうか
+ */
+export const BranchSessionNode: React.FC<NodeProps<BranchSessionNodeData>> = React.memo(
+  ({ id, data, selected }) => {
+    // ラベルのデフォルト値
+    const label = data.label || 'Branch Session';
+
+    // 作業内容のプレビュー（最初の100文字）
+    const workDescription = data.workDescription || '';
+    const previewText =
+      workDescription.length > 100 ? `${workDescription.substring(0, 100)}...` : workDescription;
+
+    return (
+      <div
+        style={{
+          position: 'relative',
+          padding: '12px',
+          borderRadius: '8px',
+          border: `2px solid ${selected ? 'var(--vscode-focusBorder)' : '#14b8a6'}`,
+          backgroundColor: 'var(--vscode-editor-background)',
+          minWidth: '200px',
+          maxWidth: '300px',
+        }}
+      >
+        {/* Delete Button */}
+        <DeleteButton nodeId={id} selected={selected} />
+        {/* Node Header */}
+        <div
+          style={{
+            fontSize: '11px',
+            fontWeight: 600,
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: '8px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+          }}
+        >
+          <GitBranchPlus size={18} />
+          Branch Session
+        </div>
+
+        {/* Label */}
+        <div
+          style={{
+            fontSize: '13px',
+            color: 'var(--vscode-foreground)',
+            marginBottom: '8px',
+            fontWeight: 500,
+          }}
+        >
+          {label}
+        </div>
+
+        {/* Work Description Preview */}
+        {workDescription && (
+          <div
+            style={{
+              fontSize: '11px',
+              color: 'var(--vscode-descriptionForeground)',
+              marginBottom: '8px',
+              lineHeight: '1.4',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {previewText}
+          </div>
+        )}
+
+        {/* Claude Code Only Badge */}
+        <div
+          style={{
+            fontSize: '10px',
+            color: 'var(--vscode-badge-foreground)',
+            backgroundColor: 'var(--vscode-badge-background)',
+            padding: '2px 6px',
+            borderRadius: '3px',
+            display: 'inline-block',
+          }}
+        >
+          Claude Code only
+        </div>
+
+        {/* Input Handle */}
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="in"
+          style={{
+            width: '12px',
+            height: '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            border: '2px solid var(--vscode-button-foreground)',
+          }}
+        />
+
+        {/* Output Handle */}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="out"
+          style={{
+            width: '12px',
+            height: '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            border: '2px solid var(--vscode-button-foreground)',
+          }}
+        />
+      </div>
+    );
+  }
+);
+
+BranchSessionNode.displayName = 'BranchSessionNode';
+
+export default BranchSessionNode;

--- a/packages/vscode/src/webview/src/constants/node-type-icons.ts
+++ b/packages/vscode/src/webview/src/constants/node-type-icons.ts
@@ -8,6 +8,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Bot,
   GitBranch,
+  GitBranchPlus,
   GitFork,
   MessageSquare,
   Play,
@@ -26,6 +27,7 @@ export const NODE_TYPE_ICONS: Record<string, LucideIcon> = {
   subAgent: Bot,
   subAgentFlow: Bot,
   codex: Terminal,
+  branchSession: GitBranchPlus,
   skill: Zap,
   mcp: Plug,
   ifElse: GitBranch,

--- a/packages/vscode/src/webview/src/constants/node-type-labels.ts
+++ b/packages/vscode/src/webview/src/constants/node-type-labels.ts
@@ -18,6 +18,7 @@ export const NODE_TYPE_LABELS: Record<string, string> = {
   skill: 'Skill',
   mcp: 'MCP Tool',
   codex: 'Codex Agent',
+  branchSession: 'Branch Session',
   group: 'Group',
 } as const;
 

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -155,6 +155,18 @@ export interface WebviewTranslationKeys {
   'node.codex.untitled': string;
   'node.codex.aiGenerated': string;
 
+  // Branch Session Node (Feature: branch-session-node, Claude Code only)
+  'node.branchSession.title': string;
+  'node.branchSession.description': string;
+  'property.branchSession.workDescription': string;
+  'property.branchSession.workDescriptionPlaceholder': string;
+  'property.branchSession.workDescription.help': string;
+  'property.branchSession.claudeCodeOnlyNotice': string;
+  'default.newBranchSession': string;
+  'dialog.claudeOnlyExport.title': string;
+  'dialog.claudeOnlyExport.message': string;
+  'dialog.claudeOnlyExport.confirm': string;
+
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': string;
   'codex.description': string;
@@ -947,4 +959,6 @@ export interface WebviewTranslationKeys {
   'sample.githubIssuePlanning.description': string;
   'sample.dailyDevFlowWithWorktree.name': string;
   'sample.dailyDevFlowWithWorktree.description': string;
+  'sample.dailyDevWithBranch.name': string;
+  'sample.dailyDevWithBranch.description': string;
 }

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -163,9 +163,9 @@ export interface WebviewTranslationKeys {
   'property.branchSession.workDescription.help': string;
   'property.branchSession.claudeCodeOnlyNotice': string;
   'default.newBranchSession': string;
-  'dialog.claudeOnlyExport.title': string;
-  'dialog.claudeOnlyExport.message': string;
-  'dialog.claudeOnlyExport.confirm': string;
+  'dialog.claudeOnlyWarning.title': string;
+  'dialog.claudeOnlyWarning.message': string;
+  'dialog.claudeOnlyWarning.confirm': string;
 
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -161,6 +161,23 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'node.codex.untitled': 'Untitled Codex Agent',
   'node.codex.aiGenerated': 'AI Generated',
 
+  // Branch Session Node (Feature: branch-session-node, Claude Code only)
+  'node.branchSession.title': 'Branch Session',
+  'node.branchSession.description':
+    'Pause for joint human+AI work in a branch session (Claude Code only)',
+  'property.branchSession.workDescription': 'Work Description',
+  'property.branchSession.workDescriptionPlaceholder':
+    'What the user and AI will work on together in the branch session (optional)',
+  'property.branchSession.workDescription.help':
+    'Injected into the generated instructions so the session knows the scope of the joint work',
+  'property.branchSession.claudeCodeOnlyNotice':
+    'This node only works on Claude Code. It pauses the workflow so the user can work interactively with the AI in a branch session (/branch), then hand the results back (/resume).',
+  'default.newBranchSession': 'New Branch Session',
+  'dialog.claudeOnlyExport.title': 'Claude Code-only Nodes',
+  'dialog.claudeOnlyExport.message':
+    'This workflow contains Branch Session node(s), which only work on Claude Code. Other AI agents cannot execute these steps. Export anyway?',
+  'dialog.claudeOnlyExport.confirm': 'Export Anyway',
+
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': 'Create Codex Agent',
   'codex.description': 'Configure an OpenAI Codex CLI agent for your workflow.',
@@ -1035,4 +1052,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'sample.dailyDevFlowWithWorktree.name': 'Daily Dev Flow with Git Worktree',
   'sample.dailyDevFlowWithWorktree.description':
     'Daily development flow using git worktree: hear task, propose branch & create worktree, investigate, plan, confirm, implement, run quality checks, commit & draft PR.',
+  'sample.dailyDevWithBranch.name': 'Daily Dev with Branch Session',
+  'sample.dailyDevWithBranch.description':
+    'Daily development with a human-in-the-loop checkpoint: hear the goal, plan, implement, then review and fix together with the AI in a Claude Code branch session. The long interactive review consumes context in the branch — not in the parent — keeping the parent session lean and cost-efficient through completion. Best for medium-to-large tasks. Claude Code only.',
 };

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -173,10 +173,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.branchSession.claudeCodeOnlyNotice':
     'This node only works on Claude Code. It pauses the workflow so the user can work interactively with the AI in a branch session (/branch), then hand the results back (/resume).',
   'default.newBranchSession': 'New Branch Session',
-  'dialog.claudeOnlyExport.title': 'Claude Code-only Nodes',
-  'dialog.claudeOnlyExport.message':
-    'This workflow contains Branch Session node(s), which only work on Claude Code. Other AI agents cannot execute these steps. Export anyway?',
-  'dialog.claudeOnlyExport.confirm': 'Export Anyway',
+  'dialog.claudeOnlyWarning.title': 'Claude Code-only Nodes',
+  'dialog.claudeOnlyWarning.message':
+    'This workflow contains Branch Session node(s), which only work on Claude Code. Other AI agents cannot execute these steps. Continue anyway?',
+  'dialog.claudeOnlyWarning.confirm': 'Continue',
 
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': 'Create Codex Agent',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -173,10 +173,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.branchSession.claudeCodeOnlyNotice':
     'このノードはClaude Code専用です。ワークフローを一時停止し、ユーザーがブランチセッション（/branch）でAIと対話的に作業した後、結果を引き継いで（/resume）続行します。',
   'default.newBranchSession': '新しいBranch Session',
-  'dialog.claudeOnlyExport.title': 'Claude Code専用ノード',
-  'dialog.claudeOnlyExport.message':
-    'このワークフローにはClaude Codeでのみ動作するブランチセッションノードが含まれています。他のAIエージェントはこのステップを実行できません。それでもエクスポートしますか？',
-  'dialog.claudeOnlyExport.confirm': 'エクスポートする',
+  'dialog.claudeOnlyWarning.title': 'Claude Code専用ノード',
+  'dialog.claudeOnlyWarning.message':
+    'このワークフローにはClaude Codeでのみ動作するブランチセッションノードが含まれています。他のAIエージェントはこのステップを実行できません。それでも続行しますか？',
+  'dialog.claudeOnlyWarning.confirm': '続行',
 
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': 'Codex Agentを作成',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -161,6 +161,23 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'node.codex.untitled': '無題のCodex Agent',
   'node.codex.aiGenerated': 'AI生成',
 
+  // Branch Session Node (Feature: branch-session-node, Claude Code only)
+  'node.branchSession.title': 'Branch Session',
+  'node.branchSession.description':
+    'ブランチセッションで人とAIが共同作業するための一時停止点（Claude Code限定）',
+  'property.branchSession.workDescription': '作業内容',
+  'property.branchSession.workDescriptionPlaceholder':
+    'ブランチセッションでユーザーとAIが共同で行う作業内容（省略可能）',
+  'property.branchSession.workDescription.help':
+    '生成される指示文に埋め込まれ、セッションが共同作業のスコープを把握できます',
+  'property.branchSession.claudeCodeOnlyNotice':
+    'このノードはClaude Code専用です。ワークフローを一時停止し、ユーザーがブランチセッション（/branch）でAIと対話的に作業した後、結果を引き継いで（/resume）続行します。',
+  'default.newBranchSession': '新しいBranch Session',
+  'dialog.claudeOnlyExport.title': 'Claude Code専用ノード',
+  'dialog.claudeOnlyExport.message':
+    'このワークフローにはClaude Codeでのみ動作するブランチセッションノードが含まれています。他のAIエージェントはこのステップを実行できません。それでもエクスポートしますか？',
+  'dialog.claudeOnlyExport.confirm': 'エクスポートする',
+
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': 'Codex Agentを作成',
   'codex.description': 'ワークフロー用のOpenAI Codex CLIエージェントを設定します。',
@@ -1030,4 +1047,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'sample.dailyDevFlowWithWorktree.name': 'Git Worktreeを使った日常開発フロー',
   'sample.dailyDevFlowWithWorktree.description':
     'git worktreeを使った日常開発フロー：タスクヒアリング、ブランチ提案＆worktree作成、調査、計画、承認、実装、品質チェック、コミット＆PR下書き。',
+  'sample.dailyDevWithBranch.name': 'ブランチセッションを使った日常開発',
+  'sample.dailyDevWithBranch.description':
+    'ヒアリング→計画→実装ののち、レビュー・修正をClaude Codeのブランチセッションに分離して人とAIが共同で行う日常開発フロー。対話の長いレビュー作業のコンテキスト消費を分岐先に隔離し、親セッションを軽く保ったまま完了までループできる。長くコンテキストを消費する中〜大規模タスク向け。Claude Code限定。',
 };

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -173,10 +173,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.branchSession.claudeCodeOnlyNotice':
     '이 노드는 Claude Code 전용입니다. 워크플로를 일시 정지하고 사용자가 브랜치 세션(/branch)에서 AI와 대화형으로 작업한 후 결과를 인계(/resume)하여 계속합니다.',
   'default.newBranchSession': '새 Branch Session',
-  'dialog.claudeOnlyExport.title': 'Claude Code 전용 노드',
-  'dialog.claudeOnlyExport.message':
-    '이 워크플로에는 Claude Code에서만 작동하는 브랜치 세션 노드가 포함되어 있습니다. 다른 AI 에이전트는 이 단계를 실행할 수 없습니다. 그래도 내보내시겠습니까?',
-  'dialog.claudeOnlyExport.confirm': '내보내기',
+  'dialog.claudeOnlyWarning.title': 'Claude Code 전용 노드',
+  'dialog.claudeOnlyWarning.message':
+    '이 워크플로에는 Claude Code에서만 작동하는 브랜치 세션 노드가 포함되어 있습니다. 다른 AI 에이전트는 이 단계를 실행할 수 없습니다. 그래도 계속하시겠습니까?',
+  'dialog.claudeOnlyWarning.confirm': '계속',
 
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': 'Codex Agent 생성',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -161,6 +161,23 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'node.codex.untitled': '제목 없는 Codex Agent',
   'node.codex.aiGenerated': 'AI 생성',
 
+  // Branch Session Node (Feature: branch-session-node, Claude Code only)
+  'node.branchSession.title': 'Branch Session',
+  'node.branchSession.description':
+    '브랜치 세션에서 사람과 AI가 공동 작업하기 위한 일시 정지 지점 (Claude Code 전용)',
+  'property.branchSession.workDescription': '작업 내용',
+  'property.branchSession.workDescriptionPlaceholder':
+    '브랜치 세션에서 사용자와 AI가 함께 수행할 작업 내용 (선택 사항)',
+  'property.branchSession.workDescription.help':
+    '생성된 지시문에 삽입되어 세션이 공동 작업의 범위를 파악할 수 있습니다',
+  'property.branchSession.claudeCodeOnlyNotice':
+    '이 노드는 Claude Code 전용입니다. 워크플로를 일시 정지하고 사용자가 브랜치 세션(/branch)에서 AI와 대화형으로 작업한 후 결과를 인계(/resume)하여 계속합니다.',
+  'default.newBranchSession': '새 Branch Session',
+  'dialog.claudeOnlyExport.title': 'Claude Code 전용 노드',
+  'dialog.claudeOnlyExport.message':
+    '이 워크플로에는 Claude Code에서만 작동하는 브랜치 세션 노드가 포함되어 있습니다. 다른 AI 에이전트는 이 단계를 실행할 수 없습니다. 그래도 내보내시겠습니까?',
+  'dialog.claudeOnlyExport.confirm': '내보내기',
+
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': 'Codex Agent 생성',
   'codex.description': '워크플로용 OpenAI Codex CLI 에이전트를 구성합니다.',
@@ -1020,4 +1037,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'sample.dailyDevFlowWithWorktree.name': 'Git Worktree 기반 일일 개발 플로우',
   'sample.dailyDevFlowWithWorktree.description':
     'git worktree를 활용한 일일 개발 플로우: 작업 인터뷰, 브랜치 제안 및 worktree 생성, 코드 조사, 계획 수립, 승인, 구현, 품질 검사, 커밋 및 PR 초안 작성.',
+  'sample.dailyDevWithBranch.name': '브랜치 세션을 활용한 일일 개발',
+  'sample.dailyDevWithBranch.description':
+    '인터뷰→계획→구현 후, 리뷰·수정을 Claude Code 브랜치 세션으로 분리하여 사람과 AI가 함께 수행하는 일일 개발 플로우. 긴 대화형 리뷰의 컨텍스트 소비를 분기 쪽에 격리하여 부모 세션을 가볍게 유지한 채 완료까지 반복할 수 있다. 컨텍스트를 오래 소비하는 중~대규모 작업에 적합. Claude Code 전용.',
 };

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -157,6 +157,21 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'node.codex.untitled': '未命名Codex Agent',
   'node.codex.aiGenerated': 'AI生成',
 
+  // Branch Session Node (Feature: branch-session-node, Claude Code only)
+  'node.branchSession.title': 'Branch Session',
+  'node.branchSession.description': '暂停工作流，让用户与AI在分支会话中协作（仅限Claude Code）',
+  'property.branchSession.workDescription': '工作内容',
+  'property.branchSession.workDescriptionPlaceholder':
+    '用户与AI在分支会话中共同完成的工作内容（可选）',
+  'property.branchSession.workDescription.help': '将嵌入生成的指令中，使会话了解协作范围',
+  'property.branchSession.claudeCodeOnlyNotice':
+    '此节点仅适用于Claude Code。它会暂停工作流，用户可在分支会话（/branch）中与AI交互协作，然后将结果交回（/resume）继续执行。',
+  'default.newBranchSession': '新Branch Session',
+  'dialog.claudeOnlyExport.title': 'Claude Code专用节点',
+  'dialog.claudeOnlyExport.message':
+    '此工作流包含仅在Claude Code上运行的分支会话节点。其他AI代理无法执行这些步骤。仍要导出吗？',
+  'dialog.claudeOnlyExport.confirm': '仍然导出',
+
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': '创建Codex Agent',
   'codex.description': '为工作流配置OpenAI Codex CLI代理。',
@@ -988,4 +1003,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'sample.dailyDevFlowWithWorktree.name': '基于 Git Worktree 的日常开发流程',
   'sample.dailyDevFlowWithWorktree.description':
     '使用 git worktree 的日常开发流程：任务访谈、分支提议与 worktree 创建、代码调查、计划制定、确认、实现、质量检查、提交与 PR 草稿。',
+  'sample.dailyDevWithBranch.name': '使用分支会话的日常开发',
+  'sample.dailyDevWithBranch.description':
+    '访谈→计划→实现后，将评审与修改分离到 Claude Code 分支会话中由人与AI共同完成的日常开发流程。冗长的交互式评审在分支中消耗上下文，父会话保持轻量并可循环至完成。适合长期消耗上下文的中大型任务。仅限 Claude Code。',
 };

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -167,10 +167,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.branchSession.claudeCodeOnlyNotice':
     '此节点仅适用于Claude Code。它会暂停工作流，用户可在分支会话（/branch）中与AI交互协作，然后将结果交回（/resume）继续执行。',
   'default.newBranchSession': '新Branch Session',
-  'dialog.claudeOnlyExport.title': 'Claude Code专用节点',
-  'dialog.claudeOnlyExport.message':
-    '此工作流包含仅在Claude Code上运行的分支会话节点。其他AI代理无法执行这些步骤。仍要导出吗？',
-  'dialog.claudeOnlyExport.confirm': '仍然导出',
+  'dialog.claudeOnlyWarning.title': 'Claude Code专用节点',
+  'dialog.claudeOnlyWarning.message':
+    '此工作流包含仅在Claude Code上运行的分支会话节点。其他AI代理无法执行这些步骤。仍要继续吗？',
+  'dialog.claudeOnlyWarning.confirm': '继续',
 
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': '创建Codex Agent',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -157,6 +157,22 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'node.codex.untitled': '未命名Codex Agent',
   'node.codex.aiGenerated': 'AI生成',
 
+  // Branch Session Node (Feature: branch-session-node, Claude Code only)
+  'node.branchSession.title': 'Branch Session',
+  'node.branchSession.description':
+    '暫停工作流程，讓使用者與AI在分支工作階段中協作（僅限Claude Code）',
+  'property.branchSession.workDescription': '工作內容',
+  'property.branchSession.workDescriptionPlaceholder':
+    '使用者與AI在分支工作階段中共同完成的工作內容（可選）',
+  'property.branchSession.workDescription.help': '將嵌入產生的指令中，使工作階段了解協作範圍',
+  'property.branchSession.claudeCodeOnlyNotice':
+    '此節點僅適用於Claude Code。它會暫停工作流程，使用者可在分支工作階段（/branch）中與AI互動協作，然後將結果交回（/resume）繼續執行。',
+  'default.newBranchSession': '新Branch Session',
+  'dialog.claudeOnlyExport.title': 'Claude Code專用節點',
+  'dialog.claudeOnlyExport.message':
+    '此工作流程包含僅在Claude Code上運行的分支工作階段節點。其他AI代理無法執行這些步驟。仍要匯出嗎？',
+  'dialog.claudeOnlyExport.confirm': '仍然匯出',
+
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': '建立Codex Agent',
   'codex.description': '為工作流程配置OpenAI Codex CLI代理。',
@@ -990,4 +1006,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'sample.dailyDevFlowWithWorktree.name': '基於 Git Worktree 的日常開發流程',
   'sample.dailyDevFlowWithWorktree.description':
     '使用 git worktree 的日常開發流程：任務訪談、分支提議與 worktree 建立、程式碼調查、計畫制定、確認、實作、品質檢查、提交與 PR 草稿。',
+  'sample.dailyDevWithBranch.name': '使用分支工作階段的日常開發',
+  'sample.dailyDevWithBranch.description':
+    '訪談→計畫→實作後，將審查與修改分離到 Claude Code 分支工作階段中由人與AI共同完成的日常開發流程。冗長的互動式審查在分支中消耗脈絡，父工作階段保持輕量並可循環至完成。適合長期消耗脈絡的中大型任務。僅限 Claude Code。',
 };

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -168,10 +168,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.branchSession.claudeCodeOnlyNotice':
     '此節點僅適用於Claude Code。它會暫停工作流程，使用者可在分支工作階段（/branch）中與AI互動協作，然後將結果交回（/resume）繼續執行。',
   'default.newBranchSession': '新Branch Session',
-  'dialog.claudeOnlyExport.title': 'Claude Code專用節點',
-  'dialog.claudeOnlyExport.message':
-    '此工作流程包含僅在Claude Code上運行的分支工作階段節點。其他AI代理無法執行這些步驟。仍要匯出嗎？',
-  'dialog.claudeOnlyExport.confirm': '仍然匯出',
+  'dialog.claudeOnlyWarning.title': 'Claude Code專用節點',
+  'dialog.claudeOnlyWarning.message':
+    '此工作流程包含僅在Claude Code上運行的分支工作階段節點。其他AI代理無法執行這些步驟。仍要繼續嗎？',
+  'dialog.claudeOnlyWarning.confirm': '繼續',
 
   // Codex Dialog (Feature: 518-codex-agent-node)
   'codex.title': '建立Codex Agent',

--- a/packages/vscode/src/webview/src/types/node-types.ts
+++ b/packages/vscode/src/webview/src/types/node-types.ts
@@ -162,6 +162,43 @@ export interface BranchNodeData {
 export type BranchNode = Node<BranchNodeData, 'branch'>;
 
 // ============================================================================
+// Branch Session Node
+// ============================================================================
+
+/**
+ * Branch Sessionノードのデータ構造 (Claude Code 限定)
+ *
+ * ワークフローを一時停止し、ユーザーが Claude Code のブランチセッション
+ * (/branch) で AI と共同作業した後、親セッション (/resume) に引き継いで
+ * 続行するヒューマン・イン・ザ・ループ・チェックポイントです。
+ */
+export interface BranchSessionNodeData {
+  /**
+   * ノードのラベル (必須)
+   */
+  label: string;
+
+  /**
+   * ブランチセッションでの作業内容 (省略可能)
+   *
+   * 人と AI の共同作業のスコープ。生成される指示文に埋め込まれます。
+   */
+  workDescription?: string;
+
+  /**
+   * 出力ポート数 (1固定)
+   */
+  outputPorts: 1;
+}
+
+/**
+ * Branch Sessionノード型
+ *
+ * ブランチセッション・チェックポイントを表すノード。入力と出力の両方の接続を持ちます。
+ */
+export type BranchSessionNode = Node<BranchSessionNodeData, 'branchSession'>;
+
+// ============================================================================
 // Union Type
 // ============================================================================
 
@@ -171,4 +208,4 @@ export type BranchNode = Node<BranchNodeData, 'branch'>;
  * すべてのカスタムノードタイプを含むユニオン型です。
  * 既存のノードタイプと組み合わせて使用します。
  */
-export type WorkflowNode = StartNode | EndNode | PromptNode | BranchNode;
+export type WorkflowNode = StartNode | EndNode | PromptNode | BranchNode | BranchSessionNode;


### PR DESCRIPTION
## Summary

Adds a new `branchSession` node type: a **Claude Code-only human-in-the-loop checkpoint**. When workflow execution reaches this node, the orchestrating session pauses and guides the user into a Claude Code branch session (`/branch <session-name>`) to work **interactively together with the AI** (code understanding, review, edits — not a sub-agent delegation). When done, the branch session writes a handoff markdown, copies it to the clipboard, and points the user back to the parent session (`/resume <parent-session-id>`); pasting the handoff resumes the workflow at the next node.

## Motivation

Some workflow steps need joint human+AI work rather than autonomous execution (`subAgent`) or a single question (`askUserQuestion`) — e.g. reviewing generated code interactively. Claude Code's branch sessions isolate that long interactive context from the parent session, keeping the parent lightweight for mid-to-large tasks. This pattern was validated manually with a prompt-node workflow before productizing it as a node type.

## Changes

**New Files:**
- `packages/core/src/schema/claude-code-only.ts` - `CLAUDE_CODE_ONLY_NODE_TYPES` set + helpers to detect Claude Code-only nodes in a workflow
- `packages/vscode/src/webview/src/components/nodes/BranchSessionNode.tsx` - canvas node component (1-in/1-out, "Claude Code only" badge)
- `packages/vscode/resources/samples/daily-dev-with-branch-sample.{en,ja,ko,zh-CN,zh-TW}.json` - "Daily Dev with Branch Session" sample workflow

**Modified Files:**
- `packages/core/src/types/workflow-definition.ts` - `NodeType.BranchSession`, `BranchSessionNodeData { label, workDescription?, outputPorts: 1 }`, validation rules
- `packages/core/resources/workflow-schema.json` - node type definition (AI generation guidance) + added to `subAgentFlowConstraints.prohibitedNodeTypes` (`.toon` regenerated)
- `packages/core/src/services/workflow-prompt-generator.ts` - Mermaid shape + generated instruction template (branch-session name suggestion via literal `/branch <name>`, OS-aware clipboard copy with handoff-file-path fallback, `/compact` caveat)
- `packages/core/src/services/workflow-overview-formatter.ts` - Overview rendering
- `packages/vscode/src/webview/...` - palette button (hidden while editing Sub-Agent Flows), PropertyOverlay editor (label + work description), React Flow/minimap registration, i18n for 5 locales
- `packages/vscode/src/webview/src/components/Toolbar.tsx` - **confirmation dialog** before exporting/running for non-Claude-Code targets when the canvas contains Claude Code-only nodes (all 14 non-Claude export/run handlers gated)
- `packages/cli/src/commands/export.ts` - non-blocking stderr warning for non-Claude targets
- `packages/vscode/src/extension/services/mcp-server-service.ts`, `packages/vscode/src/extension/commands/open-editor.ts` - fix: MCP server manager could get stuck in "already running" after a failed `listen` (e.g. EADDRINUSE), permanently breaking the AI Edit button until extension host restart; `start()` is now idempotent, failed servers are cleaned up, and launch failures surface via `showErrorMessage`

## Release

- Changeset: `minor` for `@cc-wf-studio/core` and `cc-wf-studio` (VSCode extension); `cli`/`mcp` follow via dependency bumps

## Testing

- [x] Manual E2E testing completed (Extension Development Host: palette/properties/export dialog; generated SKILL.md executed in Claude Code end-to-end incl. `/branch` → handoff → `/resume`; `ccwf export --agent gemini` warning; MCP server recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code–only **Branch Session** node to pause execution, run a human+AI branch workflow, and then resume the parent session.
  * Updated the workflow builder UI to add and edit Branch Session nodes, including labels, work descriptions, and clearer node rendering in the editor.
  * Added export/run safeguards with a confirmation prompt when Claude Code–only nodes are present.
  * Added a localized **Daily Dev with Branch Session** sample workflow in multiple languages.
* **Bug Fixes**
  * Improved MCP server start recovery so it no longer gets stuck after a failed start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->