### PR TITLE
improvement(vscode): copy/paste the canvas selection with Ctrl/Cmd+C / Ctrl/Cmd+V

### DIFF
--- a/.changeset/canvas-copy-paste-selection.md
+++ b/.changeset/canvas-copy-paste-selection.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Copy and paste the canvas selection with Ctrl/Cmd+C / Ctrl/Cmd+V: the selected nodes (with the edges between them) are written to the system clipboard as a versioned JSON payload, so a sub-flow can be pasted back with fresh ids — including into a different workflow's canvas in another editor window. Ordinary text copy/paste is never hijacked.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Copy/paste the canvas selection with Ctrl/Cmd+C / Ctrl/Cmd+V
+- **User value**: a user can now copy the selected nodes (with the edges
+  between them) and paste them — including into a **different workflow's
+  canvas** in another editor window — instead of rebuilding sub-flows by
+  hand. Completes the selection story queued by the last two iterations
+  (select-all #889, multi-duplicate #891); previously Ctrl+C/V did nothing.
+- **Issue/PR**: #893 / PR from `claude/sleepy-curie-7t2atg`
+- **Outcome**: done — implemented via DOM `copy`/`paste` events
+  (permission-free in VSCode webviews, unlike `navigator.clipboard.readText`)
+  with the existing editable-target guard; a non-collapsed text selection
+  keeps the native copy, and paste only intercepts text that parses as a
+  versioned `cc-wf-studio/selection` JSON payload. `serializeSelection`
+  reuses the duplicateSelection inclusion policy (Start/End excluded,
+  groups bring children, edges with both endpoints inside); children copied
+  without their group are made self-contained (parentId dropped, position
+  made absolute). `pasteSelection` inserts with fresh ids (shared
+  `makeUniqueNodeId`/`makeUniqueEdgeId` helpers extracted from
+  duplicateSelection), +40/+40 offset, deep-copied data, pasted nodes
+  become the selection, single `set()` → one undo entry. Malformed payloads
+  are shape-checked and rejected. No new i18n strings, no schema changes.
+- **Next proposals**:
+  - Localization mini-sweep: `Toolbar.tsx` "Stop MCP Server",
+    `McpServerSection.tsx` "Open documentation"/"Stop MCP Server (Port …)",
+    `WhatsNewDialog` "View changes on GitHub", `CodexNodeDialog` "Open
+    documentation" are still hardcoded English (verified this round).
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y is enabled — `disableKeyboardA11y`
+    is not set); only add grid-step nudging if it's actually missing.
+  - Manual E2E: confirm webview `copy`/`paste` events fire on all three
+    OSes (Linux webviews historically quirky) — if paste is unreliable,
+    fall back to Ctrl+V keydown + `navigator.clipboard.readText()`.
+
 ## 2026-07-23 — Duplicate a multi-node selection with Ctrl/Cmd+D
 - **User value**: a user can now select several nodes (Ctrl/Cmd+A,
   rubber-band, or shift-click) and press Ctrl/Cmd+D to duplicate the whole

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -25,7 +25,7 @@ import { CURRENT_ANNOUNCEMENT, cleanupDismissedAnnouncements } from '../constant
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
-import { useWorkflowStore } from '../stores/workflow-store';
+import { parseSelectionClipboardPayload, useWorkflowStore } from '../stores/workflow-store';
 import { CanvasToolbar } from './CanvasToolbar';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
 import { DescriptionPanel } from './DescriptionPanel';
