### PR TITLE
improvement(core,cli,vscode): name affected nodes in Claude Code-only warnings

### DIFF
--- a/.changeset/name-claude-only-nodes-in-warnings.md
+++ b/.changeset/name-claude-only-nodes-in-warnings.md
@@ -1,0 +1,6 @@
+---
+'@cc-wf-studio/core': patch
+'cc-wf-studio': patch
+---
+
+Target-compatibility warnings now name each Claude Code-only node by its canvas label (e.g. `"Branch Session Work" (branchSession)`) instead of a generic `(e.g. branchSession)` hint, in `ccwf export`/`run`/`validate --agent` and the VSCode export warning alike.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,36 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Name the affected nodes in Claude Code-only warnings
+- **User value**: a user exporting, running, or preflighting a workflow for a
+  non-Claude agent now sees exactly which nodes that agent cannot execute —
+  `"Branch Session Work" (branchSession)` — instead of the vague
+  `(e.g. branchSession)` hint, in `ccwf export/run/validate --agent` and the
+  VSCode export-warning notification alike.
+- **Issue/PR**: #857 / PR from `claude/sleepy-curie-6j9vke`
+- **Outcome**: done — new core helper `describeClaudeCodeOnlyNodes` (prefers
+  the node's canvas `data.label`, then `name`, then id) replaces the
+  hard-coded phrasing in both the CLI's `collectAgentCompatibilityWarnings`
+  and the extension's `collectTargetCompatibilityWarnings`, so the two
+  surfaces cannot drift. E2E-verified: codex/gemini warn with the node
+  label, claude-code stays silent, `validate --json` carries the richer
+  string. Also judged-and-dropped this round: the thrice-proposed JSON
+  line/col translator for `load-workflow.ts` — Node 22+ already appends
+  `(line N column M)` to `JSON.parse` errors, so the value is marginal on
+  supported runtimes. Note: the loop could not lock issue #857 (no `gh`
+  CLI, no MCP lock tool, direct GitHub API blocked by the session proxy) —
+  flagged in the issue body instead.
+- **Next proposals**:
+  - MCP tool descriptions/error text (`packages/mcp/src/tools.ts`) hard-code
+    VSCode-canvas language ("open the workflow in CC Workflow Studio",
+    "review mode" diff preview) even when served by `FileWorkflowAdapter`
+    (`ccwf mcp --file`) — misleads AI agents driving the CLI MCP server.
+  - Canvas: no way to duplicate a configured node (subAgent/prompt) —
+    cloning one means recreating every field by hand.
+  - Give the loop a supported way to lock its idea issues (e.g. an MCP lock
+    tool or `gh` in the session image) — currently the lock step of
+    `next-task` cannot be honored.
+
 ## 2026-07-22 — Target-compatibility warnings in the VSCode export/run flows
 - **User value**: exporting or running a workflow for Codex / Copilot /
   Gemini / Cursor / Zoo Code / Antigravity from the canvas now shows a

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -19,10 +19,10 @@ import {
   type Workflow,
   agentSkillProviderToTarget,
   collectIgnoredFieldWarnings,
+  describeClaudeCodeOnlyNodes,
   nodeNameToFileName,
   planAgentSkillFiles,
   planWorkflowExportFiles,
-  workflowContainsClaudeCodeOnlyNodes,
 } from '@cc-wf-studio/core';
 import { Command, InvalidArgumentError } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
