### PR TITLE
feat(cli): support codex/copilot/gemini in ccwf run --launch

### DIFF
--- a/.changeset/ccwf-run-launch-multi-agent.md
+++ b/.changeset/ccwf-run-launch-multi-agent.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': patch
+---
+
+`ccwf run --launch` now spawns Codex CLI, Copilot CLI, or Gemini CLI (in addition to Claude Code) when `--agent` targets one of them, instead of warning that launch is claude-code only.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,29 @@ Entry format:
 
 ---
 
+## 2026-07-22 — `ccwf run --launch` supports codex/copilot/gemini, not just claude-code
+- **User value**: a user running `ccwf run <file> --agent codex --launch` (or
+  `copilot` / `gemini`) now gets that agent's CLI launched interactively,
+  instead of a warning saying `--launch` only works with claude-code.
+- **Issue/PR**: (opened this iteration)
+- **Outcome**: done — extracted the agent bin/label map `ccwf tour` already
+  had (`LAUNCHERS`) into a shared `packages/cli/src/utils/agent-launchers.ts`
+  (`LAUNCHABLE_AGENTS`), and had `run.ts`'s `--launch` path use it instead of
+  a hardcoded `agent !== 'claude-code'` bail-out. `tour.ts` now composes the
+  shared map with its own prompt-args builder, so the two commands can't
+  drift apart on which agents are launchable again.
+- **Next proposals**:
+  - CLI commands (`validate`, `render`, `export`, `canvas`, `preview`, `tour`)
+    surface raw `JSON.parse` errors (byte offset, not line/col) on malformed
+    workflow JSON via `load-workflow.ts` — a shared line/col translator there
+    would fix this for every command at once.
+  - `ccwf export`'s "Claude Code-only node" warning is a single aggregate
+    line; it never names which node ids are affected, so a user targeting
+    `--agent cursor` can't tell what will silently break without opening the
+    JSON.
+  - Canvas: no way to duplicate a configured node (subAgent/prompt) — cloning
+    one currently means manually recreating every field by hand.
+
 ## 2026-07-22 — Validate `ccwf tour` output before declaring success
 - **User value**: a user running `ccwf tour` no longer gets a false "success"
   when the launched AI agent writes a malformed `tour` field or references

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -12,6 +12,7 @@
 import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import { Command } from 'commander';
+import { LAUNCHABLE_AGENTS } from '../utils/agent-launchers.js';
 import { findBinaryInPath } from '../utils/find-binary.js';
 import { WorkflowLoadError } from '../utils/load-workflow.js';
 import { asSupportedAgent, runExport } from './export.js';
