### PR TITLE
improvement(mcp,cli): mode-aware MCP tool text for file mode

### DIFF
--- a/.changeset/mode-aware-mcp-tool-text.md
+++ b/.changeset/mode-aware-mcp-tool-text.md
@@ -1,0 +1,6 @@
+---
+'@cc-wf-studio/mcp': patch
+'@cc-wf-studio/cli': patch
+---
+
+Make MCP tool descriptions and errors mode-aware: in file mode (`ccwf mcp --file` / `ccwf-mcp`) the tools now describe the workflow file being edited — including sha256-revision conflict detection and the fact that sub-agent `.md` files are not auto-created — instead of instructing AI agents to open the VSCode canvas or promising a review dialog that file mode does not have. Canvas-mode text is unchanged.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,33 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Mode-aware MCP tool text for file mode
+- **User value**: an AI agent editing a workflow through `ccwf mcp --file` or
+  the `ccwf-mcp` stdio bin is no longer told to "open a workflow in CC
+  Workflow Studio first" or promised a review-dialog diff preview and
+  auto-created sub-agent `.md` files that don't exist in file mode — tool
+  descriptions and errors now describe the workflow file, sha256-revision
+  conflict detection, and the "set commandFilePath yourself" rule, so agents
+  stop giving users wrong advice.
+- **Issue/PR**: #860 / PR from `claude/sleepy-curie-ralz5b`
+- **Outcome**: done — `registerWorkflowTools`/`createWorkflowMcpServer` gained
+  a `mode: 'canvas' | 'file'` option (default `'canvas'`); a per-mode text
+  table in `tools.ts` keeps the canvas strings byte-for-byte identical
+  (verified against the built dist) while both file-mode entry points
+  (`ccwf mcp`, `ccwf-mcp`) pass `mode: 'file'`. E2E-verified over stdio:
+  tools/list shows file-oriented descriptions and a missing file now says
+  "Use apply_workflow to create it". Also filed #861 (duplicate-node canvas
+  action) as the runner-up idea. Locking #860/#861 remains impossible in
+  this session (no `gh` CLI, no MCP lock tool) — noted in the issue bodies.
+- **Next proposals**:
+  - #861: Duplicate button for configured canvas nodes (store action +
+    button next to DeleteButton; skip start/end/group initially).
+  - File mode returns `plannedFiles: []` silently — consider implementing
+    sub-agent auto-creation in `FileWorkflowAdapter` so file-mode parity
+    with the canvas grows instead of being documented away.
+  - Give the loop a supported way to lock its idea issues (e.g. `gh` in the
+    session image or an MCP lock tool).
+
 ## 2026-07-22 — Name the affected nodes in Claude Code-only warnings
 - **User value**: a user exporting, running, or preflighting a workflow for a
   non-Claude agent now sees exactly which nodes that agent cannot execute —

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -30,7 +30,7 @@ export function registerMcpCommand(program: Command): void {
         filePath: options.file,
         projectRoot: options.projectRoot,
       });
-      const server = createWorkflowMcpServer(adapter);
+      const server = createWorkflowMcpServer(adapter, { mode: 'file' });
       const transport = new StdioServerTransport();
       await server.connect(transport);
     });

--- a/packages/mcp/src/factory.ts
+++ b/packages/mcp/src/factory.ts
@@ -6,7 +6,7 @@
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { registerWorkflowTools } from './tools.js';
+import { registerWorkflowTools, type WorkflowMcpMode } from './tools.js';
 import type { WorkflowIoAdapter } from './types.js';
 
 export interface CreateWorkflowMcpServerOptions {
@@ -16,6 +16,13 @@ export interface CreateWorkflowMcpServerOptions {
    */
   name?: string;
   version?: string;
+  /**
+   * Which surface the adapter edits — selects the tool description/error
+   * text. `'canvas'` (default) keeps the historical canvas-oriented wording;
+   * `'file'` describes the workflow file instead (no editor, no review
+   * dialog, no sub-agent auto-creation).
+   */
+  mode?: WorkflowMcpMode;
 }
 
 const DEFAULT_SERVER_NAME = 'cc-workflow-studio';
@@ -43,6 +50,6 @@ export function createWorkflowMcpServer(
     }
   );
 
-  registerWorkflowTools(server, adapter);
+  registerWorkflowTools(server, adapter, { mode: options.mode });
   return server;
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -18,7 +18,11 @@ export type {
   WorkflowIoAdapter,
 } from './types.js';
 