@@ -417,12 +417,55 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       }
     };
 
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      const element = target as HTMLElement | null;
+      return Boolean(
+        element &&
+          (element.tagName === 'INPUT' ||
+            element.tagName === 'TEXTAREA' ||
+            element.isContentEditable)
+      );
+    };
+
+    // Copy/paste the canvas selection via the DOM clipboard events —
+    // permission-free in VSCode webviews (navigator.clipboard.readText is
+    // not), and the system clipboard carries the payload across canvas
+    // windows, so paste works into a different workflow too.
+    const handleCopy = (event: ClipboardEvent) => {
+      if (isEditableTarget(event.target)) return;
+      // A real text selection (e.g. inside a panel) keeps the native copy
+      const textSelection = window.getSelection();
+      if (textSelection && !textSelection.isCollapsed) return;
+      const { nodes: currentNodes, serializeSelection } = useWorkflowStore.getState();
+      const selectedIds = currentNodes.filter((n) => n.selected).map((n) => n.id);
+      if (selectedIds.length === 0) return;
+      const payload = serializeSelection(selectedIds);
+      if (!payload || !event.clipboardData) return;
+      event.preventDefault();
+      event.clipboardData.setData('text/plain', JSON.stringify(payload, null, 2));
+    };
+
+    const handlePaste = (event: ClipboardEvent) => {
+      if (isEditableTarget(event.target)) return;
+      const text = event.clipboardData?.getData('text/plain');
+      if (!text) return;
+      const payload = parseSelectionClipboardPayload(text);
+      // Anything that isn't a cc-wf-studio selection keeps the native paste
+      if (!payload) return;
+      event.preventDefault();
+      useWorkflowStore.getState().pasteSelection(payload);
+    };
+
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
+    document.addEventListener('copy', handleCopy);
+    document.addEventListener('paste', handlePaste);
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
+      document.removeEventListener('copy', handleCopy);
+      document.removeEventListener('paste', handlePaste);
     };
   }, []);
 

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -42,6 +42,86 @@ export type InteractionMode = 'pan' | 'selection';
  */
 export type ScrollMode = 'classic' | 'freehand';
 
+// ============================================================================
+// Selection Clipboard (Ctrl/Cmd+C / Ctrl/Cmd+V)
+// ============================================================================
+
+/** Marker distinguishing a cc-wf-studio selection payload from ordinary text */
+export const SELECTION_CLIPBOARD_TYPE = 'cc-wf-studio/selection';
+
+/** A node serialized for the clipboard — self-contained (a child copied
+ *  without its group carries its absolute position and no parentId). */
+export interface SelectionClipboardNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: Record<string, unknown>;
+  parentId?: string;
+  style?: Record<string, unknown>;
+}
+
+/** An edge serialized for the clipboard (both endpoints are payload nodes) */
+export interface SelectionClipboardEdge {
+  id: string;
+  source: string;
+  target: string;
+  [key: string]: unknown;
+}
+
+/** Versioned clipboard payload written as plain text — the system clipboard
+ *  carries it across canvas windows, so paste works between workflows. */
+export interface SelectionClipboardPayload {
+  type: typeof SELECTION_CLIPBOARD_TYPE;
+  version: 1;
+  nodes: SelectionClipboardNode[];
+  edges: SelectionClipboardEdge[];
+}
+
+/**
+ * Parse clipboard text into a selection payload, or null if it is anything
+ * else (ordinary text pastes must never be hijacked). Shape-checks every
+ * node and edge so a malformed payload cannot corrupt the canvas.
+ */
+export function parseSelectionClipboardPayload(text: string): SelectionClipboardPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const payload = parsed as Record<string, unknown>;
+  if (payload.type !== SELECTION_CLIPBOARD_TYPE || payload.version !== 1) return null;
+  if (!Array.isArray(payload.nodes) || !Array.isArray(payload.edges)) return null;
+
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+  const isValidNode = (value: unknown): boolean => {
+    if (!isRecord(value)) return false;
+    const position = value.position;
+    return (
+      typeof value.id === 'string' &&
+      typeof value.type === 'string' &&
+      value.type.length > 0 &&
+      isRecord(position) &&
+      typeof position.x === 'number' &&
+      Number.isFinite(position.x) &&
+      typeof position.y === 'number' &&
+      Number.isFinite(position.y) &&
+      isRecord(value.data) &&
+      (value.parentId === undefined || typeof value.parentId === 'string')
+    );
+  };
+  const isValidEdge = (value: unknown): boolean =>
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.source === 'string' &&
+    typeof value.target === 'string';
+
+  if (!payload.nodes.every(isValidNode) || !payload.edges.every(isValidEdge)) return null;
+  return parsed as SelectionClipboardPayload;
+}
+
 /**
  * Snapshot of main workflow state for restoration after Sub-Agent Flow editing
  */
