### PR TITLE
improvement(vscode): add Duplicate button for canvas nodes

### DIFF
--- a/.changeset/canvas-duplicate-node-action.md
+++ b/.changeset/canvas-duplicate-node-action.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Canvas nodes now have a Duplicate button next to the delete button: one click clones a configured node (Sub-Agent, Prompt, MCP, ...) with a fresh id, a +40/+40 offset, the same parent group, and all data fields intact — no more recreating every field by hand. Start, End, and Group nodes are excluded.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,28 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Duplicate button for configured canvas nodes
+- **User value**: a user who has carefully configured a node (Sub-Agent with
+  model/tools, a long Prompt, an MCP node, ...) can now clone it with one
+  click — a Duplicate button next to the delete button creates a copy with a
+  fresh id, +40/+40 offset, same parent group, and all data fields intact —
+  instead of recreating every field by hand.
+- **Issue/PR**: #861 / PR from `claude/sleepy-curie-emspxx`
+- **Outcome**: done — new `duplicateNode` store action (deep-copies `data`,
+  keeps the palette's `<prefix>-<timestamp>` id convention, moves React Flow's
+  visual selection to the copy, sets `lastAddedNodeId` so the canvas
+  auto-centers on it; single `set` = single undo entry) plus a
+  `DuplicateButton` component rendered in the 11 duplicatable node components.
+  Start/End/Group excluded (group-with-children duplication left as a
+  follow-up per the issue). Edges are not copied.
+- **Next proposals**:
+  - Group duplication including children (the follow-up #861 explicitly
+    deferred).
+  - File mode returns `plannedFiles: []` silently — implement sub-agent
+    auto-creation in `FileWorkflowAdapter` for canvas/file parity.
+  - Keyboard shortcut (Ctrl/Cmd+D) for duplicating the selected node, wired
+    to the same store action.
+
 ## 2026-07-22 — Mode-aware MCP tool text for file mode
 - **User value**: an AI agent editing a workflow through `ccwf mcp --file` or
   the `ccwf-mcp` stdio bin is no longer told to "open a workflow in CC

--- a/packages/vscode/src/webview/src/components/nodes/AskUserQuestionNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/AskUserQuestionNode.tsx
@@ -10,6 +10,7 @@ import { ShieldQuestion } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * AskUserQuestionNode Component
@@ -38,6 +39,7 @@ export const AskUserQuestionNodeComponent: React.FC<NodeProps<AskUserQuestionDat
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/components/nodes/BranchNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/BranchNode.tsx
@@ -9,6 +9,7 @@ import { GitBranch } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * BranchNode Component
@@ -39,6 +40,7 @@ export const BranchNodeComponent: React.FC<NodeProps<BranchNodeData>> = React.me
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/components/nodes/BranchSessionNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/BranchSessionNode.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import type { BranchSessionNodeData } from '../../types/node-types';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * BranchSessionNodeコンポーネント
@@ -45,6 +46,7 @@ export const BranchSessionNode: React.FC<NodeProps<BranchSessionNodeData>> = Rea
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/components/nodes/CodexNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/CodexNode.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * Truncate text with ellipsis
@@ -122,6 +123,7 @@ export const CodexNodeComponent: React.FC<NodeProps<CodexNodeData>> = React.memo
 
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
 
         {/* Node Header */}
         <div

