### PR TITLE
fix(vscode): show broken-link message in Sub-Agent Flow panel

### DIFF
--- a/.changeset/subagentflow-panel-broken-link.md
+++ b/.changeset/subagentflow-panel-broken-link.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Sub-Agent Flow property panel now shows a "Sub-Agent Flow not found" message instead of a silently empty header when the linked flow is missing.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,35 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Sub-Agent Flow property panel surfaces broken links
+- **User value**: a user who opens the property panel for a Sub-Agent Flow
+  reference node whose linked flow no longer exists (e.g. after opening an
+  externally edited or hand-crafted workflow file — `validateWorkflowFile`
+  does not check `subAgentFlowId` references, only `validateAIGeneratedWorkflow`
+  does) now sees a "Sub-Agent Flow not found" message in the panel instead of
+  a header that silently renders nothing (no description, no edit button, no
+  explanation) while the rest of the panel's fields still edit normally.
+- **Issue/PR**: (opened this iteration)
+- **Outcome**: done — `sub-agent-flow-panel.tsx`'s `SubAgentFlowHeader` now
+  renders the existing `node.subAgentFlow.subAgentFlowNotFound` i18n string
+  (already used by the canvas node's own warning badge, so no new
+  translations needed) when `subAgentFlowId` is set but unresolved.
+- **Next proposals**:
+  - `apply_workflow`'s MCP tool description says SubAgent `.md` files are
+    "auto-created" during apply; both adapters return `[]` at apply time and
+    actually materialise the file later at export/run. The claim is
+    functionally accurate but the timing is unclear from the description —
+    low priority, reconsider only if an agent is observed acting on the
+    apply-time assumption.
+  - `ccwf validate`: several error messages embed `node.id` (e.g.
+    `Node "${node.id}" ...`) but node ids are often opaque
+    (`group-<timestamp>` etc.) with no shared "display name" accessor across
+    node types in core — before adding a label, first design a
+    `getNodeDisplayName(node)` helper (data shape differs per node type:
+    `label` for Group, `name` for Skill, etc.).
+  - Walk the canvas → export → share flow as a user and propose the top
+    friction fix (still not done despite being proposed 3 times).
+
 ## 2026-07-22 — Friendly error when `ccwf canvas`/`ccwf preview` port is taken
 - **User value**: a user who runs `ccwf canvas --port <n>` or `ccwf preview
   --port <n>` against a port already in use now gets "port <n> is already in

--- a/packages/vscode/src/webview/src/components/property/panels/sub-agent-flow-panel.tsx
+++ b/packages/vscode/src/webview/src/components/property/panels/sub-agent-flow-panel.tsx
@@ -23,7 +23,14 @@ const SubAgentFlowHeader: React.FC<PanelSlotProps> = ({ node }) => {
   const linkedSubAgentFlow = subAgentFlows.find((sf) => sf.id === subAgentFlowId);
 
   if (!linkedSubAgentFlow) {
-    return null;
+    // subAgentFlowId is set but no matching flow exists (e.g. an externally
+    // edited or corrupted workflow file) — the canvas node already shows a
+    // warning badge; mirror it here so the panel isn't silently empty.
+    return subAgentFlowId ? (
+      <div style={{ fontSize: '11px', color: 'var(--vscode-editorWarning-foreground)' }}>
+        {t('node.subAgentFlow.subAgentFlowNotFound')}
+      </div>
+    ) : null;
   }
 
   return (


### PR DESCRIPTION
## Summary
- `sub-agent-flow-panel.tsx`'s `SubAgentFlowHeader` returned `null` whenever a Sub-Agent Flow reference node's `subAgentFlowId` didn't resolve to an entry in `subAgentFlows` — the panel silently showed no description and no "Edit Sub-Agent Flow" button, with no explanation, while the rest of the schema-driven fields (model/tools/memory/color) kept rendering normally.
- This is reachable in practice because `validateWorkflowFile` (used by "Open Workflow" and the Slack import command) does not check `subAgentFlowId` references — only the stricter `validateAIGeneratedWorkflow` (used by MCP `apply_workflow`) does. So a hand-edited or externally modified workflow JSON can load with a dangling reference.
- The canvas node itself already shows a warning badge in this situation (`node.subAgentFlow.subAgentFlowNotFound`), so this change reuses that same, already-translated i18n string in the property panel instead of adding new keys.

## User value
A user who opens the property panel for a Sub-Agent Flow node whose linked flow is missing now sees a "Sub-Agent Flow not found" message instead of a panel that quietly omits the description/edit button with no explanation.

## Changeset
- `.changeset/subagentflow-panel-broken-link.md` — `cc-wf-studio` patch

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] Manual: open a workflow JSON with a Sub-Agent Flow node whose `subAgentFlowId` doesn't match any entry in `subAgentFlows`, open its property panel, confirm the new message renders and the panel no longer looks blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1AHsx4unNHQqxhWWGvx4N)_