### PR TITLE
fix(cli): friendly error when canvas/preview port is taken

### DIFF
--- a/.changeset/ccwf-eaddrinuse-friendly-error.md
+++ b/.changeset/ccwf-eaddrinuse-friendly-error.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': patch
+---
+
+`ccwf canvas`/`ccwf preview` now print a clear "port already in use" message with next steps instead of a raw Node `EADDRINUSE` error when `--port` is taken.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,32 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Friendly error when `ccwf canvas`/`ccwf preview` port is taken
+- **User value**: a user who runs `ccwf canvas --port <n>` or `ccwf preview
+  --port <n>` against a port already in use now gets "port <n> is already in
+  use ... Try a different --port, or omit --port to bind an ephemeral one"
+  instead of a raw Node `EADDRINUSE` stack-shaped message with no next step.
+- **Issue/PR**: (opened this iteration)
+- **Outcome**: done — new `packages/cli/src/utils/server-start-error.ts`
+  (`formatServerStartError`) used by both commands' catch blocks; verified
+  manually by occupying a port and running each command against it, and that
+  the pre-existing invalid `--port` (`NaN`) message is unchanged.
+- **Next proposals**:
+  - `apply_workflow`'s MCP tool description claims SubAgent `.md` files are
+    "auto-created" during apply, but both adapters
+    (`packages/mcp/src/file-adapter.ts:128`,
+    `packages/vscode/.../mcp-server-service.ts:438`) always return `[]` by
+    design — clarify the tool description so AI agents don't expect
+    `autoCreatedFiles` in the apply response.
+  - `ccwf validate`: include the node label alongside the node id in error
+    output so users can find the offending node on the canvas faster
+    (verify what `ValidationError` carries first).
+  - Note: closed stale GitHub issues #816 and #826 this iteration — both were
+    already fixed on `auto-dev` in prior iterations, but merging into
+    `auto-dev` (not `main`) means `Closes #NN` never auto-closed them. Worth
+    remembering this loop's PRs should double-check issue state manually
+    rather than trusting auto-close until `auto-dev` is promoted.
+
 ## 2026-07-22 — Add `-o/--output` to `ccwf render`
 - **User value**: a user running `ccwf render` can now write the Mermaid/Markdown
   output directly to a file (`-o <path>`) instead of manually redirecting stdout,

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -27,6 +27,7 @@ import { createCanvasHandlers } from '../canvas/handlers.js';
 import { startCanvasServer } from '../canvas/server.js';
 import { reachabilityNote } from '../utils/host-warning.js';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import { formatServerStartError } from '../utils/server-start-error.js';
 
 interface CanvasOptions {
   port?: string;
@@ -99,6 +100,7 @@ export function registerCanvasCommand(program: Command): void {
     .option('--port <number>', 'Preferred port (default: ephemeral / 0).')
     .option('--host <address>', 'Bind host. Default 127.0.0.1; do not change for public networks.')
     .action(async (file: string, options: CanvasOptions) => {
+      let portOption = 0;
       try {
         // Validate the file is parseable JSON up-front so the user gets a clear
         // error instead of a confused empty canvas in the browser.
@@ -106,7 +108,7 @@ export function registerCanvasCommand(program: Command): void {
 
         const webviewDistDir = await resolveWebviewDistDir();
         const handlers = createCanvasHandlers({ workflowPath: file });
-        const portOption = options.port ? Number(options.port) : 0;
+        portOption = options.port ? Number(options.port) : 0;
         if (Number.isNaN(portOption)) {
           process.stderr.write(`error: --port must be a number, got '${options.port}'\n`);
           process.exit(2);
@@ -167,7 +169,7 @@ export function registerCanvasCommand(program: Command): void {
           process.stderr.write(`error: ${error.message}\n`);
           process.exit(error.exitCode);
         }
-        process.stderr.write(`error: ${error instanceof Error ? error.message : String(error)}\n`);
+        process.stderr.write(`${formatServerStartError(error, portOption)}\n`);
         process.exit(1);
       }
     });

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -21,6 +21,7 @@ import { startPreviewServer } from '../preview/server.js';
 import { watchWorkflowFile } from '../preview/watcher.js';
 import { reachabilityNote } from '../utils/host-warning.js';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import { formatServerStartError } from '../utils/server-start-error.js';
 
 interface PreviewOptions {
   port?: string;
@@ -98,12 +99,13 @@ export function registerPreviewCommand(program: Command): void {
       false
     )
     .action(async (file: string, options: PreviewOptions) => {
+      let portOption = 0;
       try {
         const workflowAbsPath = path.resolve(file);
         const initialWorkflow = await readMigratedWorkflow(workflowAbsPath);
 
         const webviewDistDir = await resolveWebviewDistDir();
-        const portOption = options.port ? Number(options.port) : 0;
+        portOption = options.port ? Number(options.port) : 0;
         if (Number.isNaN(portOption)) {
           process.stderr.write(`error: --port must be a number, got '${options.port}'\n`);
           process.exit(2);
@@ -200,7 +202,7 @@ export function registerPreviewCommand(program: Command): void {
           process.stderr.write(`error: ${error.message}\n`);
           process.exit(error.exitCode);
         }
-        process.stderr.write(`error: ${error instanceof Error ? error.message : String(error)}\n`);
+        process.stderr.write(`${formatServerStartError(error, portOption)}\n`);
         process.exit(1);
       }
     });

--- a/packages/cli/src/utils/server-start-error.ts
+++ b/packages/cli/src/utils/server-start-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Friendly error message for a failed local server bind (`ccwf canvas` /
+ * `ccwf preview`). Node's raw `EADDRINUSE` message ("listen EADDRINUSE:
+ * address already in use :::5175") gives no hint about what to do next —
+ * this adds one when the user requested a specific port.
+ */
+
+export function formatServerStartError(error: unknown, requestedPort: number): string {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  const message = error instanceof Error ? error.message : String(error);
+  if (code === 'EADDRINUSE' && requestedPort !== 0) {
+    return `error: port ${requestedPort} is already in use (${message}). Try a different --port, or omit --port to bind an ephemeral one.`;
+  }
+  return `error: ${message}`;
+}


### PR DESCRIPTION
## Summary
- `ccwf canvas --port <n>` and `ccwf preview --port <n>` previously surfaced Node's raw `EADDRINUSE` error ("listen EADDRINUSE: address already in use :::5175") with no hint about what to do next when the requested port was already taken.
- Adds `formatServerStartError` (`packages/cli/src/utils/server-start-error.ts`) that detects `EADDRINUSE` and prints `port <n> is already in use ... Try a different --port, or omit --port to bind an ephemeral one.` Both commands now use it in their top-level catch block.
- The pre-existing invalid `--port` (non-numeric) validation message is unchanged.

## User value
A user who runs `ccwf canvas`/`ccwf preview` against a port that's already bound to another process gets an actionable message instead of a bare Node stack-shaped error.

## Changeset
- `.changeset/ccwf-eaddrinuse-friendly-error.md` — `@cc-wf-studio/cli` patch

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [x] Manual: occupied a local port, ran `ccwf canvas <file> --port <that port>` and `ccwf preview <file> --port <that port>` — both print the new friendly message
- [x] Manual: `--port abc` still prints the original "must be a number" message unchanged

## Notes
- While investigating open bug-labeled issues this iteration, found #816 and #826 were already fixed in earlier iterations (merged into `auto-dev` via #844/#845) but never auto-closed, since `Closes #NN` only fires on merge to the repo's default branch (`main`), not `auto-dev`. Closed both manually with a reference to the fixing commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JBg1j2aYmsL8LwSWchV8UV)_