### PR TITLE
fix(cli): accept {meta, workflow} wrapper files instead of crashing

### DIFF
--- a/.changeset/accept-wrapper-workflow-files.md
+++ b/.changeset/accept-wrapper-workflow-files.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': patch
+---
+
+Accept `{meta, workflow}` wrapper files (the bundled sample shape) in every `ccwf` command that takes a workflow file: the wrapper is unwrapped automatically instead of crashing with a raw `TypeError`, and non-workflow JSON now fails with a clear "does not look like a workflow file" error.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,29 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Accept `{meta, workflow}` wrapper files in `ccwf`
+- **User value**: a user who points `ccwf render/export/run/preview/validate`
+  at one of the bundled sample workflows (all of `resources/samples/*.json`
+  ship as `{meta, workflow}` wrappers) no longer gets a raw
+  `TypeError: Cannot read properties of undefined (reading 'filter')` — the
+  CLI unwraps the wrapper automatically, and any other non-workflow JSON
+  fails with a clear `error: ... does not look like a workflow file` (exit 2)
+  instead of a stack trace.
+- **Issue/PR**: #867 / PR from `claude/sleepy-curie-pc87jz`
+- **Outcome**: done — `loadWorkflowFromFile` now shape-checks the parsed JSON
+  (`nodes` array = workflow; `{ workflow: {...nodes...} }` = wrapper,
+  unwrapped; anything else = `WorkflowLoadError`). All seven `<file>`
+  commands share the loader, so one change covers them all; `ccwf validate`
+  on a wrapper now validates the inner workflow instead of reporting
+  misleading `MISSING_FIELD` errors. E2E-verified on the built CLI: wrapper
+  sample renders + validates, bare workflow unchanged, `{"foo":1}` and
+  `[1,2,3]` produce the clear error.
+- **Next proposals**:
+  - #865: Ctrl/Cmd+D keyboard shortcut for the node Duplicate action.
+  - Group duplication including children (deferred follow-up of #861).
+  - File mode returns `plannedFiles: []` silently — sub-agent auto-creation
+    in `FileWorkflowAdapter` for canvas/file parity.
+
 ## 2026-07-22 — Idempotent `ccwf export` / `ccwf run` re-runs
 - **User value**: a user re-running `ccwf export` / `ccwf run` on an unchanged
   workflow no longer gets a false `error: N file(s) already exist. Pass

--- a/packages/cli/src/utils/load-workflow.ts
+++ b/packages/cli/src/utils/load-workflow.ts
@@ -20,6 +20,17 @@ export class WorkflowLoadError extends Error {
   }
 }
 
+/**
+ * Minimal shape check — every workflow carries a `nodes` array. Full
+ * validation stays in `ccwf validate`; this only exists so downstream
+ * generators never dereference `undefined`.
+ */
+function looksLikeWorkflow(value: unknown): value is Workflow {
+  return (
+    typeof value === 'object' && value !== null && Array.isArray((value as Partial<Workflow>).nodes)
+  );
+}
+
 export async function loadWorkflowFromFile(filePath: string): Promise<{
   workflow: Workflow;
   absolutePath: string;
@@ -45,5 +56,18 @@ export async function loadWorkflowFromFile(filePath: string): Promise<{
       `Invalid JSON in ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`
     );
   }
-  return { workflow: parsed as Workflow, absolutePath };
+  if (looksLikeWorkflow(parsed)) {
+    return { workflow: parsed, absolutePath };
+  }
+  // Sample/share files wrap the workflow: { meta: {...}, workflow: {...} }
+  const wrapped =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as { workflow?: unknown }).workflow
+      : undefined;
+  if (looksLikeWorkflow(wrapped)) {
+    return { workflow: wrapped, absolutePath };
+  }
+  throw new WorkflowLoadError(
+    `${absolutePath} does not look like a workflow file: expected a top-level "nodes" array or a { meta, workflow } wrapper`
+  );
 }


### PR DESCRIPTION
## Summary

Closes #867

Pointing any `ccwf` file-taking command at one of the bundled sample workflows (all of `resources/samples/*.json` ship as `{meta, workflow}` wrappers) crashed with a raw `TypeError: Cannot read properties of undefined (reading 'filter')` — `loadWorkflowFromFile` cast the parsed JSON straight to `Workflow` with no shape check.

This PR makes the loader shape-aware:

- Top-level object with a `nodes` array → a workflow, unchanged behavior.
- Otherwise, if it has a `workflow` property with a `nodes` array → the sample/share wrapper shape; unwrapped automatically, so every command just works on sample files.
- Anything else → `WorkflowLoadError` (`... does not look like a workflow file: expected a top-level "nodes" array or a { meta, workflow } wrapper`), exit 2 like the existing load errors.

All seven `<file>` commands (`render`, `validate`, `export`, `run`, `preview`, `canvas`, `tour`) share the loader, so one change covers them all. `ccwf validate` improves too: a wrapper file is now validated on its inner workflow instead of reporting misleading `MISSING_FIELD` errors for `id`/`name`.

## E2E verification (built CLI)

- `render` on `daily-dev-with-branch-sample.en.json` (crashed before) → `✓ Wrote render output`
- `validate` on the same wrapper → `✓ ... is valid.`, exit 0
- Bare (unwrapped) workflow file → unchanged, renders fine
- `{"foo": 1}` and `[1,2,3]` → clear `error: ... does not look like a workflow file`, exit 2

## Changeset

- `.changeset/accept-wrapper-workflow-files.md` — patch for `@cc-wf-studio/cli`

`pnpm build && pnpm check` green from the repo root; progress-log entry included per the autonomous-loop contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFhKD8FcePuCu7cb1tuCWU

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFhKD8FcePuCu7cb1tuCWU)_