### PR TITLE
feat(vscode): add agent terminal session visibility

### DIFF
--- a/.changeset/khaki-berries-tan.md
+++ b/.changeset/khaki-berries-tan.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": minor
+---
+
+Add live Codex and Claude Code terminal session visibility

--- a/packages/vscode/src/extension/commands/codex-handlers.ts
+++ b/packages/vscode/src/extension/commands/codex-handlers.ts
@@ -23,6 +23,7 @@ import {
   checkExistingCodexSkill,
   exportWorkflowAsCodexSkill,
 } from '../services/codex-skill-export-service';
+import { codexTerminalSessionManager } from '../services/codex-terminal-session-manager';
 import { extractMcpServerIdsFromWorkflow } from '../services/copilot-export-service';
 import type { FileService } from '../services/file-service';
 import {
@@ -269,11 +270,19 @@ export async function handleRunForCodexCli(
       syncedMcpServers = await syncMcpConfigForCodexCli(mcpServerIds, workspacePath);
     }
 
-    // Step 5: Execute in terminal
+    // Step 5: Keep the native interactive terminal UX and observe its local session transcript.
+    const sessionBaseline = codexTerminalSessionManager.snapshotSessionFiles();
     const terminalResult = executeCodexCliInTerminal({
       skillName: exportResult.skillName,
       workingDirectory: workspacePath,
     });
+    codexTerminalSessionManager.start(
+      workflow.name,
+      workspacePath,
+      sessionBaseline,
+      webview,
+      terminalResult.terminal
+    );
 
     // Send success response
     const successPayload: RunForCodexCliSuccessPayload = {

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -35,7 +35,9 @@ import {
   startAntigravityTask,
 } from '../services/antigravity-extension-service';
 import { cancelGeneration } from '../services/claude-code-service';
+import { codexTerminalSessionManager } from '../services/codex-terminal-session-manager';
 import { CommentarySessionManager } from '../services/commentary-session-manager';
+import { ExecutionSessionManager } from '../services/execution-session-manager';
 import { FileService } from '../services/file-service';
 import {
   checkPortMismatch,
@@ -120,6 +122,7 @@ let slackApiService: SlackApiService;
 let activeOAuthService: ReturnType<typeof createOAuthService> | null = null;
 let anthropicApiKeyManager: AnthropicApiKeyManager;
 let commentarySessionManager: CommentarySessionManager;
+let executionSessionManager: ExecutionSessionManager;
 let isCommentaryEnabled = false;
 let commentaryProvider: import('../../shared/types/messages').CommentaryProvider = 'claude-code';
 let commentaryCopilotModel: import('../../shared/types/messages').CopilotModel | undefined;
@@ -250,6 +253,7 @@ export function registerOpenEditorCommand(
 
       // Initialize Commentary Session Manager
       commentarySessionManager = new CommentarySessionManager();
+      executionSessionManager = new ExecutionSessionManager();
 
       // Create new webview panel
       currentPanel = vscode.window.createWebviewPanel(
@@ -541,7 +545,8 @@ export function registerOpenEditorCommand(
                   }
 
                   // Generate session ID for JSONL tracking (Commentary AI)
-                  const sessionId = isCommentaryEnabled ? crypto.randomUUID() : undefined;
+                  const runId = crypto.randomUUID();
+                  const sessionId = crypto.randomUUID();
 
                   // Run the slash command in terminal
                   const result = executeSlashCommandInTerminal({
@@ -549,6 +554,15 @@ export function registerOpenEditorCommand(
                     workingDirectory: workspacePath,
                     sessionId,
                   });
+
+                  executionSessionManager.start(
+                    runId,
+                    sessionId,
+                    message.payload.workflow.name,
+                    workspacePath,
+                    webview,
+                    result.terminal
+                  );
 
                   // Start Commentary AI if enabled
                   if (isCommentaryEnabled && sessionId) {
@@ -583,6 +597,7 @@ export function registerOpenEditorCommand(
                       terminalName: result.terminalName,
                       timestamp: new Date().toISOString(),
                       sessionId,
+                      runId,
                     },
                   });
                 } catch (error) {
@@ -2506,6 +2521,11 @@ export function registerOpenEditorCommand(
               break;
             }
 
+            case 'FOCUS_EXECUTION_TERMINAL': {
+              codexTerminalSessionManager.focus();
+              break;
+            }
+
             default:
               console.warn('Unknown message type:', message);
           }
@@ -2524,6 +2544,8 @@ export function registerOpenEditorCommand(
           }
           // Stop Commentary AI session
           commentarySessionManager?.dispose();
+          executionSessionManager?.dispose();
+          codexTerminalSessionManager.dispose();
 
           // Disconnect MCP server manager from webview
           const disposeManager = getMcpServerManager();

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -1878,11 +1878,38 @@ export function registerOpenEditorCommand(
                   if (!workspacePath) {
                     throw new Error('No workspace folder is open');
                   }
-                  await generateAndRunAiEditingSkill(
-                    aiEditPayload.provider as AiEditingProvider,
+                  const provider = aiEditPayload.provider as AiEditingProvider;
+                  const codexBaseline =
+                    provider === 'codex'
+                      ? codexTerminalSessionManager.snapshotSessionFiles()
+                      : new Set<string>();
+                  const launchResult = await generateAndRunAiEditingSkill(
+                    provider,
                     context.extensionPath,
                     workspacePath
                   );
+                  if (
+                    provider === 'claude-code' &&
+                    launchResult.terminal &&
+                    launchResult.sessionId
+                  ) {
+                    executionSessionManager.start(
+                      crypto.randomUUID(),
+                      launchResult.sessionId,
+                      'AI Edit',
+                      workspacePath,
+                      webview,
+                      launchResult.terminal
+                    );
+                  } else if (provider === 'codex' && launchResult.terminal) {
+                    codexTerminalSessionManager.start(
+                      'AI Edit',
+                      workspacePath,
+                      codexBaseline,
+                      webview,
+                      launchResult.terminal
+                    );
+                  }
                   webview.postMessage({
                     type: 'RUN_AI_EDITING_SKILL_SUCCESS',
                     requestId: message.requestId,
@@ -1981,11 +2008,34 @@ export function registerOpenEditorCommand(
                 });
 
                 // 4. Generate and run AI editing skill
-                await generateAndRunAiEditingSkill(
-                  launchPayload.provider as AiEditingProvider,
+                const provider = launchPayload.provider as AiEditingProvider;
+                const codexBaseline =
+                  provider === 'codex'
+                    ? codexTerminalSessionManager.snapshotSessionFiles()
+                    : new Set<string>();
+                const launchResult = await generateAndRunAiEditingSkill(
+                  provider,
                   context.extensionPath,
                   workspacePath
                 );
+                if (provider === 'claude-code' && launchResult.terminal && launchResult.sessionId) {
+                  executionSessionManager.start(
+                    crypto.randomUUID(),
+                    launchResult.sessionId,
+                    'AI Edit',
+                    workspacePath,
+                    webview,
+                    launchResult.terminal
+                  );
+                } else if (provider === 'codex' && launchResult.terminal) {
+                  codexTerminalSessionManager.start(
+                    'AI Edit',
+                    workspacePath,
+                    codexBaseline,
+                    webview,
+                    launchResult.terminal
+                  );
+                }
 
                 // For Antigravity, pause and let the user manually refresh MCP
                 if (launchPayload.provider === 'antigravity') {

--- a/packages/vscode/src/extension/commands/open-editor.ts
+++ b/packages/vscode/src/extension/commands/open-editor.ts
@@ -2522,7 +2522,8 @@ export function registerOpenEditorCommand(
             }
 
             case 'FOCUS_EXECUTION_TERMINAL': {
-              codexTerminalSessionManager.focus();
+              executionSessionManager.focus(message.payload.runId);
+              codexTerminalSessionManager.focus(message.payload.runId);
               break;
             }
 

--- a/packages/vscode/src/extension/services/ai-editing-skill-service.ts
+++ b/packages/vscode/src/extension/services/ai-editing-skill-service.ts
@@ -6,6 +6,7 @@
  * launches the provider to execute it.
  */
 
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
@@ -39,6 +40,11 @@ interface SkillSpec {
   templateFile: string;
   /** Prefix for the launch terminal name (e.g. 'AI Edit', 'Import Skill') */
   terminalLabel: string;
+}
+
+export interface SkillLaunchResult {
+  terminal?: vscode.Terminal;
+  sessionId?: string;
 }
 
 const AI_EDIT_SPEC: SkillSpec = {
@@ -114,18 +120,19 @@ async function launchProvider(
   provider: AiEditingProvider,
   workingDirectory: string,
   spec: SkillSpec
-): Promise<void> {
+): Promise<SkillLaunchResult> {
   const { skillName, terminalLabel } = spec;
   switch (provider) {
     case 'claude-code': {
+      const sessionId = crypto.randomUUID();
       const terminalName = `${terminalLabel}: Claude Code`;
       const terminal = vscode.window.createTerminal({
         name: terminalName,
         cwd: workingDirectory,
       });
       terminal.show(true);
-      terminal.sendText(`claude "/${skillName}"`);
-      break;
+      terminal.sendText(`claude "/${skillName}" --session-id "${sessionId}"`);
+      return { terminal, sessionId };
     }
 
     case 'copilot-cli': {
@@ -136,7 +143,7 @@ async function launchProvider(
       });
       terminal.show(true);
       terminal.sendText(`copilot -i ":skill ${skillName}" --allow-all-tools`);
-      break;
+      return { terminal };
     }
 
     case 'copilot-chat': {
@@ -156,7 +163,7 @@ async function launchProvider(
           throw new Error('GitHub Copilot Chat is not installed or not available.');
         }
       }
-      break;
+      return {};
     }
 
     case 'codex': {
@@ -167,7 +174,7 @@ async function launchProvider(
       });
       terminal.show(true);
       terminal.sendText(`codex "\\$${skillName}"`);
-      break;
+      return { terminal };
     }
 
     case 'roo-code': {
@@ -179,7 +186,7 @@ async function launchProvider(
           'Zoo Code extension is not installed. (The legacy Roo Code extension is also supported if installed.)'
         );
       }
-      break;
+      return {};
     }
 
     case 'gemini': {
@@ -190,7 +197,7 @@ async function launchProvider(
       });
       terminal.show(true);
       terminal.sendText(`gemini -i ":skill ${skillName}"`);
-      break;
+      return { terminal };
     }
 
     case 'antigravity': {
@@ -199,7 +206,7 @@ async function launchProvider(
       if (!isAntigravityInstalled()) {
         throw new Error('Antigravity extension is not installed.');
       }
-      break;
+      return {};
     }
 
     case 'cursor': {
@@ -212,7 +219,7 @@ async function launchProvider(
       } catch {
         throw new Error('Failed to launch Cursor agent.');
       }
-      break;
+      return {};
     }
   }
 }
@@ -226,7 +233,7 @@ async function generateAndRunSkill(
   extensionPath: string,
   workingDirectory: string,
   spec: SkillSpec
-): Promise<void> {
+): Promise<SkillLaunchResult> {
   log('INFO', 'Skill: generating and running', { provider, skill: spec.skillName });
 
   // 1. Load template
@@ -238,8 +245,9 @@ async function generateAndRunSkill(
   log('INFO', 'Skill: wrote skill file', { destPath });
 
   // 3. Launch provider
-  await launchProvider(provider, workingDirectory, spec);
+  const result = await launchProvider(provider, workingDirectory, spec);
   log('INFO', 'Skill: provider launched', { provider, skill: spec.skillName });
+  return result;
 }
 
 /**
@@ -249,8 +257,8 @@ export async function generateAndRunAiEditingSkill(
   provider: AiEditingProvider,
   extensionPath: string,
   workingDirectory: string
-): Promise<void> {
-  await generateAndRunSkill(provider, extensionPath, workingDirectory, AI_EDIT_SPEC);
+): Promise<SkillLaunchResult> {
+  return generateAndRunSkill(provider, extensionPath, workingDirectory, AI_EDIT_SPEC);
 }
 
 /**

--- a/packages/vscode/src/extension/services/codex-terminal-session-manager.ts
+++ b/packages/vscode/src/extension/services/codex-terminal-session-manager.ts
@@ -1,0 +1,205 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { ExecutionSessionPayload } from '../../shared/types/messages';
+
+type JsonObject = Record<string, unknown>;
+
+/** Links a workflow run card to Codex's terminal and observes turn lifecycle only. */
+export class CodexTerminalSessionManager {
+  private terminal: vscode.Terminal | null = null;
+  private terminalDisposable: vscode.Disposable | null = null;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private baseline = new Set<string>();
+  private workspacePath = '';
+  private sessionFile: string | null = null;
+  private byteOffset = 0;
+  private trailingLine = '';
+  private webview: vscode.Webview | null = null;
+  private state: ExecutionSessionPayload | null = null;
+
+  snapshotSessionFiles(): Set<string> {
+    return new Set(this.listSessionFiles());
+  }
+
+  start(
+    workflowName: string,
+    workspacePath: string,
+    baseline: Set<string>,
+    webview: vscode.Webview,
+    terminal: vscode.Terminal
+  ): string {
+    this.stop(false);
+    this.terminal = terminal;
+    this.workspacePath = workspacePath;
+    this.baseline = baseline;
+    this.webview = webview;
+    const runId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    this.state = {
+      runId,
+      sessionId: terminal.name,
+      workflowName,
+      provider: 'codex',
+      status: 'waiting',
+      startedAt: now,
+      updatedAt: now,
+    };
+    this.postUpdate();
+    this.interval = setInterval(() => this.poll(), 500);
+    this.terminalDisposable = vscode.window.onDidCloseTerminal((closedTerminal) => {
+      if (closedTerminal === terminal) this.stop(true);
+    });
+    return runId;
+  }
+
+  focus(): void {
+    this.terminal?.show(false);
+  }
+
+  stop(markEnded = true): void {
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+    this.terminalDisposable?.dispose();
+    this.terminalDisposable = null;
+    this.terminal = null;
+    this.sessionFile = null;
+    this.byteOffset = 0;
+    this.trailingLine = '';
+    if (markEnded && this.state) {
+      this.state = {
+        ...this.state,
+        status: 'ended',
+        updatedAt: new Date().toISOString(),
+      };
+      this.postUpdate();
+    }
+    if (!markEnded) this.state = null;
+  }
+
+  dispose(): void {
+    this.stop(false);
+    this.webview = null;
+  }
+
+  private poll(): void {
+    try {
+      if (!this.sessionFile) this.detectNewSession();
+      if (this.sessionFile) this.readNewEvents();
+    } catch {
+      // Codex creates and appends the transcript asynchronously.
+    }
+  }
+
+  private detectNewSession(): void {
+    const candidates = this.listSessionFiles()
+      .filter((file) => !this.baseline.has(file))
+      .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+    for (const candidate of candidates) {
+      const firstLine = this.readFirstLine(candidate);
+      if (!firstLine) continue;
+      const entry = JSON.parse(firstLine) as JsonObject;
+      const payload = entry.payload as JsonObject | undefined;
+      if (entry.type !== 'session_meta' || payload?.cwd !== this.workspacePath) continue;
+      this.sessionFile = candidate;
+      if (this.state) {
+        this.state = {
+          ...this.state,
+          sessionId: String(payload.id ?? path.basename(candidate, '.jsonl')),
+          updatedAt: new Date().toISOString(),
+        };
+        this.postUpdate();
+      }
+      return;
+    }
+  }
+
+  private listSessionFiles(): string[] {
+    const files: string[] = [];
+    for (const daysAgo of [0, 1]) {
+      const date = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+      const directory = path.join(
+        os.homedir(),
+        '.codex',
+        'sessions',
+        String(date.getFullYear()),
+        String(date.getMonth() + 1).padStart(2, '0'),
+        String(date.getDate()).padStart(2, '0')
+      );
+      if (!fs.existsSync(directory)) continue;
+      for (const name of fs.readdirSync(directory)) {
+        if (name.endsWith('.jsonl')) files.push(path.join(directory, name));
+      }
+    }
+    return files;
+  }
+
+  private readFirstLine(file: string): string | null {
+    const fd = fs.openSync(file, 'r');
+    const chunks: Buffer[] = [];
+    let position = 0;
+    try {
+      while (position < 1024 * 1024) {
+        const buffer = Buffer.alloc(4096);
+        const bytes = fs.readSync(fd, buffer, 0, buffer.length, position);
+        if (bytes === 0) break;
+        const chunk = buffer.subarray(0, bytes);
+        const newline = chunk.indexOf(10);
+        if (newline >= 0) {
+          chunks.push(chunk.subarray(0, newline));
+          return Buffer.concat(chunks).toString('utf8');
+        }
+        chunks.push(chunk);
+        position += bytes;
+      }
+      return null;
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  private readNewEvents(): void {
+    if (!this.sessionFile) return;
+    const stat = fs.statSync(this.sessionFile);
+    if (stat.size <= this.byteOffset) return;
+    const fd = fs.openSync(this.sessionFile, 'r');
+    const buffer = Buffer.alloc(stat.size - this.byteOffset);
+    try {
+      fs.readSync(fd, buffer, 0, buffer.length, this.byteOffset);
+    } finally {
+      fs.closeSync(fd);
+    }
+    this.byteOffset = stat.size;
+    const lines = (this.trailingLine + buffer.toString('utf8')).split('\n');
+    this.trailingLine = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line) as JsonObject;
+        const payload = entry.payload as JsonObject | undefined;
+        if (entry.type !== 'event_msg' || !payload) continue;
+        if (payload.type === 'task_started') this.updateStatus('running');
+        else if (payload.type === 'task_complete') this.updateStatus('waiting');
+        else if (payload.type === 'turn_aborted') this.updateStatus('failed');
+      } catch {
+        // Ignore unknown transcript entries.
+      }
+    }
+  }
+
+  private updateStatus(status: ExecutionSessionPayload['status']): void {
+    if (!this.state) return;
+    this.state = { ...this.state, status, updatedAt: new Date().toISOString() };
+    this.postUpdate();
+  }
+
+  private postUpdate(): void {
+    if (this.state) {
+      this.webview?.postMessage({ type: 'EXECUTION_SESSION_UPDATED', payload: this.state });
+    }
+  }
+}
+
+export const codexTerminalSessionManager = new CodexTerminalSessionManager();

--- a/packages/vscode/src/extension/services/codex-terminal-session-manager.ts
+++ b/packages/vscode/src/extension/services/codex-terminal-session-manager.ts
@@ -185,6 +185,9 @@ export class CodexTerminalSessionManager {
         if (payload.type === 'task_started') this.updateStatus('running');
         else if (payload.type === 'task_complete') this.updateStatus('waiting');
         else if (payload.type === 'turn_aborted') this.updateStatus('aborted');
+        else if (payload.type === 'agent_message' && typeof payload.message === 'string') {
+          this.updateLastActivity(payload.message);
+        }
       } catch {
         // Ignore unknown transcript entries.
       }
@@ -193,7 +196,24 @@ export class CodexTerminalSessionManager {
 
   private updateStatus(status: ExecutionSessionPayload['status']): void {
     if (!this.state) return;
-    this.state = { ...this.state, status, updatedAt: new Date().toISOString() };
+    this.state = {
+      ...this.state,
+      status,
+      updatedAt: new Date().toISOString(),
+      ...(status === 'running' ? { lastActivity: undefined } : {}),
+    };
+    this.postUpdate();
+  }
+
+  private updateLastActivity(message: string): void {
+    if (!this.state) return;
+    const summary = message.replace(/\s+/g, ' ').trim().slice(0, 160);
+    if (!summary) return;
+    this.state = {
+      ...this.state,
+      updatedAt: new Date().toISOString(),
+      lastActivity: { type: 'assistant', summary },
+    };
     this.postUpdate();
   }
 

--- a/packages/vscode/src/extension/services/codex-terminal-session-manager.ts
+++ b/packages/vscode/src/extension/services/codex-terminal-session-manager.ts
@@ -55,8 +55,10 @@ export class CodexTerminalSessionManager {
     return runId;
   }
 
-  focus(): void {
-    this.terminal?.show(false);
+  focus(runId: string): void {
+    if (this.state?.runId === runId && this.state.status !== 'ended') {
+      this.terminal?.show(false);
+    }
   }
 
   stop(markEnded = true): void {
@@ -182,7 +184,7 @@ export class CodexTerminalSessionManager {
         if (entry.type !== 'event_msg' || !payload) continue;
         if (payload.type === 'task_started') this.updateStatus('running');
         else if (payload.type === 'task_complete') this.updateStatus('waiting');
-        else if (payload.type === 'turn_aborted') this.updateStatus('failed');
+        else if (payload.type === 'turn_aborted') this.updateStatus('aborted');
       } catch {
         // Ignore unknown transcript entries.
       }

--- a/packages/vscode/src/extension/services/commentary-jsonl-watcher.ts
+++ b/packages/vscode/src/extension/services/commentary-jsonl-watcher.ts
@@ -21,6 +21,8 @@ export interface CommentaryEvent {
 }
 
 export type CommentaryEventCallback = (events: CommentaryEvent[]) => void;
+export type ClaudeTurnStatus = 'running' | 'waiting' | 'failed';
+export type ClaudeTurnStatusCallback = (status: ClaudeTurnStatus, timestamp: string) => void;
 
 /**
  * Resolve the JSONL file path for a given session ID.
@@ -61,18 +63,21 @@ export class CommentaryJsonlWatcher {
   private readonly sessionId: string;
   private readonly workspacePath: string;
   private readonly callback: CommentaryEventCallback;
+  private readonly statusCallback?: ClaudeTurnStatusCallback;
   private readonly pollIntervalMs: number;
 
   constructor(
     sessionId: string,
     workspacePath: string,
     callback: CommentaryEventCallback,
-    pollIntervalMs = 500
+    pollIntervalMs = 500,
+    statusCallback?: ClaudeTurnStatusCallback
   ) {
     this.sessionId = sessionId;
     this.workspacePath = workspacePath;
     this.callback = callback;
     this.pollIntervalMs = pollIntervalMs;
+    this.statusCallback = statusCallback;
 
     log('INFO', 'CommentaryJsonlWatcher initialized', {
       sessionId,
@@ -141,6 +146,7 @@ export class CommentaryJsonlWatcher {
       for (const line of newLines) {
         try {
           const parsed = JSON.parse(line);
+          this.notifyTurnStatus(parsed);
           const event = this.filterEvent(parsed);
           if (event) events.push(event);
         } catch {
@@ -160,6 +166,23 @@ export class CommentaryJsonlWatcher {
       log('DEBUG', 'CommentaryJsonlWatcher poll error', {
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  /** Observe Claude's own transcript lifecycle without relying on user-configured hooks. */
+  private notifyTurnStatus(entry: Record<string, unknown>): void {
+    if (!this.statusCallback) return;
+    const type = entry.type;
+    const subtype = entry.subtype;
+    const timestamp =
+      typeof entry.timestamp === 'string' ? entry.timestamp : new Date().toISOString();
+
+    if (type === 'user') {
+      this.statusCallback('running', timestamp);
+    } else if (type === 'system' && subtype === 'turn_duration') {
+      this.statusCallback('waiting', timestamp);
+    } else if (type === 'error') {
+      this.statusCallback('failed', timestamp);
     }
   }
 

--- a/packages/vscode/src/extension/services/execution-session-manager.ts
+++ b/packages/vscode/src/extension/services/execution-session-manager.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+import type { ExecutionSessionPayload } from '../../shared/types/messages';
+import { CommentaryJsonlWatcher } from './commentary-jsonl-watcher';
+
+/**
+ * Minimal execution-observability PoC.
+ *
+ * Claude Code is launched with a known session id. Its local JSONL transcript
+ * supplies activity while VS Code terminal lifecycle supplies the coarse run
+ * lifecycle. This intentionally does not claim node-level completion.
+ */
+export class ExecutionSessionManager {
+  private watcher: CommentaryJsonlWatcher | null = null;
+  private terminalDisposable: vscode.Disposable | null = null;
+  private session: ExecutionSessionPayload | null = null;
+  private webview: vscode.Webview | null = null;
+
+  start(
+    runId: string,
+    sessionId: string,
+    workflowName: string,
+    workspacePath: string,
+    webview: vscode.Webview,
+    terminal: vscode.Terminal
+  ): void {
+    this.stop(false);
+    this.webview = webview;
+    const now = new Date().toISOString();
+    this.session = {
+      runId,
+      sessionId,
+      workflowName,
+      status: 'running',
+      startedAt: now,
+      updatedAt: now,
+    };
+    this.postUpdate();
+
+    this.watcher = new CommentaryJsonlWatcher(sessionId, workspacePath, (events) => {
+      const latest = events.at(-1);
+      if (!latest || !this.session) return;
+      this.session = {
+        ...this.session,
+        updatedAt: latest.timestamp,
+        lastActivity: {
+          type: latest.type,
+          summary: latest.content.replace(/\s+/g, ' ').slice(0, 160),
+        },
+      };
+      this.postUpdate();
+    });
+    this.watcher.start();
+
+    this.terminalDisposable = vscode.window.onDidCloseTerminal((closedTerminal) => {
+      if (closedTerminal === terminal) this.stop(true);
+    });
+  }
+
+  stop(markEnded = true): void {
+    this.watcher?.stop();
+    this.watcher = null;
+    this.terminalDisposable?.dispose();
+    this.terminalDisposable = null;
+    if (markEnded && this.session) {
+      this.session = {
+        ...this.session,
+        status: 'ended',
+        updatedAt: new Date().toISOString(),
+      };
+      this.postUpdate();
+    }
+    if (!markEnded) this.session = null;
+  }
+
+  dispose(): void {
+    this.stop(false);
+    this.webview = null;
+  }
+
+  private postUpdate(): void {
+    if (this.session) {
+      this.webview?.postMessage({ type: 'EXECUTION_SESSION_UPDATED', payload: this.session });
+    }
+  }
+}

--- a/packages/vscode/src/extension/services/execution-session-manager.ts
+++ b/packages/vscode/src/extension/services/execution-session-manager.ts
@@ -58,7 +58,12 @@ export class ExecutionSessionManager {
       500,
       (status, timestamp) => {
         if (!this.session || this.session.status === 'ended') return;
-        this.session = { ...this.session, status, updatedAt: timestamp };
+        this.session = {
+          ...this.session,
+          status,
+          updatedAt: timestamp,
+          ...(status === 'running' ? { lastActivity: undefined } : {}),
+        };
         this.postUpdate();
       }
     );

--- a/packages/vscode/src/extension/services/execution-session-manager.ts
+++ b/packages/vscode/src/extension/services/execution-session-manager.ts
@@ -14,6 +14,7 @@ export class ExecutionSessionManager {
   private terminalDisposable: vscode.Disposable | null = null;
   private session: ExecutionSessionPayload | null = null;
   private webview: vscode.Webview | null = null;
+  private terminal: vscode.Terminal | null = null;
 
   start(
     runId: string,
@@ -25,35 +26,53 @@ export class ExecutionSessionManager {
   ): void {
     this.stop(false);
     this.webview = webview;
+    this.terminal = terminal;
     const now = new Date().toISOString();
     this.session = {
       runId,
       sessionId,
       workflowName,
+      provider: 'claude-code',
       status: 'running',
       startedAt: now,
       updatedAt: now,
     };
     this.postUpdate();
 
-    this.watcher = new CommentaryJsonlWatcher(sessionId, workspacePath, (events) => {
-      const latest = events.at(-1);
-      if (!latest || !this.session) return;
-      this.session = {
-        ...this.session,
-        updatedAt: latest.timestamp,
-        lastActivity: {
-          type: latest.type,
-          summary: latest.content.replace(/\s+/g, ' ').slice(0, 160),
-        },
-      };
-      this.postUpdate();
-    });
+    this.watcher = new CommentaryJsonlWatcher(
+      sessionId,
+      workspacePath,
+      (events) => {
+        const latest = events.at(-1);
+        if (!latest || !this.session) return;
+        this.session = {
+          ...this.session,
+          updatedAt: latest.timestamp,
+          lastActivity: {
+            type: latest.type,
+            summary: latest.content.replace(/\s+/g, ' ').slice(0, 160),
+          },
+        };
+        this.postUpdate();
+      },
+      500,
+      (status, timestamp) => {
+        if (!this.session || this.session.status === 'ended') return;
+        this.session = { ...this.session, status, updatedAt: timestamp };
+        this.postUpdate();
+      }
+    );
     this.watcher.start();
 
     this.terminalDisposable = vscode.window.onDidCloseTerminal((closedTerminal) => {
       if (closedTerminal === terminal) this.stop(true);
     });
+  }
+
+  focus(runId: string): void {
+    if (this.session?.runId === runId && this.session.status !== 'ended') {
+      this.terminal?.show(false);
+    }
   }
 
   stop(markEnded = true): void {
@@ -69,6 +88,7 @@ export class ExecutionSessionManager {
       };
       this.postUpdate();
     }
+    this.terminal = null;
     if (!markEnded) this.session = null;
   }
 

--- a/packages/vscode/src/shared/types/messages.ts
+++ b/packages/vscode/src/shared/types/messages.ts
@@ -221,13 +221,18 @@ export interface ExecutionSessionPayload {
   sessionId: string;
   workflowName: string;
   provider?: 'claude-code' | 'codex';
-  status: 'running' | 'waiting' | 'ended' | 'failed';
+  status: 'running' | 'waiting' | 'ended' | 'failed' | 'aborted';
   startedAt: string;
   updatedAt: string;
   lastActivity?: {
     type: 'assistant' | 'tool_use' | 'error';
     summary: string;
   };
+}
+
+/** Identifies the execution session whose terminal should receive focus. */
+export interface FocusExecutionTerminalPayload {
+  runId: string;
 }
 
 // ============================================================================
@@ -2490,7 +2495,7 @@ export type WebviewMessage =
   | Message<ExportForCopilotCliPayload, 'EXPORT_FOR_COPILOT_CLI'>
   | Message<ExportForCodexCliPayload, 'EXPORT_FOR_CODEX_CLI'>
   | Message<RunForCodexCliPayload, 'RUN_FOR_CODEX_CLI'>
-  | Message<void, 'FOCUS_EXECUTION_TERMINAL'>
+  | Message<FocusExecutionTerminalPayload, 'FOCUS_EXECUTION_TERMINAL'>
   | Message<ExportForRooCodePayload, 'EXPORT_FOR_ROO_CODE'>
   | Message<RunForRooCodePayload, 'RUN_FOR_ROO_CODE'>
   | Message<ExportForGeminiCliPayload, 'EXPORT_FOR_GEMINI_CLI'>

--- a/packages/vscode/src/shared/types/messages.ts
+++ b/packages/vscode/src/shared/types/messages.ts
@@ -203,6 +203,8 @@ export interface RunAsSlashCommandPayload {
  * Run as slash command success payload
  */
 export interface RunAsSlashCommandSuccessPayload {
+  /** Correlates the launch with execution observability events. */
+  runId?: string;
   /** Workflow name that was run */
   workflowName: string;
   /** Terminal name where command is running */
@@ -211,6 +213,21 @@ export interface RunAsSlashCommandSuccessPayload {
   timestamp: string; // ISO 8601
   /** Session ID for JSONL tracking (Commentary AI) */
   sessionId?: string;
+}
+
+/** Live Claude Code session state used by the execution observability PoC. */
+export interface ExecutionSessionPayload {
+  runId: string;
+  sessionId: string;
+  workflowName: string;
+  provider?: 'claude-code' | 'codex';
+  status: 'running' | 'waiting' | 'ended' | 'failed';
+  startedAt: string;
+  updatedAt: string;
+  lastActivity?: {
+    type: 'assistant' | 'tool_use' | 'error';
+    summary: string;
+  };
 }
 
 // ============================================================================
@@ -1283,6 +1300,7 @@ export type ExtensionMessage =
   | Message<CommentarySessionPayload, 'COMMENTARY_SESSION_STARTED'>
   | Message<void, 'COMMENTARY_SESSION_ENDED'>
   | Message<CommentaryErrorPayload, 'COMMENTARY_ERROR'>
+  | Message<ExecutionSessionPayload, 'EXECUTION_SESSION_UPDATED'>
   | Message<SampleWorkflowListPayload, 'SAMPLE_WORKFLOW_LIST'>
   | Message<SampleWorkflowLoadedPayload, 'SAMPLE_WORKFLOW_LOADED'>
   | Message<SampleWorkflowPreviewLoadedPayload, 'SAMPLE_WORKFLOW_PREVIEW_LOADED'>;
@@ -2472,6 +2490,7 @@ export type WebviewMessage =
   | Message<ExportForCopilotCliPayload, 'EXPORT_FOR_COPILOT_CLI'>
   | Message<ExportForCodexCliPayload, 'EXPORT_FOR_CODEX_CLI'>
   | Message<RunForCodexCliPayload, 'RUN_FOR_CODEX_CLI'>
+  | Message<void, 'FOCUS_EXECUTION_TERMINAL'>
   | Message<ExportForRooCodePayload, 'EXPORT_FOR_ROO_CODE'>
   | Message<RunForRooCodePayload, 'RUN_FOR_ROO_CODE'>
   | Message<ExportForGeminiCliPayload, 'EXPORT_FOR_GEMINI_CLI'>

--- a/packages/vscode/src/webview/src/App.tsx
+++ b/packages/vscode/src/webview/src/App.tsx
@@ -10,6 +10,7 @@ import type {
   AntigravityMcpRefreshNeededPayload,
   ApplyWorkflowFromMcpPayload,
   ErrorPayload,
+  ExecutionSessionPayload,
   GetCurrentWorkflowRequestPayload,
   HighlightGroupNodePayload,
   ImportWorkflowFromSlackPayload,
@@ -38,6 +39,7 @@ import { SlackShareDialog } from './components/dialogs/SlackShareDialog';
 import { SubAgentFlowDialog } from './components/dialogs/SubAgentFlowDialog';
 import { WhatsNewDialog } from './components/dialogs/WhatsNewDialog';
 import { ErrorNotification } from './components/ErrorNotification';
+import { ExecutionSessionPanel } from './components/ExecutionSessionPanel';
 import { NodePalette } from './components/NodePalette';
 import { OverviewMode } from './components/overview/OverviewMode';
 import { PropertyOverlay } from './components/PropertyOverlay';
@@ -210,6 +212,7 @@ const App: React.FC = () => {
   const [overviewHasGitChanges, setOverviewHasGitChanges] = useState<boolean>(false);
 
   const [error, setError] = useState<ErrorPayload | null>(null);
+  const [executionSession, setExecutionSession] = useState<ExecutionSessionPayload | null>(null);
   const [runTour, setRunTour] = useState(false);
   const [tourKey, setTourKey] = useState(0); // Used to force Tour component remount
   const [isSlackShareDialogOpen, setIsSlackShareDialogOpen] = useState(false);
@@ -536,6 +539,8 @@ const App: React.FC = () => {
         if (payload.groupNodeId === null || useWorkflowStore.getState().isHighlightEnabled) {
           useWorkflowStore.getState().setHighlightedGroupNodeId(payload.groupNodeId);
         }
+      } else if (message.type === 'EXECUTION_SESSION_UPDATED') {
+        setExecutionSession(message.payload as ExecutionSessionPayload);
       } else if (message.type === 'ANTIGRAVITY_MCP_REFRESH_NEEDED') {
         const refreshPayload = message.payload as AntigravityMcpRefreshNeededPayload | undefined;
         setMcpRefreshSkillName(refreshPayload?.skillName || 'cc-workflow-ai-editor');
@@ -792,66 +797,72 @@ const App: React.FC = () => {
         </Collapsible.Root>
 
         {/* Center: Workflow Editor with processing overlay (Phase 3.10 - modified) */}
-        <div style={{ flex: 1, position: 'relative' }}>
-          <WorkflowEditor
-            isNodePaletteCollapsed={isNodePaletteCollapsed}
-            onExpandNodePalette={expandNodePalette}
-            showEmptyState={showEmptyState}
-            onOpenSample={() => setIsSampleDialogOpen(true)}
-            onDismissEmptyState={() => setEmptyStateDismissed(true)}
-            onLoadWorkflow={handleLoadWorkflowFromEmptyState}
-            extensionVersion={extensionVersion}
-            recentWorkflows={recentWorkflows}
-            onLoadRecent={(id) => {
-              vscode.postMessage({
-                type: 'LOAD_WORKFLOW',
-                payload: { workflowId: id },
-              });
-            }}
-            onVersionClick={() => setIsWhatsNewFromStartMenu(true)}
-          />
-          {/* Processing overlay for canvas area only (with message centered in canvas) */}
-          <ProcessingOverlay isVisible={isProcessing} message={t('refinement.processingOverlay')} />
-
-          {/* Property Overlay - overlay on canvas right side */}
-          {selectedNodeId && isPropertyOverlayOpen && (
-            <div
-              style={{
-                position: 'absolute',
-                top: 5,
-                right: 5,
-                bottom: 5,
-                zIndex: 10,
+        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+            <WorkflowEditor
+              isNodePaletteCollapsed={isNodePaletteCollapsed}
+              onExpandNodePalette={expandNodePalette}
+              showEmptyState={showEmptyState}
+              onOpenSample={() => setIsSampleDialogOpen(true)}
+              onDismissEmptyState={() => setEmptyStateDismissed(true)}
+              onLoadWorkflow={handleLoadWorkflowFromEmptyState}
+              extensionVersion={extensionVersion}
+              recentWorkflows={recentWorkflows}
+              onLoadRecent={(id) => {
+                vscode.postMessage({
+                  type: 'LOAD_WORKFLOW',
+                  payload: { workflowId: id },
+                });
               }}
-            >
-              <PropertyOverlay
-                onShowInOverview={(nodeId) => {
-                  // Snapshot the live canvas, switch to Overview mode and
-                  // ask InstructionsPanel to scroll to the matching section
-                  // (which in turn drives the Mermaid follow-mode pan).
-                  const live = serializeWorkflow(
-                    nodes,
-                    edges,
-                    workflowName || 'Untitled',
-                    workflowDescription || undefined,
-                    activeWorkflow?.conversationHistory,
-                    subAgentFlows,
-                    undefined,
-                    activeWorkflow?.tour
-                  );
-                  if (activeWorkflow?.id) {
-                    live.id = activeWorkflow.id;
-                  }
-                  setOverviewWorkflow(live);
-                  setOverviewIsHistoricalVersion(false);
-                  setOverviewHasGitChanges(false);
-                  setOverviewIsExternal(false);
-                  setOverviewFocusRequest({ nodeId, key: Date.now() });
-                  setMode('overview');
+              onVersionClick={() => setIsWhatsNewFromStartMenu(true)}
+            />
+            {/* Processing overlay for canvas area only (with message centered in canvas) */}
+            <ProcessingOverlay
+              isVisible={isProcessing}
+              message={t('refinement.processingOverlay')}
+            />
+
+            {/* Property Overlay - overlay on canvas right side */}
+            {selectedNodeId && isPropertyOverlayOpen && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 5,
+                  right: 5,
+                  bottom: 5,
+                  zIndex: 10,
                 }}
-              />
-            </div>
-          )}
+              >
+                <PropertyOverlay
+                  onShowInOverview={(nodeId) => {
+                    // Snapshot the live canvas, switch to Overview mode and
+                    // ask InstructionsPanel to scroll to the matching section
+                    // (which in turn drives the Mermaid follow-mode pan).
+                    const live = serializeWorkflow(
+                      nodes,
+                      edges,
+                      workflowName || 'Untitled',
+                      workflowDescription || undefined,
+                      activeWorkflow?.conversationHistory,
+                      subAgentFlows,
+                      undefined,
+                      activeWorkflow?.tour
+                    );
+                    if (activeWorkflow?.id) {
+                      live.id = activeWorkflow.id;
+                    }
+                    setOverviewWorkflow(live);
+                    setOverviewIsHistoricalVersion(false);
+                    setOverviewHasGitChanges(false);
+                    setOverviewIsExternal(false);
+                    setOverviewFocusRequest({ nodeId, key: Date.now() });
+                    setMode('overview');
+                  }}
+                />
+              </div>
+            )}
+          </div>
+          {executionSession && <ExecutionSessionPanel session={executionSession} />}
         </div>
 
         {/* Refinement Panel with Radix Collapsible for slide animation */}

--- a/packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx
+++ b/packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx
@@ -3,6 +3,7 @@ import { Activity, Terminal } from 'lucide-react';
 import type React from 'react';
 import { useTranslation } from '../i18n/i18n-context';
 import { vscode } from '../main';
+import { StyledTooltip } from './common/StyledTooltip';
 
 export const ExecutionSessionPanel: React.FC<{ session: ExecutionSessionPayload }> = ({
   session,
@@ -28,11 +29,28 @@ export const ExecutionSessionPanel: React.FC<{ session: ExecutionSessionPayload 
           : session.status === 'failed'
             ? t('executionSession.failed')
             : t('executionSession.ended');
+  const activityText =
+    session.lastActivity?.summary ??
+    (session.provider === 'codex'
+      ? t('executionSession.codexTerminal')
+      : t('executionSession.waiting'));
+  const activityLabel = (
+    <span
+      style={{
+        flex: '1 1 auto',
+        minWidth: 0,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {activityText}
+    </span>
+  );
   return (
     <div
       role={canFocusTerminal ? 'button' : undefined}
       tabIndex={canFocusTerminal ? 0 : undefined}
-      title={canFocusTerminal ? t('executionSession.focusTerminal') : undefined}
       onClick={focusTerminal}
       onKeyDown={(event) => {
         if (canFocusTerminal && (event.key === 'Enter' || event.key === ' ')) focusTerminal();
@@ -51,7 +69,15 @@ export const ExecutionSessionPanel: React.FC<{ session: ExecutionSessionPayload 
         flexShrink: 0,
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 600 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          fontWeight: 600,
+          flexShrink: 0,
+        }}
+      >
         <Activity size={14} />
         <span>{session.workflowName}</span>
         <span style={{ color: running ? '#89d185' : 'var(--vscode-descriptionForeground)' }}>
@@ -64,17 +90,21 @@ export const ExecutionSessionPanel: React.FC<{ session: ExecutionSessionPayload 
           alignItems: 'center',
           gap: 7,
           color: 'var(--vscode-descriptionForeground)',
+          flex: '1 1 auto',
+          minWidth: 0,
+          overflow: 'hidden',
         }}
       >
         <Terminal size={13} style={{ flexShrink: 0 }} />
-        <span>
-          {session.lastActivity?.summary ??
-            (session.provider === 'codex'
-              ? t('executionSession.codexTerminal')
-              : t('executionSession.waiting'))}
-        </span>
+        {session.lastActivity?.summary ? (
+          <StyledTooltip content={session.lastActivity.summary} side="top" delayDuration={150}>
+            {activityLabel}
+          </StyledTooltip>
+        ) : (
+          activityLabel
+        )}
       </div>
-      <div style={{ marginLeft: 'auto', opacity: 0.65, fontSize: 10 }}>
+      <div style={{ marginLeft: 'auto', flexShrink: 0, opacity: 0.65, fontSize: 10 }}>
         {t('executionSession.metadata', {
           sessionId: session.sessionId.slice(0, 8),
           time: new Date(session.updatedAt).toLocaleTimeString(),

--- a/packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx
+++ b/packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx
@@ -1,0 +1,78 @@
+import type { ExecutionSessionPayload } from '@shared/types/messages';
+import { Activity, Terminal } from 'lucide-react';
+import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
+import { vscode } from '../main';
+
+export const ExecutionSessionPanel: React.FC<{ session: ExecutionSessionPayload }> = ({
+  session,
+}) => {
+  const { t } = useTranslation();
+  const running = session.status === 'running';
+  const canFocusTerminal = session.provider === 'codex' && session.status !== 'ended';
+  const focusTerminal = () => {
+    if (canFocusTerminal) vscode.postMessage({ type: 'FOCUS_EXECUTION_TERMINAL' });
+  };
+  const statusLabel =
+    session.status === 'running'
+      ? t('executionSession.running')
+      : session.status === 'waiting'
+        ? t('executionSession.waitingForInput')
+        : session.status === 'failed'
+          ? t('executionSession.failed')
+          : t('executionSession.ended');
+  return (
+    <div
+      role={canFocusTerminal ? 'button' : undefined}
+      tabIndex={canFocusTerminal ? 0 : undefined}
+      title={canFocusTerminal ? t('executionSession.focusTerminal') : undefined}
+      onClick={focusTerminal}
+      onKeyDown={(event) => {
+        if (canFocusTerminal && (event.key === 'Enter' || event.key === ' ')) focusTerminal();
+      }}
+      style={{
+        minHeight: 36,
+        padding: '7px 12px',
+        borderTop: '1px solid var(--vscode-panel-border)',
+        background: 'var(--vscode-sideBar-background)',
+        color: 'var(--vscode-foreground)',
+        fontSize: 12,
+        cursor: canFocusTerminal ? 'pointer' : 'default',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        flexShrink: 0,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 600 }}>
+        <Activity size={14} />
+        <span>{session.workflowName}</span>
+        <span style={{ color: running ? '#89d185' : 'var(--vscode-descriptionForeground)' }}>
+          {running ? '●' : '○'} {statusLabel}
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          color: 'var(--vscode-descriptionForeground)',
+        }}
+      >
+        <Terminal size={13} style={{ flexShrink: 0 }} />
+        <span>
+          {session.lastActivity?.summary ??
+            (session.provider === 'codex'
+              ? t('executionSession.codexTerminal')
+              : t('executionSession.waiting'))}
+        </span>
+      </div>
+      <div style={{ marginLeft: 'auto', opacity: 0.65, fontSize: 10 }}>
+        {t('executionSession.metadata', {
+          sessionId: session.sessionId.slice(0, 8),
+          time: new Date(session.updatedAt).toLocaleTimeString(),
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx
+++ b/packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx
@@ -9,18 +9,25 @@ export const ExecutionSessionPanel: React.FC<{ session: ExecutionSessionPayload 
 }) => {
   const { t } = useTranslation();
   const running = session.status === 'running';
-  const canFocusTerminal = session.provider === 'codex' && session.status !== 'ended';
+  const canFocusTerminal = session.status !== 'ended';
   const focusTerminal = () => {
-    if (canFocusTerminal) vscode.postMessage({ type: 'FOCUS_EXECUTION_TERMINAL' });
+    if (canFocusTerminal) {
+      vscode.postMessage({
+        type: 'FOCUS_EXECUTION_TERMINAL',
+        payload: { runId: session.runId },
+      });
+    }
   };
   const statusLabel =
     session.status === 'running'
       ? t('executionSession.running')
       : session.status === 'waiting'
         ? t('executionSession.waitingForInput')
-        : session.status === 'failed'
-          ? t('executionSession.failed')
-          : t('executionSession.ended');
+        : session.status === 'aborted'
+          ? t('executionSession.aborted')
+          : session.status === 'failed'
+            ? t('executionSession.failed')
+            : t('executionSession.ended');
   return (
     <div
       role={canFocusTerminal ? 'button' : undefined}

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -1010,7 +1010,6 @@ export interface WebviewTranslationKeys {
   'executionSession.aborted': string;
   'executionSession.failed': string;
   'executionSession.codexTerminal': string;
-  'executionSession.focusTerminal': string;
 
   // Sample Workflows
   'toolbar.sampleWorkflows': string;

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -1007,6 +1007,7 @@ export interface WebviewTranslationKeys {
   'executionSession.waiting': string;
   'executionSession.metadata': string;
   'executionSession.waitingForInput': string;
+  'executionSession.aborted': string;
   'executionSession.failed': string;
   'executionSession.codexTerminal': string;
   'executionSession.focusTerminal': string;

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -1002,6 +1002,14 @@ export interface WebviewTranslationKeys {
   'commentary.waiting': string;
   'commentary.inactive': string;
   'commentary.providerSelect': string;
+  'executionSession.running': string;
+  'executionSession.ended': string;
+  'executionSession.waiting': string;
+  'executionSession.metadata': string;
+  'executionSession.waitingForInput': string;
+  'executionSession.failed': string;
+  'executionSession.codexTerminal': string;
+  'executionSession.focusTerminal': string;
 
   // Sample Workflows
   'toolbar.sampleWorkflows': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -1096,7 +1096,6 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.aborted': 'Cancelled',
   'executionSession.failed': 'Failed',
   'executionSession.codexTerminal': 'Interactive Codex terminal',
-  'executionSession.focusTerminal': 'Focus the Codex terminal',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': 'Sample Workflows',

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -1088,6 +1088,14 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'commentary.waiting': 'Waiting for agent activity...',
   'commentary.inactive': 'Run a workflow with Commentary enabled to see real-time commentary.',
   'commentary.providerSelect': 'Select Commentary AI provider',
+  'executionSession.running': 'Running',
+  'executionSession.ended': 'Ended',
+  'executionSession.waiting': 'Waiting for Claude Code activity…',
+  'executionSession.metadata': 'Session {{sessionId}} · updated {{time}}',
+  'executionSession.waitingForInput': 'Idle / awaiting input',
+  'executionSession.failed': 'Failed',
+  'executionSession.codexTerminal': 'Interactive Codex terminal',
+  'executionSession.focusTerminal': 'Focus the Codex terminal',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': 'Sample Workflows',

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -1093,6 +1093,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.waiting': 'Waiting for Claude Code activity…',
   'executionSession.metadata': 'Session {{sessionId}} · updated {{time}}',
   'executionSession.waitingForInput': 'Idle / awaiting input',
+  'executionSession.aborted': 'Cancelled',
   'executionSession.failed': 'Failed',
   'executionSession.codexTerminal': 'Interactive Codex terminal',
   'executionSession.focusTerminal': 'Focus the Codex terminal',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -1090,7 +1090,6 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.aborted': '中止',
   'executionSession.failed': '失敗',
   'executionSession.codexTerminal': 'Codex対話ターミナル',
-  'executionSession.focusTerminal': 'Codexターミナルへフォーカス',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': 'サンプルワークフロー',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -1082,6 +1082,14 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'commentary.inactive':
     'Commentary を有効にしてワークフローを実行すると、リアルタイム実況が表示されます。',
   'commentary.providerSelect': 'Commentary AI プロバイダーを選択',
+  'executionSession.running': '実行中',
+  'executionSession.ended': '終了',
+  'executionSession.waiting': 'Claude Code の活動を待機中…',
+  'executionSession.metadata': 'セッション {{sessionId}} · 更新 {{time}}',
+  'executionSession.waitingForInput': '停止中・入力待ち',
+  'executionSession.failed': '失敗',
+  'executionSession.codexTerminal': 'Codex対話ターミナル',
+  'executionSession.focusTerminal': 'Codexターミナルへフォーカス',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': 'サンプルワークフロー',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -1087,6 +1087,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.waiting': 'Claude Code の活動を待機中…',
   'executionSession.metadata': 'セッション {{sessionId}} · 更新 {{time}}',
   'executionSession.waitingForInput': '停止中・入力待ち',
+  'executionSession.aborted': '中止',
   'executionSession.failed': '失敗',
   'executionSession.codexTerminal': 'Codex対話ターミナル',
   'executionSession.focusTerminal': 'Codexターミナルへフォーカス',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -1078,6 +1078,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.waiting': 'Claude Code 활동을 기다리는 중…',
   'executionSession.metadata': '세션 {{sessionId}} · 업데이트 {{time}}',
   'executionSession.waitingForInput': '유휴・입력 대기 중',
+  'executionSession.aborted': '취소됨',
   'executionSession.failed': '실패',
   'executionSession.codexTerminal': 'Codex 대화형 터미널',
   'executionSession.focusTerminal': 'Codex 터미널에 포커스',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -1073,6 +1073,14 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'commentary.waiting': '에이전트 활동 대기 중...',
   'commentary.inactive': 'Commentary를 활성화하고 워크플로우를 실행하면 실시간 해설이 표시됩니다.',
   'commentary.providerSelect': 'Commentary AI 프로바이더 선택',
+  'executionSession.running': '실행 중',
+  'executionSession.ended': '종료됨',
+  'executionSession.waiting': 'Claude Code 활동을 기다리는 중…',
+  'executionSession.metadata': '세션 {{sessionId}} · 업데이트 {{time}}',
+  'executionSession.waitingForInput': '유휴・입력 대기 중',
+  'executionSession.failed': '실패',
+  'executionSession.codexTerminal': 'Codex 대화형 터미널',
+  'executionSession.focusTerminal': 'Codex 터미널에 포커스',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': '샘플 워크플로우',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -1081,7 +1081,6 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.aborted': '취소됨',
   'executionSession.failed': '실패',
   'executionSession.codexTerminal': 'Codex 대화형 터미널',
-  'executionSession.focusTerminal': 'Codex 터미널에 포커스',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': '샘플 워크플로우',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -1048,7 +1048,6 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.aborted': '已取消',
   'executionSession.failed': '失败',
   'executionSession.codexTerminal': 'Codex 交互终端',
-  'executionSession.focusTerminal': '聚焦 Codex 终端',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': '示例工作流',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -1040,6 +1040,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'commentary.waiting': '等待代理活动中...',
   'commentary.inactive': '启用 Commentary 并运行工作流，即可看到实时解说。',
   'commentary.providerSelect': '选择 Commentary AI 提供商',
+  'executionSession.running': '运行中',
+  'executionSession.ended': '已结束',
+  'executionSession.waiting': '正在等待 Claude Code 活动…',
+  'executionSession.metadata': '会话 {{sessionId}} · 更新于 {{time}}',
+  'executionSession.waitingForInput': '空闲・等待输入',
+  'executionSession.failed': '失败',
+  'executionSession.codexTerminal': 'Codex 交互终端',
+  'executionSession.focusTerminal': '聚焦 Codex 终端',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': '示例工作流',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -1045,6 +1045,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.waiting': '正在等待 Claude Code 活动…',
   'executionSession.metadata': '会话 {{sessionId}} · 更新于 {{time}}',
   'executionSession.waitingForInput': '空闲・等待输入',
+  'executionSession.aborted': '已取消',
   'executionSession.failed': '失败',
   'executionSession.codexTerminal': 'Codex 交互终端',
   'executionSession.focusTerminal': '聚焦 Codex 终端',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -1051,7 +1051,6 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.aborted': '已取消',
   'executionSession.failed': '失敗',
   'executionSession.codexTerminal': 'Codex 互動式終端機',
-  'executionSession.focusTerminal': '聚焦 Codex 終端機',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': '範例工作流程',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -1048,6 +1048,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.waiting': '正在等待 Claude Code 活動…',
   'executionSession.metadata': '工作階段 {{sessionId}} · 更新於 {{time}}',
   'executionSession.waitingForInput': '閒置・等待輸入',
+  'executionSession.aborted': '已取消',
   'executionSession.failed': '失敗',
   'executionSession.codexTerminal': 'Codex 互動式終端機',
   'executionSession.focusTerminal': '聚焦 Codex 終端機',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -1043,6 +1043,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'commentary.waiting': '等待代理活動中...',
   'commentary.inactive': '啟用 Commentary 並執行工作流程，即可看到即時解說。',
   'commentary.providerSelect': '選擇 Commentary AI 提供商',
+  'executionSession.running': '執行中',
+  'executionSession.ended': '已結束',
+  'executionSession.waiting': '正在等待 Claude Code 活動…',
+  'executionSession.metadata': '工作階段 {{sessionId}} · 更新於 {{time}}',
+  'executionSession.waitingForInput': '閒置・等待輸入',
+  'executionSession.failed': '失敗',
+  'executionSession.codexTerminal': 'Codex 互動式終端機',
+  'executionSession.focusTerminal': '聚焦 Codex 終端機',
 
   // Sample Workflows
   'toolbar.sampleWorkflows': '範例工作流程',


### PR DESCRIPTION
## Summary

Add a bottom session bar that links active Codex and Claude Code runs to their VS Code terminals and reports coarse execution state.

## Motivation

Workflow and AI Edit runs should remain fully interactive in the integrated terminal while their current state stays visible from the canvas.

## Changes

**New Files:**
- `packages/vscode/src/extension/services/codex-terminal-session-manager.ts` - Track Codex terminal sessions and JSONL lifecycle events
- `packages/vscode/src/extension/services/execution-session-manager.ts` - Track Claude Code terminal sessions
- `packages/vscode/src/webview/src/components/ExecutionSessionPanel.tsx` - Render the interactive session bar

**Modified Files:**
- `packages/vscode/src/extension/commands/open-editor.ts` - Connect workflow and AI Edit launches to session tracking
- `packages/vscode/src/extension/services/ai-editing-skill-service.ts` - Return launched terminals and Claude session IDs
- `packages/vscode/src/extension/services/commentary-jsonl-watcher.ts` - Observe Claude turn lifecycle without hooks
- `packages/vscode/src/shared/types/messages.ts` - Add execution-session messages and statuses
- `packages/vscode/src/webview/src/App.tsx` - Place the session bar below the canvas
- `packages/vscode/src/webview/src/i18n/` - Add localized session labels

## Release

- Adds a `minor` changeset for `cc-wf-studio`

## Screenshots / Demo

- Manually verified in the Extension Development Host with Codex and Claude Code workflow runs and AI Edit sessions

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] Manual E2E testing completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live execution-session visibility for Codex and Claude Code terminal runs (including run correlation and incremental progress updates).
  * Introduced an in-editor execution session panel showing workflow status, last activity, session details, and terminal context.
  * Click or keyboard-focus an active session to bring the relevant terminal forward.
  * Added localized UI labels for execution-session states and terminal actions across all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->