### PR TITLE
fix(vscode): support Delete key and stop edge loss on canceled node deletion

### DIFF
--- a/.changeset/canvas-delete-key-parity.md
+++ b/.changeset/canvas-delete-key-parity.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Canvas keyboard deletion: the Delete key now deletes the selection (previously only Backspace), and canceling the node-delete confirmation no longer silently removes the node's connected edges

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,35 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Fix canvas keyboard deletion (Delete key + edge loss on cancel)
+- **User value**: a user can now delete the selected nodes/edges with the
+  Delete key (previously only Backspace was bound — the standard delete key
+  on Windows/Linux did nothing), and canceling the delete-confirmation
+  dialog no longer silently removes the node's connected edges.
+- **Issue/PR**: #885 / PR from `claude/sleepy-curie-e5jbnc`
+- **Outcome**: done — verified React Flow v11's `deleteElements` emits
+  connected-edge remove-changes *before* node remove-changes; the store
+  applied edge removals unconditionally while node removal waited behind
+  the confirm dialog, so cancel stranded the node without its edges.
+  Replaced the built-in handler (`deleteKeyCode={null}`) with explicit
+  Delete/Backspace handling in `WorkflowEditor`'s existing keydown handler
+  (skips inputs/contentEditable and modifier combos): selected non-start
+  nodes go through the confirm flow with a new `requestDeleteSelection`
+  action (`pendingDeleteEdgeIds` defers explicitly selected edges with
+  them); edge-only selections delete immediately (parity with the edge ✕
+  button). Side effect: keyboard-deleting a group now releases its children
+  (matches the group's ✕ button) instead of React Flow's delete-children
+  behavior. No new i18n strings. Guard step this round also closed #883
+  (merged as #884).
+- **Next proposals**:
+  - Localize the hardcoded node/edge action tooltips (`"Delete node"` in
+    `DeleteButton.tsx`, `"Delete connection"` in `DeletableEdge.tsx`).
+  - Multi-node copy/paste (or multi-select duplicate) — only single-node
+    Ctrl+D duplicate exists today; needs id remapping + group handling,
+    likely its own design pass.
+  - MCP `apply_workflow` compat warnings — still parked until more
+    Claude-Code-only node types land.
+
 ## 2026-07-23 — Show difficulty and tags on sample gallery cards
 - **User value**: a user browsing the canvas sample gallery can now see each
   sample's difficulty level (localized badge) and topic tags (slug chips)

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -319,8 +319,47 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         setIsModifierKeyPressed(true);
       }
 
-      // Undo/Redo/Duplicate shortcuts — skip when focus is in editable elements
       const mod = event.metaKey || event.ctrlKey;
+
+      // Delete/Backspace — deletion is routed through the store so node
+      // removal waits for the confirmation dialog. React Flow's built-in
+      // handler is disabled (deleteKeyCode={null}): it removes connected
+      // edges immediately, before the dialog can be answered.
+      if ((event.key === 'Delete' || event.key === 'Backspace') && !mod && !event.altKey) {
+        const target = event.target as HTMLElement | null;
+        if (
+          target &&
+          (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        ) {
+          return;
+        }
+        const {
+          nodes: currentNodes,
+          edges: currentEdges,
+          pendingDeleteNodeIds,
+          requestDeleteSelection,
+          setEdges,
+        } = useWorkflowStore.getState();
+        // Ignore repeats while the confirmation dialog is open
+        if (pendingDeleteNodeIds.length > 0) return;
+
+        const selectedNodeIds = currentNodes
+          .filter((n) => n.selected && n.type !== 'start')
+          .map((n) => n.id);
+        const selectedEdgeIds = currentEdges.filter((e) => e.selected).map((e) => e.id);
+
+        if (selectedNodeIds.length > 0) {
+          event.preventDefault();
+          requestDeleteSelection(selectedNodeIds, selectedEdgeIds);
+        } else if (selectedEdgeIds.length > 0) {
+          // Edge-only selection: delete immediately (parity with the edge ✕ button)
+          event.preventDefault();
+          setEdges(currentEdges.filter((e) => !e.selected));
+        }
+        return;
+      }
+
+      // Undo/Redo/Duplicate shortcuts — skip when focus is in editable elements
       if (mod) {
         const target = event.target as HTMLElement | null;
         if (
@@ -444,6 +483,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           edgeTypes={edgeTypes}
           defaultEdgeOptions={defaultEdgeOptions}
           isValidConnection={isValidConnection}
+          deleteKeyCode={null}
           snapToGrid={true}
           snapGrid={snapGrid}
           panOnDrag={panOnDrag}

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -59,6 +59,8 @@ interface WorkflowStore {
   edges: Edge[];
   selectedNodeId: string | null;
   pendingDeleteNodeIds: string[];
+  /** Explicitly selected edges deleted together with pendingDeleteNodeIds on confirm */
+  pendingDeleteEdgeIds: string[];
   activeWorkflow: Workflow | null;
   interactionMode: InteractionMode;
   scrollMode: ScrollMode;
@@ -164,6 +166,8 @@ interface WorkflowStore {
   prevTourStep: () => void;
   removeNode: (nodeId: string) => void;
   requestDeleteNode: (nodeId: string) => void;
+  /** Request deletion of a multi-selection (nodes via confirm dialog, edges deferred with them) */
+  requestDeleteSelection: (nodeIds: string[], edgeIds: string[]) => void;
   confirmDeleteNodes: () => void;
   cancelDeleteNodes: () => void;
   clearWorkflow: () => void;
@@ -340,6 +344,7 @@ export const useWorkflowStore = create<WorkflowStore>()(
       edges: [],
       selectedNodeId: null,
       pendingDeleteNodeIds: [],
+      pendingDeleteEdgeIds: [],
       activeWorkflow: null,
       interactionMode: 'pan', // Default: pan mode
       scrollMode: (() => {
@@ -407,7 +412,7 @@ export const useWorkflowStore = create<WorkflowStore>()(
 
           // If there are nodes to delete, show confirmation dialog
           if (nodeIdsToDelete.length > 0) {
-            set({ pendingDeleteNodeIds: nodeIdsToDelete });
+            set({ pendingDeleteNodeIds: nodeIdsToDelete, pendingDeleteEdgeIds: [] });
             // Don't apply remove changes yet - wait for confirmation
           }
         }
@@ -886,11 +891,25 @@ export const useWorkflowStore = create<WorkflowStore>()(
         }
 
         // 確認ダイアログを表示するために pendingDeleteNodeIds にセット
-        set({ pendingDeleteNodeIds: [nodeId] });
+        set({ pendingDeleteNodeIds: [nodeId], pendingDeleteEdgeIds: [] });
+      },
+
+      requestDeleteSelection: (nodeIds: string[], edgeIds: string[]) => {
+        // Delete/Backspaceキーからの削除要求（複数選択対応）
+        // Start nodeは削除不可
+        const deletableIds = nodeIds.filter((nodeId) => {
+          const nodeToRemove = get().nodes.find((node) => node.id === nodeId);
+          return nodeToRemove !== undefined && nodeToRemove.type !== 'start';
+        });
+        if (deletableIds.length === 0) return;
+
+        // 確認ダイアログを表示。エッジも確認までは削除しない
+        set({ pendingDeleteNodeIds: deletableIds, pendingDeleteEdgeIds: edgeIds });
       },
 
       confirmDeleteNodes: () => {
         const nodeIds = get().pendingDeleteNodeIds;
+        const edgeIds = get().pendingDeleteEdgeIds;
         if (nodeIds.length === 0) return;
 
         // Clear selection if the deleted node is currently selected
@@ -920,19 +939,23 @@ export const useWorkflowStore = create<WorkflowStore>()(
           }
         }
 
-        // Delete all pending nodes
+        // Delete all pending nodes (and any explicitly selected edges)
         set({
           nodes: updatedNodes.filter((node) => !nodeIds.includes(node.id)),
           edges: get().edges.filter(
-            (edge) => !nodeIds.includes(edge.source) && !nodeIds.includes(edge.target)
+            (edge) =>
+              !nodeIds.includes(edge.source) &&
+              !nodeIds.includes(edge.target) &&
+              !edgeIds.includes(edge.id)
           ),
           pendingDeleteNodeIds: [],
+          pendingDeleteEdgeIds: [],
           ...(shouldClearSelection && { selectedNodeId: null }),
         });
       },
 
       cancelDeleteNodes: () => {
-        set({ pendingDeleteNodeIds: [] });
+        set({ pendingDeleteNodeIds: [], pendingDeleteEdgeIds: [] });
       },
 
       clearWorkflow: () => {


### PR DESCRIPTION
## Summary

Fixes canvas keyboard deletion (Closes #885):

- **Delete key now works.** The canvas previously relied on React Flow v11's default `deleteKeyCode` (`Backspace` only), so the standard delete key on Windows/Linux did nothing.
- **Canceling the delete confirmation no longer loses edges.** React Flow's built-in delete emits connected-**edge** remove-changes *before* node remove-changes; the store applied edge removals immediately while node removal waited behind the confirm dialog — so pressing Backspace on a connected node deleted its edges instantly, and canceling the dialog left the node stranded without them (recoverable only via undo).

## Changes

- `WorkflowEditor.tsx`: disable the built-in handler (`deleteKeyCode={null}`) and handle `Delete`/`Backspace` in the existing keydown handler — skips inputs/textareas/contentEditable and modifier combos, ignores repeats while the confirm dialog is open.
- `workflow-store.ts`: new `requestDeleteSelection(nodeIds, edgeIds)` action routes selected non-start nodes through the existing confirm flow; a new `pendingDeleteEdgeIds` defers explicitly selected edges with them, so nothing is removed until the user confirms. Edge-only selections still delete immediately (parity with the edge ✕ button).
- Behavior note: keyboard-deleting a group node now matches the group's ✕ button (children are released and repositioned), instead of React Flow's delete-children behavior.

Webview-only; no schema, message, or extension-host changes; no new i18n strings (the existing `dialog.deleteNode.*` keys cover the dialog).

## Changeset

- `cc-wf-studio`: patch

## Testing

- `pnpm build && pnpm check` pass from the repo root.
- Manual E2E (Extension Development Host) not run in this unattended session — the deferred-delete confirm flow is exercised unchanged from the existing ✕-button path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZAukYzHmNFAoBEkX6EnQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZAukYzHmNFAoBEkX6EnQN)_