### PR TITLE
improvement: auto-fallback MCP port when preferred port is in use

### DIFF
--- a/.changeset/mcp-port-auto-fallback.md
+++ b/.changeset/mcp-port-auto-fallback.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+MCP server: when the configured port is already in use (another VS Code window, a stale process), automatically fall back to an OS-assigned free port instead of failing AI agent launch. The setting cc-wf-studio.mcp.port now acts as a preferred port; an info toast reports the fallback.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -95,7 +95,7 @@
           "default": 6282,
           "minimum": 1024,
           "maximum": 65535,
-          "description": "Port number for the built-in MCP server. Change only if the default port (6282) is already in use."
+          "description": "Preferred port for the built-in MCP server. If this port is already in use (e.g. by another VS Code window), the server automatically falls back to an OS-assigned free port."
         }
       }
     }

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -298,6 +298,14 @@ export function registerOpenEditorCommand(
             return vscode.workspace.getConfiguration('cc-wf-studio').get<number>('mcp.port', 6282);
           }
 
+          // Helper: toast shown when the preferred MCP port was taken and the
+          // server auto-fell back to an OS-assigned free port.
+          function notifyMcpPortFallback(preferredPort: number, actualPort: number): void {
+            vscode.window.showInformationMessage(
+              `cc-wf-studio: Port ${preferredPort} is in use (possibly by another window), so the MCP server started on port ${actualPort} instead.`
+            );
+          }
+
           // Helper: ensure MCP server is running and config written for Run operations
           async function ensureMcpServerForRun(
             provider: AiEditingProvider,
@@ -311,7 +319,11 @@ export function registerOpenEditorCommand(
             const previousPort = mcpManager.getPort();
             let serverPort = previousPort;
             if (!mcpManager.isRunning()) {
-              serverPort = await mcpManager.start(context.extensionPath, getConfiguredMcpPort());
+              serverPort = await mcpManager.start(
+                context.extensionPath,
+                getConfiguredMcpPort(),
+                notifyMcpPortFallback
+              );
             }
             const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
 
@@ -1720,7 +1732,8 @@ export function registerOpenEditorCommand(
 
                 const port = await startManager.start(
                   context.extensionPath,
-                  getConfiguredMcpPort()
+                  getConfiguredMcpPort(),
+                  notifyMcpPortFallback
                 );
                 const serverUrl = `http://127.0.0.1:${port}/mcp`;
 
@@ -1899,7 +1912,8 @@ export function registerOpenEditorCommand(
                 if (!launchManager.isRunning()) {
                   serverPort = await launchManager.start(
                     context.extensionPath,
-                    getConfiguredMcpPort()
+                    getConfiguredMcpPort(),
+                    notifyMcpPortFallback
                   );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
@@ -2027,7 +2041,8 @@ export function registerOpenEditorCommand(
                 if (!importManager.isRunning()) {
                   serverPort = await importManager.start(
                     context.extensionPath,
-                    getConfiguredMcpPort()
+                    getConfiguredMcpPort(),
+                    notifyMcpPortFallback
                   );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;
@@ -2157,7 +2172,8 @@ export function registerOpenEditorCommand(
                 if (!tourManager.isRunning()) {
                   serverPort = await tourManager.start(
                     context.extensionPath,
-                    getConfiguredMcpPort()
+                    getConfiguredMcpPort(),
+                    notifyMcpPortFallback
                   );
                 }
                 const serverUrl = `http://127.0.0.1:${serverPort}/mcp`;

--- a/packages/vscode/src/extension/services/mcp-server-service.ts
+++ b/packages/vscode/src/extension/services/mcp-server-service.ts
@@ -65,7 +65,11 @@ export class McpServerManager implements WorkflowIoAdapter {
   >();
   private pendingApplyRequests = new Map<string, PendingRequest<boolean>>();
 
-  async start(extensionPath: string, port?: number): Promise<number> {
+  async start(
+    extensionPath: string,
+    port?: number,
+    onPortFallback?: (preferredPort: number, actualPort: number) => void
+  ): Promise<number> {
     if (this.httpServer) {
       // Idempotent: a listening server is reused instead of erroring.
       if (this.httpServer.listening && this.port !== null) {
@@ -80,7 +84,31 @@ export class McpServerManager implements WorkflowIoAdapter {
 
     this.extensionPath = extensionPath;
 
-    this.httpServer = http.createServer(async (req, res) => {
+    const preferredPort = port ?? 0;
+    this.httpServer = this.buildHttpServer();
+    try {
+      return await this.listenOn(this.httpServer, preferredPort);
+    } catch (error) {
+      // Preferred port taken — common with multiple VS Code windows or a
+      // stale process. Retry once on an OS-assigned free port: callers derive
+      // the server URL and agent configs from the RETURNED port, so running
+      // on a different port is safe.
+      if (preferredPort === 0 || (error as NodeJS.ErrnoException).code !== 'EADDRINUSE') {
+        throw error;
+      }
+      log('WARN', 'MCP Server: Preferred port in use, falling back to an OS-assigned port', {
+        preferredPort,
+      });
+      this.httpServer = this.buildHttpServer();
+      const actualPort = await this.listenOn(this.httpServer, 0);
+      onPortFallback?.(preferredPort, actualPort);
+      return actualPort;
+    }
+  }
+
+  /** Build the HTTP server with the MCP request handler (not yet listening). */
+  private buildHttpServer(): http.Server {
+    return http.createServer(async (req, res) => {
       // DNS rebinding protection: validate Host header
       const host = (req.headers.host || '').split(':')[0];
       if (host !== '127.0.0.1' && host !== 'localhost') {
@@ -153,9 +181,10 @@ export class McpServerManager implements WorkflowIoAdapter {
         res.end(JSON.stringify({ error: 'Method not allowed' }));
       }
     });
+  }
 
-    const listenPort = port ?? 0;
-    const httpServer = this.httpServer;
+  /** Listen on `listenPort` (0 = OS-assigned); resolves with the actual port. */
+  private listenOn(httpServer: http.Server, listenPort: number): Promise<number> {
     return new Promise<number>((resolve, reject) => {
       // Failed startup must not leave a half-initialized server behind —
       // otherwise every later start() would wrongly see "already running".
@@ -183,7 +212,9 @@ export class McpServerManager implements WorkflowIoAdapter {
         if (error.code === 'EADDRINUSE') {
           const msg = `Port ${listenPort} is already in use. Change the port in Settings (cc-wf-studio.mcp.port) or close the application using port ${listenPort}.`;
           log('ERROR', 'MCP Server: Port in use', { port: listenPort });
-          rejectAndCleanup(new Error(msg));
+          // Preserve the errno code so start() can distinguish a port
+          // conflict (retryable on a free port) from other listen failures.
+          rejectAndCleanup(Object.assign(new Error(msg), { code: 'EADDRINUSE' }));
         } else {
           log('ERROR', 'MCP Server: HTTP server error', { error: error.message });
           rejectAndCleanup(error);


### PR DESCRIPTION
## Summary

Launching AI editing fails hard when the configured MCP port is already taken:

> Failed to launch AI agent: Port 6289 is already in use. Change the port in Settings (cc-wf-studio.mcp.port) or close the application using port 6289.

This is not just a stale-process problem — with a fixed port, **two VS Code windows can never both use AI editing**, so the conflict occurs in normal multi-window use.

### Change

`McpServerManager.start()` now retries once on an **OS-assigned free port (port 0)** when the preferred port raises `EADDRINUSE`. This is safe by construction: every caller already derives the server URL and rewrites agent configs from the port `start()` *returns* (the existing `checkPortMismatch` + config-rewrite machinery propagates a changed port), so nothing outside `start()` needed correctness changes.

- The fallback shows an info toast: "Port 6289 is in use (possibly by another window), so the MCP server started on port 51234 instead."
- `cc-wf-studio.mcp.port` is reworded as a **preferred** port (setting description updated).
- The hard error remains only for genuinely unrecoverable cases (non-`EADDRINUSE` listen failures, or `EADDRINUSE` on an OS-assigned port).
- Refactor: the request handler and listen promise are extracted into `buildHttpServer()` / `listenOn()` so the retry can rebuild a fresh server; the `EADDRINUSE` rejection now carries its errno `code` for the retry decision.

Deliberately NOT done: reusing an existing server from another window — the MCP server is bound to its window's canvas, so cross-window reuse would edit the wrong workflow. One window, one server, one port.

## Manual E2E checklist (Extension Development Host)

- [ ] With another process holding the configured port (e.g. a second VS Code window with AI editing active): launch AI editing → info toast appears, agent launches, `get_workflow` / `apply_workflow` work against the fallback port
- [ ] With the port free: server starts on the configured port as before, no toast
- [ ] Agent config files (.mcp.json etc.) contain the fallback port URL after a fallback launch
- [ ] Workflow Run / import / tour flows (the other `start()` call sites) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The built-in MCP server now automatically selects an available port if the preferred port is already in use.
  * An informational notification displays when a fallback port is selected.
  * MCP port configuration now clearly identifies the setting as a preferred port.

* **Bug Fixes**
  * AI agent launches and related workflows no longer fail when the configured MCP port is occupied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->