@@ -152,6 +232,14 @@ interface WorkflowStore {
    *  both endpoints in the duplicated set are copied too. Start/End excluded.
    *  The copies become the new selection. */
   duplicateSelection: (nodeIds: string[]) => void;
+  /** Serialize a selection into a clipboard payload (Start/End excluded;
+   *  selected groups bring their children; edges with both endpoints in the
+   *  set ride along). Returns null when nothing serializable is selected. */
+  serializeSelection: (nodeIds: string[]) => SelectionClipboardPayload | null;
+  /** Insert a clipboard payload as new nodes/edges: fresh ids, +40/+40
+   *  offset, deep-copied data, one undo entry. The pasted nodes become the
+   *  new selection. Works with payloads copied from another workflow. */
+  pasteSelection: (payload: SelectionClipboardPayload) => void;
   clearLastAddedNodeId: () => void;
   /** Request the canvas to pan to a specific node (e.g. when jumping in from
    *  Overview mode). The canvas-side hook clears it after centring. */
@@ -204,6 +292,32 @@ function sortNodesParentFirst(nodes: Node[]): Node[] {
   const parents = nodes.filter((n) => parentIds.has(n.id));
   const others = nodes.filter((n) => !parentIds.has(n.id));
   return [...parents, ...others];
+}
+
+/**
+ * Keep the palette's `<prefix>-<timestamp>` id convention: strip a trailing
+ * timestamp from the original id, then append a fresh one. `usedIds` tracks
+ * ids already taken so same-millisecond copies stay unique (the new id is
+ * added to the set).
+ */
+function makeUniqueNodeId(usedIds: Set<string>, originalId: string): string {
+  const baseId = originalId.replace(/[-_]\d+$/, '');
+  let newId = `${baseId}-${Date.now()}`;
+  while (usedIds.has(newId)) {
+    newId = `${baseId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  }
+  usedIds.add(newId);
+  return newId;
+}
+
+/** Same uniqueness contract as makeUniqueNodeId, for `edge-<src>-<tgt>` ids. */
+function makeUniqueEdgeId(usedIds: Set<string>, source: string, target: string): string {
+  let newEdgeId = `edge-${source}-${target}`;
+  while (usedIds.has(newEdgeId)) {
+    newEdgeId = `edge-${source}-${target}-${Math.random().toString(36).slice(2, 6)}`;
+  }
+  usedIds.add(newEdgeId);
+  return newEdgeId;
 }
 
 /**
@@ -730,23 +844,10 @@ export const useWorkflowStore = create<WorkflowStore>()(
           (node) => node.parentId && sourceIds.has(node.parentId) && !sourceIds.has(node.id)
         );
 
-        // Keep the palette's `<prefix>-<timestamp>` id convention: strip a
-        // trailing timestamp from the source id, then append a fresh one.
-        // Track used ids so same-millisecond copies stay unique.
         const usedIds = new Set(allNodes.map((node) => node.id));
-        const makeNodeId = (originalId: string) => {
-          const baseId = originalId.replace(/[-_]\d+$/, '');
-          let newId = `${baseId}-${Date.now()}`;
-          while (usedIds.has(newId)) {
-            newId = `${baseId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-          }
-          usedIds.add(newId);
-          return newId;
-        };
-
         const idMap = new Map<string, string>();
         for (const node of [...sources, ...children]) {
-          idMap.set(node.id, makeNodeId(node.id));
+          idMap.set(node.id, makeUniqueNodeId(usedIds, node.id));
         }
 
         const copyNode = (node: Node): Node => ({
@@ -784,14 +885,9 @@ export const useWorkflowStore = create<WorkflowStore>()(
           .map((edge) => {
             const newSource = idMap.get(edge.source) as string;
             const newTarget = idMap.get(edge.target) as string;
-            let newEdgeId = `edge-${newSource}-${newTarget}`;
-            while (usedEdgeIds.has(newEdgeId)) {
-              newEdgeId = `edge-${newSource}-${newTarget}-${Math.random().toString(36).slice(2, 6)}`;
-            }
-            usedEdgeIds.add(newEdgeId);
             return {
               ...edge,
-              id: newEdgeId,
+              id: makeUniqueEdgeId(usedEdgeIds, newSource, newTarget),
               source: newSource,
               target: newTarget,
               selected: false,
@@ -815,6 +911,143 @@ export const useWorkflowStore = create<WorkflowStore>()(
         set({
           nodes: [...deselected, ...copies],
           ...(edgesChanged && { edges: [...edgesDeselected, ...edgeCopies] }),
+          ...(newSelectedId && { lastAddedNodeId: newSelectedId }),
+          selectedNodeId: newSelectedId,
+        });
+      },
+
+      serializeSelection: (nodeIds: string[]) => {
+        const allNodes = get().nodes;
+        const requested = new Set(nodeIds);
+        // Start/End are structural and must stay unique — never copied
+        const sources = allNodes.filter(
+          (node) => requested.has(node.id) && node.type !== 'start' && node.type !== 'end'
+        );
+        if (sources.length === 0) return null;
+        const sourceIds = new Set(sources.map((node) => node.id));
+
+        // Same policy as duplicateSelection: a group brings its children
+        const children = allNodes.filter(
+          (node) => node.parentId && sourceIds.has(node.parentId) && !sourceIds.has(node.id)
+        );
+        const included = [...sources, ...children];
+        const includedIds = new Set(included.map((node) => node.id));
+
+        const toClipboardNode = (node: Node): SelectionClipboardNode => {
+          // A child copied without its group must be self-contained: drop the
+          // parentId and convert its group-relative position to absolute
+          // (groups never nest, so parent position + offset is enough)
+          let position = { ...node.position };
+          let parentId = node.parentId;
+          if (parentId && !includedIds.has(parentId)) {
+            const parent = allNodes.find((n) => n.id === parentId);
+            if (parent) {
+              position = {
+                x: parent.position.x + node.position.x,
+                y: parent.position.y + node.position.y,
+              };
+            }
+            parentId = undefined;
+          }
+          return {
+            id: node.id,
+            type: node.type ?? 'default',
+            position,
+            data: JSON.parse(JSON.stringify(node.data ?? {})),
+            ...(parentId ? { parentId } : {}),
+            ...(node.style ? { style: { ...node.style } } : {}),
+          };
+        };
+
+        const edges = get()
+          .edges.filter((edge) => includedIds.has(edge.source) && includedIds.has(edge.target))
+          .map((edge) => {
+            const { selected: _selected, ...rest } = edge;
+            return JSON.parse(JSON.stringify(rest)) as SelectionClipboardEdge;
+          });
+
+        return {
+          type: SELECTION_CLIPBOARD_TYPE,
+          version: 1,
+          nodes: included.map(toClipboardNode),
+          edges,
+        };
+      },
+
+      pasteSelection: (payload: SelectionClipboardPayload) => {
+        const allNodes = get().nodes;
+        // Defense in depth — serializeSelection never emits these, but the
+        // clipboard is user-editable text
+        const incoming = payload.nodes.filter(
+          (node) => node.type !== 'start' && node.type !== 'end'
+        );
+        if (incoming.length === 0) return;
+
+        const usedIds = new Set(allNodes.map((node) => node.id));
+        const idMap = new Map<string, string>();
+        for (const node of incoming) {
+          idMap.set(node.id, makeUniqueNodeId(usedIds, node.id));
+        }
+
+        const copies: Node[] = incoming.map((node) => ({
+          id: idMap.get(node.id) as string,
+          type: node.type,
+          // Deep copy so pasting twice never shares data between the copies
+          data: JSON.parse(JSON.stringify(node.data ?? {})),
+          // Children of a pasted group keep their group-relative position;
+          // every other node shifts +40/+40 (same offset as duplication)
+          position:
+            node.parentId && idMap.has(node.parentId)
+              ? { ...node.position }
+              : { x: node.position.x + 40, y: node.position.y + 40 },
+          ...(node.parentId && idMap.has(node.parentId)
+            ? { parentId: idMap.get(node.parentId) as string }
+            : {}),
+          ...(node.style ? { style: { ...node.style } } : {}),
+          // The pasted content becomes the new selection
+          selected: true,
+        }));
+
+        const currentEdges = get().edges;
+        const usedEdgeIds = new Set(currentEdges.map((edge) => edge.id));
+        const edgeCopies: Edge[] = payload.edges
+          .filter((edge) => idMap.has(edge.source) && idMap.has(edge.target))
+          .map((edge) => {
+            const newSource = idMap.get(edge.source) as string;
+            const newTarget = idMap.get(edge.target) as string;
+            const {
+              id: _id,
+              source: _source,
+              target: _target,
+              selected: _selected,
+              ...rest
+            } = edge;
+            return {
+              ...(JSON.parse(JSON.stringify(rest)) as Record<string, unknown>),
+              id: makeUniqueEdgeId(usedEdgeIds, newSource, newTarget),
+              source: newSource,
+              target: newTarget,
+              selected: false,
+            } as Edge;
+          });
+
+        // Move the visual selection from whatever was selected to the copies
+        const deselectedNodes = allNodes.map((node) =>
+          node.selected ? { ...node, selected: false } : node
+        );
+        const deselectedEdges = currentEdges.map((edge) =>
+          edge.selected ? { ...edge, selected: false } : edge
+        );
+
+        // Same rule as handleNodesChange: exactly one selected node syncs its
+        // id (and gets the auto-focus pan); a multi-paste keeps the view still
+        const newSelectedId = copies.length === 1 ? copies[0].id : null;
+
+        // Parent copies first so React Flow sees a group before its children.
+        // Single set() call → single undo/redo history entry
+        set({
+          nodes: [...deselectedNodes, ...sortNodesParentFirst(copies)],
+          edges: [...deselectedEdges, ...edgeCopies],
           ...(newSelectedId && { lastAddedNodeId: newSelectedId }),
           selectedNodeId: newSelectedId,
         });


### PR DESCRIPTION
## Summary

Adds clipboard copy/paste to the workflow canvas. Ctrl/Cmd+C serializes the selected nodes — with the edges between them — into a versioned JSON payload on the **system clipboard**, and Ctrl/Cmd+V pastes it back with fresh ids. Because the payload travels through the system clipboard, a sub-flow can be pasted into a **different workflow's canvas** in another editor window, which neither select-all (#889) nor in-place duplicate (#891) could do.

Closes #893

## User value

A user can now copy a selected sub-flow and paste it anywhere — same canvas or another workflow — instead of rebuilding it node by node. Previously Ctrl+C/V silently did nothing on the canvas.

## Implementation

- **DOM `copy`/`paste` events** (not `navigator.clipboard.readText`, which needs permissions in webviews), registered in `WorkflowEditor`'s existing keyboard-effect with the same editable-target guard as Ctrl+Z/A/D. A non-collapsed text selection keeps the native copy; paste only intercepts text that parses as a `cc-wf-studio/selection` payload, so ordinary text copy/paste is never hijacked.
- **`serializeSelection` (new store action)**: same inclusion policy as `duplicateSelection` — Start/End excluded, a selected group brings its children, edges with both endpoints inside the set ride along. A child copied *without* its group is made self-contained: `parentId` dropped, position converted to absolute (groups never nest).
- **`pasteSelection` (new store action)**: shape-checked payload → fresh ids via the shared `makeUniqueNodeId`/`makeUniqueEdgeId` helpers (extracted from `duplicateSelection`, behavior unchanged), +40/+40 offset for roots, group children keep relative positions, deep-copied `data`, edges remapped, pasted nodes become the new selection, single `set()` → one undo entry. `selectedNodeId`/auto-focus follow the exactly-one rule so multi-pastes keep the viewport still.
- Malformed or foreign clipboard JSON is rejected by `parseSelectionClipboardPayload` (strict per-node/per-edge shape checks); `start`/`end` nodes are additionally filtered defensively at paste time.

## Scope notes

- No new i18n strings (keyboard-only feature), no schema changes, no cut (deletion has its own confirmation flow).
- Changeset: `canvas-copy-paste-selection.md` (`cc-wf-studio` patch).
- Progress log entry appended (2026-07-23 iteration).

## Manual E2E checklist

- [ ] Copy a multi-node selection, paste in the same canvas → copies +40/+40, edges kept, one undo entry
- [ ] Paste into a different workflow's canvas window
- [ ] Copy a group (children ride along), paste — children stay inside the pasted group
- [ ] Copy a child without its group → pastes ungrouped at its absolute position
- [ ] Copy text in an input, paste in an input → native behavior untouched
- [ ] Paste arbitrary text on the canvas → nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hEjt3sSz2TWSeqPLvNMzj

---
_Generated by [Claude Code](https://claude.ai/code/session_012hEjt3sSz2TWSeqPLvNMzj)_