### PR TITLE
fix(vscode): surface SubAgent file write errors and commit node state after write

### DIFF
--- a/.changeset/subagent-edit-write-order.md
+++ b/.changeset/subagent-edit-write-order.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+fix: SubAgent edit no longer desyncs node state when the agent file write fails — the form dialog now surfaces the error and keeps the node unchanged

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,24 @@ Entry format:
 
 ---
 
+## 2026-07-22 — SubAgent edit no longer desyncs node from agent file on failed write
+- **User value**: a user editing a command-linked SubAgent whose agent-file
+  write fails no longer gets a canvas node silently out of sync with the
+  file — the edit dialog stays open with a visible error, and the node only
+  updates once the write succeeds.
+- **Issue/PR**: Closes #826
+- **Outcome**: done — `sub-agent-panel.tsx` now awaits `createSubAgent`
+  before `updateNodeData`; `SubAgentFormDialog` awaits `onSubmit`, shows a
+  submit error (new `subAgent.form.error.saveFailed` i18n key, all 5
+  locales), and guards against double-submit. The creation path gets the
+  same error feedback through the shared dialog.
+- **Next proposals**:
+  - Walk the canvas → export → share flow as a user and propose the top
+    friction fix.
+  - `ccwf validate`: include the node label alongside the node id in error
+    output so users can find the offending node on the canvas faster
+    (verify what `ValidationError` carries first).
+
 ## 2026-07-21 — Fix SubAgent creation from existing agent discarding form edits
 - **User value**: a user editing Color/Model/Tools/Memory in the SubAgent
   form before adding an existing agent to the canvas no longer has those

--- a/packages/vscode/src/webview/src/components/dialogs/SubAgentFormDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/SubAgentFormDialog.tsx
@@ -97,6 +97,8 @@ export function SubAgentFormDialog({
     memory: '',
   });
   const [errors, setErrors] = useState<FormErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isEditingAgentDefinition, setIsEditingAgentDefinition] = useState(false);
   const [isEditingPrompt, setIsEditingPrompt] = useState(false);
 
@@ -121,6 +123,8 @@ export function SubAgentFormDialog({
         });
       }
       setErrors({});
+      setSubmitError(null);
+      setIsSubmitting(false);
     }
   }, [isOpen, initialData]);
 
@@ -128,7 +132,9 @@ export function SubAgentFormDialog({
     onClose();
   }, [onClose]);
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
+    if (isSubmitting) return;
+
     const validationErrors: FormErrors = {};
 
     if (!formData.description.trim()) {
@@ -147,8 +153,17 @@ export function SubAgentFormDialog({
     }
 
     setErrors({});
-    onSubmit({ ...formData, agentType });
-  }, [formData, agentType, onSubmit, t]);
+    setSubmitError(null);
+    setIsSubmitting(true);
+    try {
+      await onSubmit({ ...formData, agentType });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      setSubmitError(`${t('subAgent.form.error.saveFailed')} ${detail}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [formData, agentType, onSubmit, t, isSubmitting]);
 
   const handleFieldChange = (field: keyof SubAgentFormData, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
@@ -735,6 +750,24 @@ export function SubAgentFormDialog({
               </CollapsibleSection>
             </div>
 
+            {/* Submit error */}
+            {submitError && (
+              <div
+                style={{
+                  marginTop: '16px',
+                  padding: '8px 10px',
+                  fontSize: '12px',
+                  color: 'var(--vscode-errorForeground)',
+                  backgroundColor: 'var(--vscode-inputValidation-errorBackground)',
+                  border: '1px solid var(--vscode-inputValidation-errorBorder)',
+                  borderRadius: '4px',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {submitError}
+              </div>
+            )}
+
             {/* Actions */}
             <div
               style={{
@@ -762,6 +795,7 @@ export function SubAgentFormDialog({
               <button
                 type="button"
                 onClick={handleSubmit}
+                disabled={isSubmitting}
                 style={{
                   padding: '8px 16px',
                   fontSize: '13px',
@@ -769,8 +803,9 @@ export function SubAgentFormDialog({
                   borderRadius: '4px',
                   backgroundColor: 'var(--vscode-button-background)',
                   color: 'var(--vscode-button-foreground)',
-                  cursor: 'pointer',
+                  cursor: isSubmitting ? 'default' : 'pointer',
                   fontWeight: 600,
+                  opacity: isSubmitting ? 0.6 : 1,
                 }}
               >
                 {isEditMode ? t('subAgent.form.saveButton') : t('subAgent.form.createButton')}

--- a/packages/vscode/src/webview/src/components/property/panels/sub-agent-panel.tsx
+++ b/packages/vscode/src/webview/src/components/property/panels/sub-agent-panel.tsx
@@ -131,6 +131,15 @@ const SubAgentHeader: React.FC<PanelSlotProps> = ({ node, updateNodeData }) => {
           builtInType: data.builtInType,
         }}
         onSubmit={async (formData) => {
+          // Write the agent file first so node state is only committed when
+          // the write succeeds; on failure the dialog stays open with an error.
+          if (data.commandFilePath) {
+            await createSubAgent({
+              ...formData,
+              commandFilePath: data.commandFilePath,
+            });
+          }
+
           updateNodeData(node.id, {
             description: formData.description,
             agentDefinition: formData.agentDefinition,
@@ -144,13 +153,6 @@ const SubAgentHeader: React.FC<PanelSlotProps> = ({ node, updateNodeData }) => {
             memory: formData.memory || undefined,
             color: formData.color,
           });
-
-          if (data.commandFilePath) {
-            await createSubAgent({
-              ...formData,
-              commandFilePath: data.commandFilePath,
-            });
-          }
 
           setIsEditDialogOpen(false);
         }}

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -979,6 +979,7 @@ export interface WebviewTranslationKeys {
   'subAgent.form.error.descriptionRequired': string;
   'subAgent.form.error.agentDefinitionRequired': string;
   'subAgent.form.error.promptRequired': string;
+  'subAgent.form.error.saveFailed': string;
 
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -1055,6 +1055,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.form.error.descriptionRequired': 'Description is required.',
   'subAgent.form.error.agentDefinitionRequired': 'Agent Definition is required.',
   'subAgent.form.error.promptRequired': 'Prompt is required.',
+  'subAgent.form.error.saveFailed': 'Failed to save the agent file.',
 
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': 'Built-in',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -1049,6 +1049,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.form.error.descriptionRequired': '説明は必須です。',
   'subAgent.form.error.agentDefinitionRequired': 'エージェント定義は必須です。',
   'subAgent.form.error.promptRequired': 'プロンプトは必須です。',
+  'subAgent.form.error.saveFailed': 'エージェントファイルの保存に失敗しました。',
 
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': 'ビルトイン',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -1042,6 +1042,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.form.error.descriptionRequired': '설명은 필수입니다.',
   'subAgent.form.error.agentDefinitionRequired': '에이전트 정의는 필수입니다.',
   'subAgent.form.error.promptRequired': '프롬프트는 필수입니다.',
+  'subAgent.form.error.saveFailed': '에이전트 파일 저장에 실패했습니다.',
 
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': '내장',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -1010,6 +1010,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.form.error.descriptionRequired': '描述为必填项。',
   'subAgent.form.error.agentDefinitionRequired': '代理定义为必填项。',
   'subAgent.form.error.promptRequired': '提示词为必填项。',
+  'subAgent.form.error.saveFailed': '保存代理文件失败。',
 
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': '内置',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -1013,6 +1013,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.form.error.descriptionRequired': '描述為必填項。',
   'subAgent.form.error.agentDefinitionRequired': '代理定義為必填項。',
   'subAgent.form.error.promptRequired': '提示詞為必填項。',
+  'subAgent.form.error.saveFailed': '儲存代理檔案失敗。',
 
   // Sub-Agent Built-in Presets
   'subAgent.dialog.builtInTab': '內建',


### PR DESCRIPTION
## Summary
- In the SubAgent property panel's edit flow (`sub-agent-panel.tsx`), `updateNodeData` was committed **before** `await createSubAgent(...)`. If the agent-file write failed (no workspace open, permission error, timeout), the canvas node kept the edited values while `.claude/agents/*.md` did not — a silent node ↔ file desync with an unhandled promise rejection and zero user feedback.
- The fix reorders the flow: the file is written first, and node state is only committed when the write succeeds.
- `SubAgentFormDialog.handleSubmit` now awaits `onSubmit` in a try/catch: on failure the dialog stays open and shows an inline error (new `subAgent.form.error.saveFailed` i18n key, added to all 5 locales), with a double-submit guard while the write is in flight.
- The creation path (`SubAgentCreationDialog` → `onCreateWithForm` → `createSubAgent`) already had the correct write-then-add order but also swallowed failures; it now gets the same visible error feedback through the shared form dialog.

## User value
A user editing a command-linked SubAgent whose file write fails no longer gets a canvas node silently out of sync with the agent file — the dialog stays open with a visible error, and the node only updates once the write succeeds.

Closes #826

## Changeset
- `.changeset/subagent-edit-write-order.md` — `cc-wf-studio` patch

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] Manual E2E: edit a command-linked SubAgent with no workspace folder open (or make `.claude/agents/` read-only) → Save → dialog stays open with the error, node unchanged; with a writable workspace → Save → file and node both update, dialog closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU86pawtdhvjG63RFFZ1kE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU86pawtdhvjG63RFFZ1kE)_