### PR TITLE
improvement(vscode): duplicate a group node including its child nodes

### DIFF
--- a/.changeset/duplicate-group-with-children.md
+++ b/.changeset/duplicate-group-with-children.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+Duplicate a group node including its child nodes: the Duplicate button and Ctrl/Cmd+D now clone a group together with its children and their internal connections (fresh ids, preserved layout, single undo entry).

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,31 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Duplicate a group node including its child nodes
+- **User value**: a user who built a phase group containing several configured
+  nodes can now duplicate the whole structure — group, child nodes, and the
+  connections between them — with the Duplicate button or Ctrl/Cmd+D, instead
+  of recreating it node by node (group duplication was explicitly excluded in
+  #861/#869 as a deferred follow-up, filed as #871).
+- **Issue/PR**: Closes #871 / PR from `claude/sleepy-curie-jfe161`
+- **Outcome**: done — `duplicateNode` in `workflow-store.ts` now handles
+  groups: collects direct children by `parentId` (groups never nest, per
+  `onNodeDragStop`), deep-copies group + children through an id-remap table,
+  re-links copied `parentId`s, copies only edges whose source AND target are
+  both inside the group (boundary-crossing edges are dropped — same policy as
+  single-node duplication, which copies no edges), offsets the group copy
+  +40/+40 while children keep group-relative positions, selects the new group,
+  and commits everything in one `set()` → one undo entry. `GroupNode` now
+  renders `DuplicateButton`, and the Ctrl/Cmd+D branch in `WorkflowEditor.tsx`
+  lifts the group exclusion.
+- **Next proposals**:
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+  - `ccwf samples` could back a canvas empty-state "start from an example"
+    action in `ccwf canvas` / preview.
+  - `ccwf validate`: design a `getNodeDisplayName(node)` core helper so error
+    messages can show a human label alongside opaque node ids.
+
 ## 2026-07-22 — `ccwf samples` — discover and scaffold bundled example workflows
 - **User value**: a user who installs `@cc-wf-studio/cli` from npm can now run
   `ccwf samples list` to see the bundled example workflows (id, difficulty,

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -349,12 +349,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           // selectedNodeId is set only when exactly one node is selected
           if (currentSelectedId) {
             const selectedNode = currentNodes.find((n) => n.id === currentSelectedId);
-            if (
-              selectedNode &&
-              selectedNode.type !== 'start' &&
-              selectedNode.type !== 'end' &&
-              selectedNode.type !== 'group'
-            ) {
+            if (selectedNode && selectedNode.type !== 'start' && selectedNode.type !== 'end') {
               event.preventDefault();
               duplicateNode(currentSelectedId);
             }

--- a/packages/vscode/src/webview/src/components/nodes/GroupNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/GroupNode.tsx
@@ -10,6 +10,7 @@ import type React from 'react';
 import { type NodeProps, NodeResizer } from 'reactflow';
 import { useWorkflowStore } from '../../stores/workflow-store';
 import { DeleteButton } from './DeleteButton';
+import { DuplicateButton } from './DuplicateButton';
 
 export interface GroupNodeData {
   label: string;
@@ -84,6 +85,7 @@ export const GroupNodeComponent: React.FC<NodeProps<GroupNodeData>> = ({ id, dat
           }}
         >
           <span>{label}</span>
+          <DuplicateButton nodeId={id} selected={selected} />
           <DeleteButton nodeId={id} selected={selected} />
         </div>
       </div>

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -142,7 +142,8 @@ interface WorkflowStore {
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
   addNode: (node: Node) => void;
   /** Duplicate a configured node (fresh id, +40/+40 offset, same parent group,
-   *  deep-copied data; edges are not copied). Start/End/Group nodes are excluded. */
+   *  deep-copied data; edges are not copied). Duplicating a group also copies
+   *  its child nodes and the edges fully inside the group. Start/End excluded. */
   duplicateNode: (nodeId: string) => void;
   clearLastAddedNodeId: () => void;
   /** Request the canvas to pan to a specific node (e.g. when jumping in from
@@ -693,40 +694,97 @@ export const useWorkflowStore = create<WorkflowStore>()(
       },
 
       duplicateNode: (nodeId: string) => {
-        const source = get().nodes.find((node) => node.id === nodeId);
+        const allNodes = get().nodes;
+        const source = allNodes.find((node) => node.id === nodeId);
         if (!source) return;
-        // Start/End are structural; group duplication (with children) is out of scope
-        if (source.type === 'start' || source.type === 'end' || source.type === 'group') {
+        // Start/End are structural and must stay unique
+        if (source.type === 'start' || source.type === 'end') {
           console.warn(`Cannot duplicate node of type "${source.type}"`);
           return;
         }
 
-        // Keep the palette's `<prefix>-<timestamp>` id convention: strip a
-        // trailing timestamp from the source id, then append a fresh one
-        const baseId = nodeId.replace(/[-_]\d+$/, '');
-        let newId = `${baseId}-${Date.now()}`;
-        while (get().nodes.some((node) => node.id === newId)) {
-          newId = `${baseId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-        }
+        // A group is duplicated together with its child nodes (groups never
+        // nest — see onNodeDragStop — so direct children are all of them)
+        const children =
+          source.type === 'group' ? allNodes.filter((node) => node.parentId === nodeId) : [];
 
-        const copy: Node = {
-          ...source,
-          id: newId,
-          // Deep copy so later edits to the copy never mutate the original
-          data: JSON.parse(JSON.stringify(source.data ?? {})),
-          position: { x: source.position.x + 40, y: source.position.y + 40 },
-          selected: true,
+        // Keep the palette's `<prefix>-<timestamp>` id convention: strip a
+        // trailing timestamp from the source id, then append a fresh one.
+        // Track used ids so same-millisecond copies stay unique.
+        const usedIds = new Set(allNodes.map((node) => node.id));
+        const makeNodeId = (originalId: string) => {
+          const baseId = originalId.replace(/[-_]\d+$/, '');
+          let newId = `${baseId}-${Date.now()}`;
+          while (usedIds.has(newId)) {
+            newId = `${baseId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+          }
+          usedIds.add(newId);
+          return newId;
         };
 
+        const idMap = new Map<string, string>();
+        idMap.set(source.id, makeNodeId(source.id));
+        for (const child of children) {
+          idMap.set(child.id, makeNodeId(child.id));
+        }
+        const newSourceId = idMap.get(source.id) as string;
+
+        const copyNode = (node: Node): Node => ({
+          ...node,
+          id: idMap.get(node.id) as string,
+          // Deep copy so later edits to the copy never mutate the original
+          data: JSON.parse(JSON.stringify(node.data ?? {})),
+          ...(node.style && { style: { ...node.style } }),
+          // Children keep their group-relative position; only the root moves
+          position:
+            node.id === source.id
+              ? { x: node.position.x + 40, y: node.position.y + 40 }
+              : { ...node.position },
+          // Re-link copied children to the copied group
+          ...(node.parentId && idMap.has(node.parentId)
+            ? { parentId: idMap.get(node.parentId) as string }
+            : {}),
+          selected: node.id === source.id,
+        });
+
+        // Root copy first so React Flow sees the parent before its children
+        const copies = [copyNode(source), ...children.map(copyNode)];
+
+        // Copy edges fully inside the duplicated set (both endpoints copied);
+        // edges crossing the group boundary are not copied — same policy as
+        // single-node duplication, which copies no edges
+        const currentEdges = get().edges;
+        const usedEdgeIds = new Set(currentEdges.map((edge) => edge.id));
+        const edgeCopies = currentEdges
+          .filter((edge) => idMap.has(edge.source) && idMap.has(edge.target))
+          .map((edge) => {
+            const newSource = idMap.get(edge.source) as string;
+            const newTarget = idMap.get(edge.target) as string;
+            let newEdgeId = `edge-${newSource}-${newTarget}`;
+            while (usedEdgeIds.has(newEdgeId)) {
+              newEdgeId = `edge-${newSource}-${newTarget}-${Math.random().toString(36).slice(2, 6)}`;
+            }
+            usedEdgeIds.add(newEdgeId);
+            return {
+              ...edge,
+              id: newEdgeId,
+              source: newSource,
+              target: newTarget,
+              selected: false,
+            };
+          });
+
         // Move React Flow's visual selection from the source to the copy
-        const deselected = get().nodes.map((node) =>
+        const deselected = allNodes.map((node) =>
           node.selected ? { ...node, selected: false } : node
         );
 
+        // Single set() call → single undo/redo history entry
         set({
-          nodes: [...deselected, copy],
-          lastAddedNodeId: newId,
-          selectedNodeId: newId,
+          nodes: [...deselected, ...copies],
+          ...(edgeCopies.length > 0 && { edges: [...currentEdges, ...edgeCopies] }),
+          lastAddedNodeId: newSourceId,
+          selectedNodeId: newSourceId,
         });
       },
 


### PR DESCRIPTION
## Summary

Closes #871

#861 added node duplication (button) and #869 the Ctrl/Cmd+D shortcut, but both deliberately excluded Group nodes. A user who built a phase group containing several configured nodes still had to recreate the whole structure by hand to repeat the pattern. Now, duplicating a group clones the group node **and every child node inside it** — fresh ids, preserved intra-group edges and `parentId` links, +40/+40 offset for the group while children keep their group-relative positions, the copy selected, and everything in a single undo entry.

## Changes

- `packages/vscode/src/webview/src/stores/workflow-store.ts` — `duplicateNode` now handles groups: collects direct children by `parentId` (groups never nest, per `onNodeDragStop`), deep-copies group + children through an id-remap table (id collisions within the same-millisecond batch handled), re-links copied `parentId`s, copies only edges whose source AND target are both inside the group (boundary-crossing edges are not copied — same policy as single-node duplication, which copies no edges), and commits nodes + edges + selection in one `set()` call → one zundo history entry. Group `style` (NodeResizer size) is shallow-copied so later resizes don't alias.
- `packages/vscode/src/webview/src/components/nodes/GroupNode.tsx` — renders the existing `DuplicateButton` next to the Delete button (both absolutely positioned, same pattern as every other node).
- `packages/vscode/src/webview/src/components/WorkflowEditor.tsx` — lifts the group exclusion from the Ctrl/Cmd+D branch.

Single-node duplication behavior is unchanged (Start/End still excluded; no edges copied).

## Verification

- `pnpm build && pnpm check` green from the repo root (Biome reformat applied).
- Store-level logic verified by code walk-through against React Flow's parent/child contract: parent listed before children (copies appended `[group, ...children]`), children hold group-relative positions, `parentId` remapped only when the parent is in the copied set.

## Changeset

- `.changeset/duplicate-group-with-children.md` — **patch** for `cc-wf-studio` (same precedent as #863's Duplicate button changeset).

Progress-log entry included per the autonomous-loop contract.

---

Note for the next loop iteration: the push response surfaced 3 Dependabot alerts on the default branch (2 high, 1 low) — worth evaluating as a security interrupt next round.

---
_Generated by [Claude Code](https://claude.ai/code/session_012nm22Eq1LyY1rpFJFkEM1z)_