### PR TITLE
improvement(vscode): surface target-compatibility warnings in export/run flows

### DIFF
--- a/.changeset/vscode-export-compat-warnings.md
+++ b/.changeset/vscode-export-compat-warnings.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Show target-compatibility warnings when exporting or running a workflow for a non-Claude agent (Codex, Copilot, Gemini, Cursor, Zoo Code, Antigravity) from the canvas: a notification reports how many configured settings the target ignores, and "Show Details" opens the full per-field list in an output channel — the same report `ccwf export` / `ccwf run` print.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,26 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Target-compatibility warnings in the VSCode export/run flows
+- **User value**: exporting or running a workflow for Codex / Copilot /
+  Gemini / Cursor / Zoo Code / Antigravity from the canvas now shows a
+  warning notification naming how many configured settings that agent
+  ignores, with a "Show Details" button listing every dropped field —
+  instead of the extension silently writing a lossy export.
+- **Issue/PR**: #852 / PR from `claude/sleepy-curie-rd0zcn`
+- **Outcome**: done — new `export-warning-service.ts` mirrors the CLI's
+  compatibility report (Claude Code-only nodes + `collectIgnoredFieldWarnings`)
+  and is called from all 14 non-Claude export/run handler paths. UX decision:
+  non-modal notification + output channel (matches the CLI's warn-but-proceed
+  behavior); no i18n needed since extension-side notifications are uniformly
+  English (the webview i18n rules don't apply to `vscode.window` messages).
+- **Next proposals**:
+  - `load-workflow.ts` still surfaces raw `JSON.parse` errors (byte offset,
+    no line/col) for every CLI command — a shared line/col translator would
+    fix all commands at once.
+  - The CLI's "Claude Code-only node" warning is aggregate-only; naming the
+    affected node ids would tell users what exactly breaks on export.
+
 ## 2026-07-22 — `ccwf validate --agent <target>` preflight compatibility check
 - **User value**: a user can now answer "will this workflow survive export to
   codex/gemini/... intact?" before writing any files — `ccwf validate

--- a/packages/vscode/src/extension/commands/antigravity-handlers.ts
+++ b/packages/vscode/src/extension/commands/antigravity-handlers.ts
@@ -20,6 +20,7 @@ import {
   checkExistingAntigravitySkill,
   exportWorkflowAsAntigravitySkill,
 } from '../services/antigravity-skill-export-service';
+import { notifyTargetCompatibilityWarnings } from '../services/export-warning-service';
 import type { FileService } from '../services/file-service';
 import {
   hasNonStandardSkills,
@@ -80,6 +81,8 @@ export async function handleExportForAntigravity(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'antigravity', 'Antigravity');
 
     // Send success response
     const successPayload: ExportForAntigravitySuccessPayload = {
@@ -192,6 +195,8 @@ export async function handleRunForAntigravity(
       });
       return { status: 'failed' };
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'antigravity', 'Antigravity');
 
     // If skipCascadeLaunch is set, stop after export (MCP refresh dialog will handle launch)
     if (options?.skipCascadeLaunch) {

--- a/packages/vscode/src/extension/commands/codex-handlers.ts
+++ b/packages/vscode/src/extension/commands/codex-handlers.ts
@@ -25,6 +25,7 @@ import {
 } from '../services/codex-skill-export-service';
 import { codexTerminalSessionManager } from '../services/codex-terminal-session-manager';
 import { extractMcpServerIdsFromWorkflow } from '../services/copilot-export-service';
+import { notifyTargetCompatibilityWarnings } from '../services/export-warning-service';
 import type { FileService } from '../services/file-service';
 import {
   hasNonStandardSkills,
@@ -109,6 +110,8 @@ export async function handleExportForCodexCli(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'codex', 'Codex CLI');
 
     // Send success response
     const successPayload: ExportForCodexCliSuccessPayload = {
@@ -263,6 +266,8 @@ export async function handleRunForCodexCli(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'codex', 'Codex CLI');
 
     // Step 4: Sync MCP servers to $HOME/.codex/config.toml if confirmed
     let syncedMcpServers: string[] = [];

--- a/packages/vscode/src/extension/commands/copilot-handlers.ts
+++ b/packages/vscode/src/extension/commands/copilot-handlers.ts
@@ -33,6 +33,7 @@ import {
   exportWorkflowAsSkill,
 } from '../services/copilot-skill-export-service';
 import { nodeNameToFileName } from '../services/export-service';
+import { notifyTargetCompatibilityWarnings } from '../services/export-warning-service';
 import type { FileService } from '../services/file-service';
 import {
   hasNonStandardSkills,
@@ -115,6 +116,8 @@ export async function handleExportForCopilot(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'copilot', 'GitHub Copilot');
 
     // Execute MCP sync if user confirmed
     let syncedMcpServers: string[] = [];
@@ -231,6 +234,8 @@ export async function handleRunForCopilot(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'copilot', 'GitHub Copilot');
 
     // Execute MCP sync if user confirmed
     if (mcpSyncConfirmed) {
@@ -407,6 +412,8 @@ export async function handleRunForCopilotCli(
       return;
     }
 
+    notifyTargetCompatibilityWarnings(workflow, 'copilot', 'Copilot CLI');
+
     // Step 4: Sync MCP servers to $HOME/.copilot/mcp-config.json if confirmed
     let syncedMcpServers: string[] = [];
     if (mcpSyncConfirmed) {
@@ -508,6 +515,8 @@ export async function handleExportForCopilotCli(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'copilot', 'Copilot CLI');
 
     // Send success response
     const successPayload: ExportForCopilotCliSuccessPayload = {

--- a/packages/vscode/src/extension/commands/cursor-handlers.ts
+++ b/packages/vscode/src/extension/commands/cursor-handlers.ts
@@ -17,6 +17,7 @@ import {
   checkExistingCursorSkill,
   exportWorkflowAsCursorSkill,
 } from '../services/cursor-skill-export-service';
+import { notifyTargetCompatibilityWarnings } from '../services/export-warning-service';
 import type { FileService } from '../services/file-service';
 import {
   hasNonStandardSkills,
@@ -77,6 +78,8 @@ export async function handleExportForCursor(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'cursor', 'Cursor');
 
     // Send success response
     const successPayload: ExportForCursorSuccessPayload = {
@@ -185,6 +188,8 @@ export async function handleRunForCursor(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'cursor', 'Cursor');
 
     // Step 3: Check if Cursor is installed
     if (!isCursorInstalled()) {

--- a/packages/vscode/src/extension/commands/gemini-handlers.ts
+++ b/packages/vscode/src/extension/commands/gemini-handlers.ts
@@ -14,6 +14,7 @@ import type {
   RunForGeminiCliSuccessPayload,
 } from '../../shared/types/messages';
 import { extractMcpServerIdsFromWorkflow } from '../services/copilot-export-service';
+import { notifyTargetCompatibilityWarnings } from '../services/export-warning-service';
 import type { FileService } from '../services/file-service';
 import {
   checkGeminiAgentsEnabled,
@@ -108,6 +109,8 @@ export async function handleExportForGeminiCli(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'gemini', 'Gemini CLI');
 
     // Send success response
     const successPayload: ExportForGeminiCliSuccessPayload = {
@@ -260,6 +263,8 @@ export async function handleRunForGeminiCli(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'gemini', 'Gemini CLI');
 
     // Step 4: Sync MCP servers to ~/.gemini/settings.json if confirmed
     let syncedMcpServers: string[] = [];

--- a/packages/vscode/src/extension/commands/roo-code-handlers.ts
+++ b/packages/vscode/src/extension/commands/roo-code-handlers.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../shared/types/messages';
 import { extractMcpServerIdsFromWorkflow } from '../services/copilot-export-service';
 import { nodeNameToFileName } from '../services/export-service';
+import { notifyTargetCompatibilityWarnings } from '../services/export-warning-service';
 import type { FileService } from '../services/file-service';
 import {
   getInstalledRooCodeFlavor,
@@ -109,6 +110,8 @@ export async function handleExportForRooCode(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'roo-code', 'Zoo Code');
 
     // Send success response
     const successPayload: ExportForRooCodeSuccessPayload = {
@@ -256,6 +259,8 @@ export async function handleRunForRooCode(
       });
       return;
     }
+
+    notifyTargetCompatibilityWarnings(workflow, 'roo-code', 'Zoo Code');
 
     // Step 4: Sync MCP servers to .roo/mcp.json if confirmed
     let syncedMcpServers: string[] = [];

--- a/packages/vscode/src/extension/services/export-warning-service.ts
+++ b/packages/vscode/src/extension/services/export-warning-service.ts
@@ -1,0 +1,84 @@
+/**
+ * Claude Code Workflow Studio - Export Warning Service
+ *
+ * Surfaces target-compatibility warnings when a workflow is exported or run
+ * for a non-Claude agent from the canvas (issue #852). Mirrors the warnings
+ * `ccwf export` / `ccwf run` print on stderr: Claude Code-only nodes the
+ * target cannot execute, plus every configured node field the target ignores
+ * (derived from the same schema registry the property panels render from).
+ *
+ * Non-blocking by design: the export has already succeeded when this runs;
+ * the notification tells the user what the target silently drops.
+ */
+
+import {
+  collectIgnoredFieldWarnings,
+  type ExportTarget,
+  type Workflow,
+  workflowContainsClaudeCodeOnlyNodes,
+} from '@cc-wf-studio/core';
+import * as vscode from 'vscode';
+
+let outputChannel: vscode.OutputChannel | undefined;
+
+function getOutputChannel(): vscode.OutputChannel {
+  if (!outputChannel) {
+    outputChannel = vscode.window.createOutputChannel('CC Workflow Studio: Export Warnings');
+  }
+  return outputChannel;
+}
+
+/**
+ * Collect the same target-compatibility report `ccwf export` / `ccwf run` /
+ * `ccwf validate --agent` produce: Claude Code-only nodes plus per-field
+ * "ignored when exporting to <target>" warnings.
+ */
+export function collectTargetCompatibilityWarnings(
+  workflow: Workflow,
+  target: ExportTarget,
+  agentLabel: string
+): string[] {
+  const warnings: string[] = [];
+  if (target !== 'claudeCode' && workflowContainsClaudeCodeOnlyNodes(workflow)) {
+    warnings.push(
+      `This workflow contains Claude Code-only node(s) (e.g. branchSession); ${agentLabel} cannot execute those steps.`
+    );
+  }
+  warnings.push(...collectIgnoredFieldWarnings(workflow, target));
+  return warnings;
+}
+
+/**
+ * Show a non-modal warning notification for any compatibility warnings, with
+ * a "Show Details" button that opens the full per-field list in the output
+ * channel. No-op when the workflow is fully compatible with the target.
+ */
+export function notifyTargetCompatibilityWarnings(
+  workflow: Workflow,
+  target: ExportTarget,
+  agentLabel: string
+): void {
+  const warnings = collectTargetCompatibilityWarnings(workflow, target, agentLabel);
+  if (warnings.length === 0) {
+    return;
+  }
+
+  const channel = getOutputChannel();
+  channel.appendLine(`Workflow "${workflow.name}" exported for ${agentLabel}:`);
+  for (const warning of warnings) {
+    channel.appendLine(`  warning: ${warning}`);
+  }
+  channel.appendLine('');
+
+  const summary =
+    warnings.length === 1
+      ? warnings[0]
+      : `${warnings.length} configured settings are ignored by ${agentLabel}.`;
+  vscode.window
+    .showWarningMessage(`Exported with warnings: ${summary}`, 'Show Details')
+    .then((choice) => {
+      if (choice === 'Show Details') {
+        channel.show(true);
+      }
+    });
+}


### PR DESCRIPTION
## Summary

Closes #852.

`ccwf export` / `ccwf run` warn (since #851/#855) which configured node fields a non-Claude target ignores — but the VSCode extension's export/run flows still wrote lossy exports silently. This PR surfaces the same compatibility report in the extension.

## What changed

- **New `packages/vscode/src/extension/services/export-warning-service.ts`** — collects the same report the CLI prints (Claude Code-only nodes the target cannot execute + every configured field the target ignores, via core's `collectIgnoredFieldWarnings`) and shows a **non-modal warning notification** with a **"Show Details"** button that opens the full per-field list in a `CC Workflow Studio: Export Warnings` output channel. No-op when the workflow is fully compatible.
- Wired into **all 14 non-Claude export/run handler paths**: Codex (2), Copilot chat (2), Copilot CLI (2), Cursor (2), Gemini (2), Zoo Code (2), Antigravity (2). Each call runs right after the export succeeds, matching the CLI's warn-but-proceed behavior.

## UX decision (deferred in #852)

Notification + output channel rather than a blocking dialog — the export already succeeded; the user just needs to know what was dropped. No i18n changes needed: extension-side `vscode.window` notifications are uniformly English across the codebase (the webview i18n rules do not apply here), which resolves the locale-file concern that split this from #851.

## Notes

- Changeset added: `cc-wf-studio` patch.
- Progress-log entry included per the autonomous-loop contract.
- `pnpm build` and `pnpm check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SawCpDxcd3FXyekn37J2f

---
_Generated by [Claude Code](https://claude.ai/code/session_015SawCpDxcd3FXyekn37J2f)_