### PR TITLE
improvement(vscode): show difficulty and tags on sample gallery cards

### DIFF
--- a/.changeset/sample-gallery-difficulty-tags.md
+++ b/.changeset/sample-gallery-difficulty-tags.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Show each sample's difficulty badge (localized) and topic tags on the sample gallery cards, matching what `ccwf samples list` already displays

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,30 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Show difficulty and tags on sample gallery cards
+- **User value**: a user browsing the canvas sample gallery can now see each
+  sample's difficulty level (localized badge) and topic tags (slug chips)
+  before loading it, instead of judging a sample only by its name and node
+  count — parity with `ccwf samples list`, which already prints
+  `difficulty · nodes · tags` for the same bundled files.
+- **Issue/PR**: #883 / PR from `claude/sleepy-curie-7ziuc1`
+- **Outcome**: done — `SampleWorkflowMeta` always shipped `difficulty` and
+  `tags` and `listSampleWorkflows` already posts the full meta to the
+  webview; `SampleWorkflowDialog.tsx` simply dropped both. Added a
+  BetaBadge-styled difficulty badge next to the sample name (new
+  `sample.difficulty.beginner/intermediate/advanced` keys in all 5 locales:
+  初級/中級/上級, 초급/중급/고급, 初级/中级/高级, 初級/中級/高級) with raw-string
+  fallback for unknown values, and untranslated tag chips (slug identifiers,
+  same presentation policy as the CLI). Guard step this round also closed
+  #881 (merged as #882). Rejected this round: confirm-before-replacing-canvas
+  on sample load (premise false — `handleLoadSample` already routes through
+  the unsaved-changes confirm at `App.tsx:304`).
+- **Next proposals**:
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+  - MCP `apply_workflow` compat warnings — still parked until more
+    Claude-Code-only node types land.
+
 ## 2026-07-23 — Localize the Commentary options dropdown
 - **User value**: a user running VSCode in Japanese, Korean, or Chinese no
   longer sees hardcoded English chrome ("Commentary options", "Provider",

--- a/packages/vscode/src/webview/src/components/dialogs/SampleWorkflowDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/SampleWorkflowDialog.tsx
@@ -22,6 +22,12 @@ interface SampleWorkflowDialogProps {
   onLoadSample: (sampleId: string) => void;
 }
 
+const DIFFICULTY_KEYS: Record<SampleWorkflowMeta['difficulty'], keyof WebviewTranslationKeys> = {
+  beginner: 'sample.difficulty.beginner',
+  intermediate: 'sample.difficulty.intermediate',
+  advanced: 'sample.difficulty.advanced',
+};
+
 /**
  * SampleWorkflowDialog component
  */
@@ -229,12 +235,37 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
                       >
                         <span
                           style={{
-                            fontSize: '13px',
-                            fontWeight: 600,
-                            color: 'var(--vscode-foreground)',
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: '8px',
+                            minWidth: 0,
                           }}
                         >
-                          {t(sample.nameKey as keyof WebviewTranslationKeys)}
+                          <span
+                            style={{
+                              fontSize: '13px',
+                              fontWeight: 600,
+                              color: 'var(--vscode-foreground)',
+                            }}
+                          >
+                            {t(sample.nameKey as keyof WebviewTranslationKeys)}
+                          </span>
+                          {sample.difficulty && (
+                            <span
+                              style={{
+                                fontSize: '9px',
+                                padding: '1px 4px',
+                                backgroundColor: 'var(--vscode-badge-background)',
+                                color: 'var(--vscode-badge-foreground)',
+                                borderRadius: '2px',
+                                flexShrink: 0,
+                              }}
+                            >
+                              {DIFFICULTY_KEYS[sample.difficulty]
+                                ? t(DIFFICULTY_KEYS[sample.difficulty])
+                                : sample.difficulty}
+                            </span>
+                          )}
                         </span>
                         {/* Node count */}
                         <span
@@ -259,6 +290,32 @@ export const SampleWorkflowDialog: React.FC<SampleWorkflowDialogProps> = ({
                       >
                         {t(sample.descriptionKey as keyof WebviewTranslationKeys)}
                       </p>
+
+                      {/* Tags (untranslated slug identifiers, same as `ccwf samples list`) */}
+                      {Array.isArray(sample.tags) && sample.tags.length > 0 && (
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            gap: '4px',
+                          }}
+                        >
+                          {sample.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              style={{
+                                fontSize: '10px',
+                                padding: '1px 6px',
+                                color: 'var(--vscode-descriptionForeground)',
+                                border: '1px solid var(--vscode-panel-border)',
+                                borderRadius: '8px',
+                              }}
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
 
                       {/* Preview + Load buttons */}
                       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -1031,6 +1031,9 @@ export interface WebviewTranslationKeys {
   'sample.dialog.loadButton': string;
   'sample.dialog.previewButton': string;
   'sample.dialog.empty': string;
+  'sample.difficulty.beginner': string;
+  'sample.difficulty.intermediate': string;
+  'sample.difficulty.advanced': string;
   'sample.githubIssuePlanning.name': string;
   'sample.githubIssuePlanning.description': string;
   'sample.dailyDevFlowWithWorktree.name': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -1115,6 +1115,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'sample.dialog.loadButton': 'Load',
   'sample.dialog.previewButton': 'Preview',
   'sample.dialog.empty': 'No samples available.',
+  'sample.difficulty.beginner': 'Beginner',
+  'sample.difficulty.intermediate': 'Intermediate',
+  'sample.difficulty.advanced': 'Advanced',
   'sample.githubIssuePlanning.name': 'GitHub Issue Planning',
   'sample.githubIssuePlanning.description':
     'A planning workflow for GitHub issues: fetch issue, analyze current code, verify fixes, and retrospective.',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -1110,6 +1110,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'sample.dialog.loadButton': '読み込む',
   'sample.dialog.previewButton': 'プレビュー',
   'sample.dialog.empty': '利用できるサンプルがありません。',
+  'sample.difficulty.beginner': '初級',
+  'sample.difficulty.intermediate': '中級',
+  'sample.difficulty.advanced': '上級',
   'sample.githubIssuePlanning.name': 'GitHub Issue プランニング',
   'sample.githubIssuePlanning.description':
     'GitHub Issueに対するプランニングワークフロー：Issue取得、現状コード分析、修正の検証確認、振り返り。',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -1100,6 +1100,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'sample.dialog.loadButton': '불러오기',
   'sample.dialog.previewButton': '미리보기',
   'sample.dialog.empty': '사용 가능한 샘플이 없습니다.',
+  'sample.difficulty.beginner': '초급',
+  'sample.difficulty.intermediate': '중급',
+  'sample.difficulty.advanced': '고급',
   'sample.githubIssuePlanning.name': 'GitHub Issue 플래닝',
   'sample.githubIssuePlanning.description':
     'GitHub Issue 플래닝 워크플로우: Issue 조회, 현재 코드 분석, 수정 검증 확인, 회고.',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -1067,6 +1067,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'sample.dialog.loadButton': '加载',
   'sample.dialog.previewButton': '预览',
   'sample.dialog.empty': '没有可用的示例。',
+  'sample.difficulty.beginner': '初级',
+  'sample.difficulty.intermediate': '中级',
+  'sample.difficulty.advanced': '高级',
   'sample.githubIssuePlanning.name': 'GitHub Issue 规划',
   'sample.githubIssuePlanning.description':
     'GitHub Issue 规划工作流：获取 Issue、分析现有代码、验证修复、回顾总结。',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -1070,6 +1070,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'sample.dialog.loadButton': '載入',
   'sample.dialog.previewButton': '預覽',
   'sample.dialog.empty': '沒有可用的範例。',
+  'sample.difficulty.beginner': '初級',
+  'sample.difficulty.intermediate': '中級',
+  'sample.difficulty.advanced': '高級',
   'sample.githubIssuePlanning.name': 'GitHub Issue 規劃',
   'sample.githubIssuePlanning.description':
     'GitHub Issue 規劃工作流程：取得 Issue、分析現有程式碼、驗證修復、回顧總結。',


### PR DESCRIPTION
## Summary

Closes #883

A user browsing the canvas sample gallery can now see each sample's difficulty level and topic tags before loading it, instead of judging a sample only by its name and node count. This restores parity with `ccwf samples list`, which already prints `difficulty · nodes · tags` for the same bundled sample files.

## Changes

- Difficulty badge next to the sample name on each card, styled after `BetaBadge` (VSCode badge theme colors), with localized labels via new `sample.difficulty.beginner/intermediate/advanced` keys in `translation-keys.ts` and all 5 locale files (初級/中級/上級, 초급/중급/고급, 初级/中级/高级, 初級/中級/高級); unknown difficulty values fall back to the raw string, and a missing value renders no badge
- Tags rendered as small untranslated chips (they are English slug identifiers like `git`, `planning` — same presentation policy as the CLI), guarded with `Array.isArray` since sample JSON is unvalidated data
- Webview-only change: `listSampleWorkflows` already posts the full `SampleWorkflowMeta` to the webview, so no schema, message, or extension-host changes

## Changeset

`patch` for `cc-wf-studio` (`.changeset/sample-gallery-difficulty-tags.md`)

## Verification

- `pnpm build` and `pnpm check` pass from the repo root

---
_Generated by [Claude Code](https://claude.ai/code/session_016saHDQ8aZMYUdKmN9Gt91B)_