### PR TITLE
improvement(vscode): add Ctrl/Cmd+D shortcut to duplicate the selected node

### DIFF
--- a/.changeset/duplicate-node-shortcut.md
+++ b/.changeset/duplicate-node-shortcut.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+Add Ctrl/Cmd+D keyboard shortcut to duplicate the selected canvas node

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,27 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Ctrl/Cmd+D keyboard shortcut to duplicate the selected node
+- **User value**: a user who prefers the keyboard can now clone the selected
+  canvas node with Ctrl+D (Cmd+D on macOS) — same exclusions (Start/End/Group),
+  same single-undo-entry behavior as the Duplicate button from #863 — instead
+  of reaching for the mouse; the Duplicate button's tooltip now advertises the
+  shortcut.
+- **Issue/PR**: #865 / PR from `claude/duplicate-node-shortcut`
+- **Outcome**: done — extended the existing global keydown handler in
+  `WorkflowEditor.tsx` (the one owning Ctrl/Cmd+Z/Y undo/redo, sharing its
+  input/textarea/contenteditable guard) with a Ctrl/Cmd+D branch that calls
+  the `duplicateNode` store action when exactly one duplicatable node is
+  selected (`selectedNodeId` is non-null only for single selection) and
+  prevents the browser/webview default for the chord only when it acts.
+  Tooltip hint follows the `UndoRedoControls` isMac pattern.
+- **Next proposals**:
+  - Group duplication including children (deferred follow-up of #861).
+  - File mode returns `plannedFiles: []` silently — sub-agent auto-creation
+    in `FileWorkflowAdapter` for canvas/file parity.
+  - Arrow-key nudge of the selected node (move by grid step, Shift for
+    larger steps) to complete keyboard-first canvas editing.
+
 ## 2026-07-22 — Accept `{meta, workflow}` wrapper files in `ccwf`
 - **User value**: a user who points `ccwf render/export/run/preview/validate`
   at one of the bundled sample workflows (all of `resources/samples/*.json`

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -319,7 +319,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         setIsModifierKeyPressed(true);
       }
 
-      // Undo/Redo shortcuts — skip when focus is in editable elements
+      // Undo/Redo/Duplicate shortcuts — skip when focus is in editable elements
       const mod = event.metaKey || event.ctrlKey;
       if (mod) {
         const target = event.target as HTMLElement | null;
@@ -339,6 +339,26 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           event.preventDefault();
           const { redo, futureStates } = useWorkflowStore.temporal.getState();
           if (futureStates.length > 0) redo();
+        }
+        if (key === 'd' && !event.shiftKey) {
+          const {
+            selectedNodeId: currentSelectedId,
+            nodes: currentNodes,
+            duplicateNode,
+          } = useWorkflowStore.getState();
+          // selectedNodeId is set only when exactly one node is selected
+          if (currentSelectedId) {
+            const selectedNode = currentNodes.find((n) => n.id === currentSelectedId);
+            if (
+              selectedNode &&
+              selectedNode.type !== 'start' &&
+              selectedNode.type !== 'end' &&
+              selectedNode.type !== 'group'
+            ) {
+              event.preventDefault();
+              duplicateNode(currentSelectedId);
+            }
+          }
         }
       }
     };

--- a/packages/vscode/src/webview/src/components/nodes/DuplicateButton.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/DuplicateButton.tsx
@@ -8,6 +8,9 @@
 import type React from 'react';
 import { useWorkflowStore } from '../../stores/workflow-store';
 
+const isMac = typeof navigator !== 'undefined' && /Macintosh|Mac OS X/.test(navigator.userAgent);
+const duplicateShortcut = isMac ? 'Cmd+D' : 'Ctrl+D';
+
 interface DuplicateButtonProps {
   nodeId: string;
   selected: boolean;
@@ -59,7 +62,7 @@ export const DuplicateButton: React.FC<DuplicateButtonProps> = ({ nodeId, select
       onMouseLeave={(e) => {
         e.currentTarget.style.opacity = '1';
       }}
-      title="Duplicate node"
+      title={`Duplicate node (${duplicateShortcut})`}
     >
       <svg
         width="10"


### PR DESCRIPTION
## Summary

Closes #865

PR #863 added a Duplicate button to configured canvas nodes, but a keyboard-first user still had to reach for the mouse to clone the selected node. Pressing **Ctrl+D** (**Cmd+D** on macOS) now duplicates the currently selected node via the same `duplicateNode` store action — same exclusions (Start/End/Group), same single-undo-entry behavior — and prevents the browser/webview default for the chord only when it actually acts.

## Changes

- `packages/vscode/src/webview/src/components/WorkflowEditor.tsx`: extended the existing global keydown handler (the one owning Ctrl/Cmd+Z/Y undo/redo) with a Ctrl/Cmd+D branch. It shares the established input/textarea/contenteditable guard, fires only when exactly one node is selected (`selectedNodeId` is non-null only for single selection — multi-select clears it), and re-checks the Start/End/Group exclusion before calling `duplicateNode` so `preventDefault` never swallows the chord without acting.
- `packages/vscode/src/webview/src/components/nodes/DuplicateButton.tsx`: tooltip now advertises the shortcut (`Duplicate node (Ctrl+D)` / `(Cmd+D)`), following the `UndoRedoControls` isMac pattern.
- No new store logic — reuses `duplicateNode` from #863 unchanged (fresh id, +40/+40 offset, same parent group, selection moves to the copy, one undo entry).

## Verification

- `pnpm build && pnpm check` green from the repo root.
- No conflict with existing shortcuts: the handler only adds the `d` key branch next to the existing `z`/`y` branches; React Flow binds no Ctrl/Cmd+D.
- UI-only change; no schema, i18n-key, or API changes (tooltip is hardcoded English matching the existing `DeleteButton`/`DuplicateButton` precedent).

## Changeset

- `.changeset/duplicate-node-shortcut.md` — patch for `cc-wf-studio` (webview-only change, matching #863 precedent).

Progress-log entry included per the autonomous-loop contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1pBt1sAuiYT9X7ts6p6S2)_