--- a/packages/vscode/src/webview/src/components/nodes/DuplicateButton.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/DuplicateButton.tsx
@@ -1,0 +1,94 @@
+/**
+ * DuplicateButton Component
+ *
+ * ノード複製ボタンコンポーネント
+ * ノードが選択されている時のみ、DeleteButtonの左隣に表示される
+ */
+
+import type React from 'react';
+import { useWorkflowStore } from '../../stores/workflow-store';
+
+interface DuplicateButtonProps {
+  nodeId: string;
+  selected: boolean;
+}
+
+/**
+ * 複製ボタンコンポーネント
+ *
+ * @param nodeId - 複製対象のノードID
+ * @param selected - ノードが選択されているかどうか
+ */
+export const DuplicateButton: React.FC<DuplicateButtonProps> = ({ nodeId, selected }) => {
+  const { duplicateNode } = useWorkflowStore();
+
+  if (!selected) {
+    return null;
+  }
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // ノードの選択イベントを防ぐ
+    duplicateNode(nodeId);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleButtonClick}
+      className="nodrag nopan" // ReactFlowのドラッグ・パンを無効化
+      style={{
+        position: 'absolute',
+        top: '2px',
+        right: '24px',
+        width: '18px',
+        height: '18px',
+        borderRadius: '3px',
+        backgroundColor: 'var(--vscode-button-secondaryBackground)',
+        color: 'var(--vscode-button-secondaryForeground)',
+        border: 'none',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 0,
+        zIndex: 10,
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.opacity = '0.8';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.opacity = '1';
+      }}
+      title="Duplicate node"
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ display: 'block' }}
+        aria-labelledby="duplicate-icon-title"
+      >
+        <title id="duplicate-icon-title">Duplicate</title>
+        <rect
+          x="3.25"
+          y="3.25"
+          width="5.5"
+          height="5.5"
+          rx="1"
+          stroke="currentColor"
+          strokeWidth="1.2"
+        />
+        <path
+          d="M6.75 1.75H2.75C2.19772 1.75 1.75 2.19772 1.75 2.75V6.75"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+        />
+      </svg>
+    </button>
+  );
+};
+
+export default DuplicateButton;

--- a/packages/vscode/src/webview/src/components/nodes/IfElseNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/IfElseNode.tsx
@@ -10,6 +10,7 @@ import { GitBranch } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * IfElseNode Component
@@ -41,6 +42,7 @@ export const IfElseNodeComponent: React.FC<NodeProps<IfElseNodeData>> = React.me
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/components/nodes/McpNode/McpNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/McpNode/McpNode.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from '../../../i18n/i18n-context';
 import { AIProviderBadge, type AIProviderType } from '../../common/AIProviderBadge';
 import { ModeIndicatorBadge } from '../../mode-selection/ModeIndicatorBadge';
 import { DeleteButton } from '../DeleteButton';
+import { DuplicateButton } from '../DuplicateButton';
 
 /**
  * Get validation status icon
@@ -117,6 +118,7 @@ export const McpNodeComponent: React.FC<NodeProps<McpNodeData>> = React.memo(
 
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
 
         {/* Node Header */}
         <div

--- a/packages/vscode/src/webview/src/components/nodes/PromptNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/PromptNode.tsx
@@ -17,6 +17,7 @@ import { Handle, type NodeProps, Position } from 'reactflow';
 import type { PromptNodeData } from '../../types/node-types';
 import { extractVariables } from '../../utils/template-utils';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * PromptNodeコンポーネント
@@ -50,6 +51,7 @@ export const PromptNode: React.FC<NodeProps<PromptNodeData>> = React.memo(
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/components/nodes/SkillNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/SkillNode.tsx
@@ -14,6 +14,7 @@ import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
 import { AIProviderBadge, type AIProviderType } from '../common/AIProviderBadge';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * Get validation status icon
@@ -77,6 +78,7 @@ export const SkillNodeComponent: React.FC<NodeProps<SkillNodeData>> = React.memo
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
 
         {/* Node Header */}
         <div

--- a/packages/vscode/src/webview/src/components/nodes/SubAgentFlowNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/SubAgentFlowNode.tsx
@@ -16,6 +16,7 @@ import { Handle, type NodeProps, Position } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
 import { useWorkflowStore } from '../../stores/workflow-store';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * SubAgentFlowNode Component
@@ -47,6 +48,7 @@ export const SubAgentFlowNodeComponent: React.FC<NodeProps<SubAgentFlowNodeData>
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
 
         {/* Node Header */}
         <div

--- a/packages/vscode/src/webview/src/components/nodes/SubAgentNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/SubAgentNode.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { Handle, type NodeProps, Position } from 'reactflow';
 import { AIProviderBadge } from '../common/AIProviderBadge';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * SubAgentNode Component
@@ -36,6 +37,7 @@ export const SubAgentNodeComponent: React.FC<NodeProps<SubAgentData>> = React.me
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/components/nodes/SwitchNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/SwitchNode.tsx
@@ -10,6 +10,7 @@ import { GitFork } from 'lucide-react';
 import React, { useEffect } from 'react';
 import { Handle, type NodeProps, Position, useUpdateNodeInternals } from 'reactflow';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 /**
  * SwitchNode Component
@@ -38,6 +39,7 @@ export const SwitchNodeComponent: React.FC<NodeProps<SwitchNodeData>> = React.me
       >
         {/* Delete Button */}
         <DeleteButton nodeId={id} selected={selected} />
