### PR TITLE
improvement(vscode): localize start menu and sample gallery strings

### DIFF
--- a/.changeset/localize-start-menu-sample-gallery.md
+++ b/.changeset/localize-start-menu-sample-gallery.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+The empty-canvas start menu ("New", "Load", "Recent", "Sample Workflow") and the sample gallery's remaining strings ("Loading...", "No samples available.", "Preview") are now translated into all 5 supported display languages instead of showing hardcoded English — the first screen a Japanese, Korean, or Chinese user sees now matches their VSCode display language.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,34 @@ Entry format:
 
 ---
 
+## 2026-07-22 — Localize the canvas start menu and sample gallery strings
+- **User value**: a user running VSCode in Japanese, Korean, or Chinese now
+  sees the first screen of the canvas — the empty-state start menu ("New",
+  "Load", "Recent", "Sample Workflow") — and the sample gallery's remaining
+  strings ("Loading...", "No samples available.", "Preview") in their display
+  language, instead of hardcoded English mixed into an otherwise fully
+  localized UI.
+- **Issue/PR**: #877 / PR from `claude/sleepy-curie-x5ftgw`
+- **Outcome**: done — `StartMenu.tsx` was the only first-run surface bypassing
+  i18n entirely; new `startMenu.*` keys plus `sample.dialog.previewButton` /
+  `sample.dialog.empty` added to `translation-keys.ts` and all 5 locale files
+  (wording reused from the established `toolbar.load` / `toolbar.loading` /
+  `dialog.diffPreview.previewOverview` translations); `WhatsNewDialog`'s
+  hardcoded "Loading..." now reuses the existing generic `loading` key
+  (`{t('loading')}...`, same pattern as `SlackShareDialog`). Product name
+  "CC Workflow Studio" intentionally stays English per the translation rules.
+  Also this round: verified #875 (empty-state "start from an example") against
+  the code and closed it as premise-false — `StartMenu` + `SampleWorkflowDialog`
+  already provide exactly that affordance.
+- **Next proposals**:
+  - `CommentaryOptionsDropdown` has no i18n at all (section labels, error
+    strings, "Loading..." all hardcoded) — localize the whole component as
+    its own scoped task.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+  - Sample gallery could show each sample's `difficulty` badge (metadata
+    already ships in `SampleWorkflowMeta`; `ccwf samples list` shows it).
+
 ## 2026-07-22 — Name the offending node in workflow validation errors
 - **User value**: a user running `ccwf validate` (and an AI agent getting
   `apply_workflow`/`update_workflow` errors back, and the extension's export

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -37,6 +37,10 @@ Entry format:
   the code and closed it as premise-false — `StartMenu` + `SampleWorkflowDialog`
   already provide exactly that affordance.
 - **Next proposals**:
+  - **Interrupt candidate for next round**: at push time GitHub reported
+    3 Dependabot vulnerabilities on the default branch (2 high, 1 low) —
+    check https://github.com/breaking-brake/cc-wf-studio/security/dependabot
+    and fix if actionable (security interrupts outrank invention).
   - `CommentaryOptionsDropdown` has no i18n at all (section labels, error
     strings, "Loading..." all hardcoded) — localize the whole component as
     its own scoped task.

--- a/packages/vscode/src/webview/src/components/StartMenu.tsx
+++ b/packages/vscode/src/webview/src/components/StartMenu.tsx
@@ -9,6 +9,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { FileDown, FolderOpen, Plus } from 'lucide-react';
 import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
 
 interface StartMenuProps {
   isOpen: boolean;
@@ -47,6 +48,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
   onLoadRecent,
   onVersionClick,
 }) => {
+  const { t } = useTranslation();
   const hasRecent = recentWorkflows && recentWorkflows.length > 0;
 
   return (
@@ -119,7 +121,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
                   style={buttonStyle}
                 >
                   <Plus size={16} style={{ flexShrink: 0 }} />
-                  New
+                  {t('startMenu.new')}
                 </button>
 
                 <button
@@ -134,7 +136,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
                   style={buttonStyle}
                 >
                   <FileDown size={16} style={{ flexShrink: 0 }} />
-                  Load
+                  {t('startMenu.load')}
                 </button>
               </div>
 
@@ -159,7 +161,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
                       flexShrink: 0,
                     }}
                   >
