### PR TITLE
improvement(vscode): add Ctrl/Cmd+A select-all to the workflow canvas

### DIFF
--- a/.changeset/canvas-select-all-shortcut.md
+++ b/.changeset/canvas-select-all-shortcut.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Add Ctrl/Cmd+A select-all on the workflow canvas: selects every node and edge for bulk move or delete (via the existing delete confirmation flow)

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,34 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Add Ctrl/Cmd+A select-all to the workflow canvas
+- **User value**: a user can now press Ctrl/Cmd+A on the canvas to select
+  every node and edge at once — then move the whole workflow, or delete it
+  through the existing multi-delete confirmation flow. Previously the only
+  multi-select was the rubber-band drag in selection mode; there was no
+  keyboard path at all.
+- **Issue/PR**: #889 / PR from `claude/sleepy-curie-2ldj9j`
+- **Outcome**: done — added a `mod+A` branch to `WorkflowEditor`'s existing
+  keydown handler (same editable-target guard as Ctrl+Z/Y/D), marking all
+  nodes/edges `selected: true` via `setNodes`/`setEdges` and syncing
+  `selectedNodeId` with `handleNodesChange`'s rule (exactly one node → its
+  id, else null). Verified selection state is excluded from undo history
+  (`partialize`) and canvas-revision tracking, so select-all neither
+  dirties the workflow nor pollutes undo. Security-interrupt check this
+  round: the previous iteration's flagged Dependabot alerts did not
+  reproduce — `pnpm audit` shows only the known unfixable moderate
+  `@hono/node-server` advisory tracked in #879. Rejected this round:
+  Escape-to-deselect (would clear a selection the user still wants when
+  dismissing dialogs, e.g. canceling the delete confirm).
+- **Next proposals**:
+  - Multi-node copy/paste or multi-select Ctrl+D duplicate — now more
+    valuable with select-all in place; needs id remapping + group handling
+    design pass.
+  - Toolbar.tsx "Stop MCP Server" tooltip and WhatsNewDialog "View changes
+    on GitHub" are still hardcoded English — small localization sweep.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+
 ## 2026-07-23 — Localize the Workflow Tour UI, Overview zoom controls, and remaining canvas tooltips
 - **User value**: a user running VSCode in Japanese, Korean, or Chinese now
   sees the Workflow Tour feature (Start/Generate pills and popover,

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -369,6 +369,24 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           return;
         }
         const key = event.key.toLowerCase();
+        if (key === 'a' && !event.shiftKey && !event.altKey) {
+          // Select all nodes and edges. Selection state is excluded from undo
+          // history and canvas-revision tracking, so this never dirties the
+          // workflow or pollutes undo.
+          event.preventDefault();
+          const {
+            nodes: currentNodes,
+            edges: currentEdges,
+            setNodes,
+            setEdges,
+            syncSelectedNodeId,
+          } = useWorkflowStore.getState();
+          if (currentNodes.length === 0 && currentEdges.length === 0) return;
+          setNodes(currentNodes.map((n) => (n.selected ? n : { ...n, selected: true })));
+          setEdges(currentEdges.map((e) => (e.selected ? e : { ...e, selected: true })));
+          // Same rule as handleNodesChange: exactly one selected node syncs its id
+          syncSelectedNodeId(currentNodes.length === 1 ? currentNodes[0].id : null);
+        }
         if (key === 'z' && !event.shiftKey) {
           event.preventDefault();
           const { undo, pastStates } = useWorkflowStore.temporal.getState();


### PR DESCRIPTION
## Summary

A user can now press **Ctrl/Cmd+A** on the canvas to select every node and edge at once — then move the whole workflow in one drag, or delete it through the existing multi-delete confirmation flow. Previously the only multi-select was the rubber-band drag in selection mode; there was no keyboard path at all.

Closes #889

## Changes

- Added a `mod+A` branch to `WorkflowEditor`'s existing window-level keydown handler (the one already handling Ctrl+Z/Y/D and Delete/Backspace), guarded by the same editable-target check (INPUT/TEXTAREA/contentEditable) so text fields keep native select-all.
- All nodes and edges get `selected: true` via the store's `setNodes`/`setEdges`; `selectedNodeId` syncs with the same rule as `handleNodesChange` (exactly one node selected → that id, otherwise `null`, so the property overlay never opens spuriously).
- Selection state is already excluded from undo history (`partialize`) and canvas-revision tracking, so select-all neither dirties the workflow nor pollutes undo — verified in `workflow-store.ts`.
- Progress-log entry appended per the loop contract.

## Changeset

- `canvas-select-all-shortcut.md` — patch bump for `cc-wf-studio` (webview is bundled into the extension).

## Verification

- `pnpm build` and `pnpm check` pass from the repo root.
- Delete-after-select-all routes through `requestDeleteSelection`, which already filters out the start node and defers edge removal behind the confirmation dialog (#885/#886 behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdAohHnsicuRxyfBAxPWmQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdAohHnsicuRxyfBAxPWmQ)_