### PR TITLE
improvement(vscode): duplicate a multi-node selection with Ctrl/Cmd+D

### DIFF
--- a/.changeset/multi-select-duplicate.md
+++ b/.changeset/multi-select-duplicate.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Duplicate a multi-node selection with Ctrl/Cmd+D: the shortcut now clones every selected node at once (edges between copied nodes included, fresh ids, single undo entry) instead of only working when exactly one node is selected.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,35 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Duplicate a multi-node selection with Ctrl/Cmd+D
+- **User value**: a user can now select several nodes (Ctrl/Cmd+A,
+  rubber-band, or shift-click) and press Ctrl/Cmd+D to duplicate the whole
+  sub-flow at once — the copies keep the edges between each other.
+  Previously the shortcut was gated on `selectedNodeId` (set only when
+  exactly one node is selected), so duplicate on a multi-selection silently
+  did nothing.
+- **Issue/PR**: #891 / PR from `claude/multi-select-duplicate`
+- **Outcome**: done — generalized `duplicateNode` into a new
+  `duplicateSelection(nodeIds)` store action (`duplicateNode` now delegates
+  to it): same id-remapping convention, deep-copied `data`, single `set()`
+  → one undo entry. Start/End filtered out; a selected group brings its
+  children even if unselected (existing policy); a selected child whose
+  group is outside the set stays in its original group with the +40/+40
+  offset applied to its group-relative position. Edges with both endpoints
+  copied are duplicated and remapped; boundary-crossing edges are not
+  (matches group duplication). Selection moves wholly to the copies
+  (original nodes AND edges deselected); `selectedNodeId`/auto-focus pan
+  follow the exactly-one rule so multi-copies keep the viewport still. The
+  `mod+D` handler now reads the `selected` flags instead of
+  `selectedNodeId`. Guard step this round closed #889 (merged as #890).
+- **Next proposals**:
+  - Localization mini-sweep: `Toolbar.tsx` "Stop MCP Server" tooltip and
+    WhatsNewDialog "View changes on GitHub" are still hardcoded English.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow a11y); if not, add grid-step nudging.
+  - Clipboard copy/paste (Ctrl+C/V) of selections — would enable pasting
+    across workflows; needs a serialization format + paste-position design.
+
 ## 2026-07-23 — Add Ctrl/Cmd+A select-all to the workflow canvas
 - **User value**: a user can now press Ctrl/Cmd+A on the canvas to select
   every node and edge at once — then move the whole workflow, or delete it

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -398,18 +398,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           if (futureStates.length > 0) redo();
         }
         if (key === 'd' && !event.shiftKey) {
-          const {
-            selectedNodeId: currentSelectedId,
-            nodes: currentNodes,
-            duplicateNode,
-          } = useWorkflowStore.getState();
-          // selectedNodeId is set only when exactly one node is selected
-          if (currentSelectedId) {
-            const selectedNode = currentNodes.find((n) => n.id === currentSelectedId);
-            if (selectedNode && selectedNode.type !== 'start' && selectedNode.type !== 'end') {
-              event.preventDefault();
-              duplicateNode(currentSelectedId);
-            }
+          const { nodes: currentNodes, duplicateSelection } = useWorkflowStore.getState();
+          // Duplicate the whole selection (Start/End are structural and skipped)
+          const selectedIds = currentNodes
+            .filter((n) => n.selected && n.type !== 'start' && n.type !== 'end')
+            .map((n) => n.id);
+          if (selectedIds.length > 0) {
+            event.preventDefault();
+            duplicateSelection(selectedIds);
           }
         }
       }

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -147,6 +147,11 @@ interface WorkflowStore {
    *  deep-copied data; edges are not copied). Duplicating a group also copies
    *  its child nodes and the edges fully inside the group. Start/End excluded. */
   duplicateNode: (nodeId: string) => void;
+  /** Duplicate every node in the selection at once (fresh ids, +40/+40 offset,
+   *  deep-copied data). Selected groups bring their children along; edges with
+   *  both endpoints in the duplicated set are copied too. Start/End excluded.
+   *  The copies become the new selection. */
+  duplicateSelection: (nodeIds: string[]) => void;
   clearLastAddedNodeId: () => void;
   /** Request the canvas to pan to a specific node (e.g. when jumping in from
    *  Overview mode). The canvas-side hook clears it after centring. */
