### PR TITLE
fix(deps): patch vulnerable transitive dependencies

### DIFF
--- a/.changeset/patch-vulnerable-transitive-deps.md
+++ b/.changeset/patch-vulnerable-transitive-deps.md
@@ -1,0 +1,6 @@
+---
+"cc-wf-studio": patch
+"@cc-wf-studio/cli": patch
+---
+
+Patch vulnerable transitive dependencies in the lockfile (brace-expansion, fast-uri, body-parser, and the dompurify that mermaid embeds in the bundled webview) — all in-range bumps; `pnpm audit` high-severity findings resolved.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,33 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Security interrupt: patch vulnerable transitive dependencies
+- **User value**: a user no longer installs/bundles known-vulnerable code —
+  the 3 high-severity advisories (`brace-expansion` DoS, `fast-uri` host
+  confusion ×2) and 2 low ones (`body-parser` DoS, `dompurify` sanitize
+  bypass — the latter shipping inside the extension/CLI webview bundle via
+  mermaid) are gone from the lockfile.
+- **Issue/PR**: #879 / PR from `claude/fix-vulnerable-transitive-deps`
+- **Outcome**: done — interrupt round (security outranks invention; flagged
+  by the previous iteration's push). Verified with `pnpm audit`: 7 advisories
+  before, 1 after. Fix is lockfile-only in-range bumps via
+  `pnpm update --recursive --depth Infinity brace-expansion fast-uri
+  dompurify body-parser`. The remaining moderate advisory
+  (`@hono/node-server` <2.0.5, Windows-only path traversal in serve-static)
+  is NOT fixable in-range: latest `@modelcontextprotocol/sdk` 1.29.0 still
+  declares `^1.19.9` and the patch exists only in 2.x — tracked in #879,
+  do not burn iterations re-checking until the SDK moves. Changeset: patch
+  for `cc-wf-studio` + `@cc-wf-studio/cli` (their built bundles embed
+  dompurify via mermaid). Guard step also closed #877 (merged as #878).
+- **Next proposals**:
+  - `CommentaryOptionsDropdown` has no i18n at all (section labels, error
+    strings, "Loading..." all hardcoded) — localize the whole component as
+    its own scoped task.
+  - Sample gallery could show each sample's `difficulty` badge (metadata
+    already ships in `SampleWorkflowMeta`; `ccwf samples list` shows it).
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+
 ## 2026-07-22 — Localize the canvas start menu and sample gallery strings
 - **User value**: a user running VSCode in Japanese, Korean, or Chinese now
   sees the first screen of the canvas — the empty-state start menu ("New",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1790,8 +1790,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boolbase@1.0.0:
@@ -1800,11 +1800,11 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2201,8 +2201,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2358,8 +2358,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5663,7 +5663,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5740,10 +5740,10 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
@@ -5758,12 +5758,12 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6169,7 +6169,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6313,7 +6313,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -6357,7 +6357,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6994,7 +6994,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.46.1
       katex: 0.16.46
       khroma: 2.1.0
@@ -7219,11 +7219,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimist@1.2.8:
     optional: true


### PR DESCRIPTION
## Summary

Closes #879

Security interrupt round (flagged by the previous iteration's push, which reported Dependabot alerts on the default branch — 2 high, 1 low). Verified locally with `pnpm audit`: **7 advisories (3 high) before, 1 moderate after**. All fixed advisories were in transitive dependencies with patched versions available inside the parents' declared semver ranges, so the fix is **lockfile-only**:

| Severity | Package | Fixed version | Reached via |
|---|---|---|---|
| high | `brace-expansion` | 1.1.14 → 1.1.16, 5.0.6 → 5.0.7 (DoS) | `@vscode/vsce` (dev) |
| high ×2 | `fast-uri` | 3.1.2 → 3.1.4 (host confusion) | `@modelcontextprotocol/sdk > ajv` |
| low | `body-parser` | 2.2.2 → 2.3.0 (DoS) | `@modelcontextprotocol/sdk > express` |
| low | `dompurify` | 3.4.11 → 3.4.12 (sanitize bypass) | `mermaid` in the webview bundle |

Applied with `pnpm update --recursive --depth Infinity brace-expansion fast-uri dompurify body-parser`.

## Not fixed (out of range)

`@hono/node-server` 1.19.14 (moderate, Windows-only path traversal in `serve-static`): patched only in 2.0.5+, while the latest `@modelcontextprotocol/sdk` (1.29.0) still declares `^1.19.9`. A forced major override would be riskier than the vulnerability; tracked in #879 for when the SDK moves.

## Verification

- `pnpm build && pnpm check` green from the repo root after the update.
- `pnpm audit` reports only the out-of-range `@hono/node-server` moderate advisory.
- Working tree diff is `pnpm-lock.yaml` only (plus progress log + changeset).

## Changeset

`.changeset/patch-vulnerable-transitive-deps.md` — **patch** for `cc-wf-studio` and `@cc-wf-studio/cli`, whose built bundles embed dompurify via mermaid. The other fixes are dev-time or install-time-resolved and need no release, but ride along.

Progress-log entry included per the autonomous-loop contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vofDGyPQwLxHmpwiXMJCB)_