-export { registerWorkflowTools } from './tools.js';
+export {
+  registerWorkflowTools,
+  type RegisterWorkflowToolsOptions,
+  type WorkflowMcpMode,
+} from './tools.js';
 export {
   createWorkflowMcpServer,
   type CreateWorkflowMcpServerOptions,

--- a/packages/mcp/src/mcp.ts
+++ b/packages/mcp/src/mcp.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
     projectRoot: typeof projectRoot === 'string' ? projectRoot : undefined,
   });
 
-  const server = createWorkflowMcpServer(adapter);
+  const server = createWorkflowMcpServer(adapter, { mode: 'file' });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,10 +1,13 @@
 /**
  * Tool registrations for the cc-wf-studio MCP server.
  *
- * Each tool delegates IO to the supplied `WorkflowIoAdapter`. The MCP request
- * shape (name, description, zod schema, response envelope) is preserved
- * byte-for-byte from the previous in-process VSCode implementation so AI
- * clients connected via the existing skill continue to work.
+ * Each tool delegates IO to the supplied `WorkflowIoAdapter`. In `canvas`
+ * mode the MCP request shape (name, description, zod schema, response
+ * envelope) is preserved byte-for-byte from the previous in-process VSCode
+ * implementation so AI clients connected via the existing skill continue to
+ * work. In `file` mode the descriptions and error strings describe the
+ * workflow file being edited instead of the canvas — there is no editor to
+ * open, no review dialog, and no sub-agent auto-creation.
  */
 
 import {
@@ -35,22 +38,93 @@ const fail = (payload: unknown, isError = true): ToolReply => ({
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-export function registerWorkflowTools(
-  server: McpServer,
-  adapter: WorkflowIoAdapter
-): void {
-  registerGetCurrentWorkflow(server, adapter);
-  registerGetWorkflowSchema(server, adapter);
-  registerApplyWorkflow(server, adapter);
-  registerListAvailableAgents(server, adapter);
-  registerUpdateNodes(server, adapter);
-  registerHighlightGroupNode(server, adapter);
+/**
+ * Which surface the server edits. Selects the tool description/error text:
+ *   - `canvas` — the live CC Workflow Studio webview (VSCode in-process server)
+ *   - `file`   — a workflow JSON file (`ccwf mcp --file` / `ccwf-mcp` stdio bin)
+ */
+export type WorkflowMcpMode = 'canvas' | 'file';
+
+export interface RegisterWorkflowToolsOptions {
+  /** Defaults to `'canvas'`, which preserves the historical tool text exactly. */
+  mode?: WorkflowMcpMode;
 }
 
-function registerGetCurrentWorkflow(server: McpServer, adapter: WorkflowIoAdapter): void {
+interface ToolText {
+  getCurrentWorkflowDescription: string;
+  noActiveWorkflowError: string;
+  applyWorkflowDescription: string;
+  applyWorkflowParamDescription: string;
+  applyChangeDescriptionParam: string;
+  applyRevisionParamDescription: string;
+  updateNodesDescription: string;
+  updateNodesChangeDescriptionParam: string;
+  highlightGroupNodeDescription: string;
+}
+
+const TOOL_TEXT: Record<WorkflowMcpMode, ToolText> = {
+  canvas: {
+    getCurrentWorkflowDescription:
+      'Get the currently active workflow from CC Workflow Studio canvas. Returns the workflow JSON and whether it is stale (from cache when the editor is closed).',
+    noActiveWorkflowError:
+      'No active workflow. Please open a workflow in CC Workflow Studio first.',
+    applyWorkflowDescription:
+      'Apply a workflow to the CC Workflow Studio canvas. The workflow is validated before being applied. If the user has review mode enabled, they will see a diff preview and must accept changes before they are applied. If rejected, an error with message "User rejected the changes" is returned. The editor must be open. SubAgent nodes without commandFilePath will have .md files auto-created in .claude/agents/.',
+    applyWorkflowParamDescription: 'The workflow JSON string to apply to the canvas',
+    applyChangeDescriptionParam:
+      'A brief description of the changes being made (e.g., "Added error handling step after API call"). Shown to the user in the review dialog.',
+    applyRevisionParamDescription:
+      'Workflow revision from get_current_workflow for conflict detection. If provided and the workflow has been modified since, the apply will be rejected or a warning shown.',
+    updateNodesDescription:
+      'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and applies to the canvas. Only updates existing nodes — use apply_workflow to add or remove nodes.',
+    updateNodesChangeDescriptionParam:
+      'A brief description of the changes being made. Shown to the user in the review dialog.',
+    highlightGroupNodeDescription:
+      'Highlight a group node on the CC Workflow Studio canvas to indicate it is currently being executed. Call this before executing nodes within a group to visually track progress.',
+  },
+  file: {
+    getCurrentWorkflowDescription:
+      'Get the current workflow from the target workflow JSON file. Returns the workflow JSON and a revision hash (sha256 of the file contents) for conflict detection.',
+    noActiveWorkflowError:
+      'No workflow found: the target workflow file does not exist yet. Use apply_workflow to create it.',
+    applyWorkflowDescription:
+      'Write a workflow to the target workflow JSON file. The workflow is validated before being written; the write is atomic and is rejected with a revision-conflict error if the file changed since the provided revision was read. File mode does NOT auto-create sub-agent .md files — set commandFilePath to an existing file on each SubAgent node.',
+    applyWorkflowParamDescription: 'The workflow JSON string to write to the workflow file',
+    applyChangeDescriptionParam:
+      'A brief description of the changes being made (e.g., "Added error handling step after API call"). Not displayed in file mode; safe to omit.',
+    applyRevisionParamDescription:
+      'Workflow revision from get_current_workflow for conflict detection. If provided and the file has changed since it was read, the write is rejected with a revision-conflict error.',
+    updateNodesDescription:
+      'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and writes it back to the workflow file. Only updates existing nodes — use apply_workflow to add or remove nodes.',
+    updateNodesChangeDescriptionParam:
+      'A brief description of the changes being made. Not displayed in file mode; safe to omit.',
+    highlightGroupNodeDescription:
+      'Highlight a group node to indicate it is currently being executed. In file mode this is a no-op kept for compatibility — highlighting is only visible on the CC Workflow Studio canvas.',
+  },
+};
+
+export function registerWorkflowTools(
+  server: McpServer,
+  adapter: WorkflowIoAdapter,
+  options: RegisterWorkflowToolsOptions = {}
+): void {
+  const text = TOOL_TEXT[options.mode ?? 'canvas'];
+  registerGetCurrentWorkflow(server, adapter, text);
+  registerGetWorkflowSchema(server, adapter);
+  registerApplyWorkflow(server, adapter, text);
+  registerListAvailableAgents(server, adapter);
+  registerUpdateNodes(server, adapter, text);
+  registerHighlightGroupNode(server, adapter, text);
+}
+
+function registerGetCurrentWorkflow(
+  server: McpServer,
+  adapter: WorkflowIoAdapter,
+  text: ToolText
+): void {
   server.tool(
     'get_current_workflow',
-    'Get the currently active workflow from CC Workflow Studio canvas. Returns the workflow JSON and whether it is stale (from cache when the editor is closed).',
+    text.getCurrentWorkflowDescription,
     {},
     async () => {
       try {
@@ -59,8 +133,7 @@ function registerGetCurrentWorkflow(server: McpServer, adapter: WorkflowIoAdapte
           return fail(
             {
               success: false,
-              error:
-                'No active workflow. Please open a workflow in CC Workflow Studio first.',
+              error: text.noActiveWorkflowError,
             },
             false
           );
@@ -99,24 +172,18 @@ function registerGetWorkflowSchema(server: McpServer, adapter: WorkflowIoAdapter
   );
 }
 
-function registerApplyWorkflow(server: McpServer, adapter: WorkflowIoAdapter): void {
+function registerApplyWorkflow(
+  server: McpServer,
+  adapter: WorkflowIoAdapter,
+  text: ToolText
+): void {
   server.tool(
     'apply_workflow',
-    'Apply a workflow to the CC Workflow Studio canvas. The workflow is validated before being applied. If the user has review mode enabled, they will see a diff preview and must accept changes before they are applied. If rejected, an error with message "User rejected the changes" is returned. The editor must be open. SubAgent nodes without commandFilePath will have .md files auto-created in .claude/agents/.',
+    text.applyWorkflowDescription,
     {
-      workflow: z.string().describe('The workflow JSON string to apply to the canvas'),
-      description: z
-        .string()
-        .optional()
-        .describe(
-          'A brief description of the changes being made (e.g., "Added error handling step after API call"). Shown to the user in the review dialog.'
-        ),
-      revision: z
-        .string()
-        .optional()
-        .describe(
-          'Workflow revision from get_current_workflow for conflict detection. If provided and the workflow has been modified since, the apply will be rejected or a warning shown.'
-        ),
+      workflow: z.string().describe(text.applyWorkflowParamDescription),
+      description: z.string().optional().describe(text.applyChangeDescriptionParam),
+      revision: z.string().optional().describe(text.applyRevisionParamDescription),
     },
     async ({ workflow: workflowJson, description, revision }) => {
       try {
@@ -208,10 +275,14 @@ function registerListAvailableAgents(
   );
 }
 
-function registerUpdateNodes(server: McpServer, adapter: WorkflowIoAdapter): void {
+function registerUpdateNodes(
+  server: McpServer,
+  adapter: WorkflowIoAdapter,
+  text: ToolText
+): void {
   server.tool(
     'update_nodes',
-    'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and applies to the canvas. Only updates existing nodes — use apply_workflow to add or remove nodes.',
+    text.updateNodesDescription,
     {
       nodes: z
         .array(
@@ -251,12 +322,7 @@ function registerUpdateNodes(server: McpServer, adapter: WorkflowIoAdapter): voi
         .describe(
           'Array of node updates. Each must include an id and at least one of: name, position, data, type, parentId, or style.'
         ),
-      description: z
-        .string()
-        .optional()
-        .describe(
-          'A brief description of the changes being made. Shown to the user in the review dialog.'
-        ),
+      description: z.string().optional().describe(text.updateNodesChangeDescriptionParam),
       revision: z
         .string()
         .optional()
@@ -270,8 +336,7 @@ function registerUpdateNodes(server: McpServer, adapter: WorkflowIoAdapter): voi
         if (!current.workflow) {
           return fail({
             success: false,
-            error:
-              'No active workflow. Please open a workflow in CC Workflow Studio first.',
+            error: text.noActiveWorkflowError,
           });
         }
 
@@ -366,11 +431,12 @@ function registerUpdateNodes(server: McpServer, adapter: WorkflowIoAdapter): voi
 
 function registerHighlightGroupNode(
   server: McpServer,
-  adapter: WorkflowIoAdapter
+  adapter: WorkflowIoAdapter,
+  text: ToolText
 ): void {
   server.tool(
     'highlight_group_node',
-    'Highlight a group node on the CC Workflow Studio canvas to indicate it is currently being executed. Call this before executing nodes within a group to visually track progress.',
+    text.highlightGroupNodeDescription,
     {
       groupNodeId: z
         .string()


### PR DESCRIPTION
## Summary

Closes #860

The MCP tools served in file mode (`ccwf mcp --file <path>` and the `ccwf-mcp` stdio bin) previously reused the canvas-oriented tool text byte-for-byte, telling AI agents to "open a workflow in CC Workflow Studio first", promising a review-mode diff preview, and claiming SubAgent `.md` files "will be auto-created in .claude/agents/" — none of which is true for `FileWorkflowAdapter` (no canvas, no review dialog, `planAndPersistSubAgentFiles` returns `[]`). Agents driving the file-mode server were being misled into giving users wrong advice and relying on auto-creation that never happens.

## Changes

- `packages/mcp/src/tools.ts`: added `WorkflowMcpMode` (`'canvas' | 'file'`) and a per-mode text table; each tool registration now takes its description/error strings from the table. Canvas strings are preserved **byte-for-byte** (verified against the built dist).
- `packages/mcp/src/factory.ts`: `CreateWorkflowMcpServerOptions.mode` (default `'canvas'`) passed through to `registerWorkflowTools`.
- `packages/mcp/src/mcp.ts` (`ccwf-mcp` bin) and `packages/cli/src/commands/mcp.ts` (`ccwf mcp`): pass `mode: 'file'`.
- `packages/mcp/src/index.ts`: export `WorkflowMcpMode` / `RegisterWorkflowToolsOptions`.
- Progress-log entry appended; changeset added (patch for `@cc-wf-studio/mcp` and `@cc-wf-studio/cli`).

## Verification

- `pnpm build && pnpm check` green from the repo root.
- E2E over stdio against the built `ccwf-mcp`: `tools/list` shows the file-oriented descriptions; calling `get_current_workflow` with a missing file returns `"No workflow found: the target workflow file does not exist yet. Use apply_workflow to create it."`
- Default-mode factory instantiation checked against the historical strings for `get_current_workflow`, `apply_workflow`, `update_nodes`, `highlight_group_node` — all unchanged, so the VSCode in-process server (port 6282) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNUMogxbjygtdpCgm6wjvX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNUMogxbjygtdpCgm6wjvX)_