### PR TITLE
feat: schema validation wiring + drift guards (Phase 4)

### DIFF
--- a/.changeset/mcp-port-auto-fallback.md
+++ b/.changeset/mcp-port-auto-fallback.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+MCP server: when the configured port is already in use (another VS Code window, a stale process), automatically fall back to an OS-assigned free port instead of failing AI agent launch. The setting cc-wf-studio.mcp.port now acts as a preferred port; an info toast reports the fallback.

--- a/.changeset/schema-driven-property-panel-phase4.md
+++ b/.changeset/schema-driven-property-panel-phase4.md
@@ -1,0 +1,6 @@
+---
+'@cc-wf-studio/core': minor
+'cc-wf-studio': patch
+---
+
+Schema-driven property panel phase 4: wire registry-driven zod validation into validateAIGeneratedWorkflow (present fields only; visibleWhen-inactive fields skipped), remove the seven hand-written enum checks it supersedes, add compile-time schema↔interface drift guards to all node schemas, and deprecate validateSubAgentData.

--- a/packages/core/src/schema/field.ts
+++ b/packages/core/src/schema/field.ts
@@ -101,6 +101,14 @@ export function appliesToTarget(meta: FieldMeta, target: ExportTarget): boolean 
 }
 
 /**
+ * Compile-time assertion that `T` is assignable to `U`. Each node schema
+ * declares drift guards with this so a schema whose field names or value
+ * types diverge from the node's public interface fails `tsc` instead of
+ * surfacing at runtime (e.g. a mistyped enum value).
+ */
+export type AssertAssignable<T extends U, U> = T;
+
+/**
  * Min/max item counts of a zod array type, read from its checks so the UI
  * never duplicates bounds the validator already declares. `length(n)` yields
  * `min === max === n` (the UI hides add/remove entirely).

--- a/packages/core/src/schema/node-schema-registry.ts
+++ b/packages/core/src/schema/node-schema-registry.ts
@@ -3,8 +3,10 @@
  *
  * Maps node types to their schema-driven property definitions under
  * `./nodes/`. Consumed by the webview property panel (rendering), export
- * warning derivation, and (later) the workflow validator, so all three read
- * the same single definition per node.
+ * warning derivation (warnings.ts), and the workflow validator
+ * (validate-workflow.ts: present fields are checked against their zod types;
+ * fields whose `visibleWhen` fails are skipped as inactive), so all three
+ * read the same single definition per node.
  *
  * Adding a field to a node type = edit its `nodes/<type>-schema.ts` + add the
  * `<nodeType>.field.<name>` label to the five webview locale files. If AI

--- a/packages/core/src/schema/nodes/ask-user-question-schema.ts
+++ b/packages/core/src/schema/nodes/ask-user-question-schema.ts
@@ -12,7 +12,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { AskUserQuestionData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 const questionOptionZod = z.object({
   id: z.string().optional(),
@@ -84,3 +85,9 @@ export function deriveAskUserQuestionUpdate(
   }
   return patch;
 }
+
+// Compile-time drift guards: schema field names must exist on AskUserQuestionData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type AskUserQuestionSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof askUserQuestionZodObject>, keyof AskUserQuestionData>;
+export type AskUserQuestionSchemaValueTypesGuard = AssertAssignable<z.infer<typeof askUserQuestionZodObject>, Partial<AskUserQuestionData>>;

--- a/packages/core/src/schema/nodes/branch-schema.ts
+++ b/packages/core/src/schema/nodes/branch-schema.ts
@@ -7,7 +7,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { BranchNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 const branchConditionZod = z.object({
   id: z.string().optional(),
@@ -69,3 +70,9 @@ export function deriveBranchUpdate(
   }
   return patch;
 }
+
+// Compile-time drift guards: schema field names must exist on BranchNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type BranchSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof branchZodObject>, keyof BranchNodeData>;
+export type BranchSchemaValueTypesGuard = AssertAssignable<z.infer<typeof branchZodObject>, Partial<BranchNodeData>>;

--- a/packages/core/src/schema/nodes/branch-session-schema.ts
+++ b/packages/core/src/schema/nodes/branch-session-schema.ts
@@ -7,7 +7,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { BranchSessionNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 export const branchSessionPropertySchema = {
   label: field(z.string(), {
@@ -30,3 +31,9 @@ export type BranchSessionPropertySchema = typeof branchSessionPropertySchema;
 
 /** zod object validator derived from {@link branchSessionPropertySchema}. */
 export const branchSessionZodObject = toZodObject(branchSessionPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on BranchSessionNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type BranchSessionSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof branchSessionZodObject>, keyof BranchSessionNodeData>;
+export type BranchSessionSchemaValueTypesGuard = AssertAssignable<z.infer<typeof branchSessionZodObject>, Partial<BranchSessionNodeData>>;

--- a/packages/core/src/schema/nodes/codex-schema.ts
+++ b/packages/core/src/schema/nodes/codex-schema.ts
@@ -12,7 +12,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { CodexNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 /** Predefined Codex model choices; the UI select also allows a custom name. */
 export const CODEX_PREDEFINED_MODELS = [
@@ -73,3 +74,9 @@ export type CodexPropertySchema = typeof codexPropertySchema;
 
 /** zod object validator derived from {@link codexPropertySchema}. */
 export const codexZodObject = toZodObject(codexPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on CodexNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type CodexSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof codexZodObject>, keyof CodexNodeData>;
+export type CodexSchemaValueTypesGuard = AssertAssignable<z.infer<typeof codexZodObject>, Partial<CodexNodeData>>;

--- a/packages/core/src/schema/nodes/group-schema.ts
+++ b/packages/core/src/schema/nodes/group-schema.ts
@@ -6,7 +6,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { GroupNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 export const groupPropertySchema = {
   label: field(z.string(), {
@@ -21,3 +22,9 @@ export type GroupPropertySchema = typeof groupPropertySchema;
 
 /** zod object validator derived from {@link groupPropertySchema}. */
 export const groupZodObject = toZodObject(groupPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on GroupNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type GroupSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof groupZodObject>, keyof GroupNodeData>;
+export type GroupSchemaValueTypesGuard = AssertAssignable<z.infer<typeof groupZodObject>, Partial<GroupNodeData>>;

--- a/packages/core/src/schema/nodes/if-else-schema.ts
+++ b/packages/core/src/schema/nodes/if-else-schema.ts
@@ -7,7 +7,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { IfElseNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 const ifElseConditionZod = z.object({
   id: z.string().optional(),
@@ -59,3 +60,9 @@ export function deriveIfElseUpdate(
   }
   return patch;
 }
+
+// Compile-time drift guards: schema field names must exist on IfElseNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type IfElseSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof ifElseZodObject>, keyof IfElseNodeData>;
+export type IfElseSchemaValueTypesGuard = AssertAssignable<z.infer<typeof ifElseZodObject>, Partial<IfElseNodeData>>;

--- a/packages/core/src/schema/nodes/mcp-schema.ts
+++ b/packages/core/src/schema/nodes/mcp-schema.ts
@@ -10,7 +10,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { McpNodeData } from '../../types/mcp-node.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 export const MCP_NODE_MODES = [
   'manualParameterConfig',
@@ -90,3 +91,10 @@ export type McpPropertySchema = typeof mcpPropertySchema;
 
 /** zod object validator derived from {@link mcpPropertySchema}. */
 export const mcpZodObject = toZodObject(mcpPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on McpNodeData and
+// declared value types must stay assignable to the interface. Permissive
+// data-only fields (parameters, aiToolSelectionConfig, aiParameterConfig, parameterValues) are exempt — their zod types are
+// intentionally looser than the interface (custom-rendered, dialog-edited).
+export type McpSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof mcpZodObject>, keyof McpNodeData>;
+export type McpSchemaValueTypesGuard = AssertAssignable<Omit<z.infer<typeof mcpZodObject>, 'parameters' | 'aiToolSelectionConfig' | 'aiParameterConfig' | 'parameterValues'>, Partial<Omit<McpNodeData, 'parameters' | 'aiToolSelectionConfig' | 'aiParameterConfig' | 'parameterValues'>>>;

--- a/packages/core/src/schema/nodes/prompt-schema.ts
+++ b/packages/core/src/schema/nodes/prompt-schema.ts
@@ -8,7 +8,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { PromptNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 export const promptPropertySchema = {
   label: field(z.string().optional(), {
@@ -35,3 +36,9 @@ export type PromptPropertySchema = typeof promptPropertySchema;
 
 /** zod object validator derived from {@link promptPropertySchema}. */
 export const promptZodObject = toZodObject(promptPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on PromptNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type PromptSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof promptZodObject>, keyof PromptNodeData>;
+export type PromptSchemaValueTypesGuard = AssertAssignable<z.infer<typeof promptZodObject>, Partial<PromptNodeData>>;

--- a/packages/core/src/schema/nodes/skill-schema.ts
+++ b/packages/core/src/schema/nodes/skill-schema.ts
@@ -10,7 +10,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { SkillNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 export const skillPropertySchema = {
   name: field(z.string(), {
@@ -72,3 +73,9 @@ export type SkillPropertySchema = typeof skillPropertySchema;
 
 /** zod object validator derived from {@link skillPropertySchema}. */
 export const skillZodObject = toZodObject(skillPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on SkillNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type SkillSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof skillZodObject>, keyof SkillNodeData>;
+export type SkillSchemaValueTypesGuard = AssertAssignable<z.infer<typeof skillZodObject>, Partial<SkillNodeData>>;

--- a/packages/core/src/schema/nodes/sub-agent-flow-schema.ts
+++ b/packages/core/src/schema/nodes/sub-agent-flow-schema.ts
@@ -8,7 +8,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { SubAgentFlowNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 import { SUB_AGENT_MODEL_VALUES } from './sub-agent-schema.js';
 
 export const subAgentFlowPropertySchema = {
@@ -57,3 +58,9 @@ export type SubAgentFlowPropertySchema = typeof subAgentFlowPropertySchema;
 
 /** zod object validator derived from {@link subAgentFlowPropertySchema}. */
 export const subAgentFlowZodObject = toZodObject(subAgentFlowPropertySchema);
+
+// Compile-time drift guards: schema field names must exist on SubAgentFlowNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type SubAgentFlowSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof subAgentFlowZodObject>, keyof SubAgentFlowNodeData>;
+export type SubAgentFlowSchemaValueTypesGuard = AssertAssignable<z.infer<typeof subAgentFlowZodObject>, Partial<SubAgentFlowNodeData>>;

--- a/packages/core/src/schema/nodes/sub-agent-schema.ts
+++ b/packages/core/src/schema/nodes/sub-agent-schema.ts
@@ -14,7 +14,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { SubAgentData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 export const SUB_AGENT_MODEL_VALUES = ['sonnet', 'opus', 'haiku', 'fable', 'inherit'] as const;
 export type SubAgentModel = (typeof SUB_AGENT_MODEL_VALUES)[number];
@@ -102,3 +103,9 @@ export const subAgentZodObject = toZodObject(subAgentPropertySchema);
 
 /** Inferred shape of the validated SubAgent property set. */
 export type SubAgentSchemaShape = z.infer<typeof subAgentZodObject>;
+
+// Compile-time drift guards: schema field names must exist on SubAgentData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type SubAgentSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof subAgentZodObject>, keyof SubAgentData>;
+export type SubAgentSchemaValueTypesGuard = AssertAssignable<z.infer<typeof subAgentZodObject>, Partial<SubAgentData>>;

--- a/packages/core/src/schema/nodes/switch-schema.ts
+++ b/packages/core/src/schema/nodes/switch-schema.ts
@@ -9,7 +9,8 @@
  */
 
 import { z } from 'zod';
-import { field, type PropertyField, toZodObject } from '../field.js';
+import type { SwitchNodeData } from '../../types/workflow-definition.js';
+import { type AssertAssignable, field, type PropertyField, toZodObject } from '../field.js';
 
 const switchConditionZod = z.object({
   id: z.string().optional(),
@@ -71,3 +72,9 @@ export function deriveSwitchUpdate(
   }
   return patch;
 }
+
+// Compile-time drift guards: schema field names must exist on SwitchNodeData and
+// declared value types must stay assignable to the interface (optionality may
+// be looser in the schema; see each field's comment).
+export type SwitchSchemaFieldNamesGuard = AssertAssignable<keyof z.infer<typeof switchZodObject>, keyof SwitchNodeData>;
+export type SwitchSchemaValueTypesGuard = AssertAssignable<z.infer<typeof switchZodObject>, Partial<SwitchNodeData>>;

--- a/packages/core/src/schema/queries.ts
+++ b/packages/core/src/schema/queries.ts
@@ -86,8 +86,9 @@ export function clearFieldsNotAppliedToTarget(
   return cleared;
 }
 
-/** Thin `safeParse` wrapper over the SubAgent zod object. Not yet wired into
- *  the hand-written workflow validator (see plan's validation section). */
+/** @deprecated Schema validation is wired into `validateAIGeneratedWorkflow`
+ *  (registry-driven, per present field) — use that instead. Kept for API
+ *  stability. */
 export function validateSubAgentData(data: unknown): ReturnType<typeof subAgentZodObject.safeParse> {
   return subAgentZodObject.safeParse(data);
 }

--- a/packages/core/src/utils/validate-workflow.ts
+++ b/packages/core/src/utils/validate-workflow.ts
@@ -5,7 +5,7 @@
  * Based on: /specs/001-ai-workflow-generation/research.md Q3
  */
 
-import { SUB_AGENT_MODEL_VALUES } from '../schema/nodes/sub-agent-schema.js';
+import { NODE_PROPERTY_SCHEMAS } from '../schema/node-schema-registry.js';
 import {
   type Connection,
   type HookType,
@@ -222,6 +222,57 @@ function validateSubAgentFlowReferences(workflow: Workflow): ValidationError[] {
 }
 
 /**
+ * Validate a node's data fields against its registered property schema.
+ *
+ * Semantics (deliberately conservative — this pass prevents drift, it does
+ * not add new required-field rules):
+ * - Only fields PRESENT on the data are validated (`undefined` is skipped),
+ *   matching the legacy `if (x !== undefined)` enum checks and keeping old
+ *   workflow files loadable. Presence requirements stay with the hand-written
+ *   checks below.
+ * - Fields whose `visibleWhen` predicate fails are skipped as inactive: their
+ *   values are not consumed in the node's current state. This is also the
+ *   resolution of the AskUserQuestion tension (see ask-user-question-schema):
+ *   `options` bounds (min 2 / max 4) apply in manual mode only; AI-suggestions
+ *   mode legitimately keeps an empty array. `outputPorts` is not schema-
+ *   validated at all — the legacy-tolerated `outputPorts: 0` transient state
+ *   remains accepted.
+ */
+function validateNodeSchemaFields(node: WorkflowNode): ValidationError[] {
+  const schema = NODE_PROPERTY_SCHEMAS[node.type];
+  if (!schema) {
+    return [];
+  }
+  const data = node.data as unknown as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  for (const [name, propertyField] of Object.entries(schema)) {
+    const value = data[name];
+    if (value === undefined) {
+      continue;
+    }
+    if (propertyField.meta.visibleWhen && !propertyField.meta.visibleWhen(data)) {
+      continue;
+    }
+    const result = propertyField.zod.safeParse(value);
+    if (!result.success) {
+      const detail = result.error.issues
+        .map((issue) =>
+          issue.path.length > 0 ? `${issue.message} (at ${issue.path.join('.')})` : issue.message,
+        )
+        .join('; ');
+      errors.push({
+        code: 'NODE_SCHEMA_VIOLATION',
+        message: `${node.type} node field "${name}" is invalid: ${detail}`,
+        field: `nodes[${node.id}].data.${name}`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Validate all nodes in the workflow
  */
 function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
@@ -271,6 +322,11 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
         field: `nodes[${node.id}].position`,
       });
     }
+
+    // Structural field validation from the node property schema registry —
+    // the same zod definitions the property panel renders from, so the UI
+    // and this validator cannot drift apart.
+    errors.push(...validateNodeSchemaFields(node));
 
     // Validate Skill nodes (T026)
     if (node.type === NodeType.Skill) {
@@ -327,25 +383,16 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
     }
 
     // Validate SubAgent fields (Feature: 540-persistent-memory, 636-reference-model, 684-built-in-presets)
+    // builtInType/model/memory enum membership is covered by the schema pass
+    // (validateNodeSchemaFields); only checks the schema does not model remain.
     if (node.type === NodeType.SubAgent) {
       const subAgentData = node.data as {
-        model?: string;
-        memory?: string;
         commandFilePath?: string;
         commandScope?: string;
         builtInType?: string;
       };
-      // builtInType enum validation
+      // builtInType and commandFilePath/commandScope are mutually exclusive
       if (subAgentData.builtInType !== undefined) {
-        const validBuiltInTypes = ['general-purpose', 'explore', 'plan'];
-        if (!validBuiltInTypes.includes(subAgentData.builtInType)) {
-          errors.push({
-            code: 'SUBAGENT_INVALID_BUILT_IN_TYPE',
-            message: `SubAgent builtInType must be one of: ${validBuiltInTypes.join(', ')}`,
-            field: `nodes[${node.id}].data.builtInType`,
-          });
-        }
-        // builtInType and commandFilePath/commandScope are mutually exclusive
         if (subAgentData.commandFilePath) {
           errors.push({
             code: 'SUBAGENT_BUILTIN_COMMAND_FILE_CONFLICT',
@@ -361,27 +408,7 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
           });
         }
       }
-      if (
-        subAgentData.model !== undefined &&
-        !(SUB_AGENT_MODEL_VALUES as readonly string[]).includes(subAgentData.model)
-      ) {
-        errors.push({
-          code: 'SUBAGENT_INVALID_MODEL',
-          message: `SubAgent model must be one of: ${SUB_AGENT_MODEL_VALUES.join(', ')}`,
-          field: `nodes[${node.id}].data.model`,
-        });
-      }
-      if (subAgentData.memory !== undefined) {
-        const validMemoryScopes = ['user', 'project', 'local'];
-        if (!validMemoryScopes.includes(subAgentData.memory)) {
-          errors.push({
-            code: 'SUBAGENT_INVALID_MEMORY',
-            message: `SubAgent memory must be one of: ${validMemoryScopes.join(', ')}`,
-            field: `nodes[${node.id}].data.memory`,
-          });
-        }
-      }
-      // commandScope enum validation
+      // commandScope enum validation (commandScope is not in the property schema)
       if (subAgentData.commandScope !== undefined) {
         const validScopes = ['user', 'project'];
         if (!validScopes.includes(subAgentData.commandScope)) {
@@ -481,17 +508,7 @@ function validateSubAgentFlowNode(node: WorkflowNode): ValidationError[] {
     });
   }
 
-  // Memory enum validation
-  if (refData.memory !== undefined) {
-    const validMemoryScopes = ['user', 'project', 'local'];
-    if (!validMemoryScopes.includes(refData.memory)) {
-      errors.push({
-        code: 'SUBAGENTFLOW_INVALID_MEMORY',
-        message: `SubAgentFlow memory must be one of: ${validMemoryScopes.join(', ')}`,
-        field: `nodes[${node.id}].data.memory`,
-      });
-    }
-  }
+  // memory/model enum membership is covered by the schema pass.
 
   return errors;
 }
@@ -664,17 +681,7 @@ function validateSkillNode(node: WorkflowNode): ValidationError[] {
     });
   }
 
-  // Execution mode validation
-  if (skillData.executionMode !== undefined) {
-    const validModes = ['load', 'execute'];
-    if (!validModes.includes(skillData.executionMode)) {
-      errors.push({
-        code: 'SKILL_INVALID_EXECUTION_MODE',
-        message: `Skill executionMode must be one of: ${validModes.join(', ')}`,
-        field: `nodes[${node.id}].data.executionMode`,
-      });
-    }
-  }
+  // executionMode enum membership is covered by the schema pass.
 
   // Execution prompt length validation
   if (skillData.executionPrompt) {
@@ -796,17 +803,7 @@ function validateMcpNode(node: WorkflowNode): ValidationError[] {
     }
   }
 
-  // Validation status check
-  if (mcpData.validationStatus) {
-    const validStatuses = ['valid', 'missing', 'invalid'];
-    if (!validStatuses.includes(mcpData.validationStatus)) {
-      errors.push({
-        code: 'MCP_INVALID_STATUS',
-        message: `MCP validationStatus must be one of: ${validStatuses.join(', ')}`,
-        field: `nodes[${node.id}].data.validationStatus`,
-      });
-    }
-  }
+  // validationStatus enum membership is covered by the schema pass.
 
   // Output ports validation
   if (mcpData.outputPorts !== VALIDATION_RULES.MCP.OUTPUT_PORTS) {
@@ -924,12 +921,9 @@ function validateMcpNode(node: WorkflowNode): ValidationError[] {
       break;
 
     default:
-      // Unknown mode
-      errors.push({
-        code: 'MCP_INVALID_MODE',
-        message: `Invalid MCP mode: ${mode}. Must be one of: manualParameterConfig, aiParameterConfig, aiToolSelection`,
-        field: `nodes[${node.id}].data.mode`,
-      });
+      // Unknown mode: reported by the schema pass (mode enum); the
+      // mode-specific config checks above simply don't apply.
+      break;
   }
 
   return errors;

--- a/packages/core/src/utils/validate-workflow.ts
+++ b/packages/core/src/utils/validate-workflow.ts
@@ -323,6 +323,18 @@ function validateNodes(nodes: WorkflowNode[]): ValidationError[] {
       });
     }
 
+    // Every check below reads node.data properties; corrupted input (null,
+    // missing, or non-object data) must become a structured error, not a
+    // TypeError out of the validator.
+    if (typeof node.data !== 'object' || node.data === null || Array.isArray(node.data)) {
+      errors.push({
+        code: 'INVALID_NODE_DATA',
+        message: `Node "${node.id}" data must be an object`,
+        field: `nodes[${node.id}].data`,
+      });
+      continue;
+    }
+
     // Structural field validation from the node property schema registry —
     // the same zod definitions the property panel renders from, so the UI
     // and this validator cannot drift apart.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -95,7 +95,7 @@
           "default": 6282,
           "minimum": 1024,
           "maximum": 65535,
-          "description": "Port number for the built-in MCP server. Change only if the default port (6282) is already in use."
+          "description": "Preferred port for the built-in MCP server. If this port is already in use (e.g. by another VS Code window), the server automatically falls back to an OS-assigned free port."
         }
       }
     }

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -298,6 +298,14 @@ export function registerOpenEditorCommand(
             return vscode.workspace.getConfiguration('cc-wf-studio').get<number>('mcp.port', 6282);
           }
 
+          // Helper: toast shown when the preferred MCP port was taken and the
+          // server auto-fell back to an OS-assigned free port.
+          function notifyMcpPortFallback(preferredPort: number, actualPort: number): void {
+            vscode.window.showInformationMessage(
+              `cc-wf-studio: Port ${preferredPort} is in use (possibly by another window), so the MCP server started on port ${actualPort} instead.`
+            );
+          }
+
           // Helper: ensure MCP server is running and config written for Run operations
           async function ensureMcpServerForRun(
             provider: AiEditingProvider,
@@ -311,7 +319,11 @@ export function registerOpenEditorCommand(
             const previousPort = mcpManager.getPort();
             let serverPort = previousPort;
             if (!mcpManager.isRunning()) {
-              serverPort = await mcpManager.start(context.extensionPath, getConfiguredMcpPort());
+              serverPort = await mcpManager.start(
+                context.extensionPath,
+                getConfiguredMcpPort(),
+                notifyMcpPortFallback
+              );
             }
             const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
 
@@ -1720,7 +1732,8 @@ export function registerOpenEditorCommand(
 
                 const port = await startManager.start(
                   context.extensionPath,
-                  getConfiguredMcpPort()
+                  getConfiguredMcpPort(),
+                  notifyMcpPortFallback
                 );
                 const serverUrl = `http://127.0.0.1:${port}/mcp`;
 
@@ -1899,7 +1912,8 @@ export function registerOpenEditorCommand(
                 if (!launchManager.isRunning()) {
                   serverPort = await launchManager.start(
                     context.extensionPath,
-                    getConfiguredMcpPort()
+                    getConfiguredMcpPort(),
+                    notifyMcpPortFallback
                   );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
@@ -2027,7 +2041,8 @@ export function registerOpenEditorCommand(
                 if (!importManager.isRunning()) {
                   serverPort = await importManager.start(
                     context.extensionPath,
-                    getConfiguredMcpPort()
+                    getConfiguredMcpPort(),
+                    notifyMcpPortFallback
                   );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
@@ -2157,7 +2172,8 @@ export function registerOpenEditorCommand(
                 if (!tourManager.isRunning()) {
                   serverPort = await tourManager.start(
                     context.extensionPath,
-                    getConfiguredMcpPort()
+                    getConfiguredMcpPort(),
+                    notifyMcpPortFallback
                   );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;

--- a/packages/vscode/src/extension/services/mcp-server-service.ts
+++ b/packages/vscode/src/extension/services/mcp-server-service.ts
@@ -65,7 +65,11 @@ export class McpServerManager implements WorkflowIoAdapter {
   >();
   private pendingApplyRequests = new Map<string, PendingRequest<boolean>>();
 
-  async start(extensionPath: string, port?: number): Promise<number> {
+  async start(
+    extensionPath: string,
+    port?: number,
+    onPortFallback?: (preferredPort: number, actualPort: number) => void
+  ): Promise<number> {
     if (this.httpServer) {
       // Idempotent: a listening server is reused instead of erroring.
       if (this.httpServer.listening && this.port !== null) {
@@ -80,7 +84,31 @@ export class McpServerManager implements WorkflowIoAdapter {
 
     this.extensionPath = extensionPath;
 
-    this.httpServer = http.createServer(async (req, res) => {
+    const preferredPort = port ?? 0;
+    this.httpServer = this.buildHttpServer();
+    try {
+      return await this.listenOn(this.httpServer, preferredPort);
+    } catch (error) {
+      // Preferred port taken — common with multiple VS Code windows or a
+      // stale process. Retry once on an OS-assigned free port: callers derive
+      // the server URL and agent configs from the RETURNED port, so running
+      // on a different port is safe.
+      if (preferredPort === 0 || (error as NodeJS.ErrnoException).code !== 'EADDRINUSE') {
+        throw error;
+      }
+      log('WARN', 'MCP Server: Preferred port in use, falling back to an OS-assigned port', {
+        preferredPort,
+      });
+      this.httpServer = this.buildHttpServer();
+      const actualPort = await this.listenOn(this.httpServer, 0);
+      onPortFallback?.(preferredPort, actualPort);
+      return actualPort;
+    }
+  }
+
+  /** Build the HTTP server with the MCP request handler (not yet listening). */
+  private buildHttpServer(): http.Server {
+    return http.createServer(async (req, res) => {
       // DNS rebinding protection: validate Host header
       const host = (req.headers.host || '').split(':')[0];
       if (host !== '127.0.0.1' && host !== 'localhost') {
@@ -153,9 +181,10 @@ export class McpServerManager implements WorkflowIoAdapter {
         res.end(JSON.stringify({ error: 'Method not allowed' }));
       }
     });
+  }
 
-    const listenPort = port ?? 0;
-    const httpServer = this.httpServer;
+  /** Listen on `listenPort` (0 = OS-assigned); resolves with the actual port. */
+  private listenOn(httpServer: http.Server, listenPort: number): Promise<number> {
     return new Promise<number>((resolve, reject) => {
       // Failed startup must not leave a half-initialized server behind —
       // otherwise every later start() would wrongly see "already running".
@@ -183,7 +212,9 @@ export class McpServerManager implements WorkflowIoAdapter {
         if (error.code === 'EADDRINUSE') {
           const msg = `Port ${listenPort} is already in use. Change the port in Settings (cc-wf-studio.mcp.port) or close the application using port ${listenPort}.`;
           log('ERROR', 'MCP Server: Port in use', { port: listenPort });
-          rejectAndCleanup(new Error(msg));
+          // Preserve the errno code so start() can distinguish a port
+          // conflict (retryable on a free port) from other listen failures.
+          rejectAndCleanup(Object.assign(new Error(msg), { code: 'EADDRINUSE' }));
         } else {
           log('ERROR', 'MCP Server: HTTP server error', { error: error.message });
           rejectAndCleanup(error);

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -252,7 +252,6 @@ export interface WebviewTranslationKeys {
   'property.nodeName.placeholder': string;
   'property.nodeName.help': string;
   'property.select.custom': string;
-  'property.prompt': string;
 
   // Start/End node descriptions
   'property.startNodeDescription': string;
@@ -284,7 +283,6 @@ export interface WebviewTranslationKeys {
   'property.multiSelect.disabled': string;
   'property.aiSuggestions.enabled': string;
   'property.aiSuggestions.disabled': string;
-  'property.options': string;
   'property.remove': string;
   'property.optionLabel.placeholder': string;
   'property.optionDescription.placeholder': string;
@@ -296,7 +294,6 @@ export interface WebviewTranslationKeys {
   // Branch properties
   'property.branchType.conditional.help': string;
   'property.branchType.switch.help': string;
-  'property.branches': string;
   'property.branchLabel': string;
   'property.branchLabel.placeholder': string;
   'property.branchCondition': string;
@@ -606,18 +603,13 @@ export interface WebviewTranslationKeys {
   // MCP Property Panel
   'property.mcp.serverId': string;
   'property.mcp.toolName': string;
-  'property.mcp.toolDescription': string;
-  'property.mcp.parameters': string;
-  'property.mcp.parameterValues': string;
   'property.mcp.parameterCount': string;
-  'property.mcp.editParameters': string;
   'property.mcp.edit.manualParameterConfig': string;
   'property.mcp.edit.aiParameterConfig': string;
   'property.mcp.edit.aiToolSelection': string;
   'property.mcp.taskDescription': string;
   'property.mcp.parameterDescription': string;
   'property.mcp.configuredValues': string;
-  'property.mcp.infoNote': string;
 
   // MCP Parameter Form
   'mcp.parameter.formTitle': string;
@@ -867,9 +859,6 @@ export interface WebviewTranslationKeys {
   // Sub-Agent Form Dialog (Create New)
   'subAgent.form.title': string;
   'subAgent.form.description': string;
-  'subAgent.form.agentTypeLabel': string;
-  'subAgent.form.agentType.claudeCode': string;
-  'subAgent.form.agentType.other': string;
   // Schema-driven property panel field labels (skill/mcp/subAgentFlow)
   'skill.field.name': string;
   'skill.field.description': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -265,7 +265,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.nodeName.placeholder': 'Enter node name',
   'property.nodeName.help': 'Used for exported file name (e.g., "data-analysis")',
   'property.select.custom': 'Custom...',
-  'property.prompt': 'Prompt',
 
   // Start/End node descriptions
   'property.startNodeDescription':
@@ -302,7 +301,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'property.multiSelect.disabled': 'User selects one option (branches to corresponding node)',
   'property.aiSuggestions.enabled': 'AI will dynamically generate options based on context',
   'property.aiSuggestions.disabled': 'Manually define options below',
-  'property.options': 'Options',
   'property.remove': 'Remove',
   'property.optionLabel.placeholder': 'Label',
   'property.optionDescription.placeholder': 'Description',
@@ -314,7 +312,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Branch properties
   'property.branchType.conditional.help': '2 branches (True/False)',
   'property.branchType.switch.help': 'Multiple branches (2-N way)',
-  'property.branches': 'Branches',
   'property.branchLabel': 'Label',
   'property.branchLabel.placeholder': 'e.g., Success, Error',
   'property.branchCondition': 'Condition (natural language)',
@@ -661,19 +658,13 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // MCP Property Panel
   'property.mcp.serverId': 'Server',
   'property.mcp.toolName': 'Tool Name',
-  'property.mcp.toolDescription': 'Description',
-  'property.mcp.parameters': 'Parameters',
-  'property.mcp.parameterValues': 'Parameter Values',
   'property.mcp.parameterCount': 'Parameter Count',
-  'property.mcp.editParameters': 'Edit Parameters',
   'property.mcp.edit.manualParameterConfig': 'Edit Parameters',
   'property.mcp.edit.aiParameterConfig': 'Edit Parameter Content',
   'property.mcp.edit.aiToolSelection': 'Edit Task Content',
   'property.mcp.taskDescription': 'Task Content',
   'property.mcp.parameterDescription': 'Parameter Content',
   'property.mcp.configuredValues': 'Configured Values',
-  'property.mcp.infoNote':
-    'MCP tool properties are loaded from the server. Click "Edit Parameters" to configure parameter values.',
 
   // MCP Parameter Form
   'mcp.parameter.formTitle': 'Tool Parameters',
@@ -944,9 +935,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Sub-Agent Form Dialog (Create New)
   'subAgent.form.title': 'Create New Sub-Agent',
   'subAgent.form.description': 'Define a new Sub-Agent node with custom settings.',
-  'subAgent.form.agentTypeLabel': 'Agent Type',
-  'subAgent.form.agentType.claudeCode': 'Claude Code',
-  'subAgent.form.agentType.other': 'Other',
   'skill.field.name': 'Name',
   'skill.field.description': 'Description',
   'skill.field.skillPath': 'Skill Path',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -263,7 +263,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.nodeName.placeholder': 'ノード名を入力',
   'property.nodeName.help': 'エクスポート時のファイル名に使用されます（例: "data-analysis"）',
   'property.select.custom': 'カスタム...',
-  'property.prompt': 'プロンプト',
 
   // Start/End node descriptions
   'property.startNodeDescription':
@@ -300,7 +299,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'property.multiSelect.disabled': 'ユーザーは1つの選択肢を選択（対応するノードに分岐）',
   'property.aiSuggestions.enabled': 'AIが文脈に基づいて選択肢を動的に生成します',
   'property.aiSuggestions.disabled': '以下で選択肢を手動定義',
-  'property.options': '選択肢',
   'property.remove': '削除',
   'property.optionLabel.placeholder': 'ラベル',
   'property.optionDescription.placeholder': '説明',
@@ -312,7 +310,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Branch properties
   'property.branchType.conditional.help': '2つの分岐（True/False）',
   'property.branchType.switch.help': '複数の分岐（2-N分岐）',
-  'property.branches': '分岐',
   'property.branchLabel': 'ラベル',
   'property.branchLabel.placeholder': '例: 成功, エラー',
   'property.branchCondition': '条件（自然言語）',
@@ -658,19 +655,13 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // MCP Property Panel
   'property.mcp.serverId': 'サーバー',
   'property.mcp.toolName': 'ツール名',
-  'property.mcp.toolDescription': '説明',
-  'property.mcp.parameters': 'パラメータ',
-  'property.mcp.parameterValues': 'パラメータ値',
   'property.mcp.parameterCount': 'パラメータ数',
-  'property.mcp.editParameters': 'パラメータを編集',
   'property.mcp.edit.manualParameterConfig': 'パラメータを編集',
   'property.mcp.edit.aiParameterConfig': 'パラメータ内容を編集',
   'property.mcp.edit.aiToolSelection': 'タスク内容を編集',
   'property.mcp.taskDescription': 'タスク内容',
   'property.mcp.parameterDescription': 'パラメータ内容',
   'property.mcp.configuredValues': '設定値',
-  'property.mcp.infoNote':
-    'MCPツールのプロパティはサーバーから読み込まれます。「パラメータを編集」をクリックしてパラメータ値を設定してください。',
 
   // MCP Parameter Form
   'mcp.parameter.formTitle': 'ツールパラメータ',
@@ -938,9 +929,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Sub-Agent Form Dialog (Create New)
   'subAgent.form.title': '新しいSub-Agentを作成',
   'subAgent.form.description': 'カスタム設定で新しいSub-Agentノードを定義します。',
-  'subAgent.form.agentTypeLabel': 'エージェントタイプ',
-  'subAgent.form.agentType.claudeCode': 'Claude Code',
-  'subAgent.form.agentType.other': 'その他',
   'skill.field.name': '名前',
   'skill.field.description': '説明',
   'skill.field.skillPath': 'Skillパス',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -263,7 +263,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.nodeName.placeholder': '노드 이름 입력',
   'property.nodeName.help': '내보내기 파일 이름으로 사용됨 (예: "data-analysis")',
   'property.select.custom': '사용자 지정...',
-  'property.prompt': '프롬프트',
 
   // Start/End node descriptions
   'property.startNodeDescription':
@@ -300,7 +299,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'property.multiSelect.disabled': '사용자가 하나의 옵션을 선택 (해당 노드로 분기)',
   'property.aiSuggestions.enabled': 'AI가 컨텍스트를 기반으로 옵션을 동적으로 생성합니다',
   'property.aiSuggestions.disabled': '아래에서 옵션을 수동으로 정의',
-  'property.options': '옵션',
   'property.remove': '제거',
   'property.optionLabel.placeholder': '레이블',
   'property.optionDescription.placeholder': '설명',
@@ -312,7 +310,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Branch properties
   'property.branchType.conditional.help': '2개 분기 (True/False)',
   'property.branchType.switch.help': '다중 분기 (2-N 방향)',
-  'property.branches': '분기',
   'property.branchLabel': '레이블',
   'property.branchLabel.placeholder': '예: 성공, 오류',
   'property.branchCondition': '조건 (자연어)',
@@ -653,19 +650,13 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // MCP Property Panel
   'property.mcp.serverId': '서버',
   'property.mcp.toolName': '도구 이름',
-  'property.mcp.toolDescription': '설명',
-  'property.mcp.parameters': '매개변수',
-  'property.mcp.parameterValues': '매개변수 값',
   'property.mcp.parameterCount': '매개변수 개수',
-  'property.mcp.editParameters': '매개변수 편집',
   'property.mcp.edit.manualParameterConfig': '매개변수 편집',
   'property.mcp.edit.aiParameterConfig': '매개변수 내용 편집',
   'property.mcp.edit.aiToolSelection': '작업 내용 편집',
   'property.mcp.taskDescription': '작업 내용',
   'property.mcp.parameterDescription': '매개변수 내용',
   'property.mcp.configuredValues': '구성된 값',
-  'property.mcp.infoNote':
-    'MCP 도구 속성은 서버에서 로드됩니다. "매개변수 편집"을 클릭하여 매개변수 값을 구성하세요.',
 
   // MCP Parameter Form
   'mcp.parameter.formTitle': '도구 매개변수',
@@ -932,9 +923,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Sub-Agent Form Dialog (Create New)
   'subAgent.form.title': '새 Sub-Agent 만들기',
   'subAgent.form.description': '사용자 지정 설정으로 새 Sub-Agent 노드를 정의합니다.',
-  'subAgent.form.agentTypeLabel': '에이전트 유형',
-  'subAgent.form.agentType.claudeCode': 'Claude Code',
-  'subAgent.form.agentType.other': '기타',
   'skill.field.name': '이름',
   'skill.field.description': '설명',
   'skill.field.skillPath': 'Skill 경로',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -256,7 +256,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.nodeName.placeholder': '输入节点名称',
   'property.nodeName.help': '用于导出的文件名（例如："data-analysis"）',
   'property.select.custom': '自定义...',
-  'property.prompt': '提示',
 
   // Start/End node descriptions
   'property.startNodeDescription': 'Start节点标记工作流的开始。它不能被删除且没有可编辑的属性。',
@@ -290,7 +289,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'property.multiSelect.disabled': '用户选择一个选项（分支到相应节点）',
   'property.aiSuggestions.enabled': 'AI将根据上下文动态生成选项',
   'property.aiSuggestions.disabled': '在下方手动定义选项',
-  'property.options': '选项',
   'property.remove': '删除',
   'property.optionLabel.placeholder': '标签',
   'property.optionDescription.placeholder': '描述',
@@ -302,7 +300,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Branch properties
   'property.branchType.conditional.help': '2个分支（True/False）',
   'property.branchType.switch.help': '多个分支（2-N向）',
-  'property.branches': '分支',
   'property.branchLabel': '标签',
   'property.branchLabel.placeholder': '例如：成功，错误',
   'property.branchCondition': '条件（自然语言）',
@@ -631,18 +628,13 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // MCP Property Panel
   'property.mcp.serverId': '服务器',
   'property.mcp.toolName': '工具名称',
-  'property.mcp.toolDescription': '描述',
-  'property.mcp.parameters': '参数',
-  'property.mcp.parameterValues': '参数值',
   'property.mcp.parameterCount': '参数数量',
-  'property.mcp.editParameters': '编辑参数',
   'property.mcp.edit.manualParameterConfig': '编辑参数',
   'property.mcp.edit.aiParameterConfig': '编辑参数内容',
   'property.mcp.edit.aiToolSelection': '编辑任务内容',
   'property.mcp.taskDescription': '任务内容',
   'property.mcp.parameterDescription': '参数内容',
   'property.mcp.configuredValues': '配置值',
-  'property.mcp.infoNote': 'MCP工具属性从服务器加载。点击"编辑参数"以配置参数值。',
 
   // MCP Parameter Form
   'mcp.parameter.formTitle': '工具参数',
@@ -901,9 +893,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Sub-Agent Form Dialog (Create New)
   'subAgent.form.title': '创建新 Sub-Agent',
   'subAgent.form.description': '使用自定义设置定义新的 Sub-Agent 节点。',
-  'subAgent.form.agentTypeLabel': '代理类型',
-  'subAgent.form.agentType.claudeCode': 'Claude Code',
-  'subAgent.form.agentType.other': '其他',
   'skill.field.name': '名称',
   'skill.field.description': '描述',
   'skill.field.skillPath': 'Skill路径',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -257,7 +257,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.nodeName.placeholder': '輸入節點名稱',
   'property.nodeName.help': '用於匯出的檔案名稱（例如："data-analysis"）',
   'property.select.custom': '自訂...',
-  'property.prompt': '提示',
 
   // Start/End node descriptions
   'property.startNodeDescription': 'Start節點標記工作流的開始。它不能被刪除且沒有可編輯的屬性。',
@@ -291,7 +290,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'property.multiSelect.disabled': '使用者選擇一個選項（分支到相應節點）',
   'property.aiSuggestions.enabled': 'AI將根據上下文動態生成選項',
   'property.aiSuggestions.disabled': '在下方手動定義選項',
-  'property.options': '選項',
   'property.remove': '刪除',
   'property.optionLabel.placeholder': '標籤',
   'property.optionDescription.placeholder': '描述',
@@ -303,7 +301,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Branch properties
   'property.branchType.conditional.help': '2個分支（True/False）',
   'property.branchType.switch.help': '多個分支（2-N向）',
-  'property.branches': '分支',
   'property.branchLabel': '標籤',
   'property.branchLabel.placeholder': '例如：成功，錯誤',
   'property.branchCondition': '條件（自然語言）',
@@ -633,18 +630,13 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // MCP Property Panel
   'property.mcp.serverId': '伺服器',
   'property.mcp.toolName': '工具名稱',
-  'property.mcp.toolDescription': '描述',
-  'property.mcp.parameters': '參數',
-  'property.mcp.parameterValues': '參數值',
   'property.mcp.parameterCount': '參數數量',
-  'property.mcp.editParameters': '編輯參數',
   'property.mcp.edit.manualParameterConfig': '編輯參數',
   'property.mcp.edit.aiParameterConfig': '編輯參數內容',
   'property.mcp.edit.aiToolSelection': '編輯任務內容',
   'property.mcp.taskDescription': '任務內容',
   'property.mcp.parameterDescription': '參數內容',
   'property.mcp.configuredValues': '配置值',
-  'property.mcp.infoNote': 'MCP工具屬性從伺服器載入。點擊「編輯參數」以設定參數值。',
 
   // MCP Parameter Form
   'mcp.parameter.formTitle': '工具參數',
@@ -904,9 +896,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Sub-Agent Form Dialog (Create New)
   'subAgent.form.title': '建立新 Sub-Agent',
   'subAgent.form.description': '使用自訂設定定義新的 Sub-Agent 節點。',
-  'subAgent.form.agentTypeLabel': '代理類型',
-  'subAgent.form.agentType.claudeCode': 'Claude Code',
-  'subAgent.form.agentType.other': '其他',
   'skill.field.name': '名稱',
   'skill.field.description': '描述',
   'skill.field.skillPath': 'Skill路徑',


### PR DESCRIPTION
## Summary

Phase 4 (final) of the schema-driven node properties migration: the same zod definitions the property panel renders from now also validate workflow data, and compile-time guards lock the schemas to the TypeScript interfaces.

### Validation wiring (`validate-workflow.ts`)
- New `validateNodeSchemaFields`: for every node with a registered schema, each **present** data field is `safeParse`d against its zod type; failures surface as `NODE_SCHEMA_VIOLATION` with the zod message and a `nodes[<id>].data.<field>` pointer.
- **Deliberately conservative semantics** (drift prevention, not new required-field rules):
  - `undefined` fields are skipped — presence requirements stay with the existing hand-written checks, so legacy workflow files missing later-added fields keep loading.
  - Fields whose `visibleWhen` predicate fails are skipped as *inactive*.
- **Design decisions from the PR #818 review thread, resolved:**
  - AskUserQuestion `options` bounds (min 2 / max 4) apply in manual mode only; AI-suggestions mode legitimately keeps `options: []` (`visibleWhen` gate). Verdict: enforce-when-active.
  - `outputPorts` is not schema-validated; the legacy-tolerated `outputPorts: 0` transient state remains accepted. Verdict: keep tolerance (canvas port rendering doesn't consume it for AskUserQuestion).
- **7 hand-written enum checks deleted** as pure duplicates: `SUBAGENT_INVALID_BUILT_IN_TYPE` / `SUBAGENT_INVALID_MODEL` / `SUBAGENT_INVALID_MEMORY` / `SKILL_INVALID_EXECUTION_MODE` / `MCP_INVALID_STATUS` / `MCP_INVALID_MODE` / `SUBAGENTFLOW_INVALID_MEMORY` (their conditions are exactly "if present → enum member", which the schema pass covers; consumers only display codes, none branch on them). All presence, length, pattern, cross-field, and connection checks are untouched.

### Drift guards (all 12 `schema/nodes/*-schema.ts`)
- Two exported guard types per schema via the new `AssertAssignable<T extends U, U>` helper: field names must exist on the node interface, and schema value types must stay assignable to it. MCP's four intentionally-permissive data-only fields are exempted with a comment.
- Sanity-verified: re-introducing the Phase 3 `skill.source` enum typo (`'individual' | 'plugin'`) fails `tsc` with 3 errors.

### Cleanup
- `validateSubAgentData` marked `@deprecated` (superseded by the registry-driven pass).
- 11 i18n keys orphaned by the panel migration deleted. A broader sweep found ~130 pre-existing dead keys in unrelated areas (slack.*, refinement.*, sample.*, …) — left untouched as out of scope, noting some are likely dynamically constructed.
- Registry header comment updated with the validation semantics; the "adding a field" recipe was already there.

## Verification (already run)

- `pnpm check` / `pnpm build` green.
- **Zero false positives**: all 20 real workflow JSONs under `.vscode/workflows/` validate clean (the one failure is a `.tour.json` sidecar rejected by the pre-existing top-level checks).
- Negative tests: bad subAgent model, bad codex sandbox (codex previously had no validation at all), 3-branch ifElse, and 1-option manual-mode AskUserQuestion are all caught; empty options in AI-suggestions mode passes.

## Manual E2E checklist (Extension Development Host)

- [ ] AI edit (`apply_workflow`) with a valid workflow → applies as before
- [ ] AI edit with a corrupted node field (e.g. subAgent `model: "gpt-4"`) → rejected with a `NODE_SCHEMA_VIOLATION` message naming the field; no duplicate error for the same problem
- [ ] `ccwf validate` on an existing workflow file → passes; on a hand-corrupted file → reports the schema error
- [ ] Load/save/export of an existing workflow → unchanged
- [ ] Property panels unaffected (no rendering changes in this phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)