### PR TITLE
improvement(cli): add ccwf validate --agent target-compatibility preflight

### DIFF
--- a/.changeset/ccwf-validate-agent-preflight.md
+++ b/.changeset/ccwf-validate-agent-preflight.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": patch
+---
+
+`ccwf validate` gains `--agent <name>`: preflight which configured node fields the target agent ignores (and Claude Code-only nodes it cannot run) without writing any files. Warnings do not affect the exit code; with `--json` they are included as a `warnings` array.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,28 @@ Entry format:
 
 ---
 
+## 2026-07-22 — `ccwf validate --agent <target>` preflight compatibility check
+- **User value**: a user can now answer "will this workflow survive export to
+  codex/gemini/... intact?" before writing any files — `ccwf validate
+  --agent <name>` reports Claude Code-only nodes and every configured field
+  that target ignores; with `--json` the report lands in a `warnings` array.
+- **Issue/PR**: #853 / PR from `claude/sleepy-curie-3vbc9v`
+- **Outcome**: done — extracted the warning block `runExport` printed
+  (Claude Code-only check + `collectIgnoredFieldWarnings`) into a shared
+  `collectAgentCompatibilityWarnings` in `export.ts`, so `export`/`run`
+  and `validate --agent` can never drift; warnings never affect
+  `validate`'s exit code (a `--strict` promotion stays an open question on
+  #853). Compatibility is only checked when the workflow is schema-valid.
+- **Next proposals**:
+  - #852 (surface ignored-field warnings in the VSCode export flow) is still
+    open — needs a UX decision (notification vs. dialog) + i18n.
+  - `load-workflow.ts` surfaces raw `JSON.parse` errors (byte offset, no
+    line/col) for every command — a shared line/col translator would fix all
+    commands at once.
+  - GitHub reports Dependabot alerts on the default branch (2 high, 1 low at
+    push time); this loop has no alert-read access (no `gh`, no MCP tool) —
+    needs a human to review the Dependabot tab.
+
 ## 2026-07-22 — Ignored-field warnings in `ccwf export` / `ccwf run`
 - **User value**: exporting a workflow to a non-Claude agent now warns exactly
   which configured node fields (e.g. Sub-Agent model/tools/memory) the target

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ pnpm add -D @cc-wf-studio/cli
 | Command | Description |
 |---|---|
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
-| `ccwf validate <file>` | Schema-check the workflow JSON. Exit 0/1. `--json` for machine-readable output. |
+| `ccwf validate <file>` | Schema-check the workflow JSON. Exit 0/1. `--json` for machine-readable output. `--agent <name>` also preflights target compatibility. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
@@ -41,6 +41,10 @@ ccwf render ./.vscode/workflows/my-workflow.json -o out.md  # write to a file in
 ```sh
 ccwf validate ./.vscode/workflows/my-workflow.json          # exit 0/1
 ccwf validate ./.vscode/workflows/my-workflow.json --json   # prints { valid, errors[] }