-                    Recent
+                    {t('startMenu.recent')}
                   </div>
                   <div
                     style={{
@@ -235,7 +237,7 @@ export const StartMenu: React.FC<StartMenuProps> = ({
                 }}
               >
                 <FolderOpen size={12} />
-                Sample Workflow
+                {t('startMenu.sampleWorkflow')}
               </button>
               {extensionVersion && (
                 <span

--- a/packages/vscode/src/webview/src/components/dialogs/SampleWorkflowDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/SampleWorkflowDialog.tsx
@@ -164,7 +164,7 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
                     fontSize: '13px',
                   }}
                 >
-                  Loading...
+                  {t('loading')}...
                 </div>
               ) : samples.length === 0 ? (
                 <div
@@ -175,7 +175,7 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
                     fontSize: '13px',
                   }}
                 >
-                  No samples available.
+                  {t('sample.dialog.empty')}
                 </div>
               ) : (
                 samples.map((sample) => {
@@ -290,7 +290,7 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
                               'var(--vscode-button-secondaryBackground)';
                           }}
                         >
-                          Preview
+                          {t('sample.dialog.previewButton')}
                         </button>
                         <button
                           type="button"

--- a/packages/vscode/src/webview/src/components/dialogs/WhatsNewDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/WhatsNewDialog.tsx
@@ -177,7 +177,7 @@ export function WhatsNewDialog({
               }}
             >
               {loading && (
-                <p style={{ color: 'var(--vscode-descriptionForeground)' }}>Loading...</p>
+                <p style={{ color: 'var(--vscode-descriptionForeground)' }}>{t('loading')}...</p>
               )}
               {!loading && entries.length === 0 && (
                 <p style={{ color: 'var(--vscode-descriptionForeground)' }}>

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -1012,12 +1012,20 @@ export interface WebviewTranslationKeys {
   'executionSession.failed': string;
   'executionSession.codexTerminal': string;
 
+  // Start menu (empty-canvas quick actions)
+  'startMenu.new': string;
+  'startMenu.load': string;
+  'startMenu.recent': string;
+  'startMenu.sampleWorkflow': string;
+
   // Sample Workflows
   'toolbar.sampleWorkflows': string;
   'sample.dialog.title': string;
   'sample.dialog.description': string;
   'sample.dialog.nodeCount': string;
   'sample.dialog.loadButton': string;
+  'sample.dialog.previewButton': string;
+  'sample.dialog.empty': string;
   'sample.githubIssuePlanning.name': string;
   'sample.githubIssuePlanning.description': string;
   'sample.dailyDevFlowWithWorktree.name': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -1099,11 +1099,17 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.codexTerminal': 'Interactive Codex terminal',
 
   // Sample Workflows
+  'startMenu.new': 'New',
+  'startMenu.load': 'Load',
+  'startMenu.recent': 'Recent',
+  'startMenu.sampleWorkflow': 'Sample Workflow',
   'toolbar.sampleWorkflows': 'Sample Workflows',
   'sample.dialog.title': 'Sample Workflows',
   'sample.dialog.description': 'Load a sample workflow to explore what you can build.',
   'sample.dialog.nodeCount': '{{count}} nodes',
   'sample.dialog.loadButton': 'Load',
+  'sample.dialog.previewButton': 'Preview',
+  'sample.dialog.empty': 'No samples available.',
   'sample.githubIssuePlanning.name': 'GitHub Issue Planning',
   'sample.githubIssuePlanning.description':
     'A planning workflow for GitHub issues: fetch issue, analyze current code, verify fixes, and retrospective.',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -1093,12 +1093,18 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.codexTerminal': 'Codex対話ターミナル',
 
   // Sample Workflows
+  'startMenu.new': '新規作成',
+  'startMenu.load': '読み込み',
+  'startMenu.recent': '最近使用',
+  'startMenu.sampleWorkflow': 'サンプルワークフロー',
   'toolbar.sampleWorkflows': 'サンプルワークフロー',
   'sample.dialog.title': 'サンプルワークフロー',
   'sample.dialog.description':
     'サンプルワークフローを読み込んで、どんなものが作れるか体験しましょう。',
   'sample.dialog.nodeCount': '{{count}} ノード',
   'sample.dialog.loadButton': '読み込む',
+  'sample.dialog.previewButton': 'プレビュー',
+  'sample.dialog.empty': '利用できるサンプルがありません。',
   'sample.githubIssuePlanning.name': 'GitHub Issue プランニング',
   'sample.githubIssuePlanning.description':
     'GitHub Issueに対するプランニングワークフロー：Issue取得、現状コード分析、修正の検証確認、振り返り。',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -1084,11 +1084,17 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.codexTerminal': 'Codex 대화형 터미널',
 
   // Sample Workflows
+  'startMenu.new': '새로 만들기',
+  'startMenu.load': '불러오기',
+  'startMenu.recent': '최근 사용',
+  'startMenu.sampleWorkflow': '샘플 워크플로우',
   'toolbar.sampleWorkflows': '샘플 워크플로우',
   'sample.dialog.title': '샘플 워크플로우',
   'sample.dialog.description': '샘플 워크플로우를 불러와 어떤 것을 만들 수 있는지 체험해 보세요.',
   'sample.dialog.nodeCount': '{{count}}개 노드',
   'sample.dialog.loadButton': '불러오기',
+  'sample.dialog.previewButton': '미리보기',
+  'sample.dialog.empty': '사용 가능한 샘플이 없습니다.',
   'sample.githubIssuePlanning.name': 'GitHub Issue 플래닝',
   'sample.githubIssuePlanning.description':
     'GitHub Issue 플래닝 워크플로우: Issue 조회, 현재 코드 분석, 수정 검증 확인, 회고.',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -1051,11 +1051,17 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.codexTerminal': 'Codex 交互终端',
 
   // Sample Workflows
+  'startMenu.new': '新建',
+  'startMenu.load': '加载',
+  'startMenu.recent': '最近使用',
+  'startMenu.sampleWorkflow': '示例工作流',
   'toolbar.sampleWorkflows': '示例工作流',
   'sample.dialog.title': '示例工作流',
   'sample.dialog.description': '加载示例工作流，了解您可以构建什么。',
   'sample.dialog.nodeCount': '{{count}} 个节点',
   'sample.dialog.loadButton': '加载',
+  'sample.dialog.previewButton': '预览',
+  'sample.dialog.empty': '没有可用的示例。',
   'sample.githubIssuePlanning.name': 'GitHub Issue 规划',
   'sample.githubIssuePlanning.description':
     'GitHub Issue 规划工作流：获取 Issue、分析现有代码、验证修复、回顾总结。',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -1054,11 +1054,17 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'executionSession.codexTerminal': 'Codex 互動式終端機',
 
   // Sample Workflows
+  'startMenu.new': '新增',
+  'startMenu.load': '載入',
+  'startMenu.recent': '最近使用',
+  'startMenu.sampleWorkflow': '範例工作流程',
   'toolbar.sampleWorkflows': '範例工作流程',
   'sample.dialog.title': '範例工作流程',
   'sample.dialog.description': '載入範例工作流程，了解您可以建構什麼。',
   'sample.dialog.nodeCount': '{{count}} 個節點',
   'sample.dialog.loadButton': '載入',
+  'sample.dialog.previewButton': '預覽',
+  'sample.dialog.empty': '沒有可用的範例。',
   'sample.githubIssuePlanning.name': 'GitHub Issue 規劃',
   'sample.githubIssuePlanning.description':
     'GitHub Issue 規劃工作流程：取得 Issue、分析現有程式碼、驗證修復、回顧總結。',


### PR DESCRIPTION
## Summary

Closes #877

The empty-canvas start menu (`StartMenu.tsx`) was the only first-run surface bypassing webview i18n entirely — a user running VSCode in Japanese, Korean, or Chinese saw "New", "Load", "Recent", and "Sample Workflow" in hardcoded English on the very first screen, and the sample gallery still had three leftover English strings ("Loading...", "No samples available.", "Preview"). This PR localizes them into all 5 supported display languages.

## Changes

- New translation keys `startMenu.new` / `startMenu.load` / `startMenu.recent` / `startMenu.sampleWorkflow` and `sample.dialog.previewButton` / `sample.dialog.empty`, added to `translation-keys.ts` and all 5 locale files (`en`, `ja`, `ko`, `zh-CN`, `zh-TW`)
- Wording reuses established translations for consistency: `toolbar.load` / `toolbar.loading` for Load/Loading, `dialog.diffPreview.previewOverview` for Preview, `toolbar.sampleWorkflows` / `sample.dialog.title` for the sample terms
- `StartMenu.tsx` and `SampleWorkflowDialog.tsx` now render these via `t()`; the dialog's and `WhatsNewDialog`'s hardcoded "Loading..." reuse the existing generic `loading` key with the `{t('loading')}...` pattern already used by `SlackShareDialog`
- The "CC Workflow Studio" dialog title intentionally stays English (product name, per `.claude/rules/translation.md`)

## Out of scope (noted in progress log)

`CommentaryOptionsDropdown` has no i18n at all — localizing that whole component is filed as a follow-up proposal rather than partially patched here.

## Release

- Changeset: `localize-start-menu-sample-gallery.md` (`cc-wf-studio` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHKH5dxDzLyR8jfkG4CYhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHKH5dxDzLyR8jfkG4CYhJ)_