### PR TITLE
improvement(cli): warn about target-ignored fields in ccwf export/run

### DIFF
--- a/.changeset/cli-ignored-field-warnings.md
+++ b/.changeset/cli-ignored-field-warnings.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": patch
+---
+
+`ccwf export` and `ccwf run` now warn which configured node fields the chosen target ignores (e.g. Sub-Agent model/tools/memory when exporting to codex), instead of silently dropping them.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,24 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Ignored-field warnings in `ccwf export` / `ccwf run`
+- **User value**: exporting a workflow to a non-Claude agent now warns exactly
+  which configured node fields (e.g. Sub-Agent model/tools/memory) the target
+  ignores, instead of silently dropping them.
+- **Issue/PR**: #803 (schema layer, previously unwired) / PR from
+  `claude/blissful-lamport-8ijgoh`
+- **Outcome**: done — wired `collectIgnoredFieldWarnings` (built in #803 but
+  never called by any exporter) into the CLI's shared `runExport`, so both
+  `ccwf export` and `ccwf run` emit per-field `warning:` lines on stderr
+  before writing files; verified E2E for codex/gemini (warns) and
+  claude-code (silent).
+- **Next proposals**:
+  - Surface the same ignored-field warnings in the VSCode extension's export
+    flow (filed as an `idea` issue) — the sub-agent panel comment already
+    promises "reported as ignored by other targets at export time".
+  - `ccwf validate --agent <target>` preflight target-compatibility check
+    (filed as an `idea` issue).
+
 ## 2026-07-22 — `ccwf run --launch` supports codex/copilot/gemini, not just claude-code
 - **User value**: a user running `ccwf run <file> --agent codex --launch` (or
   `copilot` / `gemini`) now gets that agent's CLI launched interactively,

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -14,7 +14,10 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {
   type AgentSkillProvider,
+  type ExportTarget,
   type PlannedExportFile,
+  agentSkillProviderToTarget,
+  collectIgnoredFieldWarnings,
   nodeNameToFileName,
   planAgentSkillFiles,
   planWorkflowExportFiles,
@@ -93,6 +96,14 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
     process.stderr.write(
       `warning: this workflow contains Claude Code-only node(s) (e.g. branchSession); ${options.agent} cannot execute those steps.\n`
     );
+  }
+
+  const target: ExportTarget =
+    options.agent === CLAUDE_CODE_AGENT
+      ? 'claudeCode'
+      : agentSkillProviderToTarget(options.agent as AgentSkillProvider);
+  for (const warning of collectIgnoredFieldWarnings(workflow, target)) {
+    process.stderr.write(`warning: ${warning}\n`);
   }
 
   const plan =


### PR DESCRIPTION
## Summary

Wires the ignored-field warning engine from the schema layer (#803) into the CLI's shared `runExport` path, so `ccwf export` and `ccwf run` now tell users exactly which configured node fields the chosen target ignores instead of silently dropping them.

`collectIgnoredFieldWarnings` was built in #803 for precisely this purpose ("Exporters call collectIgnoredFieldWarnings to report node fields that the chosen target silently drops") but no exporter ever called it — the sub-agent property panel even comments that such fields are "reported as ignored by other targets at export time", a promise nothing fulfilled until now.

## Changes

- `packages/cli/src/commands/export.ts`: map the `--agent` option to an `ExportTarget` (`claudeCode` for the default, `agentSkillProviderToTarget` otherwise) and emit one `warning:` line per set-but-ignored field on stderr before writing files. Warnings are advisory — the export still succeeds with exit 0.
- `docs/progress-log.md`: iteration entry.
- Changeset: patch bump for `@cc-wf-studio/cli`.

## Example

```
$ ccwf export review.json --agent codex
warning: Node "Code Reviewer" (subAgent): field "model" (=sonnet) is ignored when exporting to codex.
warning: Node "Code Reviewer" (subAgent): field "tools" (=Read, Grep) is ignored when exporting to codex.
warning: Node "Code Reviewer" (subAgent): field "memory" (=project) is ignored when exporting to codex.
✓ Wrote 1 file(s):
  - .codex/skills/review-pipeline/SKILL.md
```

## Testing

- `pnpm build && pnpm check` from the repo root: pass.
- Manual E2E: exported a workflow with SubAgent `model`/`tools`/`memory` set to `codex` and `gemini` (warnings shown, export succeeds) and to `claude-code` (no warnings); `ccwf run --agent gemini` shows the same warnings via the shared path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQXUt6mPe4nYoKfMLznpJp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQXUt6mPe4nYoKfMLznpJp)_