@@ -94,9 +94,10 @@ export function collectAgentCompatibilityWarnings(
   agent: SupportedAgent
 ): string[] {
   const warnings: string[] = [];
-  if (agent !== CLAUDE_CODE_AGENT && workflowContainsClaudeCodeOnlyNodes(workflow)) {
+  const claudeOnlyNodes = describeClaudeCodeOnlyNodes(workflow);
+  if (agent !== CLAUDE_CODE_AGENT && claudeOnlyNodes.length > 0) {
     warnings.push(
-      `this workflow contains Claude Code-only node(s) (e.g. branchSession); ${agent} cannot execute those steps.`
+      `this workflow contains Claude Code-only node(s) that ${agent} cannot execute: ${claudeOnlyNodes.join(', ')}.`
     );
   }
   const target: ExportTarget =

--- a/packages/core/src/schema/claude-code-only.ts
+++ b/packages/core/src/schema/claude-code-only.ts
@@ -22,3 +22,19 @@ export function getClaudeCodeOnlyNodes(nodes: readonly WorkflowNode[]): Workflow
 export function workflowContainsClaudeCodeOnlyNodes(workflow: Workflow): boolean {
   return getClaudeCodeOnlyNodes(workflow.nodes).length > 0;
 }
+
+/**
+ * Human-readable descriptions of the Claude Code-only nodes in a workflow,
+ * e.g. `"Checkpoint A" (branchSession)`. Prefers the node's canvas display
+ * label (`data.label`), then its name, then its id. Used by exporters and
+ * UIs to name the exact nodes in target-compatibility warnings.
+ */
+export function describeClaudeCodeOnlyNodes(workflow: Workflow): string[] {
+  return getClaudeCodeOnlyNodes(workflow.nodes).map((node) => {
+    const label = (node.data as { label?: unknown }).label;
+    const display =
+      [label, node.name].find((v): v is string => typeof v === 'string' && v.trim().length > 0) ??
+      node.id;
+    return `"${display.trim()}" (${node.type})`;
+  });
+}

--- a/packages/vscode/src/extension/services/export-warning-service.ts
+++ b/packages/vscode/src/extension/services/export-warning-service.ts
@@ -13,9 +13,9 @@
 
 import {
   collectIgnoredFieldWarnings,
+  describeClaudeCodeOnlyNodes,
   type ExportTarget,
   type Workflow,
-  workflowContainsClaudeCodeOnlyNodes,
 } from '@cc-wf-studio/core';
 import * as vscode from 'vscode';
 
@@ -39,9 +39,10 @@ export function collectTargetCompatibilityWarnings(
   agentLabel: string
 ): string[] {
   const warnings: string[] = [];
-  if (target !== 'claudeCode' && workflowContainsClaudeCodeOnlyNodes(workflow)) {
+  const claudeOnlyNodes = describeClaudeCodeOnlyNodes(workflow);
+  if (target !== 'claudeCode' && claudeOnlyNodes.length > 0) {
     warnings.push(
-      `This workflow contains Claude Code-only node(s) (e.g. branchSession); ${agentLabel} cannot execute those steps.`
+      `This workflow contains Claude Code-only node(s) that ${agentLabel} cannot execute: ${claudeOnlyNodes.join(', ')}.`
     );
   }
   warnings.push(...collectIgnoredFieldWarnings(workflow, target));


### PR DESCRIPTION
## Summary

Closes #857.

`ccwf export/run/validate --agent <target>` and the VSCode export flow warn about Claude Code-only nodes with a hard-coded hint — `contains Claude Code-only node(s) (e.g. branchSession)` — so a user cannot tell **which** nodes will break without opening the workflow JSON. This PR makes both surfaces name each affected node.

## What changed

- **`packages/core/src/schema/claude-code-only.ts`** — new `describeClaudeCodeOnlyNodes(workflow)` helper formatting each Claude Code-only node as `"<display>" (<type>)`, preferring the node's canvas display label (`data.label`), then `name`, then `id`.
- **`packages/cli/src/commands/export.ts`** (`collectAgentCompatibilityWarnings`, shared by `export`/`run`/`validate --agent`) and **`packages/vscode/src/extension/services/export-warning-service.ts`** (`collectTargetCompatibilityWarnings`) both use the helper, replacing the hard-coded `(e.g. branchSession)` phrasing in the one place it can no longer drift.

Example (bundled branch-session sample, `--agent codex`):

```
warning: this workflow contains Claude Code-only node(s) that codex cannot execute: "Branch Session Work" (branchSession).
```

## Verification

- `pnpm build` and `pnpm check` pass from the repo root.
- E2E on the built CLI with the bundled `daily-dev-with-branch-sample`: codex/gemini warn with the node label, `--agent claude-code` stays silent, and `validate --agent gemini --json` carries the richer string in `warnings`.

## Notes

- Changeset added: `@cc-wf-studio/core` + `cc-wf-studio` patch (cli/mcp follow core via `updateInternalDependencies`).
- Progress-log entry included per the autonomous-loop contract.
- Loop note: issue #857 could not be locked from this session (no `gh`, no MCP lock tool, direct API blocked); flagged in the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAZyNc6btD6uPuqzTaKGkY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAZyNc6btD6uPuqzTaKGkY)_