### PR TITLE
improvement(cli): skip byte-identical files in ccwf export/run

### DIFF
--- a/.changeset/idempotent-export-rerun.md
+++ b/.changeset/idempotent-export-rerun.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": patch
+---
+
+`ccwf export` / `ccwf run` re-runs are now idempotent: existing files whose content already matches the planned output are reported as up to date and skipped instead of erroring; only files with different content require `--overwrite`.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,29 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Idempotent `ccwf export` / `ccwf run` re-runs
+- **User value**: a user re-running `ccwf export` / `ccwf run` on an unchanged
+  workflow no longer gets a false `error: N file(s) already exist. Pass
+  --overwrite` — files whose on-disk content is byte-identical to the plan are
+  reported as up to date and skipped (exit 0); only files with *different*
+  content are conflicts that still require `--overwrite`.
+- **Issue/PR**: #864 / PR from `claude/sleepy-curie-5fdbib`
+- **Outcome**: done — `runExport` compares existing files' content against the
+  planned contents (read failures count as conflicts, never crashes), returns
+  a new `unchangedPaths` alongside `writtenPaths`, and a shared
+  `reportExportOutcome` keeps `export`/`run` stdout in sync ("N file(s)
+  already up to date" / "All N file(s) already up to date"). `--overwrite`
+  unchanged. E2E-verified: fresh export, no-op re-run (both commands),
+  drifted-file conflict (exit 1, message now says "with different content"),
+  `--overwrite` rewrite, and a mixed 3-written/1-up-to-date cursor export.
+  Also filed #865 (Ctrl/Cmd+D duplicate shortcut) as the runner-up idea.
+- **Next proposals**:
+  - `ccwf` crashes with a raw `TypeError ... reading 'filter'` when given a
+    `{meta, workflow}` wrapper file (the shape of `resources/samples/*.json`)
+    — `load-workflow.ts` should unwrap or reject it with a clear message.
+  - #865: Ctrl/Cmd+D keyboard shortcut for the node Duplicate action.
+  - Group duplication including children (deferred follow-up of #861).
+
 ## 2026-07-22 — Duplicate button for configured canvas nodes
 - **User value**: a user who has carefully configured a node (Sub-Agent with
   model/tools, a long Prompt, an MCP node, ...) can now clone it with one

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -75,8 +75,10 @@ Example `.mcp.json`:
 ccwf export ./my-workflow.json                                # --agent claude-code (default)
 ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex into a different root
-ccwf export ./my-workflow.json --overwrite                     # replace existing files
+ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
 ```
+
+Re-running an export is idempotent: existing files whose content already matches are reported as up to date and skipped. Only files with *different* content are conflicts that require `--overwrite`.
 
 Output layout by target agent:
 

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -96,8 +96,10 @@ Materialise the workflow as **Agent Skill files** for a target agent. Pure file 
 ccwf export ./my-workflow.json                                 # --agent claude-code (default)
 ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex, custom output root
-ccwf export ./my-workflow.json --overwrite                     # replace existing files
+ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
 ```
+
+Re-running an export is idempotent: existing files whose content already matches are skipped as up to date; only files with different content require `--overwrite`.
 
 Output by `--agent`:
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -53,6 +53,8 @@ export interface ExportRunOptions {
 export interface ExportRunResult {
   /** Absolute paths of every file written. */
   writtenPaths: string[];
+  /** Absolute paths of planned files skipped because their on-disk content already matched. */
+  unchangedPaths: string[];
   /** Slash command name (used for the `run` follow-up hint). */
   slashName: string;
   /** Project root used. */
@@ -128,17 +130,22 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
       ? planWorkflowExportFiles(workflow)
       : planAgentSkillFiles(workflow, options.agent as AgentSkillProvider);
 
+  const unchangedPaths: string[] = [];
   if (!options.overwrite) {
     const conflicts: string[] = [];
     for (const planned of plan) {
       const absPath = resolvePlanned(rootDir, planned);
       if (await pathExists(absPath)) {
-        conflicts.push(absPath);
+        if (await matchesPlannedContents(absPath, planned.contents)) {
+          unchangedPaths.push(absPath);
+        } else {
+          conflicts.push(absPath);
+        }
       }
     }
     if (conflicts.length > 0) {
       process.stderr.write(
-        `error: ${conflicts.length} file(s) already exist. Pass --overwrite to replace them:\n`
+        `error: ${conflicts.length} file(s) already exist with different content. Pass --overwrite to replace them:\n`
       );
       for (const absPath of conflicts) {
         process.stderr.write(`  - ${absPath}\n`);
@@ -147,10 +154,12 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
     }
   }
 
+  const unchanged = new Set(unchangedPaths);
   const writtenPaths: string[] = [];
   const ensuredDirs = new Set<string>();
   for (const planned of plan) {
     const absPath = resolvePlanned(rootDir, planned);
+    if (unchanged.has(absPath)) continue;
     const dir = path.dirname(absPath);
     if (!ensuredDirs.has(dir)) {
       await fs.mkdir(dir, { recursive: true });
@@ -162,9 +171,43 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
 
   return {
     writtenPaths,
+    unchangedPaths,
     slashName: nodeNameToFileName(workflow.name),
     rootDir,
   };
+}
+
+/**
+ * Whether the file at `absPath` already holds exactly `contents`. Any read
+ * failure (directory in the way, permissions, ...) counts as "not matching"
+ * so it is reported as a conflict rather than crashing or silently skipping.
+ */
+async function matchesPlannedContents(absPath: string, contents: string): Promise<boolean> {
+  try {
+    return (await fs.readFile(absPath, 'utf-8')) === contents;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Print the written/up-to-date summary for a completed `runExport`. Shared by
+ * `ccwf export` and `ccwf run` so their output cannot drift.
+ */
+export function reportExportOutcome(result: ExportRunResult): void {
+  if (result.writtenPaths.length > 0 || result.unchangedPaths.length === 0) {
+    process.stdout.write(`✓ Wrote ${result.writtenPaths.length} file(s):\n`);
+    for (const writtenPath of result.writtenPaths) {
+      process.stdout.write(`  - ${path.relative(result.rootDir, writtenPath)}\n`);
+    }
+    if (result.unchangedPaths.length > 0) {
+      process.stdout.write(`  (${result.unchangedPaths.length} file(s) already up to date)\n`);
+    }
+  } else {
+    process.stdout.write(
+      `✓ All ${result.unchangedPaths.length} file(s) already up to date; nothing to write.\n`
+    );
+  }
 }
 
 /** Resolve an option spec into a `SupportedAgent`, throwing if unknown. */
@@ -205,10 +248,7 @@ export function registerExportCommand(program: Command): void {
           cwd: options.cwd,
         });
 
-        process.stdout.write(`✓ Wrote ${result.writtenPaths.length} file(s):\n`);
-        for (const writtenPath of result.writtenPaths) {
-          process.stdout.write(`  - ${path.relative(result.rootDir, writtenPath)}\n`);
-        }
+        reportExportOutcome(result);
       } catch (error) {
         if (error instanceof WorkflowLoadError) {
           process.stderr.write(`error: ${error.message}\n`);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -10,12 +10,11 @@
  */
 
 import { spawn } from 'node:child_process';
-import * as path from 'node:path';
 import { Command } from 'commander';
 import { LAUNCHABLE_AGENTS } from '../utils/agent-launchers.js';
 import { findBinaryInPath } from '../utils/find-binary.js';
 import { WorkflowLoadError } from '../utils/load-workflow.js';
-import { asSupportedAgent, runExport } from './export.js';
+import { asSupportedAgent, reportExportOutcome, runExport } from './export.js';
 
 interface CommanderRunOptions {
   agent: string;
@@ -85,10 +84,7 @@ export function registerRunCommand(program: Command): void {
           cwd: options.cwd,
         });
 
-        process.stdout.write(`✓ Wrote ${result.writtenPaths.length} file(s):\n`);
-        for (const writtenPath of result.writtenPaths) {
-          process.stdout.write(`  - ${path.relative(result.rootDir, writtenPath)}\n`);
-        }
+        reportExportOutcome(result);
 
         const hint = NEXT_STEP_HINTS[agent](result.slashName);
         // Each hint ends in its own period; no trailing dot here.


### PR DESCRIPTION
## Summary

Closes #864

Re-running `ccwf export` / `ccwf run` on an unchanged workflow currently fails with `error: N file(s) already exist. Pass --overwrite to replace them` even when every existing file is byte-identical to what would be written — a false conflict on every no-op re-run (retries, scripts, second terminals).

This PR makes re-runs idempotent:

- `runExport` now compares each existing planned file's content against the planned contents. Byte-identical → classified as **up to date**, skipped, no conflict. Different content → conflict, exactly as before (message now reads "already exist **with different content**"). Read failures (e.g. a directory in the way) count as conflicts rather than crashing or silently skipping.
- `ExportRunResult` gains `unchangedPaths` alongside `writtenPaths`.
- A shared `reportExportOutcome` helper prints the written/up-to-date summary for both `ccwf export` and `ccwf run`, replacing the duplicated output blocks so the two commands cannot drift (also removes a now-unused `path` import in `run.ts`).
- `--overwrite` behavior is unchanged (writes everything).
- Docs updated (`packages/cli/README.md`, `skills/ccwf-cli/SKILL.md`).

## E2E verification (built CLI)

- Fresh export → `✓ Wrote 1 file(s)`
- No-op re-run (`export` and `run`) → `✓ All 1 file(s) already up to date; nothing to write.`, exit 0 (`run` still prints its next-step hint)
- Hand-edited output file → `error: 1 file(s) already exist with different content...`, exit 1
- `--overwrite` → rewrites; subsequent plain re-run idempotent again
- Mixed multi-file cursor export (3 deleted, 1 intact) → writes 3, `(1 file(s) already up to date)`

## Changeset

- `.changeset/idempotent-export-rerun.md` — patch for `@cc-wf-studio/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dUhRCqjj1JMprC7eqGPdJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016dUhRCqjj1JMprC7eqGPdJ)_