+ccwf validate ./.vscode/workflows/my-workflow.json --agent codex
+# ^ also reports which configured fields codex would ignore on export,
+#   without writing any files (warnings don't affect the exit code;
+#   with --json they land in a `warnings` array)
 ```
 
 ### `ccwf mcp`

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -16,6 +16,7 @@ import {
   type AgentSkillProvider,
   type ExportTarget,
   type PlannedExportFile,
+  type Workflow,
   agentSkillProviderToTarget,
   collectIgnoredFieldWarnings,
   nodeNameToFileName,
@@ -27,7 +28,7 @@ import { Command, InvalidArgumentError } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
 
 const CLAUDE_CODE_AGENT = 'claude-code' as const;
-const SUPPORTED_AGENTS = [
+export const SUPPORTED_AGENTS = [
   CLAUDE_CODE_AGENT,
   'antigravity',
   'codex',
@@ -36,7 +37,7 @@ const SUPPORTED_AGENTS = [
   'gemini',
   'roo-code',
 ] as const;
-type SupportedAgent = (typeof SUPPORTED_AGENTS)[number];
+export type SupportedAgent = (typeof SUPPORTED_AGENTS)[number];
 
 export interface ExportRunOptions {
   /** Path to the workflow JSON. */
@@ -82,6 +83,31 @@ async function pathExists(target: string): Promise<boolean> {
 }
 
 /**
+ * Target-compatibility warnings for exporting `workflow` to `agent`:
+ * Claude Code-only nodes the agent cannot execute, plus every configured
+ * node field the target ignores. Shared by `ccwf export` / `ccwf run`
+ * (printed before writing files) and `ccwf validate --agent` (preflight,
+ * no files written).
+ */
+export function collectAgentCompatibilityWarnings(
+  workflow: Workflow,
+  agent: SupportedAgent
+): string[] {
+  const warnings: string[] = [];
+  if (agent !== CLAUDE_CODE_AGENT && workflowContainsClaudeCodeOnlyNodes(workflow)) {
+    warnings.push(
+      `this workflow contains Claude Code-only node(s) (e.g. branchSession); ${agent} cannot execute those steps.`
+    );
+  }
+  const target: ExportTarget =
+    agent === CLAUDE_CODE_AGENT
+      ? 'claudeCode'
+      : agentSkillProviderToTarget(agent as AgentSkillProvider);
+  warnings.push(...collectIgnoredFieldWarnings(workflow, target));
+  return warnings;
+}
+
+/**
  * Shared implementation invoked by both `ccwf export` and `ccwf run`.
  *
  * Throws `WorkflowLoadError` for `<file>` issues. Calls `process.exit(1)` on
@@ -92,17 +118,7 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
   const { workflow } = await loadWorkflowFromFile(options.file);
   const rootDir = path.resolve(options.cwd ?? process.cwd());
 
-  if (options.agent !== CLAUDE_CODE_AGENT && workflowContainsClaudeCodeOnlyNodes(workflow)) {
-    process.stderr.write(
-      `warning: this workflow contains Claude Code-only node(s) (e.g. branchSession); ${options.agent} cannot execute those steps.\n`
-    );
-  }
-
-  const target: ExportTarget =
-    options.agent === CLAUDE_CODE_AGENT
-      ? 'claudeCode'
-      : agentSkillProviderToTarget(options.agent as AgentSkillProvider);
-  for (const warning of collectIgnoredFieldWarnings(workflow, target)) {
+  for (const warning of collectAgentCompatibilityWarnings(workflow, options.agent)) {
     process.stderr.write(`warning: ${warning}\n`);
   }
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -4,14 +4,26 @@
  * Default output is a human-readable error list on stderr; exit 0 on pass,
  * exit 1 on validation failure. `--json` prints the raw `ValidationResult`
  * to stdout for CI scripting (still exit 0/1 by `valid` flag).
+ *
+ * `--agent <name>` additionally preflights target compatibility: it reports
+ * the same warnings `ccwf export --agent <name>` would print (Claude
+ * Code-only nodes, fields the target ignores) without writing any files.
+ * Warnings never affect the exit code — only schema validity does.
  */
 
-import { Command } from 'commander';
 import { type ValidationError, validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
+import { Command } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import {
+  SUPPORTED_AGENTS,
+  type SupportedAgent,
+  asSupportedAgent,
+  collectAgentCompatibilityWarnings,
+} from './export.js';
 
 interface ValidateOptions {
   json?: boolean;
+  agent?: SupportedAgent;
 }
 
 function formatError(err: ValidationError): string {
@@ -25,15 +37,36 @@ export function registerValidateCommand(program: Command): void {
     .description('Validate a workflow JSON file against the cc-wf-studio schema.')
     .argument('<file>', 'Path to a workflow JSON file.')
     .option('--json', 'Print the raw ValidationResult JSON to stdout.', false)
+    .option<SupportedAgent>(
+      '--agent <name>',
+      `Also preflight target compatibility for an agent (one of: ${SUPPORTED_AGENTS.join(', ')}): report which configured fields that target ignores, without writing files. Warnings do not affect the exit code.`,
+      (value) => asSupportedAgent(value)
+    )
     .action(async (file: string, options: ValidateOptions) => {
       try {
         const { workflow, absolutePath } = await loadWorkflowFromFile(file);
         const result = validateAIGeneratedWorkflow(workflow);
+        // Compatibility warnings only for a schema-valid workflow —
+        // malformed node data would produce garbage reports.
+        const warnings =
+          options.agent && result.valid
+            ? collectAgentCompatibilityWarnings(workflow, options.agent)
+            : [];
 
         if (options.json) {
-          process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+          const payload = options.agent ? { ...result, warnings } : result;
+          process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
         } else if (result.valid) {
           process.stdout.write(`✓ ${absolutePath} is valid.\n`);
+          if (options.agent) {
+            if (warnings.length === 0) {
+              process.stdout.write(`✓ No target-compatibility warnings for ${options.agent}.\n`);
+            } else {
+              for (const warning of warnings) {
+                process.stderr.write(`warning: ${warning}\n`);
+              }
+            }
+          }
         } else {
           process.stderr.write(`✗ ${absolutePath} has ${result.errors.length} error(s):\n`);
           for (const err of result.errors) {


### PR DESCRIPTION
## Summary

`ccwf validate` gains an optional `--agent <name>` flag that preflights target compatibility: it reports the same warnings `ccwf export --agent <name>` would print (Claude Code-only nodes the agent cannot execute, plus every configured node field the target ignores) **without writing any files**.

Closes #853

## Changes

- **`packages/cli/src/commands/export.ts`**: extracted the warning block `runExport` printed (Claude Code-only check + `collectIgnoredFieldWarnings`) into an exported `collectAgentCompatibilityWarnings(workflow, agent)`, so `export`/`run` and `validate --agent` share one implementation and cannot drift. Also exported `SUPPORTED_AGENTS` / `SupportedAgent`.
- **`packages/cli/src/commands/validate.ts`**: new `--agent <name>` option (validated against the same agent list as `export`). Human mode prints `warning:` lines on stderr, or a positive `✓ No target-compatibility warnings for <agent>.` confirmation. `--json` includes a `warnings` array alongside the existing `ValidationResult` (only when `--agent` is passed, so existing JSON consumers are unaffected).
- **`packages/cli/README.md`**: documented the new flag.
- Changeset: patch bump for `@cc-wf-studio/cli`. Progress-log entry included.

## Design decisions

- Warnings never affect the exit code — only schema validity does. Promoting warnings to errors (`--strict`) stays an open question on #853.
- Compatibility warnings are computed only when the workflow is schema-valid; malformed node data would produce garbage reports.

## Verification (manual E2E on the built CLI)

- `validate <file>` (no flag): output unchanged, exit 0/1 as before
- `validate <file> --agent codex` on a clean workflow: `✓ No target-compatibility warnings for codex.`
- `validate <file> --agent gemini` on a workflow with configured SubAgent `model`/`color`: 10 `warning:` lines on stderr, exit 0
- `--agent gemini --json`: `warnings` array with 10 entries alongside `valid`/`errors`
- `--agent nope`: clean commander error listing valid agents
- `ccwf export --agent gemini` still prints the same warnings after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuAsg6FkiRsjuqZ3QEp9Y1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuAsg6FkiRsjuqZ3QEp9Y1)_