### PR TITLE
fix: address PR #823 review on panel types and a11y

### DIFF
--- a/packages/vscode/src/webview/src/components/property/SchemaPropertyPanel.tsx
+++ b/packages/vscode/src/webview/src/components/property/SchemaPropertyPanel.tsx
@@ -25,7 +25,7 @@ import type { NodePanelConfig } from './types';
 interface SchemaPropertyPanelProps {
   node: Node<Record<string, unknown>>;
   config: NodePanelConfig;
-  updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
+  updateNodeData: (nodeId: string, data: Record<string, unknown>) => void;
 }
 
 type RenderItem =

--- a/packages/vscode/src/webview/src/components/property/controls/ValidationStatusValue.tsx
+++ b/packages/vscode/src/webview/src/components/property/controls/ValidationStatusValue.tsx
@@ -22,7 +22,10 @@ export const ValidationStatusValue: React.FC<ControlProps> = ({ value }) => {
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px' }}>
-      <span style={{ fontSize: '16px', color: COLORS[status], fontWeight: 'bold' }}>
+      <span
+        aria-hidden="true"
+        style={{ fontSize: '16px', color: COLORS[status], fontWeight: 'bold' }}
+      >
         {ICONS[status]}
       </span>
       <span style={{ color: 'var(--vscode-foreground)' }}>

--- a/packages/vscode/src/webview/src/components/property/types.ts
+++ b/packages/vscode/src/webview/src/components/property/types.ts
@@ -30,7 +30,7 @@ export interface ControlProps {
 /** Props passed to a panel's Header/Footer slot components. */
 export interface PanelSlotProps {
   node: Node<Record<string, unknown>>;
-  updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
+  updateNodeData: (nodeId: string, data: Record<string, unknown>) => void;
 }
 
 /** Per-node-type configuration consumed by SchemaPropertyPanel. */


### PR DESCRIPTION
Addresses two accepted findings from the CodeRabbit review on #823 (review 4679428885):

- `Partial<unknown>` resolved to `{}` and gave `updateNodeData`'s data parameter no type constraint; panel-side signatures (`PanelSlotProps`, `SchemaPropertyPanelProps`) now use `Record<string, unknown>`. The store's own signature is untouched (pre-existing) and remains assignment-compatible.
- `ValidationStatusValue` icon span gets `aria-hidden="true"` so screen readers announce only the localized label, not the Unicode symbol.

Remaining findings from that review are declined or deferred with replies on #823 (duplicate-default zod refine already covered by `SWITCH_MULTIPLE_DEFAULT`; pre-existing hardcoded strings; submit-ordering robustness split into a separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)