+        <DuplicateButton nodeId={id} selected={selected} />
         {/* Node Header */}
         <div
           style={{

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -141,6 +141,9 @@ interface WorkflowStore {
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
   addNode: (node: Node) => void;
+  /** Duplicate a configured node (fresh id, +40/+40 offset, same parent group,
+   *  deep-copied data; edges are not copied). Start/End/Group nodes are excluded. */
+  duplicateNode: (nodeId: string) => void;
   clearLastAddedNodeId: () => void;
   /** Request the canvas to pan to a specific node (e.g. when jumping in from
    *  Overview mode). The canvas-side hook clears it after centring. */
@@ -687,6 +690,44 @@ export const useWorkflowStore = create<WorkflowStore>()(
 
       clearLastAddedNodeId: () => {
         set({ lastAddedNodeId: null });
+      },
+
+      duplicateNode: (nodeId: string) => {
+        const source = get().nodes.find((node) => node.id === nodeId);
+        if (!source) return;
+        // Start/End are structural; group duplication (with children) is out of scope
+        if (source.type === 'start' || source.type === 'end' || source.type === 'group') {
+          console.warn(`Cannot duplicate node of type "${source.type}"`);
+          return;
+        }
+
+        // Keep the palette's `<prefix>-<timestamp>` id convention: strip a
+        // trailing timestamp from the source id, then append a fresh one
+        const baseId = nodeId.replace(/[-_]\d+$/, '');
+        let newId = `${baseId}-${Date.now()}`;
+        while (get().nodes.some((node) => node.id === newId)) {
+          newId = `${baseId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+        }
+
+        const copy: Node = {
+          ...source,
+          id: newId,
+          // Deep copy so later edits to the copy never mutate the original
+          data: JSON.parse(JSON.stringify(source.data ?? {})),
+          position: { x: source.position.x + 40, y: source.position.y + 40 },
+          selected: true,
+        };
+
+        // Move React Flow's visual selection from the source to the copy
+        const deselected = get().nodes.map((node) =>
+          node.selected ? { ...node, selected: false } : node
+        );
+
+        set({
+          nodes: [...deselected, copy],
+          lastAddedNodeId: newId,
+          selectedNodeId: newId,
+        });
       },
 
       requestFocusNode: (nodeId: string) => {


### PR DESCRIPTION
## Summary

Closes #861

A user who has carefully configured a node (Sub-Agent with model/tools, a long Prompt, an MCP node, ...) previously had to recreate every field by hand to make a similar node — the canvas had no duplicate/copy action anywhere. A selected node now shows a Duplicate button next to the existing delete button; one click creates a copy with a fresh id, a +40/+40 offset, the same parent group, and all data fields intact.

## Changes

- `packages/vscode/src/webview/src/stores/workflow-store.ts`: new `duplicateNode(nodeId)` action — deep-copies `data` (JSON round-trip so later edits never mutate the original), keeps the palette's `<prefix>-<timestamp>` id convention (with a collision guard), keeps `parentId` so the copy stays in its group, moves React Flow's visual selection to the copy, and sets `lastAddedNodeId` so the canvas auto-centers on it (`useAutoFocusNode`). Single `set` call = single zundo history entry, so one Undo removes the copy. Edges are not copied.
- `packages/vscode/src/webview/src/components/nodes/DuplicateButton.tsx`: new button component mirroring `DeleteButton` (shown only when the node is selected, `nodrag nopan`, positioned at `right: 24px` beside the delete button, secondary-button theme colors).
- Rendered in the 11 duplicatable node components: SubAgent, Prompt, AskUserQuestion, Branch, BranchSession, Codex, IfElse, Mcp, Skill, SubAgentFlow, Switch. Start/End/Group are excluded (the store action also guards against them); group-with-children duplication is left as a follow-up per #861.
- Progress-log entry appended; changeset added (patch for `cc-wf-studio`, matching precedent for webview-only changes).

## Verification

- `pnpm build && pnpm check` green from the repo root.
- No schema, i18n-key, or API changes — UI-only; the button tooltip is hardcoded English matching the existing `DeleteButton` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gjn5Lbb5FF4PUBwRLX4ESc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjn5Lbb5FF4PUBwRLX4ESc)_