### PR TITLE
feat(cli): add -o/--output flag to ccwf render

### DIFF
--- a/.changeset/ccwf-render-output-flag.md
+++ b/.changeset/ccwf-render-output-flag.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': patch
+---
+
+`ccwf render` now accepts `-o, --output <file>` to write the rendered Mermaid/Markdown directly to a file instead of stdout.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,27 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Add `-o/--output` to `ccwf render`
+- **User value**: a user running `ccwf render` can now write the Mermaid/Markdown
+  output directly to a file (`-o <path>`) instead of manually redirecting stdout,
+  matching the file-write pattern `ccwf export` already uses.
+- **Issue/PR**: (opened this iteration)
+- **Outcome**: done
+- **Next proposals**:
+  - `ccwf canvas --port`/`ccwf preview --port` surface a raw `EADDRINUSE` Node
+    error with no hint to try a different port or omit `--port` for an
+    ephemeral one (`packages/cli/src/commands/canvas.ts`, `preview.ts`).
+  - `apply_workflow`'s MCP tool description claims SubAgent `.md` files are
+    "auto-created" during apply, but both adapters
+    (`packages/mcp/src/file-adapter.ts:128`,
+    `packages/vscode/.../mcp-server-service.ts:438`) always return `[]` —
+    creation actually happens later at export/run time. Worth clarifying the
+    tool description so AI agents don't expect `autoCreatedFiles` in the
+    apply response.
+  - `sub-agent-flow-panel.tsx` renders an empty panel with no indicator when
+    a SubAgentFlow node's `linkedSubAgentFlow` can't be found (e.g. the
+    referenced flow was deleted) — no broken-link feedback for the user.
+
 ## 2026-07-22 — SubAgent edit no longer desyncs node from agent file on failed write
 - **User value**: a user editing a command-linked SubAgent whose agent-file
   write fails no longer gets a canvas node silently out of sync with the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ pnpm add -D @cc-wf-studio/cli
 
 | Command | Description |
 |---|---|
-| `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout. |
+| `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
 | `ccwf validate <file>` | Schema-check the workflow JSON. Exit 0/1. `--json` for machine-readable output. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). |
@@ -33,6 +33,7 @@ pnpm add -D @cc-wf-studio/cli
 ```sh
 ccwf render ./.vscode/workflows/my-workflow.json            # Markdown (default)
 ccwf render ./.vscode/workflows/my-workflow.json -f mermaid # ```mermaid block only
+ccwf render ./.vscode/workflows/my-workflow.json -o out.md  # write to a file instead of stdout
 ```
 
 ### `ccwf validate`

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -40,11 +40,12 @@ If a step fails, stop and surface the exact error to the user before moving on.
 
 ### `ccwf render <file>`
 
-Print a Markdown bundle (Mermaid flowchart + per-node execution instructions) to stdout. Use when piping to another tool or pasting into a PR / chat message.
+Print a Markdown bundle (Mermaid flowchart + per-node execution instructions) to stdout, or write it to a file with `-o`. Use when piping to another tool or pasting into a PR / chat message.
 
 ```bash
 ccwf render ./.vscode/workflows/my-workflow.json             # Markdown (default)
 ccwf render ./.vscode/workflows/my-workflow.json -f mermaid  # ```mermaid block only
+ccwf render ./.vscode/workflows/my-workflow.json -o out.md   # write to a file instead of stdout
 ```
 
 Output is the same content `ccwf preview` shows in the right pane.

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -7,6 +7,7 @@
  * `mermaid-cli` or similar.
  */
 
+import * as fs from 'node:fs/promises';
 import { Command, InvalidArgumentError } from 'commander';
 import {
   generateExecutionInstructions,
@@ -18,6 +19,7 @@ type RenderFormat = 'mermaid' | 'md';
 
 interface RenderOptions {
   format: RenderFormat;
+  output?: string;
 }
 
 export function registerRenderCommand(program: Command): void {
@@ -36,23 +38,31 @@ export function registerRenderCommand(program: Command): void {
       },
       'md'
     )
+    .option('-o, --output <file>', 'Write output to this file instead of stdout.')
     .action(async (file: string, options: RenderOptions) => {
       try {
         const { workflow } = await loadWorkflowFromFile(file);
         // generateMermaidFlowchart already returns a fenced ```mermaid block.
         const mermaidBlock = generateMermaidFlowchart(workflow);
 
+        let rendered: string;
         if (options.format === 'mermaid') {
-          process.stdout.write(`${mermaidBlock}\n`);
-          return;
+          rendered = `${mermaidBlock}\n`;
+        } else {
+          const execution = generateExecutionInstructions(workflow, {
+            provider: 'claude-code',
+          });
+          const title = `# ${workflow.name || 'Workflow'}`;
+          const descriptionBlock = workflow.description ? `\n${workflow.description}\n` : '\n';
+          rendered = `${title}\n${descriptionBlock}\n${mermaidBlock}\n\n${execution}\n`;
         }
 
-        const execution = generateExecutionInstructions(workflow, {
-          provider: 'claude-code',
-        });
-        const title = `# ${workflow.name || 'Workflow'}`;
-        const descriptionBlock = workflow.description ? `\n${workflow.description}\n` : '\n';
-        process.stdout.write(`${title}\n${descriptionBlock}\n${mermaidBlock}\n\n${execution}\n`);
+        if (options.output) {
+          await fs.writeFile(options.output, rendered, 'utf-8');
+          process.stdout.write(`✓ Wrote render output to ${options.output}\n`);
+        } else {
+          process.stdout.write(rendered);
+        }
       } catch (error) {
         if (error instanceof WorkflowLoadError) {
           process.stderr.write(`error: ${error.message}\n`);


### PR DESCRIPTION
## Summary
- `ccwf render <file>` only ever printed to stdout, forcing manual shell redirection (`> out.md`) to save output — inconsistent with `ccwf export`, which writes files directly with a confirmation message.
- Adds `-o, --output <file>`: when passed, the rendered Mermaid/Markdown is written to that file with a `✓ Wrote render output to <path>` confirmation, matching `export`'s pattern. Omitting the flag keeps the existing stdout behavior unchanged.
- Updated `packages/cli/README.md` and the `ccwf-cli` skill doc with the new flag.

## User value
A user running `ccwf render` can now save output straight to a file with `-o <path>` instead of relying on shell redirection.

## Changeset
- `.changeset/ccwf-render-output-flag.md` — `@cc-wf-studio/cli` patch

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] Manual E2E: `ccwf render packages/cli/fixtures/sample-workflow.json -o /tmp/out.md` writes the file and prints the confirmation; running without `-o` still prints to stdout; `-f mermaid -o /tmp/out.mmd` writes only the Mermaid block

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cw2wcbfxAgeo5212Y9vVVb)_