@@ -71,7 +72,7 @@ export function registerRunCommand(program: Command): void {
     )
     .option(
       '--launch',
-      'After writing files, also spawn the agent CLI (best-effort, claude-code only for now).',
+      `After writing files, also spawn the agent CLI interactively (best-effort; supported for ${Object.keys(LAUNCHABLE_AGENTS).join(', ')}).`,
       false
     )
     .action(async (file: string, options: CommanderRunOptions) => {
@@ -94,21 +95,22 @@ export function registerRunCommand(program: Command): void {
         process.stdout.write(`\nNext: in ${result.rootDir}, ${hint}\n`);
 
         if (options.launch) {
-          if (agent !== 'claude-code') {
+          const launcher = LAUNCHABLE_AGENTS[agent];
+          if (!launcher) {
             process.stderr.write(
-              `warn: --launch is currently only supported for --agent claude-code. Skipping launch.\n`
+              `warn: --launch is not supported for --agent ${agent} (no headless CLI). Skipping launch.\n`
             );
             return;
           }
-          const claudeBin = await findBinaryInPath('claude');
-          if (!claudeBin) {
+          const bin = await findBinaryInPath(launcher.bin);
+          if (!bin) {
             process.stderr.write(
-              `warn: --launch requested but \`claude\` was not found on PATH. Files were written; please launch Claude Code manually and run /${result.slashName}.\n`
+              `warn: --launch requested but \`${launcher.bin}\` was not found on PATH. Files were written; please launch ${launcher.label} manually and run /${result.slashName}.\n`
             );
             return;
           }
-          process.stdout.write(`\nLaunching: ${claudeBin} (cwd ${result.rootDir})\n`);
-          const child = spawn(claudeBin, [], {
+          process.stdout.write(`\nLaunching: ${bin} (cwd ${result.rootDir})\n`);
+          const child = spawn(bin, [], {
             cwd: result.rootDir,
             stdio: 'inherit',
             shell: false,
@@ -121,7 +123,7 @@ export function registerRunCommand(program: Command): void {
               resolve();
             });
             child.on('error', (error) => {
-              process.stderr.write(`error: failed to launch claude: ${error.message}\n`);
+              process.stderr.write(`error: failed to launch ${launcher.bin}: ${error.message}\n`);
               process.exitCode = 1;
               resolve();
             });

--- a/packages/cli/src/commands/tour.ts
+++ b/packages/cli/src/commands/tour.ts
@@ -14,6 +14,7 @@ import { spawn } from 'node:child_process';
 import * as readline from 'node:readline';
 import { Command } from 'commander';
 import { validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
+import { LAUNCHABLE_AGENTS } from '../utils/agent-launchers.js';
 import { findBinaryInPath } from '../utils/find-binary.js';
 import { loadWorkflowFromFile, WorkflowLoadError } from '../utils/load-workflow.js';
 
@@ -27,18 +28,25 @@ interface Launcher {
   args: (prompt: string) => string[];
 }
 
-/**
- * Agents that can be launched from a terminal with an inline prompt. IDE-only
- * agents (antigravity / cursor / roo-code) have no headless CLI and are not
- * supported here. Order matters: it is the picker order and the
- * non-interactive preference order (Claude Code first).
- */
-const LAUNCHERS: Record<string, Launcher> = {
-  'claude-code': { label: 'Claude Code', bin: 'claude', args: (p) => [p] },
-  codex: { label: 'Codex CLI', bin: 'codex', args: (p) => [p] },
-  copilot: { label: 'Copilot CLI', bin: 'copilot', args: (p) => ['-i', p, '--allow-all-tools'] },
-  gemini: { label: 'Gemini CLI', bin: 'gemini', args: (p) => ['-i', p] },
+/** Per-agent argv builder for the inline tour prompt. */
+const TOUR_ARGS: Record<string, (prompt: string) => string[]> = {
+  'claude-code': (p) => [p],
+  codex: (p) => [p],
+  copilot: (p) => ['-i', p, '--allow-all-tools'],
+  gemini: (p) => ['-i', p],
 };
+
+/**
+ * Agents that can be launched from a terminal with an inline prompt. Order
+ * matters: it is the picker order and the non-interactive preference order
+ * (Claude Code first) — mirrors `LAUNCHABLE_AGENTS` insertion order.
+ */
+const LAUNCHERS: Record<string, Launcher> = Object.fromEntries(
+  Object.entries(LAUNCHABLE_AGENTS).map(([key, agent]) => [
+    key,
+    { ...agent, args: TOUR_ARGS[key] },
+  ])
+);
 
 const SUPPORTED = Object.keys(LAUNCHERS).join(' | ');
 

--- a/packages/cli/src/utils/agent-launchers.ts
+++ b/packages/cli/src/utils/agent-launchers.ts
@@ -1,0 +1,20 @@
+/**
+ * Agents that can be launched from a terminal as a headless CLI binary.
+ * IDE-only agents (antigravity / cursor / roo-code) have no headless CLI and
+ * are intentionally excluded — `--launch` / `ccwf tour` skip them.
+ *
+ * Shared by `ccwf run --launch` (opens the agent interactively, no prompt)
+ * and `ccwf tour` (spawns the agent with an inline prompt) so both commands
+ * agree on which agents are launchable and what their binary is called.
+ */
+export interface AgentLauncher {
+  label: string;
+  bin: string;
+}
+
+export const LAUNCHABLE_AGENTS: Record<string, AgentLauncher> = {
+  'claude-code': { label: 'Claude Code', bin: 'claude' },
+  codex: { label: 'Codex CLI', bin: 'codex' },
+  copilot: { label: 'Copilot CLI', bin: 'copilot' },
+  gemini: { label: 'Gemini CLI', bin: 'gemini' },
+};


### PR DESCRIPTION
## Summary

`ccwf run --launch` only spawned the agent CLI for `--agent claude-code`; any other agent got a warning ("--launch is currently only supported for --agent claude-code. Skipping launch.") even though `ccwf tour` already knows how to spawn Codex CLI, Copilot CLI, and Gemini CLI (its `LAUNCHERS` map).

- Extracted that map into a shared `packages/cli/src/utils/agent-launchers.ts` (`LAUNCHABLE_AGENTS`, label + bin per agent).
- `ccwf run --launch` now uses it: for `claude-code`/`codex`/`copilot`/`gemini` it spawns the agent's CLI interactively in the output directory (same behavior as before, just no longer claude-code-only). IDE-only agents (`antigravity`/`cursor`/`roo-code`) still get a clear "not supported" warning, since they have no headless CLI to spawn.
- `ccwf tour` now composes the shared map with its own prompt-args builder (`TOUR_ARGS`), instead of duplicating the label/bin list — the two commands can no longer drift apart on which agents are launchable.

## User value

A user running `ccwf run <file> --agent codex --launch` (or `copilot` / `gemini`) now gets that agent's CLI launched automatically, instead of files being written silently with no launch and a warning telling them it isn't supported.

## Test plan

- [x] `pnpm build` — all packages build clean
- [x] `pnpm check` — lint + typecheck pass across all packages
- [x] Manually traced `ccwf run --agent codex --launch` / `--agent copilot --launch` / `--agent gemini --launch` code paths against `ccwf tour`'s existing (working) launcher logic for the same agents
- [x] `--agent antigravity/cursor/roo-code --launch` still warns cleanly (no headless CLI) instead of attempting to spawn a nonexistent binary

Closes: none (no existing issue — invented this iteration by comparing `run.ts` and `tour.ts`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hpn2kBL6nsyL1zp7L5LxfP)_