### PR TITLE
fix(cli): validate ccwf tour output before declaring success

### DIFF
--- a/.changeset/tour-verify-output.md
+++ b/.changeset/tour-verify-output.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": patch
+---
+
+`ccwf tour` now re-validates the workflow file after the launched AI agent exits, catching malformed `tour` output or nonexistent node id references immediately instead of letting them surface later as a broken `ccwf preview`.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,29 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Validate `ccwf tour` output before declaring success
+- **User value**: a user running `ccwf tour` no longer gets a false "success"
+  when the launched AI agent writes a malformed `tour` field or references
+  node ids that don't exist — the command now re-validates the file and
+  reports the failure immediately instead of leaving it to surface later as
+  a confusing `ccwf preview` break.
+- **Issue/PR**: (opened this iteration)
+- **Outcome**: done — `verifyTour()` re-loads the file after the launched
+  agent exits 0, runs `validateAIGeneratedWorkflow`, checks the `tour` field
+  is present and non-empty, and checks every `tour[].nodeIds` entry resolves
+  to a real node id, printing a clear pass/fail with a nonzero exit on
+  failure.
+- **Next proposals**:
+  - MCP tool descriptions/error text (`packages/mcp/src/tools.ts`) hard-code
+    VSCode-canvas language ("open the workflow in CC Workflow Studio",
+    "review mode" diff preview) even when served by `FileWorkflowAdapter`
+    (`ccwf mcp --file`), which has no review/diff concept — misleads
+    AI agents driving the CLI MCP server.
+  - `ccwf export`/`ccwf run` treat any pre-existing output file as a hard
+    conflict requiring `--overwrite`, even when its content is already
+    byte-identical to what would be written — false-positive conflicts on
+    every no-op re-run.
+
 ## 2026-07-22 — Sub-Agent Flow property panel surfaces broken links
 - **User value**: a user who opens the property panel for a Sub-Agent Flow
   reference node whose linked flow no longer exists (e.g. after opening an

--- a/packages/cli/src/commands/tour.ts
+++ b/packages/cli/src/commands/tour.ts
@@ -13,6 +13,7 @@
 import { spawn } from 'node:child_process';
 import * as readline from 'node:readline';
 import { Command } from 'commander';
+import { validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
 import { findBinaryInPath } from '../utils/find-binary.js';
 import { loadWorkflowFromFile, WorkflowLoadError } from '../utils/load-workflow.js';
 
@@ -120,6 +121,50 @@ async function resolveAgent(explicit: string | undefined): Promise<string> {
   return promptAgent(installed);
 }
 
+/**
+ * Re-load the file the launched agent just wrote and check the result is
+ * actually usable, rather than trusting the agent's own exit code / report.
+ * Returns the process exit code to use (0 = pass).
+ */
+async function verifyTour(absolutePath: string): Promise<number> {
+  let workflow: Awaited<ReturnType<typeof loadWorkflowFromFile>>['workflow'];
+  try {
+    ({ workflow } = await loadWorkflowFromFile(absolutePath));
+  } catch (error) {
+    const message = error instanceof WorkflowLoadError ? error.message : String(error);
+    process.stderr.write(`✗ ${absolutePath} is no longer a valid workflow file after the tour agent ran: ${message}\n`);
+    return 1;
+  }
+
+  const validation = validateAIGeneratedWorkflow(workflow);
+  if (!validation.valid) {
+    process.stderr.write(`✗ ${absolutePath} failed validation after the tour agent ran:\n`);
+    for (const err of validation.errors) {
+      process.stderr.write(`  - [${err.code}] ${err.message}${err.field ? ` (field: ${err.field})` : ''}\n`);
+    }
+    return 1;
+  }
+
+  if (!workflow.tour || workflow.tour.length === 0) {
+    process.stderr.write(`✗ ${absolutePath} has no "tour" field — the agent did not add one.\n`);
+    return 1;
+  }
+
+  const nodeIds = new Set(workflow.nodes.map((n) => n.id));
+  const badRefs = workflow.tour.flatMap((step) => step.nodeIds.filter((id) => !nodeIds.has(id)));
+  if (badRefs.length > 0) {
+    process.stderr.write(
+      `✗ ${absolutePath}'s tour references node ids that don't exist: ${[...new Set(badRefs)].join(', ')}\n`
+    );
+    return 1;
+  }
+
+  process.stdout.write(
+    `\n✓ Tour with ${workflow.tour.length} step(s) added to ${absolutePath}. Play it with:  ccwf preview "${absolutePath}"\n`
+  );
+  return 0;
+}
+
 export function registerTourCommand(program: Command): void {
   program
     .command('tour')
@@ -148,19 +193,22 @@ export function registerTourCommand(program: Command): void {
         process.stdout.write(`\nLaunching ${launcher.label} to generate a tour for ${absolutePath}\n\n`);
 
         const child = spawn(bin, launcher.args(prompt), { stdio: 'inherit', shell: false });
-        await new Promise<void>((resolve) => {
-          child.on('exit', (code) => {
-            if (typeof code === 'number' && code !== 0) {
-              process.exitCode = code;
-            }
-            resolve();
-          });
+        const exitCode = await new Promise<number | null>((resolve) => {
+          child.on('exit', (code) => resolve(code));
           child.on('error', (error) => {
             process.stderr.write(`error: failed to launch ${launcher.bin}: ${error.message}\n`);
-            process.exitCode = 1;
-            resolve();
+            resolve(1);
           });
         });
+
+        if (typeof exitCode === 'number' && exitCode !== 0) {
+          process.exitCode = exitCode;
+          return;
+        }
+
+        // The launched agent reported success, but it edited the file with its own
+        // tools — verify the result before telling the user the tour is ready.
+        process.exitCode = await verifyTour(absolutePath);
       } catch (error) {
         if (error instanceof WorkflowLoadError) {
           process.stderr.write(`error: ${error.message}\n`);


### PR DESCRIPTION
## Summary
- `ccwf tour` launches an external AI agent CLI to write a `tour` field back into the workflow JSON file, then just reports the child process's exit code — it never checks whether the agent actually produced a valid result.
- If the agent writes malformed JSON, omits the `tour` field, or references node ids that don't exist in `tour[].nodeIds`, the command still exits 0 and tells the user to run `ccwf preview`, where the breakage only surfaces later with no clear cause.
- Added `verifyTour()`: after the launched agent exits 0, it re-loads the file, runs `validateAIGeneratedWorkflow`, checks that `tour` is present and non-empty, and checks every `tour[].nodeIds` entry resolves to a real node id — printing a clear pass/fail and setting a nonzero exit code on failure.

## Test plan
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] Manual E2E: run `ccwf tour <file>` with an agent CLI installed and confirm the new pass/fail message on both a well-formed and a manually-corrupted `tour` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHmiGEm7N35T8ahTLfBxwh)_