### PR TITLE
feat(cli): add ccwf samples command to discover and scaffold bundled examples

### DIFF
--- a/.changeset/ccwf-samples-command.md
+++ b/.changeset/ccwf-samples-command.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": minor
+---
+
+Add `ccwf samples` command: `samples list` shows the bundled example workflows (id, difficulty, node count, tags, locales) and `samples copy <id> [--locale <loc>] [--output <path>]` scaffolds one locally, ready for `ccwf preview` / `ccwf run`. The sample workflows that previously shipped only with the VSCode extension are now bundled into the CLI package at build time.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,33 @@ Entry format:
 
 ---
 
+## 2026-07-22 — `ccwf samples` — discover and scaffold bundled example workflows
+- **User value**: a user who installs `@cc-wf-studio/cli` from npm can now run
+  `ccwf samples list` to see the bundled example workflows (id, difficulty,
+  node count, tags, locales) and `ccwf samples copy <id> [--locale] [--output]`
+  to scaffold one locally for `preview`/`run` — previously the CLI shipped
+  zero examples (the samples only existed inside the VSCode extension), which
+  is exactly the gap open question #448 asks about.
+- **Issue/PR**: #870 / PR from `claude/sleepy-curie-wjt035`
+- **Outcome**: done — new `sync:samples` build step copies
+  `packages/vscode/resources/samples/` into the CLI's `dist/samples/`
+  (same precedent as `sync:webview`/`sync:skills`, shipped automatically via
+  `files: ["dist"]`); new `samples` command groups locale variants
+  (`<id>.<locale>.json`) under one id, defaults to `en`, refuses to overwrite
+  an existing destination without `--overwrite`, and prints next-step hints.
+  README + ccwf-cli SKILL.md updated. Also filed #871 (group duplication with
+  children, the #861 follow-up) as the runner-up idea. Rejected this round:
+  file-mode sub-agent auto-creation (contradicts the deliberate "apply never
+  writes files" safety design — canvas mode also returns `[]`) and arrow-key
+  node nudge (React Flow v11's built-in keyboard a11y likely already covers
+  it; needs live-webview verification first).
+- **Next proposals**:
+  - #871: duplicate a group node including its children.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+  - `ccwf samples` could back a canvas empty-state "start from an example"
+    action in `ccwf canvas` / preview.
+
 ## 2026-07-22 — Ctrl/Cmd+D keyboard shortcut to duplicate the selected node
 - **User value**: a user who prefers the keyboard can now clone the selected
   canvas node with Ctrl+D (Cmd+D on macOS) — same exclusions (Start/End/Group),

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ pnpm add -D @cc-wf-studio/cli
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
 | `ccwf preview <file>` | Open a read-only viewer (Mermaid + per-node Markdown panes) in a local browser. Auto-reloads when the file changes. |
 | `ccwf canvas <file>` | (Experimental) Open the **full editable** cc-wf-studio canvas in a local browser. Saves write back to the same file. |
+| `ccwf samples list` / `ccwf samples copy <id>` | Discover the bundled example workflows and copy one locally to preview, export, or run. |
 | `ccwf install-skills` | Copy the bundled Claude Code Skill into `~/.claude/skills/` (or `./.claude/skills/` with `--project`) so AI agents learn when to use ccwf. |
 | `ccwf uninstall-skills` | Remove the bundled Claude Code Skill from `~/.claude/skills/` (or `./.claude/skills/` with `--project`). Idempotent. |
 
@@ -142,6 +143,17 @@ ccwf canvas ./my-workflow.json --port 51234   # pin to a port
 **Reachability**: the server binds to the IPv4 loopback (`127.0.0.1`) by default — only this machine can reach the server. The printed URL says `localhost` and both addresses resolve to the same listener. The entry URL and WebSocket use a per-session UUID path prefix (`http://localhost:<port>/<uuid>/`, `ws://localhost:<port>/<uuid>/ws`) so two concurrent sessions don't collide; requests without the prefix get a 403. Pass `--host` (e.g. `0.0.0.0`) only when you intentionally want other machines on the network to reach the canvas — the banner prints an explicit non-loopback notice when that happens.
 
 The bundled webview's VSCode message protocol is emulated by a small polyfill (`bootstrap.js`) injected into `index.html`. The webview source is **unchanged** — `window.acquireVsCodeApi` returns a WebSocket-backed transport that talks to this CLI process.
+
+### `ccwf samples`
+
+```sh
+ccwf samples list                                      # what examples ship with the CLI
+ccwf samples copy daily-dev-with-branch-sample         # → ./daily-dev-with-branch-sample.json (en)
+ccwf samples copy daily-dev-with-branch-sample -l ja   # Japanese variant
+ccwf samples copy github-issue-planning-sample -o ./wf/planning.json
+```
+
+The CLI bundles the same example workflows that ship with the VSCode extension. `list` shows each sample's id, difficulty, node count, tags, and available locales; `copy` writes one to a local file (default `./<id>.json`, refusing to overwrite an existing file unless `--overwrite` is passed) and prints the natural next steps (`ccwf preview` / `ccwf run`). Samples use the `{meta, workflow}` wrapper shape, which every `<file>` subcommand accepts directly.
 
 ### `ccwf install-skills` / `ccwf uninstall-skills`
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,9 +25,10 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "pnpm run sync:webview && pnpm run sync:skills && tsc && chmod +x dist/cli.js",
+    "build": "pnpm run sync:webview && pnpm run sync:skills && pnpm run sync:samples && tsc && chmod +x dist/cli.js",
     "sync:webview": "rm -rf dist/webview && mkdir -p dist/webview && cp -R ../vscode/src/webview/dist/. dist/webview/",
     "sync:skills": "rm -rf dist/skills && mkdir -p dist/skills && cp -R skills/. dist/skills/",
+    "sync:samples": "rm -rf dist/samples && mkdir -p dist/samples && cp -R ../vscode/resources/samples/. dist/samples/",
     "check": "tsc --noEmit",
     "lint": "echo 'cli: no lint config yet'",
     "format": "echo 'cli: no format config yet'",

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -152,6 +152,18 @@ Typical `.mcp.json` snippet for Claude Code:
 
 The MCP server exposes 6 tools: `get_workflow_schema`, `get_current_workflow`, `apply_workflow`, `update_nodes`, `list_available_agents`, `highlight_group_node`. Use these when the user wants AI-driven editing of the workflow itself (not just rendering / running it).
 
+### `ccwf samples list` / `ccwf samples copy <id>`
+
+Discover and scaffold the bundled example workflows.
+
+```bash
+ccwf samples list                                    # id, difficulty, node count, tags, locales
+ccwf samples copy daily-dev-with-branch-sample       # → ./daily-dev-with-branch-sample.json (en)
+ccwf samples copy <id> -l ja -o ./wf/example.json    # pick locale and destination
+```
+
+Use this when the user has no workflow yet and asks for an example, a template, or "how do I start?". `copy` refuses to overwrite an existing destination unless `--overwrite` is passed, and the copied file works directly with every `<file>` subcommand (`preview`, `render`, `validate`, `export`, `run`).
+
 ### `ccwf install-skills` / `ccwf uninstall-skills`
 
 Copy this Skill bundle into a discoverable location, or remove it again.
@@ -189,6 +201,7 @@ Use this as a lookup when the user describes intent in natural language. If the 
 | "Run this workflow", "動かして", "実行して"                                          | `ccwf run <file> --launch`                   |
 | "Edit the canvas without VSCode", "editor を browser で開いて"                       | `ccwf canvas <file>` (mention experimental)  |
 | "Let an MCP client edit this workflow"                                              | `ccwf mcp --file <file>` and configure `.mcp.json` |
+| "Show me an example workflow", "サンプルある?", "how do I start?"                    | `ccwf samples list` → `ccwf samples copy <id>` |
 | "Install the ccwf skill / teach Claude about ccwf"                                  | `ccwf install-skills [--project]`            |
 | "Update / refresh the ccwf skill"                                                   | `ccwf uninstall-skills && ccwf install-skills` |
 | "Remove the ccwf skill / cleanup"                                                   | `ccwf uninstall-skills [--project]`          |

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,6 +20,7 @@ import { registerMcpCommand } from './commands/mcp.js';
 import { registerPreviewCommand } from './commands/preview.js';
 import { registerRenderCommand } from './commands/render.js';
 import { registerRunCommand } from './commands/run.js';
+import { registerSamplesCommand } from './commands/samples.js';
 import { registerTourCommand } from './commands/tour.js';
 import { registerUninstallSkillsCommand } from './commands/uninstall-skills.js';
 import { registerValidateCommand } from './commands/validate.js';
@@ -47,6 +48,7 @@ registerRunCommand(program);
 registerPreviewCommand(program);
 registerCanvasCommand(program);
 registerTourCommand(program);
+registerSamplesCommand(program);
 registerInstallSkillsCommand(program);
 registerUninstallSkillsCommand(program);
 

--- a/packages/cli/src/commands/samples.ts
+++ b/packages/cli/src/commands/samples.ts
@@ -1,0 +1,200 @@
+/**
+ * `ccwf samples` — discover and scaffold the bundled example workflows.
+ *
+ * The same sample workflows that ship with the VSCode extension are synced
+ * into `dist/samples/` at build time (`sync:samples`), so an npm install of
+ * the CLI carries working examples. `list` shows what is available; `copy`
+ * writes one next to the user so they can immediately `ccwf preview` /
+ * `ccwf run` it. Sample files use the `{meta, workflow}` wrapper shape,
+ * which every `<file>` subcommand accepts.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+
+interface SampleMeta {
+  id?: string;
+  difficulty?: string;
+  tags?: string[];
+  nodeCount?: number;
+}
+
+interface SampleGroup {
+  id: string;
+  difficulty: string;
+  tags: string[];
+  nodeCount: number | null;
+  /** locale → file name; the empty string keys a locale-less file. */
+  files: Map<string, string>;
+}
+
+/** Matches `<id>.<locale>.json` (e.g. `foo-sample.zh-CN.json`). */
+const LOCALE_SUFFIX = /^(.*)\.([a-z]{2}(?:-[A-Z]{2})?)\.json$/;
+
+/**
+ * Resolve the directory containing the bundled samples. Compiled commands
+ * live at `<pkg>/dist/commands/samples.js`, so the synced copy is at
+ * `<pkg>/dist/samples/`; when running via tsx during development, fall back
+ * to the extension's source samples directly.
+ */
+async function resolveSamplesDir(): Promise<string> {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(moduleDir, '../samples'),
+    path.resolve(moduleDir, '../../../vscode/resources/samples'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const entries = await fs.readdir(candidate);
+      if (entries.some((entry) => entry.endsWith('.json'))) return candidate;
+    } catch {
+      // continue
+    }
+  }
+  throw new Error(
+    'Bundled samples not found. This build of @cc-wf-studio/cli may be incomplete — try reinstalling.'
+  );
+}
+
+/** Group the sample files by id, folding locale variants together. */
+async function collectSampleGroups(samplesDir: string): Promise<SampleGroup[]> {
+  const groups = new Map<string, SampleGroup>();
+  const entries = (await fs.readdir(samplesDir)).filter((entry) => entry.endsWith('.json')).sort();
+
+  for (const entry of entries) {
+    const localeMatch = LOCALE_SUFFIX.exec(entry);
+    const id = localeMatch ? localeMatch[1] : entry.replace(/\.json$/, '');
+    const locale = localeMatch ? localeMatch[2] : '';
+
+    let group = groups.get(id);
+    if (!group) {
+      group = { id, difficulty: '-', tags: [], nodeCount: null, files: new Map() };
+      groups.set(id, group);
+    }
+    group.files.set(locale, entry);
+  }
+
+  // Read metadata from one representative file per group (prefer en).
+  for (const group of groups.values()) {
+    const representative = group.files.get('en') ?? group.files.get('') ?? [...group.files.values()][0];
+    if (!representative) continue;
+    try {
+      const raw = await fs.readFile(path.join(samplesDir, representative), 'utf-8');
+      const meta = (JSON.parse(raw) as { meta?: SampleMeta }).meta;
+      if (meta) {
+        if (typeof meta.difficulty === 'string') group.difficulty = meta.difficulty;
+        if (Array.isArray(meta.tags)) group.tags = meta.tags;
+        if (typeof meta.nodeCount === 'number') group.nodeCount = meta.nodeCount;
+      }
+    } catch {
+      // Unreadable metadata only degrades the listing; the file itself may
+      // still be copied and validated by downstream commands.
+    }
+  }
+
+  return [...groups.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function formatLocales(group: SampleGroup): string {
+  const locales = [...group.files.keys()].filter((locale) => locale !== '');
+  return locales.length > 0 ? locales.sort().join(', ') : '-';
+}
+
+export function registerSamplesCommand(program: Command): void {
+  const samples = program
+    .command('samples')
+    .description('Discover and copy the bundled example workflows.');
+
+  samples
+    .command('list')
+    .description('List the bundled example workflows.')
+    .action(async () => {
+      const samplesDir = await resolveSamplesDir();
+      const groups = await collectSampleGroups(samplesDir);
+
+      process.stdout.write('Available samples:\n\n');
+      for (const group of groups) {
+        const nodes = group.nodeCount !== null ? `${group.nodeCount} nodes` : '';
+        const tags = group.tags.length > 0 ? group.tags.join(', ') : '';
+        const detail = [group.difficulty, nodes, tags].filter(Boolean).join(' · ');
+        process.stdout.write(`  ${group.id}\n`);
+        process.stdout.write(`      ${detail}\n`);
+        process.stdout.write(`      locales: ${formatLocales(group)}\n`);
+      }
+      process.stdout.write(
+        '\nCopy one locally:\n  ccwf samples copy <id> [--locale <locale>] [--output <path>]\n'
+      );
+    });
+
+  samples
+    .command('copy')
+    .description('Copy a bundled example workflow to a local file.')
+    .argument('<id>', 'Sample id (see `ccwf samples list`).')
+    .option('-l, --locale <locale>', 'Locale variant to copy (default: en when localized).')
+    .option('-o, --output <path>', 'Destination file (default: ./<id>.json).')
+    .option('--overwrite', 'Replace the destination file if it already exists.', false)
+    .action(async (id: string, options: { locale?: string; output?: string; overwrite: boolean }) => {
+      const samplesDir = await resolveSamplesDir();
+      const groups = await collectSampleGroups(samplesDir);
+      const group = groups.find((candidate) => candidate.id === id);
+
+      if (!group) {
+        const known = groups.map((candidate) => `  - ${candidate.id}`).join('\n');
+        process.stderr.write(`error: unknown sample "${id}". Available samples:\n${known}\n`);
+        process.exit(1);
+        return;
+      }
+
+      const locales = [...group.files.keys()].filter((locale) => locale !== '');
+      let sourceFile: string | undefined;
+      if (options.locale !== undefined) {
+        if (locales.length === 0) {
+          process.stderr.write(
+            `error: sample "${id}" has no locale variants; drop the --locale option.\n`
+          );
+          process.exit(1);
+          return;
+        }
+        sourceFile = group.files.get(options.locale);
+        if (!sourceFile) {
+          process.stderr.write(
+            `error: sample "${id}" has no "${options.locale}" variant. Available locales: ${formatLocales(group)}\n`
+          );
+          process.exit(1);
+          return;
+        }
+      } else {
+        sourceFile = group.files.get('en') ?? group.files.get('') ?? [...group.files.values()][0];
+      }
+      if (!sourceFile) {
+        process.stderr.write(`error: sample "${id}" has no files.\n`);
+        process.exit(1);
+        return;
+      }
+
+      const destination = path.resolve(options.output ?? `${id}.json`);
+      if (!options.overwrite) {
+        try {
+          await fs.access(destination);
+          process.stderr.write(
+            `error: ${destination} already exists. Pass --overwrite to replace it.\n`
+          );
+          process.exit(1);
+          return;
+        } catch {
+          // Destination free — proceed.
+        }
+      }
+
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.copyFile(path.join(samplesDir, sourceFile), destination);
+
+      const relative = path.relative(process.cwd(), destination) || destination;
+      process.stdout.write(`✓ Wrote ${relative}\n`);
+      process.stdout.write('\nNext steps:\n');
+      process.stdout.write(`  ccwf preview ${relative}\n`);
+      process.stdout.write(`  ccwf run ${relative}\n`);
+    });
+}


### PR DESCRIPTION
## Summary

Closes #870

A user who installs `@cc-wf-studio/cli` from npm previously got **zero example workflows** — the 11 sample files shipped only inside the VSCode extension, and no `ccwf` command referenced them (open question #448 asks exactly "where can I find usage examples?"). Now:

- `ccwf samples list` — shows each bundled sample's id, difficulty, node count, tags, and available locales.
- `ccwf samples copy <id> [--locale <loc>] [--output <path>] [--overwrite]` — scaffolds one locally (default `./<id>.json`, `en` variant when localized) and prints next-step hints (`ccwf preview` / `ccwf run`).

The copied files are `{meta, workflow}` wrappers, loadable by every `<file>` subcommand since #868.

## Changes

- `packages/cli/package.json`: new `sync:samples` build step copying `packages/vscode/resources/samples/.` → `dist/samples/` (exact precedent: `sync:webview` / `sync:skills`; `files: ["dist"]` ships it automatically).
- `packages/cli/src/commands/samples.ts`: new command; groups locale variants (`<id>.<locale>.json`) under one id, reads listing metadata from each group's representative file (tolerating unreadable meta), refuses to overwrite an existing destination without `--overwrite`, resolves the samples dir from `dist/samples` with a tsx-dev fallback to the extension's resources (mirroring `ccwf canvas`'s webview resolution).
- `packages/cli/src/cli.ts`: registers the command.
- `packages/cli/README.md` + `packages/cli/skills/ccwf-cli/SKILL.md`: documented, including a "show me an example / how do I start?" phrasing-mapping row.

## Verification

- `pnpm build && pnpm check` green from the repo root; `dist/samples/` contains all 11 files after build.
- E2E on the built CLI: `list` renders all 3 sample groups; default copy, `--overwrite` guard (exit 1) and pass-through, `-l ja -o wf/ja.json`, locale-less sample, `--locale` on a locale-less sample (clear error), unknown locale (lists available), unknown id (lists ids) — all behave as described; every copied file passes `ccwf validate` and renders.

## Changeset

- `.changeset/ccwf-samples-command.md` — **minor** for `@cc-wf-studio/cli` (new user-facing command).

Progress-log entry included per the autonomous-loop contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z4RtmnKXWT2FVjD74n67h)_