### PR TITLE
feat: add 'fable' model option and refactor model values to a single source of truth

### DIFF
--- a/.changeset/add-fable-model-ssot.md
+++ b/.changeset/add-fable-model-ssot.md
@@ -1,0 +1,10 @@
+---
+'@cc-wf-studio/core': minor
+'cc-wf-studio': minor
+---
+
+Add 'fable' (Claude Fable 5) to sub-agent and slash command model options. Model
+values are now exported from core as `SUB_AGENT_MODEL_VALUES` / `SubAgentModel`
+(single source of truth for the zod schema, TS unions, JSON schema, and UI
+dropdowns); CC-only models ('haiku', 'fable') are omitted when exporting to
+non-Claude-Code providers.

--- a/packages/core/resources/workflow-schema.json
+++ b/packages/core/resources/workflow-schema.json
@@ -56,7 +56,7 @@
         "model": {
           "type": "string",
           "required": false,
-          "enum": ["sonnet", "opus", "haiku", "inherit"],
+          "enum": ["sonnet", "opus", "haiku", "fable", "inherit"],
           "default": "sonnet"
         },
         "color": {

--- a/packages/core/resources/workflow-schema.toon
+++ b/packages/core/resources/workflow-schema.toon
@@ -58,7 +58,7 @@ nodeTypes:
       model:
         type: string
         required: false
-        enum[4]: sonnet,opus,haiku,inherit
+        enum[5]: sonnet,opus,haiku,fable,inherit
         default: sonnet
       color:
         type: string

--- a/packages/core/src/constants/built-in-sub-agents.ts
+++ b/packages/core/src/constants/built-in-sub-agents.ts
@@ -5,6 +5,7 @@
  * These agents have fixed model and tool configurations controlled by Claude Code.
  */
 
+import type { SubAgentModel } from '../schema/sub-agent-schema.js';
 import type { BuiltInSubAgentType } from '../types/workflow-definition.js';
 
 /** i18n keys for built-in sub-agent presets (must match WebviewTranslationKeys) */
@@ -31,7 +32,7 @@ export interface BuiltInSubAgentPreset {
   /** i18n key for the default task prompt template (what to TELL this agent to do) */
   defaultPromptKey: BuiltInI18nKey;
   /** Model used by this preset (e.g., 'haiku', 'inherit') */
-  model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  model?: SubAgentModel;
   /** Whether this preset is read-only (no file writes/edits) */
   readonly?: boolean;
   /** Human-readable tools description (read-only, controlled by preset) */

--- a/packages/core/src/schema/sub-agent-schema.ts
+++ b/packages/core/src/schema/sub-agent-schema.ts
@@ -16,6 +16,12 @@
 import { z } from 'zod';
 import { field, type PropertyField, toZodObject } from './field.js';
 
+export const SUB_AGENT_MODEL_VALUES = ['sonnet', 'opus', 'haiku', 'fable', 'inherit'] as const;
+export type SubAgentModel = (typeof SUB_AGENT_MODEL_VALUES)[number];
+
+/** Models that exist only in Claude Code; exporters for other providers omit them. */
+export const CC_ONLY_MODELS: readonly SubAgentModel[] = ['haiku', 'fable'];
+
 const SUB_AGENT_COLOR_VALUES = [
   'red',
   'blue',
@@ -49,11 +55,11 @@ export const subAgentPropertySchema = {
     control: 'select',
     options: ['claudeCode', 'other'],
   }),
-  model: field(z.enum(['sonnet', 'opus', 'haiku', 'inherit']).optional(), {
+  model: field(z.enum(SUB_AGENT_MODEL_VALUES).optional(), {
     targets: ['claudeCode'],
     labelKey: 'subAgent.field.model',
     control: 'select',
-    options: ['sonnet', 'opus', 'haiku', 'inherit'],
+    options: SUB_AGENT_MODEL_VALUES,
     controlledByBuiltIn: true,
   }),
   tools: field(z.string().optional(), {

--- a/packages/core/src/services/agent-skill-export.ts
+++ b/packages/core/src/services/agent-skill-export.ts
@@ -13,6 +13,7 @@
  */
 
 import { BUILT_IN_SUB_AGENTS } from '../constants/built-in-sub-agents.js';
+import { CC_ONLY_MODELS } from '../schema/sub-agent-schema.js';
 import type { SubAgentFlowNode, SubAgentNode, Workflow } from '../types/workflow-definition.js';
 import {
   type PlannedExportFile,
@@ -175,7 +176,7 @@ export function planAgentSkillFiles(
         relativePath: `${spec.agentsDir}/${fileName}.md`,
         contents: generateSubAgentFile(node, {
           readonly: preset?.readonly,
-          omitModel: node.data.model === 'haiku',
+          omitModel: node.data.model !== undefined && CC_ONLY_MODELS.includes(node.data.model),
         }),
         kind: 'subAgent',
         sourceName: node.name,

--- a/packages/core/src/services/workflow-prompt-generator.ts
+++ b/packages/core/src/services/workflow-prompt-generator.ts
@@ -7,6 +7,7 @@
  * All output is in English for consistent AI consumption.
  */
 
+import { CC_ONLY_MODELS } from '../schema/sub-agent-schema.js';
 import type {
   AskUserQuestionNode,
   BranchNode,
@@ -758,7 +759,10 @@ export function generateExecutionInstructions(
         sections.push('');
       }
       const shouldOmitModelForBuiltIn =
-        provider !== 'claude-code' && node.data.builtInType && node.data.model === 'haiku';
+        provider !== 'claude-code' &&
+        node.data.builtInType &&
+        node.data.model !== undefined &&
+        CC_ONLY_MODELS.includes(node.data.model);
       if (node.data.model && node.data.model !== 'inherit' && !shouldOmitModelForBuiltIn) {
         sections.push(`**Model**: ${node.data.model}`);
         sections.push('');

--- a/packages/core/src/types/workflow-definition.ts
+++ b/packages/core/src/types/workflow-definition.ts
@@ -4,6 +4,8 @@
  * Based on: /specs/001-cc-wf-studio/data-model.md
  */
 
+import type { SubAgentModel } from '../schema/sub-agent-schema.js';
+
 // ============================================================================
 // Core Enums
 // ============================================================================
@@ -50,7 +52,7 @@ export interface WorkflowMetadata {
 export type SlashCommandContext = 'default' | 'fork';
 
 /** Model options for Slash Command execution */
-export type SlashCommandModel = 'default' | 'sonnet' | 'opus' | 'haiku' | 'inherit';
+export type SlashCommandModel = 'default' | SubAgentModel;
 
 export interface SlashCommandOptions {
   /** Context mode for execution. 'default' means no context line in output */
@@ -120,7 +122,7 @@ export interface SubAgentData {
   /** Agent type: 'claudeCode' shows Claude Code-specific fields, 'other' hides them */
   agentType?: 'claudeCode' | 'other';
   tools?: string;
-  model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  model?: SubAgentModel;
   /** Persistent memory scope for cross-conversation knowledge retention */
   memory?: 'user' | 'project' | 'local';
   color?: 'red' | 'blue' | 'green' | 'yellow' | 'purple' | 'orange' | 'pink' | 'cyan';
@@ -317,7 +319,7 @@ export interface SubAgentFlowNodeData {
   /** Number of output ports (fixed at 1 for SubAgentFlow nodes) */
   outputPorts: 1;
   /** Model to use for this sub-agent flow execution */
-  model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  model?: SubAgentModel;
   /** Persistent memory scope for cross-conversation knowledge retention */
   memory?: 'user' | 'project' | 'local';
   /** Comma-separated list of allowed tools */

--- a/packages/core/src/utils/validate-workflow.ts
+++ b/packages/core/src/utils/validate-workflow.ts
@@ -5,6 +5,7 @@
  * Based on: /specs/001-ai-workflow-generation/research.md Q3
  */
 
+import { SUB_AGENT_MODEL_VALUES } from '../schema/sub-agent-schema.js';
 import {
   type Connection,
   type HookType,
@@ -328,6 +329,7 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
     // Validate SubAgent fields (Feature: 540-persistent-memory, 636-reference-model, 684-built-in-presets)
     if (node.type === NodeType.SubAgent) {
       const subAgentData = node.data as {
+        model?: string;
         memory?: string;
         commandFilePath?: string;
         commandScope?: string;
@@ -358,6 +360,16 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
             field: `nodes[${node.id}].data.commandScope`,
           });
         }
+      }
+      if (
+        subAgentData.model !== undefined &&
+        !(SUB_AGENT_MODEL_VALUES as readonly string[]).includes(subAgentData.model)
+      ) {
+        errors.push({
+          code: 'SUBAGENT_INVALID_MODEL',
+          message: `SubAgent model must be one of: ${SUB_AGENT_MODEL_VALUES.join(', ')}`,
+          field: `nodes[${node.id}].data.model`,
+        });
       }
       if (subAgentData.memory !== undefined) {
         const validMemoryScopes = ['user', 'project', 'local'];

--- a/packages/vscode/src/shared/types/messages.ts
+++ b/packages/vscode/src/shared/types/messages.ts
@@ -4,7 +4,13 @@
  * Based on: /specs/001-cc-wf-studio/contracts/extension-webview-api.md
  */
 
-import type { Connection, TourStep, Workflow, WorkflowNode } from '@cc-wf-studio/core';
+import type {
+  Connection,
+  SubAgentModel,
+  TourStep,
+  Workflow,
+  WorkflowNode,
+} from '@cc-wf-studio/core';
 
 // Re-export Workflow for convenience
 export type { Connection, TourStep, Workflow, WorkflowNode };
@@ -300,7 +306,7 @@ export interface CreateSubAgentPayload {
   agentDefinition: string;
   prompt: string;
   agentType: 'claudeCode' | 'other';
-  model?: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  model?: SubAgentModel;
   tools?: string;
   commandFilePath?: string;
   memory?: 'user' | 'project' | 'local' | '';

--- a/packages/vscode/src/webview/src/components/NodePalette.tsx
+++ b/packages/vscode/src/webview/src/components/NodePalette.tsx
@@ -5,7 +5,7 @@
  * Based on: /specs/001-cc-wf-studio/plan.md
  */
 
-import type { BuiltInSubAgentType, SubAgentFlow } from '@cc-wf-studio/core';
+import type { BuiltInSubAgentType, SubAgentFlow, SubAgentModel } from '@cc-wf-studio/core';
 import { BUILT_IN_SUB_AGENTS, NodeType } from '@cc-wf-studio/core';
 import type { CommandReference } from '@shared/types/messages';
 import {
@@ -209,7 +209,7 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
         description: formData.description,
         agentDefinition: formData.agentDefinition,
         prompt: formData.prompt,
-        model: (frontmatter.model as 'sonnet' | 'opus' | 'haiku' | 'inherit') || 'sonnet',
+        model: (frontmatter.model as SubAgentModel) || 'sonnet',
         tools: frontmatter.tools,
         memory: frontmatter.memory as 'user' | 'project' | 'local' | undefined,
         outputPorts: 1,

--- a/packages/vscode/src/webview/src/components/PropertyOverlay.tsx
+++ b/packages/vscode/src/webview/src/components/PropertyOverlay.tsx
@@ -17,6 +17,7 @@ import {
   SUB_AGENT_COLORS,
   type SubAgentData,
   type SubAgentFlowNodeData,
+  type SubAgentModel,
   type SwitchNodeData,
   VALIDATION_RULES,
 } from '@cc-wf-studio/core';
@@ -25,6 +26,7 @@ import { BookOpen } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import type { Node } from 'reactflow';
+import { SUB_AGENT_MODEL_OPTIONS } from '../constants/model-options';
 import { getNodeTypeLabel } from '../constants/node-type-labels';
 import { useResizablePanel } from '../hooks/useResizablePanel';
 import { useTranslation } from '../i18n/i18n-context';
@@ -2925,7 +2927,7 @@ const SubAgentFlowProperties: React.FC<{
           value={data.model || 'sonnet'}
           onChange={(e) =>
             updateNodeData(node.id, {
-              model: e.target.value as 'sonnet' | 'opus' | 'haiku' | 'inherit',
+              model: e.target.value as SubAgentModel,
             })
           }
           className="nodrag"
@@ -2939,10 +2941,11 @@ const SubAgentFlowProperties: React.FC<{
             fontSize: '13px',
           }}
         >
-          <option value="sonnet">Sonnet</option>
-          <option value="opus">Opus</option>
-          <option value="haiku">Haiku</option>
-          <option value="inherit">Inherit</option>
+          {SUB_AGENT_MODEL_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
         </select>
       </div>
 

--- a/packages/vscode/src/webview/src/components/dialogs/SubAgentCreationDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/SubAgentCreationDialog.tsx
@@ -5,7 +5,7 @@
  * UX aligned with SkillBrowserDialog: browse-first with inline create option.
  */
 
-import type { BuiltInSubAgentType } from '@cc-wf-studio/core';
+import type { BuiltInSubAgentType, SubAgentModel } from '@cc-wf-studio/core';
 import { BUILT_IN_SUB_AGENTS } from '@cc-wf-studio/core';
 import * as Dialog from '@radix-ui/react-dialog';
 import type { CommandReference } from '@shared/types/messages';
@@ -128,7 +128,7 @@ export const SubAgentCreationDialog: React.FC<SubAgentCreationDialogProps> = ({
         agentDefinition: body,
         prompt: 'Execute the following task:',
         agentType: 'claudeCode',
-        model: (frontmatter.model as 'sonnet' | 'opus' | 'haiku' | 'inherit') || 'sonnet',
+        model: (frontmatter.model as SubAgentModel) || 'sonnet',
         tools: frontmatter.tools || '',
         memory: (frontmatter.memory as 'user' | 'project' | 'local' | '') || '',
       });

--- a/packages/vscode/src/webview/src/components/dialogs/SubAgentFormDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/SubAgentFormDialog.tsx
@@ -9,11 +9,12 @@
  * - "other": Shows only common fields (Description, Prompt)
  */
 
-import type { BuiltInSubAgentType } from '@cc-wf-studio/core';
+import type { BuiltInSubAgentType, SubAgentModel } from '@cc-wf-studio/core';
 import { BUILT_IN_SUB_AGENTS } from '@cc-wf-studio/core';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as Select from '@radix-ui/react-select';
 import { useCallback, useEffect, useId, useState } from 'react';
+import { SUB_AGENT_MODEL_OPTIONS } from '../../constants/model-options';
 import { useTranslation } from '../../i18n/i18n-context';
 import { CollapsibleSection } from '../common/CollapsibleSection';
 import type { SubAgentColor } from '../common/ColorPicker';
@@ -52,7 +53,7 @@ export interface SubAgentFormData {
   agentDefinition: string;
   prompt: string;
   agentType: AgentType;
-  model: 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  model: SubAgentModel;
   tools?: string;
   memory?: 'user' | 'project' | 'local' | '';
   color?: SubAgentColor;
@@ -512,9 +513,7 @@ export function SubAgentFormDialog({
                       </label>
                       <Select.Root
                         value={formData.model}
-                        onValueChange={(val) =>
-                          handleFieldChange('model', val as 'sonnet' | 'opus' | 'haiku' | 'inherit')
-                        }
+                        onValueChange={(val) => handleFieldChange('model', val as SubAgentModel)}
                       >
                         <Select.Trigger
                           id={modelId}
@@ -548,12 +547,7 @@ export function SubAgentFormDialog({
                             }}
                           >
                             <Select.Viewport style={{ padding: '4px' }}>
-                              {[
-                                { value: 'sonnet', label: 'Sonnet' },
-                                { value: 'opus', label: 'Opus' },
-                                { value: 'haiku', label: 'Haiku' },
-                                { value: 'inherit', label: 'Inherit' },
-                              ].map((item) => (
+                              {SUB_AGENT_MODEL_OPTIONS.map((item) => (
                                 <Select.Item
                                   key={item.value}
                                   value={item.value}

--- a/packages/vscode/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
+++ b/packages/vscode/src/webview/src/components/toolbar/SlashCommandOptionsDropdown.tsx
@@ -2,18 +2,19 @@
  * Slash Command Options Dropdown Component
  *
  * Provides options for Slash Command export (Export/Run):
- * - model: Specify the model to use for execution (inherit/sonnet/opus/haiku)
+ * - model: Specify the model to use for execution (see SUB_AGENT_MODEL_VALUES in core)
  * - context: fork - Exports with `context: fork` for isolated sub-agent execution (Claude Code v2.1.0+)
  * - hooks: Configure execution hooks (PreToolUse, PostToolUse, Stop)
  * - allowedTools: Configure allowed tools for Slash Command execution
  */
 
-import type {
-  HookEntry,
-  HookType,
-  SlashCommandContext,
-  SlashCommandModel,
-  WorkflowHooks,
+import {
+  type HookEntry,
+  type HookType,
+  type SlashCommandContext,
+  type SlashCommandModel,
+  SUB_AGENT_MODEL_VALUES,
+  type WorkflowHooks,
 } from '@cc-wf-studio/core';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
@@ -51,10 +52,7 @@ const CONTEXT_PRESETS: { value: SlashCommandContext; label: string }[] = [
 
 const MODEL_PRESETS: { value: SlashCommandModel; label: string }[] = [
   { value: 'default', label: 'default' },
-  { value: 'inherit', label: 'inherit' },
-  { value: 'haiku', label: 'haiku' },
-  { value: 'sonnet', label: 'sonnet' },
-  { value: 'opus', label: 'opus' },
+  ...SUB_AGENT_MODEL_VALUES.map((v) => ({ value: v, label: v })),
 ];
 
 const HOOK_TYPES: {

--- a/packages/vscode/src/webview/src/constants/model-options.ts
+++ b/packages/vscode/src/webview/src/constants/model-options.ts
@@ -1,0 +1,15 @@
+/**
+ * Sub-Agent model dropdown options, derived from the core SSoT
+ * (`SUB_AGENT_MODEL_VALUES` in @cc-wf-studio/core).
+ *
+ * Labels are intentionally NOT localized — model names are product terms
+ * and stay in English across all UI languages.
+ */
+
+import { SUB_AGENT_MODEL_VALUES, type SubAgentModel } from '@cc-wf-studio/core';
+
+export const SUB_AGENT_MODEL_OPTIONS: { value: SubAgentModel; label: string }[] =
+  SUB_AGENT_MODEL_VALUES.map((v) => ({
+    value: v,
+    label: v.charAt(0).toUpperCase() + v.slice(1),
+  }));


### PR DESCRIPTION
## Summary

The sub-agent node's Claude Code model dropdown was missing `fable` (the Claude Fable 5 alias). Investigation showed the model option list `'sonnet' | 'opus' | 'haiku' | 'inherit'` was hardcoded independently in TS union types, the zod schema, the JSON schema resource, and three webview dropdowns.

This PR adds `fable` and refactors so the zod schema module in core is the single source of truth for model values.

## Changes

### core
- `schema/sub-agent-schema.ts` now exports `SUB_AGENT_MODEL_VALUES` (`['sonnet', 'opus', 'haiku', 'fable', 'inherit']`), the derived `SubAgentModel` type, and `CC_ONLY_MODELS` (`['haiku', 'fable']`), following the existing `SUB_AGENT_COLOR_VALUES` / `EXPORT_TARGETS` pattern. The zod enum and the field's `options` metadata reference the same constant.
- `SubAgentData.model`, the SubAgentFlow node `model`, `SlashCommandModel` (`'default' | SubAgentModel`), and the built-in preset type are all derived from `SubAgentModel`.
- `agent-skill-export.ts` and `workflow-prompt-generator.ts`: the CC-only model omission for non-Claude-Code providers (previously a hardcoded `=== 'haiku'` check in two places) now uses `CC_ONLY_MODELS`, so `fable` is omitted for Cursor etc. as well.
- `validate-workflow.ts`: added a `SUBAGENT_INVALID_MODEL` enum check (model was previously not validated at all, unlike `memory` / `builtInType` / `commandScope`).
- `resources/workflow-schema.json`: added `"fable"` to the sub-agent model enum. The `.toon` and the vscode resource copies are regenerated/synced by the build.

### vscode / webview
- New `webview/src/constants/model-options.ts` derives dropdown options from `SUB_AGENT_MODEL_VALUES` (labels stay in English per the translation rules).
- `SubAgentFormDialog`, `PropertyOverlay` (SubAgentFlow), and `SlashCommandOptionsDropdown` now map over the shared constant instead of inline arrays. Note: the slash command model dropdown order changes from `default, inherit, haiku, sonnet, opus` to `default, sonnet, opus, haiku, fable, inherit`.
- Frontmatter-parsing casts in `NodePalette` / `SubAgentCreationDialog` and `CreateSubAgentPayload.model` use `SubAgentModel`.

## Testing

- `tsc --noEmit` passes for core / mcp / cli; webview builds with `tsc && vite build`; full `pnpm build` succeeds and the regenerated schema resources contain `fable`.
- Manual E2E in the Extension Development Host: Fable appears in all three model dropdowns, exporting with Fable writes `model: fable` to the agent frontmatter, and non-Claude-Code provider exports omit the model line.
- Note: `pnpm check` currently fails on `main` due to unrelated untracked local files; the files touched here are lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Claude Fable 5 as an available model for sub-agents and slash commands.
  - Updated model selectors and workflow configuration to display and accept the new option.
  - Added validation to detect unsupported model selections.

- **Compatibility**
  - Claude Code–only models are automatically excluded when workflows target other providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->