### PR TITLE
improvement(vscode): cut the canvas selection with Ctrl/Cmd+X

### DIFF
--- a/.changeset/canvas-cut-selection.md
+++ b/.changeset/canvas-cut-selection.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Cut the canvas selection with Ctrl/Cmd+X — the selected nodes (and the edges between them) move to the clipboard and can be pasted into the same or another workflow's canvas; undoable with Ctrl/Cmd+Z, no confirmation dialog.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Cut the canvas selection with Ctrl/Cmd+X
+- **User value**: a user can now cut the selected nodes (with the edges
+  between them) and paste them elsewhere — including into a different
+  workflow's canvas — moving a sub-flow in two keystrokes instead of
+  copy → delete → confirmation dialog. Completes the clipboard triad
+  (copy/paste shipped in #893/#894); previously Ctrl+X silently did nothing.
+- **Issue/PR**: #895 / PR from `claude/sleepy-curie-zj2g8c`
+- **Outcome**: done — new `cutSelection(nodeIds)` store action delegates to
+  `serializeSelection` (same inclusion policy: Start/End excluded, groups
+  bring children, internal edges in the payload), then removes exactly the
+  serialized node set plus every edge touching it (boundary edges must not
+  dangle) in a single `set()` → one undo entry; selected edges between two
+  surviving nodes are kept (cut only removes what the clipboard holds).
+  DOM `cut` handler sits beside the existing `copy`/`paste` handlers with
+  the same editable-target and text-selection guards; it checks
+  `event.clipboardData` **before** mutating (never delete without a
+  clipboard to write to) and skips while the delete-confirmation dialog is
+  open. No confirmation dialog by design: cut is undoable and the content
+  lives on the clipboard — Delete/Backspace keeps its confirm flow. No new
+  i18n strings, no schema changes.
+- **Next proposals**:
+  - Localization mini-sweep (re-verified this round): `Toolbar.tsx`
+    "Stop MCP Server" tooltip, `WhatsNewDialog` "View changes on GitHub",
+    `CodexNodeDialog` "Open documentation" are hardcoded English in active
+    UI (the `McpServerSection.tsx` occurrences are discontinued-chat-panel
+    only — maintain-only, skip them).
+  - Manual E2E: verify the `cut` event fires in webviews on all three OSes
+    alongside the queued copy/paste check.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — Copy/paste the canvas selection with Ctrl/Cmd+C / Ctrl/Cmd+V
 - **User value**: a user can now copy the selected nodes (with the edges
   between them) and paste them — including into a **different workflow's

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -427,7 +427,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       );
     };
 
-    // Copy/paste the canvas selection via the DOM clipboard events —
+    // Copy/cut/paste the canvas selection via the DOM clipboard events —
     // permission-free in VSCode webviews (navigator.clipboard.readText is
     // not), and the system clipboard carries the payload across canvas
     // windows, so paste works into a different workflow too.
@@ -441,6 +441,30 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       if (selectedIds.length === 0) return;
       const payload = serializeSelection(selectedIds);
       if (!payload || !event.clipboardData) return;
+      event.preventDefault();
+      event.clipboardData.setData('text/plain', JSON.stringify(payload, null, 2));
+    };
+
+    const handleCut = (event: ClipboardEvent) => {
+      if (isEditableTarget(event.target)) return;
+      // A real text selection (e.g. inside a panel) keeps the native cut
+      const textSelection = window.getSelection();
+      if (textSelection && !textSelection.isCollapsed) return;
+      // Nowhere to put the payload → don't remove anything
+      if (!event.clipboardData) return;
+      const {
+        nodes: currentNodes,
+        pendingDeleteNodeIds,
+        cutSelection,
+      } = useWorkflowStore.getState();
+      // Don't race the delete-confirmation dialog over the same selection
+      if (pendingDeleteNodeIds.length > 0) return;
+      const selectedIds = currentNodes.filter((n) => n.selected).map((n) => n.id);
+      if (selectedIds.length === 0) return;
+      // No confirmation dialog: cut is undoable (Ctrl+Z) and the content
+      // lives on in the clipboard payload — standard editor semantics
+      const payload = cutSelection(selectedIds);
+      if (!payload) return;
       event.preventDefault();
       event.clipboardData.setData('text/plain', JSON.stringify(payload, null, 2));
     };
@@ -459,12 +483,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
     document.addEventListener('copy', handleCopy);
+    document.addEventListener('cut', handleCut);
     document.addEventListener('paste', handlePaste);
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
       document.removeEventListener('copy', handleCopy);