@@ -699,19 +704,31 @@ export const useWorkflowStore = create<WorkflowStore>()(
       },
 
       duplicateNode: (nodeId: string) => {
-        const allNodes = get().nodes;
-        const source = allNodes.find((node) => node.id === nodeId);
+        const source = get().nodes.find((node) => node.id === nodeId);
         if (!source) return;
         // Start/End are structural and must stay unique
         if (source.type === 'start' || source.type === 'end') {
           console.warn(`Cannot duplicate node of type "${source.type}"`);
           return;
         }
+        get().duplicateSelection([nodeId]);
+      },
+
+      duplicateSelection: (nodeIds: string[]) => {
+        const allNodes = get().nodes;
+        const requested = new Set(nodeIds);
+        // Start/End are structural and must stay unique
+        const sources = allNodes.filter(
+          (node) => requested.has(node.id) && node.type !== 'start' && node.type !== 'end'
+        );
+        if (sources.length === 0) return;
+        const sourceIds = new Set(sources.map((node) => node.id));
 
         // A group is duplicated together with its child nodes (groups never
         // nest — see onNodeDragStop — so direct children are all of them)
-        const children =
-          source.type === 'group' ? allNodes.filter((node) => node.parentId === nodeId) : [];
+        const children = allNodes.filter(
+          (node) => node.parentId && sourceIds.has(node.parentId) && !sourceIds.has(node.id)
+        );
 
         // Keep the palette's `<prefix>-<timestamp>` id convention: strip a
         // trailing timestamp from the source id, then append a fresh one.
@@ -728,11 +745,9 @@ export const useWorkflowStore = create<WorkflowStore>()(
         };
 
         const idMap = new Map<string, string>();
-        idMap.set(source.id, makeNodeId(source.id));
-        for (const child of children) {
-          idMap.set(child.id, makeNodeId(child.id));
+        for (const node of [...sources, ...children]) {
+          idMap.set(node.id, makeNodeId(node.id));
         }
-        const newSourceId = idMap.get(source.id) as string;
 
         const copyNode = (node: Node): Node => ({
           ...node,
@@ -740,24 +755,28 @@ export const useWorkflowStore = create<WorkflowStore>()(
           // Deep copy so later edits to the copy never mutate the original
           data: JSON.parse(JSON.stringify(node.data ?? {})),
           ...(node.style && { style: { ...node.style } }),
-          // Children keep their group-relative position; only the root moves
+          // Children of a copied group keep their group-relative position;
+          // every other copy shifts +40/+40 (a copied child whose group is
+          // not part of the selection stays inside its original group)
           position:
-            node.id === source.id
-              ? { x: node.position.x + 40, y: node.position.y + 40 }
-              : { ...node.position },
+            node.parentId && idMap.has(node.parentId)
+              ? { ...node.position }
+              : { x: node.position.x + 40, y: node.position.y + 40 },
           // Re-link copied children to the copied group
           ...(node.parentId && idMap.has(node.parentId)
             ? { parentId: idMap.get(node.parentId) as string }
             : {}),
-          selected: node.id === source.id,
+          // The copies become the new selection; group children ride along
+          // unselected unless they were explicitly selected themselves
+          selected: sourceIds.has(node.id),
         });
 
-        // Root copy first so React Flow sees the parent before its children
-        const copies = [copyNode(source), ...children.map(copyNode)];
+        // Parent copies first so React Flow sees a group before its children
+        const copies = sortNodesParentFirst([...sources, ...children].map(copyNode));
 
         // Copy edges fully inside the duplicated set (both endpoints copied);
-        // edges crossing the group boundary are not copied — same policy as
-        // single-node duplication, which copies no edges
+        // edges crossing the selection boundary are not copied — same policy
+        // as single-node duplication, which copies no edges
         const currentEdges = get().edges;
         const usedEdgeIds = new Set(currentEdges.map((edge) => edge.id));
         const edgeCopies = currentEdges
@@ -779,17 +798,25 @@ export const useWorkflowStore = create<WorkflowStore>()(
             };
           });
 
-        // Move React Flow's visual selection from the source to the copy
+        // Move React Flow's visual selection from the sources to the copies
         const deselected = allNodes.map((node) =>
           node.selected ? { ...node, selected: false } : node
         );
+        const edgesDeselected = currentEdges.map((edge) =>
+          edge.selected ? { ...edge, selected: false } : edge
+        );
+        const edgesChanged = edgeCopies.length > 0 || currentEdges.some((edge) => edge.selected);
+
+        // Same rule as handleNodesChange: exactly one selected node syncs its
+        // id (and gets the auto-focus pan); a multi-copy keeps the view still
+        const newSelectedId = sources.length === 1 ? (idMap.get(sources[0].id) as string) : null;
 
         // Single set() call → single undo/redo history entry
         set({
           nodes: [...deselected, ...copies],
-          ...(edgeCopies.length > 0 && { edges: [...currentEdges, ...edgeCopies] }),
-          lastAddedNodeId: newSourceId,
-          selectedNodeId: newSourceId,
+          ...(edgesChanged && { edges: [...edgesDeselected, ...edgeCopies] }),
+          ...(newSelectedId && { lastAddedNodeId: newSelectedId }),
+          selectedNodeId: newSelectedId,
         });
       },
 


### PR DESCRIPTION
## Summary

A user can now select several nodes (Ctrl/Cmd+A, rubber-band, or shift-click) and press **Ctrl/Cmd+D** to duplicate the whole sub-flow at once — the copies keep the edges between each other. Previously the shortcut was gated on `selectedNodeId`, which is set only when exactly one node is selected, so duplicate on a multi-selection silently did nothing.

Closes #891

## Changes

- Added a `duplicateSelection(nodeIds)` store action generalizing the existing `duplicateNode` (which now delegates to it): same `<prefix>-<timestamp>` id-remapping convention, deep-copied `data`, single `set()` call → one undo entry.
- Start/End nodes are filtered out of the selection (structural, must stay unique). A selected group brings its children along even when they are unselected (existing group-duplication policy); a selected child whose group is outside the set stays in its original group, with the +40/+40 offset applied to its group-relative position.
- Edges with **both** endpoints in the copied set are duplicated and remapped; edges crossing the selection boundary are not copied (same policy as group duplication today).
- Selection moves wholly to the copies — original nodes *and* edges are deselected. `selectedNodeId` and the auto-focus pan follow the existing exactly-one rule, so multi-copies keep the viewport still.
- The `mod+D` keydown branch in `WorkflowEditor.tsx` now reads the nodes' `selected` flags instead of `selectedNodeId`.
- No new i18n strings, no schema changes. Progress-log entry appended per the loop contract.

## Changeset

`.changeset/multi-select-duplicate.md` — patch bump for `cc-wf-studio` (same precedent as the earlier canvas-shortcut changesets; the webview is bundled at build time).

## Verification

- `pnpm build` and `pnpm check` pass from the repo root.
- Code-verified against `duplicateNode`'s existing semantics (group children, id conventions, undo granularity); manual E2E per repo policy rides on the Extension Development Host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S46GCDdLV2ntaTpe5paDcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01S46GCDdLV2ntaTpe5paDcL)_