### PR TITLE
fix: keep form edits when adding SubAgent from existing agent

### DIFF
--- a/.changeset/subagent-select-existing-form-edits.md
+++ b/.changeset/subagent-select-existing-form-edits.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+fix: keep form edits when adding a SubAgent from an existing agent

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,21 @@ Entry format:
 
 ---
 
+## 2026-07-21 — Fix SubAgent creation from existing agent discarding form edits
+- **User value**: a user editing Color/Model/Tools/Memory in the SubAgent
+  form before adding an existing agent to the canvas no longer has those
+  edits silently discarded — the created node now matches what they typed.
+- **Issue/PR**: Closes #816
+- **Outcome**: done — `handleSelectCommand` in `NodePalette.tsx` now builds
+  node data from the submitted `formData` (model/tools/memory/color)
+  instead of re-parsing the agent file's frontmatter, matching the
+  "+ Create New" and node-edit paths.
+- **Next proposals**:
+  - #826: SubAgent edit dialog commits node state before the agent file
+    write succeeds (fix ordering so failed writes don't desync the node).
+  - Walk the canvas → export → share flow as a user and propose the top
+    friction fix.
+
 ## 2026-07-21 — Bootstrap the value-creation loop
 - **User value**: none directly — this is the machine that will produce it.
 - **Issue/PR**: (this setup PR)

--- a/packages/vscode/src/webview/src/components/NodePalette.tsx
+++ b/packages/vscode/src/webview/src/components/NodePalette.tsx
@@ -5,7 +5,7 @@
  * Based on: /specs/001-cc-wf-studio/plan.md
  */
 
-import type { BuiltInSubAgentType, SubAgentFlow, SubAgentModel } from '@cc-wf-studio/core';
+import type { BuiltInSubAgentType, SubAgentFlow } from '@cc-wf-studio/core';
 import {
   BUILT_IN_SUB_AGENTS,
   generateBranchId,
@@ -34,7 +34,6 @@ import { useTranslation } from '../i18n/i18n-context';
 import { createSubAgent } from '../services/command-browser-service';
 import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
-import { parseAgentFrontmatter } from '../utils/agent-frontmatter';
 import { BetaBadge } from './common/BetaBadge';
 import { CodexNodeDialog } from './dialogs/CodexNodeDialog';
 import { McpNodeDialog } from './dialogs/McpNodeDialog';
@@ -203,9 +202,6 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
   const handleSelectCommand = (command: CommandReference, formData: SubAgentFormData) => {
     const position = calculateNonOverlappingPosition(250, 100);
 
-    // Parse YAML frontmatter from command content
-    const { frontmatter } = parseAgentFrontmatter(command.promptContent);
-
     const newNode = {
       id: `agent-${Date.now()}`,
       type: 'subAgent' as const,
@@ -214,9 +210,10 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
         description: formData.description,
         agentDefinition: formData.agentDefinition,
         prompt: formData.prompt,
-        model: (frontmatter.model as SubAgentModel) || 'sonnet',
-        tools: frontmatter.tools,
-        memory: frontmatter.memory as 'user' | 'project' | 'local' | undefined,
+        model: formData.model,
+        tools: formData.tools || undefined,
+        memory: formData.memory || undefined,
+        color: formData.color,
         outputPorts: 1,
         commandFilePath: command.commandPath,
         commandScope: command.scope,


### PR DESCRIPTION
## Summary
- `handleSelectCommand` in `NodePalette.tsx` used to re-parse the selected agent file's YAML frontmatter to build the new node's `model`/`tools`/`memory`, and never included `color` at all.
- This silently discarded any edits made in the `SubAgentFormDialog` before clicking Add: `color` was always lost, and `model`/`tools`/`memory` reverted to whatever the agent file already had.
- The fix uses the submitted `formData` directly for these fields, matching the "+ Create New" path (`handleCreateNewSubAgent`) and the property panel's edit dialog, both of which already persist edits correctly. Unedited flows are unaffected since `SubAgentCreationDialog.handleAdd` pre-fills `formData` from the same frontmatter.

## User value
A user who edits Color, Model, Tools, or Memory in the SubAgent form before adding an **existing** agent to the canvas now gets a node that matches what they typed, instead of having those edits silently dropped.

Closes #816

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] Manual E2E: open SubAgent creation dialog → select an existing (non-built-in) agent → edit Color/Model/Tools/Memory in the form → Add → confirm the created node reflects the edited values


---
_Generated by [Claude Code](https://claude.ai/code/session_01MarAh6Lm24rMqAV4NFBs11)_