+      document.removeEventListener('cut', handleCut);
       document.removeEventListener('paste', handlePaste);
     };
   }, []);

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -240,6 +240,12 @@ interface WorkflowStore {
    *  offset, deep-copied data, one undo entry. The pasted nodes become the
    *  new selection. Works with payloads copied from another workflow. */
   pasteSelection: (payload: SelectionClipboardPayload) => void;
+  /** Cut a selection: serialize it (same policy as serializeSelection),
+   *  then remove the serialized nodes plus every edge touching them in a
+   *  single undo entry. No confirmation dialog — cut is undoable and the
+   *  content lives on in the returned clipboard payload. Returns null (and
+   *  removes nothing) when nothing serializable is selected. */
+  cutSelection: (nodeIds: string[]) => SelectionClipboardPayload | null;
   clearLastAddedNodeId: () => void;
   /** Request the canvas to pan to a specific node (e.g. when jumping in from
    *  Overview mode). The canvas-side hook clears it after centring. */
@@ -1051,6 +1057,38 @@ export const useWorkflowStore = create<WorkflowStore>()(
           ...(newSelectedId && { lastAddedNodeId: newSelectedId }),
           selectedNodeId: newSelectedId,
         });
+      },
+
+      cutSelection: (nodeIds: string[]) => {
+        const payload = get().serializeSelection(nodeIds);
+        if (!payload) return null;
+
+        // Remove exactly the serialized set — Start/End are already
+        // excluded, and a cut group takes its children with it (they are
+        // part of the payload, so nothing the user keeps is lost)
+        const removedIds = new Set(payload.nodes.map((node) => node.id));
+
+        // Boundary-crossing edges are not in the payload, but leaving them
+        // dangling would corrupt the canvas — drop every touching edge.
+        // Selected edges between two surviving nodes are kept: cut only
+        // removes what the clipboard now holds.
+        const remainingNodes = get().nodes.filter((node) => !removedIds.has(node.id));
+        const remainingEdges = get().edges.filter(
+          (edge) => !removedIds.has(edge.source) && !removedIds.has(edge.target)
+        );
+
+        const currentSelectedNodeId = get().selectedNodeId;
+
+        // Single set() call → single undo/redo history entry
+        set({
+          nodes: remainingNodes,
+          edges: remainingEdges,
+          ...(currentSelectedNodeId && removedIds.has(currentSelectedNodeId)
+            ? { selectedNodeId: null }
+            : {}),
+        });
+
+        return payload;
       },
 
       requestFocusNode: (nodeId: string) => {


### PR DESCRIPTION
## Summary

Adds clipboard **cut** to the workflow canvas, completing the triad started by select-all (#889), multi-duplicate (#891), and copy/paste (#893). Ctrl/Cmd+X serializes the selected nodes — with the edges between them — to the system clipboard using the exact same versioned JSON payload as copy, then removes them from the canvas in a single undo entry. Because the payload travels through the system clipboard, a sub-flow can be **moved** into a different workflow's canvas in another editor window in two keystrokes, instead of copy → delete → confirmation dialog.

Closes #895

## User value

A user can now cut the selected nodes and paste them elsewhere — including another workflow — moving a sub-flow instead of copying and manually deleting. Previously Ctrl/Cmd+X silently did nothing on the canvas.

## Changes

- **`workflow-store.ts`**: new `cutSelection(nodeIds)` action — delegates to `serializeSelection` (same inclusion policy: Start/End excluded, a selected group brings its children, internal edges ride along), then removes exactly the serialized node set plus every edge touching it (boundary edges must not dangle) in one `set()` → one undo entry. Selected edges between two *surviving* nodes are kept: cut only removes what the clipboard now holds. `selectedNodeId` is cleared when it pointed at a removed node. Returns the payload for the clipboard, or `null` (removing nothing) when nothing serializable is selected.
- **`WorkflowEditor.tsx`**: DOM `cut` event handler registered beside the existing `copy`/`paste` handlers, with the same editable-target guard and native-behavior fallback for non-collapsed text selections. It checks `event.clipboardData` **before** mutating the store (never delete without a clipboard to write to) and skips while the delete-confirmation dialog is open to avoid racing it over the same selection.

## Design notes

- **No confirmation dialog** — cut is undoable (Ctrl/Cmd+Z) and the content is preserved on the clipboard, matching standard editor semantics. Delete/Backspace keeps its existing confirm flow.
- No new i18n strings, no schema changes.

## Changeset

`.changeset/canvas-cut-selection.md` — `cc-wf-studio`: patch.

## Testing

- `pnpm build` and `pnpm check` pass from the repo root.
- Manual E2E (queued in the progress log alongside the copy/paste OS check): cut a multi-selection incl. a group, paste into the same and another workflow window, undo restores nodes and edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRmBZU25bwyqBkdoeW9gF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRmBZU25bwyqBkdoeW9gF4)_