### PR TITLE
improvement(vscode): localize remaining hardcoded strings in active UI

### DIFF
--- a/.changeset/localize-active-ui-sweep.md
+++ b/.changeset/localize-active-ui-sweep.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Localize remaining hardcoded English tooltips, aria-labels, and placeholders in the active canvas UI (toolbar MCP-server stop button, What's New dialog, Codex dialog, canvas toggle switches, shared tag input, wizard steps, Sub-Agent Flow editor dialog, and Claude API upload dialog attributes) across all 5 UI languages

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Localize remaining hardcoded English strings in active UI
+- **User value**: a user running VSCode in Japanese, Korean, or Chinese no
+  longer hits stray English strings in otherwise-localized surfaces: the
+  toolbar's "Stop MCP Server" tooltip, the What's New "View changes on
+  GitHub" tooltip, the Codex dialog "Open documentation" tooltip, the four
+  canvas toggle switch aria-labels, the shared tag-input "Required" lock
+  label, wizard step navigation, the Sub-Agent Flow editor dialog label,
+  and the Claude API upload dialog's tooltips/placeholders — screen-reader
+  users get these in their UI language too.
+- **Issue/PR**: #897 / PR from `claude/localize-active-ui-sweep`
+- **Outcome**: done — 18 new keys added to `translation-keys.ts` and all 5
+  locale files (en/ja/ko/zh-CN/zh-TW) per `.claude/rules/translation.md`
+  (product terms MCP / PulseMCP / Claude Platform / Sub-Agent Flow /
+  access_token kept English); 11 components switched from hardcoded
+  attributes to `t(...)`. Guard step this round closed #895 (merged as
+  #896). Deliberately out of scope: `McpServerSection.tsx` (discontinued
+  chat panel, maintain-only), `SkillCreationDialog`'s tool-name example
+  placeholder and `CommentaryOptionsDropdown`'s `placeholder="English"`
+  (both are literal example values), and the full localization of
+  `ClaudeApiUploadDialog` — discovered this round to be almost entirely
+  unlocalized visible text (~3600 lines, one `t()` call); only its
+  attribute-level strings were covered here.
+- **Next proposals**:
+  - Full localization of `ClaudeApiUploadDialog` visible text (headings,
+    buttons, confirm dialogs, status messages) — big but mechanical;
+    the `claudeApi.*` namespace started this round is the landing zone.
+  - Right-click context menu on canvas nodes/pane exposing the now-complete
+    clipboard verbs (Copy/Cut/Paste/Duplicate/Delete) — discoverability for
+    mouse-first users; React Flow `onNodeContextMenu`/`onPaneContextMenu`.
+  - Manual E2E still queued: verify `copy`/`cut`/`paste` DOM events fire in
+    webviews on all three OSes.
+
 ## 2026-07-23 — Cut the canvas selection with Ctrl/Cmd+X
 - **User value**: a user can now cut the selected nodes (with the edges
   between them) and paste them elsewhere — including into a different

--- a/packages/vscode/src/webview/src/components/EdgeAnimationToggle.tsx
+++ b/packages/vscode/src/webview/src/components/EdgeAnimationToggle.tsx
@@ -163,7 +163,7 @@ export const EdgeAnimationToggle: React.FC<EdgeAnimationToggleProps> = ({
                   checked={isEnabled}
                   onCheckedChange={() => onToggle()}
                   onClick={(e) => e.stopPropagation()}
-                  aria-label="Edge animation"
+                  aria-label={t('toolbar.edgeAnimation.label')}
                   style={{
                     all: 'unset',
                     width: '32px',

--- a/packages/vscode/src/webview/src/components/HighlightToggle.tsx
+++ b/packages/vscode/src/webview/src/components/HighlightToggle.tsx
@@ -163,7 +163,7 @@ export const HighlightToggle: React.FC = () => {
                     checked={isHighlightEnabled}
                     onCheckedChange={() => handleDisableHighlight()}
                     onClick={(e) => e.stopPropagation()}
-                    aria-label="Group node highlight"
+                    aria-label={t('toolbar.highlight.label')}
                     style={{
                       all: 'unset',
                       width: '32px',

--- a/packages/vscode/src/webview/src/components/InteractionModeToggle.tsx
+++ b/packages/vscode/src/webview/src/components/InteractionModeToggle.tsx
@@ -142,7 +142,7 @@ export const InteractionModeToggle: React.FC = () => {
                   checked={interactionMode === 'selection'}
                   onCheckedChange={() => toggleInteractionMode()}
                   onClick={(e) => e.stopPropagation()}
-                  aria-label="Canvas interaction mode"
+                  aria-label={t('toolbar.interactionMode.label')}
                   style={{
                     all: 'unset',
                     width: '32px',

--- a/packages/vscode/src/webview/src/components/ScrollModeToggle.tsx
+++ b/packages/vscode/src/webview/src/components/ScrollModeToggle.tsx
@@ -140,7 +140,7 @@ export const ScrollModeToggle: React.FC = () => {
                   checked={scrollMode === 'freehand'}
                   onCheckedChange={() => toggleScrollMode()}
                   onClick={(e) => e.stopPropagation()}
-                  aria-label="Canvas scroll mode"
+                  aria-label={t('toolbar.scrollMode.label')}
                   style={{
                     all: 'unset',
                     width: '32px',

--- a/packages/vscode/src/webview/src/components/Toolbar.tsx
+++ b/packages/vscode/src/webview/src/components/Toolbar.tsx
@@ -1370,7 +1370,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         <button
           type="button"
           onClick={() => vscode.postMessage({ type: 'STOP_MCP_SERVER' })}
-          title="Stop MCP Server"
+          title={t('toolbar.stopMcpServer')}
           style={{
             display: 'inline-flex',
             alignItems: 'center',

--- a/packages/vscode/src/webview/src/components/common/SelectTagInput.tsx
+++ b/packages/vscode/src/webview/src/components/common/SelectTagInput.tsx
@@ -9,6 +9,7 @@
 import * as Popover from '@radix-ui/react-popover';
 import { Check, Lock, X } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
+import { useTranslation } from '../../i18n/i18n-context';
 
 interface SelectOption {
   value: string;
@@ -39,6 +40,7 @@ export function SelectTagInput({
     options: options.map((o) => ({ value: o.value, label: o.label })),
   });
 
+  const { t } = useTranslation();
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -222,7 +224,7 @@ export function SelectTagInput({
                   <Lock
                     size={10}
                     style={{ marginLeft: '2px', opacity: 0.6 }}
-                    aria-label="Required"
+                    aria-label={t('common.required')}
                   />
                 )}
               </span>

--- a/packages/vscode/src/webview/src/components/common/WizardStepIndicator.tsx
+++ b/packages/vscode/src/webview/src/components/common/WizardStepIndicator.tsx
@@ -10,12 +10,15 @@
  * Accessibility: Properly structured with <nav>, <ol role="list">, and aria-current="step"
  */
 
+import { useTranslation } from '../../i18n/i18n-context';
+
 interface WizardStepIndicatorProps {
   currentStep: number;
   totalSteps: number;
 }
 
 export function WizardStepIndicator({ currentStep, totalSteps }: WizardStepIndicatorProps) {
+  const { t } = useTranslation();
   const steps = Array.from({ length: totalSteps }, (_, i) => i + 1);
 
   return (
@@ -23,7 +26,7 @@ export function WizardStepIndicator({ currentStep, totalSteps }: WizardStepIndic
       style={{
         marginBottom: '20px',
       }}
-      aria-label="Wizard steps"
+      aria-label={t('common.wizardSteps')}
     >
       <ol
         style={{

--- a/packages/vscode/src/webview/src/components/dialogs/ClaudeApiUploadDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/ClaudeApiUploadDialog.tsx
@@ -547,6 +547,7 @@ const McpServerUrlForm: React.FC<{
   onTokenChange?: (id: string, token: string) => void;
   serverOwners?: Record<string, string[]>;
 }> = ({ serverIds, urls, onUrlChange, tokens, onTokenChange, serverOwners }) => {
+  const { t } = useTranslation();
   const [authOpen, setAuthOpen] = useState(false);
   const [copiedCmd, setCopiedCmd] = useState(false);
   const hasAnyToken = tokens && Object.values(tokens).some((t) => t.trim());
@@ -611,9 +612,10 @@ const McpServerUrlForm: React.FC<{
               color: 'var(--vscode-textLink-foreground)',
               textDecoration: 'underline',
             }}
-            title="Search MCP server URLs on PulseMCP"
+            title={t('claudeApi.searchOnPulseMcp.tooltip')}
           >
-            Search on PulseMCP <ExternalLink size={10} style={{ verticalAlign: 'middle' }} />
+            {t('claudeApi.searchOnPulseMcp')}{' '}
+            <ExternalLink size={10} style={{ verticalAlign: 'middle' }} />
           </span>
         </div>
       </div>
@@ -794,7 +796,7 @@ const McpServerUrlForm: React.FC<{
                       <input
                         id={`mcp-bearer-${id}`}
                         type="password"
-                        placeholder="Paste token here"
+                        placeholder={t('claudeApi.pasteTokenPlaceholder')}
                         value={tokens?.[id] || ''}
                         onChange={(e) => {
                           const val = e.target.value.replace(/^Bearer\s+/i, '');
@@ -959,7 +961,7 @@ const McpServerUrlForm: React.FC<{
                     <input
                       id={`mcp-token-${id}`}
                       type="password"
-                      placeholder="Paste access_token here"
+                      placeholder={t('claudeApi.pasteAccessTokenPlaceholder')}
                       value={tokens?.[id] || ''}
                       onChange={(e) => onTokenChange(id, e.target.value)}
                       style={{
@@ -2110,7 +2112,7 @@ export const ClaudeApiUploadDialog: React.FC<ClaudeApiUploadDialogProps> = ({
                           color: 'var(--vscode-textLink-foreground)',
                           fontSize: '11px',
                         }}
-                        title="Open in Claude Platform"
+                        title={t('claudeApi.openInClaudePlatform')}
                       >
                         platform.claude.com
                         <ExternalLink size={11} />
@@ -2873,7 +2875,7 @@ export const ClaudeApiUploadDialog: React.FC<ClaudeApiUploadDialogProps> = ({
                                     .map((s) => ({ value: s.id, label: s.displayTitle }))}
                                   selectedValues={additionalSkillIds}
                                   onChange={handleAdditionalSkillsChange}
-                                  placeholder="Select uploaded skills..."
+                                  placeholder={t('claudeApi.selectUploadedSkills')}
                                   lockedValues={requiredSkillIds}
                                 />
                                 {missingDependentSkillNames.length > 0 && (
@@ -3165,7 +3167,7 @@ export const ClaudeApiUploadDialog: React.FC<ClaudeApiUploadDialogProps> = ({
                                     .map((s) => ({ value: s.id, label: s.displayTitle }))}
                                   selectedValues={additionalSkillIds}
                                   onChange={handleAdditionalSkillsChange}
-                                  placeholder="Select uploaded skills..."
+                                  placeholder={t('claudeApi.selectUploadedSkills')}
                                   lockedValues={requiredSkillIds}
                                 />
                                 {missingDependentSkillNames.length > 0 && (
@@ -3380,7 +3382,7 @@ export const ClaudeApiUploadDialog: React.FC<ClaudeApiUploadDialogProps> = ({
                                   }
                                 }
                               }}
-                              placeholder="Enter your test prompt..."
+                              placeholder={t('claudeApi.testPromptPlaceholder')}
                               rows={2}
                               style={{
                                 width: '100%',
@@ -3428,9 +3430,9 @@ export const ClaudeApiUploadDialog: React.FC<ClaudeApiUploadDialogProps> = ({
                                       fontSize: '11px',
                                       whiteSpace: 'nowrap',
                                     }}
-                                    title="Reset conversation"
+                                    title={t('claudeApi.resetConversation')}
                                   >
-                                    Reset Conversation
+                                    {t('claudeApi.resetConversation')}
                                   </button>
                                 )}
                               </div>

--- a/packages/vscode/src/webview/src/components/dialogs/CodexNodeDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/CodexNodeDialog.tsx
@@ -572,7 +572,7 @@ export function CodexNodeDialog({ isOpen, onClose }: CodexNodeDialogProps) {
                         cursor: 'pointer',
                         color: 'var(--vscode-textLink-foreground)',
                       }}
-                      title="Open documentation"
+                      title={t('codex.openDocumentation')}
                     >
                       <ExternalLink size={12} />
                     </button>

--- a/packages/vscode/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/SubAgentFlowDialog.tsx
@@ -537,7 +537,7 @@ const SubAgentFlowDialogContent: React.FC<SubAgentFlowDialogProps> = ({ isOpen, 
         >
           <Dialog.Content
             ref={dialogRef}
-            aria-label="Sub-Agent Flow Editor"
+            aria-label={t('subAgentFlow.dialog.ariaLabel')}
             aria-describedby={undefined}
             onEscapeKeyDown={(e) => {
               // Only close when not focused on input

--- a/packages/vscode/src/webview/src/components/dialogs/WhatsNewDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/WhatsNewDialog.tsx
@@ -234,7 +234,7 @@ export function WhatsNewDialog({
                             cursor: 'pointer',
                             color: 'var(--vscode-textLink-foreground)',
                           }}
-                          title="View changes on GitHub"
+                          title={t('whatsNew.viewChangesOnGitHub')}
                         >
                           <ExternalLink size={11} />
                         </span>

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -9,6 +9,8 @@ export interface WebviewTranslationKeys {
   optional: string;
   cancel: string;
   'common.close': string;
+  'common.required': string;
+  'common.wizardSteps': string;
   'common.cancel': string;
   'loading.importWorkflow': string;
   'loading.openWorkflow': string;
@@ -58,8 +60,10 @@ export interface WebviewTranslationKeys {
   'toolbar.interactionMode.switchToSelection': string;
   'toolbar.edgeAnimation.enable': string;
   'toolbar.edgeAnimation.disable': string;
+  'toolbar.edgeAnimation.label': string;
   'toolbar.highlight.enable': string;
   'toolbar.highlight.disable': string;
+  'toolbar.highlight.label': string;
   'toolbar.highlight.confirmDisable.title': string;
   'toolbar.highlight.confirmDisable.message': string;
   'toolbar.highlight.confirmDisable.confirm': string;
@@ -68,6 +72,9 @@ export interface WebviewTranslationKeys {
   'toolbar.redo': string;
   'toolbar.scrollMode.switchToClassic': string;
   'toolbar.scrollMode.switchToFreehand': string;
+  'toolbar.scrollMode.label': string;
+  'toolbar.interactionMode.label': string;
+  'toolbar.stopMcpServer': string;
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.hidden': string;
@@ -120,6 +127,7 @@ export interface WebviewTranslationKeys {
   // What's New dialog
   'whatsNew.title': string;
   'whatsNew.viewAllReleases': string;
+  'whatsNew.viewChangesOnGitHub': string;
   'whatsNew.showBadge': string;
 
   // Copilot Execution Mode
@@ -212,6 +220,7 @@ export interface WebviewTranslationKeys {
   'codex.error.promptTooLong': string;
   'codex.error.modelRequired': string;
   'codex.nameHelp': string;
+  'codex.openDocumentation': string;
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': string;
@@ -236,6 +245,7 @@ export interface WebviewTranslationKeys {
   'subAgentFlow.dialog.close': string;
   'subAgentFlow.dialog.submit': string;
   'subAgentFlow.dialog.cancel': string;
+  'subAgentFlow.dialog.ariaLabel': string;
   'subAgentFlow.generateNameWithAI': string;
 
   // SubAgentFlow AI Edit
@@ -1036,6 +1046,14 @@ export interface WebviewTranslationKeys {
 
   // Claude API Upload Dialog
   'claudeApi.description': string;
+  'claudeApi.searchOnPulseMcp': string;
+  'claudeApi.searchOnPulseMcp.tooltip': string;
+  'claudeApi.pasteTokenPlaceholder': string;
+  'claudeApi.pasteAccessTokenPlaceholder': string;
+  'claudeApi.openInClaudePlatform': string;
+  'claudeApi.selectUploadedSkills': string;
+  'claudeApi.testPromptPlaceholder': string;
+  'claudeApi.resetConversation': string;
 
   // Commentary AI
   'commentary.toggle': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -11,6 +11,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   optional: 'Optional',
   cancel: 'Cancel',
   'common.close': 'Close',
+  'common.required': 'Required',
+  'common.wizardSteps': 'Wizard steps',
   'common.cancel': 'Cancel',
   'loading.importWorkflow': 'Importing workflow...',
   'loading.openWorkflow': 'Opening workflow...',
@@ -59,8 +61,10 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToSelection': 'Switch to Selection mode',
   'toolbar.edgeAnimation.enable': 'Enable edge animation',
   'toolbar.edgeAnimation.disable': 'Disable edge animation',
+  'toolbar.edgeAnimation.label': 'Edge animation',
   'toolbar.highlight.enable': 'Enable group node highlight',
   'toolbar.highlight.disable': 'Disable group node highlight',
+  'toolbar.highlight.label': 'Group node highlight',
   'toolbar.highlight.confirmDisable.title': 'Disable Group Node Highlight',
   'toolbar.highlight.confirmDisable.message':
     'A group node is currently highlighted. Are you sure you want to disable the highlight?',
@@ -70,6 +74,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.redo': 'Redo',
   'toolbar.scrollMode.switchToClassic': 'Switch to Classic mode (scroll = zoom)',
   'toolbar.scrollMode.switchToFreehand': 'Switch to Freehand mode (scroll = pan)',
+  'toolbar.scrollMode.label': 'Canvas scroll mode',
+  'toolbar.interactionMode.label': 'Canvas interaction mode',
+  'toolbar.stopMcpServer': 'Stop MCP Server',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.hidden': 'Hidden',
@@ -124,6 +131,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.whatsNew': "What's New",
   'whatsNew.title': "What's New",
   'whatsNew.viewAllReleases': 'View all releases',
+  'whatsNew.viewChangesOnGitHub': 'View changes on GitHub',
   'whatsNew.showBadge': 'Unread badge',
 
   // Copilot Execution Mode
@@ -222,6 +230,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'codex.error.promptTooLong': 'Prompt must be 10,000 characters or less',
   'codex.error.modelRequired': 'Model name is required',
   'codex.nameHelp': 'Alphanumeric characters, hyphens, and underscores only',
+  'codex.openDocumentation': 'Open documentation',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -246,6 +255,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': 'Close and return to main workflow',
   'subAgentFlow.dialog.submit': 'Submit and add to workflow',
   'subAgentFlow.dialog.cancel': 'Cancel and discard changes',
+  'subAgentFlow.dialog.ariaLabel': 'Sub-Agent Flow Editor',
   'subAgentFlow.generateNameWithAI': 'Generate name with AI',
 
   // SubAgentFlow AI Edit
@@ -1116,6 +1126,14 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
     'Design an implementation plan for the following requirement:',
 
   // Claude API Upload Dialog
+  'claudeApi.searchOnPulseMcp': 'Search on PulseMCP',
+  'claudeApi.searchOnPulseMcp.tooltip': 'Search MCP server URLs on PulseMCP',
+  'claudeApi.pasteTokenPlaceholder': 'Paste token here',
+  'claudeApi.pasteAccessTokenPlaceholder': 'Paste access_token here',
+  'claudeApi.openInClaudePlatform': 'Open in Claude Platform',
+  'claudeApi.selectUploadedSkills': 'Select uploaded skills...',
+  'claudeApi.testPromptPlaceholder': 'Enter your test prompt...',
+  'claudeApi.resetConversation': 'Reset Conversation',
   'claudeApi.description':
     'Upload workflows as Agent Skills to Claude API and run them via the Messages API.\nCombined with MCP servers, code execution, and other skills, you can publish specialized AI agents as APIs for document processing, data analysis, customer support, and more.',
 

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -11,6 +11,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   optional: '任意',
   cancel: 'キャンセル',
   'common.close': '閉じる',
+  'common.required': '必須',
+  'common.wizardSteps': 'ウィザードステップ',
   'common.cancel': 'キャンセル',
   'loading.importWorkflow': 'ワークフローをインポート中...',
   'loading.openWorkflow': 'ワークフローを開いています...',
@@ -59,8 +61,10 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToSelection': '範囲選択モードに切り替え',
   'toolbar.edgeAnimation.enable': 'エッジアニメーションを有効化',
   'toolbar.edgeAnimation.disable': 'エッジアニメーションを無効化',
+  'toolbar.edgeAnimation.label': 'エッジアニメーション',
   'toolbar.highlight.enable': 'グループノードハイライトを有効化',
   'toolbar.highlight.disable': 'グループノードハイライトを無効化',
+  'toolbar.highlight.label': 'グループノードハイライト',
   'toolbar.highlight.confirmDisable.title': 'グループノードハイライトを無効化',
   'toolbar.highlight.confirmDisable.message':
     '現在グループノードがハイライトされています。ハイライトを無効化しますか？',
@@ -70,6 +74,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.redo': 'やり直し',
   'toolbar.scrollMode.switchToClassic': 'Classicモードに切り替え（スクロール=ズーム）',
   'toolbar.scrollMode.switchToFreehand': 'Freehandモードに切り替え（スクロール=パン）',
+  'toolbar.scrollMode.label': 'キャンバススクロールモード',
+  'toolbar.interactionMode.label': 'キャンバス操作モード',
+  'toolbar.stopMcpServer': 'MCPサーバーを停止',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.hidden': '非表示',
@@ -124,6 +131,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.whatsNew': '更新情報',
   'whatsNew.title': '更新情報',
   'whatsNew.viewAllReleases': 'すべての更新情報を見る',
+  'whatsNew.viewChangesOnGitHub': 'GitHubで変更内容を表示',
   'whatsNew.showBadge': '未読バッジ',
 
   // Copilot Execution Mode
@@ -220,6 +228,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'codex.error.promptTooLong': 'プロンプトは10,000文字以内で入力してください',
   'codex.error.modelRequired': 'モデル名は必須です',
   'codex.nameHelp': '英数字、ハイフン、アンダースコアのみ使用可能',
+  'codex.openDocumentation': 'ドキュメントを開く',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -244,6 +253,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '閉じてメインワークフローに戻る',
   'subAgentFlow.dialog.submit': '確定してワークフローに追加',
   'subAgentFlow.dialog.cancel': 'キャンセルして変更を破棄',
+  'subAgentFlow.dialog.ariaLabel': 'Sub-Agent Flowエディター',
   'subAgentFlow.generateNameWithAI': 'AIで名前を生成',
 
   // SubAgentFlow AI Edit
@@ -1108,6 +1118,14 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.builtIn.plan.defaultPrompt': '以下の要件に対する実装計画を設計してください：',
 
   // Claude API Upload Dialog
+  'claudeApi.searchOnPulseMcp': 'PulseMCPで検索',
+  'claudeApi.searchOnPulseMcp.tooltip': 'PulseMCPでMCPサーバーURLを検索',
+  'claudeApi.pasteTokenPlaceholder': 'ここにトークンを貼り付け',
+  'claudeApi.pasteAccessTokenPlaceholder': 'ここにaccess_tokenを貼り付け',
+  'claudeApi.openInClaudePlatform': 'Claude Platformで開く',
+  'claudeApi.selectUploadedSkills': 'アップロード済みのSkillを選択...',
+  'claudeApi.testPromptPlaceholder': 'テストプロンプトを入力...',
+  'claudeApi.resetConversation': '会話をリセット',
   'claudeApi.description':
     'ワークフローを Agent Skills として Claude API にアップロードし、Messages API 経由で実行できます。\nMCP サーバー、コード実行、他のスキルと組み合わせることで、ドキュメント処理・データ分析・カスタマーサポートなど、専門的な AI エージェントを API として公開できます。',
 

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -11,6 +11,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   optional: '선택 사항',
   cancel: '취소',
   'common.close': '닫기',
+  'common.required': '필수',
+  'common.wizardSteps': '마법사 단계',
   'common.cancel': '취소',
   'loading.importWorkflow': '워크플로 가져오는 중...',
   'loading.openWorkflow': '워크플로 여는 중...',
@@ -59,8 +61,10 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToSelection': '선택 모드로 전환',
   'toolbar.edgeAnimation.enable': '엣지 애니메이션 활성화',
   'toolbar.edgeAnimation.disable': '엣지 애니메이션 비활성화',
+  'toolbar.edgeAnimation.label': '엣지 애니메이션',
   'toolbar.highlight.enable': '그룹 노드 하이라이트 활성화',
   'toolbar.highlight.disable': '그룹 노드 하이라이트 비활성화',
+  'toolbar.highlight.label': '그룹 노드 하이라이트',
   'toolbar.highlight.confirmDisable.title': '그룹 노드 하이라이트 비활성화',
   'toolbar.highlight.confirmDisable.message':
     '현재 그룹 노드가 하이라이트되어 있습니다. 하이라이트를 비활성화하시겠습니까?',
@@ -70,6 +74,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.redo': '다시 실행',
   'toolbar.scrollMode.switchToClassic': 'Classic 모드로 전환 (스크롤 = 줌)',
   'toolbar.scrollMode.switchToFreehand': 'Freehand 모드로 전환 (스크롤 = 팬)',
+  'toolbar.scrollMode.label': '캔버스 스크롤 모드',
+  'toolbar.interactionMode.label': '캔버스 조작 모드',
+  'toolbar.stopMcpServer': 'MCP 서버 중지',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.hidden': '숨김',
@@ -123,6 +130,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.whatsNew': '새 소식',
   'whatsNew.title': '새 소식',
   'whatsNew.viewAllReleases': '모든 업데이트 보기',
+  'whatsNew.viewChangesOnGitHub': 'GitHub에서 변경 사항 보기',
   'whatsNew.showBadge': '읽지 않은 배지',
 
   // Copilot Execution Mode
@@ -220,6 +228,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'codex.error.promptTooLong': '프롬프트는 10,000자 이내로 입력하세요',
   'codex.error.modelRequired': '모델 이름이 필요합니다',
   'codex.nameHelp': '영숫자, 하이픈, 밑줄만 사용 가능',
+  'codex.openDocumentation': '문서 열기',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -244,6 +253,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '닫고 메인 워크플로우로 돌아가기',
   'subAgentFlow.dialog.submit': '확정하고 워크플로우에 추가',
   'subAgentFlow.dialog.cancel': '취소하고 변경 사항 삭제',
+  'subAgentFlow.dialog.ariaLabel': 'Sub-Agent Flow 편집기',
   'subAgentFlow.generateNameWithAI': 'AI로 이름 생성',
 
   // SubAgentFlow AI Edit
@@ -1099,6 +1109,14 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.builtIn.plan.defaultPrompt': '다음 요구사항에 대한 구현 계획을 설계하세요:',
 
   // Claude API Upload Dialog
+  'claudeApi.searchOnPulseMcp': 'PulseMCP에서 검색',
+  'claudeApi.searchOnPulseMcp.tooltip': 'PulseMCP에서 MCP 서버 URL 검색',
+  'claudeApi.pasteTokenPlaceholder': '여기에 토큰 붙여넣기',
+  'claudeApi.pasteAccessTokenPlaceholder': '여기에 access_token 붙여넣기',
+  'claudeApi.openInClaudePlatform': 'Claude Platform에서 열기',
+  'claudeApi.selectUploadedSkills': '업로드된 스킬 선택...',
+  'claudeApi.testPromptPlaceholder': '테스트 프롬프트 입력...',
+  'claudeApi.resetConversation': '대화 재설정',
   'claudeApi.description':
     '워크플로우를 Agent Skills로 Claude API에 업로드하고 Messages API를 통해 실행할 수 있습니다.\nMCP 서버, 코드 실행, 기타 스킬과 결합하여 문서 처리, 데이터 분석, 고객 지원 등 전문 AI 에이전트를 API로 공개할 수 있습니다.',
 

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -11,6 +11,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   optional: '可选',
   cancel: '取消',
   'common.close': '关闭',
+  'common.required': '必填',
+  'common.wizardSteps': '向导步骤',
   'common.cancel': '取消',
   'loading.importWorkflow': '正在导入工作流...',
   'loading.openWorkflow': '正在打开工作流...',
@@ -59,8 +61,10 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToSelection': '切换到选择模式',
   'toolbar.edgeAnimation.enable': '启用边动画',
   'toolbar.edgeAnimation.disable': '禁用边动画',
+  'toolbar.edgeAnimation.label': '边动画',
   'toolbar.highlight.enable': '启用组节点高亮',
   'toolbar.highlight.disable': '禁用组节点高亮',
+  'toolbar.highlight.label': '组节点高亮',
   'toolbar.highlight.confirmDisable.title': '禁用组节点高亮',
   'toolbar.highlight.confirmDisable.message': '当前有组节点正在高亮显示。确定要禁用高亮吗？',
   'toolbar.highlight.confirmDisable.confirm': '禁用',
@@ -69,6 +73,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.redo': '重做',
   'toolbar.scrollMode.switchToClassic': '切换到Classic模式（滚动=缩放）',
   'toolbar.scrollMode.switchToFreehand': '切换到Freehand模式（滚动=平移）',
+  'toolbar.scrollMode.label': '画布滚动模式',
+  'toolbar.interactionMode.label': '画布交互模式',
+  'toolbar.stopMcpServer': '停止MCP服务器',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.hidden': '隐藏',
@@ -120,6 +127,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.whatsNew': '更新内容',
   'whatsNew.title': '更新内容',
   'whatsNew.viewAllReleases': '查看所有更新内容',
+  'whatsNew.viewChangesOnGitHub': '在GitHub上查看更改',
   'whatsNew.showBadge': '未读徽章',
 
   // Copilot Execution Mode
@@ -214,6 +222,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'codex.error.promptTooLong': '提示词不能超过10,000个字符',
   'codex.error.modelRequired': '模型名称是必填项',
   'codex.nameHelp': '只能使用字母、数字、连字符和下划线',
+  'codex.openDocumentation': '打开文档',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -238,6 +247,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '关闭并返回主工作流',
   'subAgentFlow.dialog.submit': '确认并添加到工作流',
   'subAgentFlow.dialog.cancel': '取消并放弃更改',
+  'subAgentFlow.dialog.ariaLabel': 'Sub-Agent Flow编辑器',
   'subAgentFlow.generateNameWithAI': '使用 AI 生成名称',
 
   // SubAgentFlow AI Edit
@@ -1066,6 +1076,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.builtIn.plan.defaultPrompt': '为以下需求设计实现计划：',
 
   // Claude API Upload Dialog
+  'claudeApi.searchOnPulseMcp': '在PulseMCP上搜索',
+  'claudeApi.searchOnPulseMcp.tooltip': '在PulseMCP上搜索MCP服务器URL',
+  'claudeApi.pasteTokenPlaceholder': '在此粘贴令牌',
+  'claudeApi.pasteAccessTokenPlaceholder': '在此粘贴access_token',
+  'claudeApi.openInClaudePlatform': '在Claude Platform中打开',
+  'claudeApi.selectUploadedSkills': '选择已上传的技能...',
+  'claudeApi.testPromptPlaceholder': '输入测试提示词...',
+  'claudeApi.resetConversation': '重置对话',
   'claudeApi.description':
     '将工作流作为 Agent Skills 上传到 Claude API，并通过 Messages API 运行。\n结合 MCP 服务器、代码执行和其他技能，您可以将专业 AI 代理作为 API 发布，用于文档处理、数据分析、客户支持等场景。',
 

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -11,6 +11,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   optional: '選填',
   cancel: '取消',
   'common.close': '關閉',
+  'common.required': '必填',
+  'common.wizardSteps': '精靈步驟',
   'common.cancel': '取消',
   'loading.importWorkflow': '正在匯入工作流程...',
   'loading.openWorkflow': '正在開啟工作流程...',
@@ -59,8 +61,10 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.interactionMode.switchToSelection': '切換到選擇模式',
   'toolbar.edgeAnimation.enable': '啟用邊動畫',
   'toolbar.edgeAnimation.disable': '停用邊動畫',
+  'toolbar.edgeAnimation.label': '邊動畫',
   'toolbar.highlight.enable': '啟用群組節點高亮',
   'toolbar.highlight.disable': '停用群組節點高亮',
+  'toolbar.highlight.label': '群組節點高亮',
   'toolbar.highlight.confirmDisable.title': '停用群組節點高亮',
   'toolbar.highlight.confirmDisable.message': '目前有群組節點正在高亮顯示。確定要停用高亮嗎？',
   'toolbar.highlight.confirmDisable.confirm': '停用',
@@ -69,6 +73,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.redo': '重做',
   'toolbar.scrollMode.switchToClassic': '切換到Classic模式（滾動=縮放）',
   'toolbar.scrollMode.switchToFreehand': '切換到Freehand模式（滾動=平移）',
+  'toolbar.scrollMode.label': '畫布捲動模式',
+  'toolbar.interactionMode.label': '畫布互動模式',
+  'toolbar.stopMcpServer': '停止MCP伺服器',
 
   // Toolbar minimap toggle
   'toolbar.minimapToggle.hidden': '隱藏',
@@ -120,6 +127,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'toolbar.whatsNew': '更新內容',
   'whatsNew.title': '更新內容',
   'whatsNew.viewAllReleases': '查看所有更新內容',
+  'whatsNew.viewChangesOnGitHub': '在GitHub上檢視變更',
   'whatsNew.showBadge': '未讀徽章',
 
   // Copilot Execution Mode
@@ -215,6 +223,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'codex.error.promptTooLong': '提示詞不能超過10,000個字元',
   'codex.error.modelRequired': '模型名稱為必填',
   'codex.nameHelp': '只能使用字母、數字、連字符和底線',
+  'codex.openDocumentation': '開啟文件',
 
   // SubAgentFlow Node (Feature: 089-subworkflow)
   'node.subAgentFlow.title': 'Sub-Agent Flow',
@@ -239,6 +248,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'subAgentFlow.dialog.close': '關閉並返回主工作流程',
   'subAgentFlow.dialog.submit': '確認並新增到工作流程',
   'subAgentFlow.dialog.cancel': '取消並捨棄變更',
+  'subAgentFlow.dialog.ariaLabel': 'Sub-Agent Flow編輯器',
   'subAgentFlow.generateNameWithAI': '使用 AI 生成名稱',
 
   // SubAgentFlow AI Edit
@@ -1069,6 +1079,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'subAgent.builtIn.plan.defaultPrompt': '為以下需求設計實作計畫：',
 
   // Claude API Upload Dialog
+  'claudeApi.searchOnPulseMcp': '在PulseMCP上搜尋',
+  'claudeApi.searchOnPulseMcp.tooltip': '在PulseMCP上搜尋MCP伺服器URL',
+  'claudeApi.pasteTokenPlaceholder': '在此貼上權杖',
+  'claudeApi.pasteAccessTokenPlaceholder': '在此貼上access_token',
+  'claudeApi.openInClaudePlatform': '在Claude Platform中開啟',
+  'claudeApi.selectUploadedSkills': '選擇已上傳的技能...',
+  'claudeApi.testPromptPlaceholder': '輸入測試提示詞...',
+  'claudeApi.resetConversation': '重設對話',
   'claudeApi.description':
     '將工作流程作為 Agent Skills 上傳到 Claude API，並透過 Messages API 執行。\n結合 MCP 伺服器、程式碼執行和其他技能，您可以將專業 AI 代理作為 API 發佈，用於文件處理、資料分析、客戶支援等場景。',
 


### PR DESCRIPTION
## Summary

Sweeps the last hardcoded English tooltips, aria-labels, and placeholders out of the **active** canvas UI so users running VSCode in Japanese, Korean, or Chinese (Simplified/Traditional) no longer hit stray English strings in otherwise-localized surfaces — and screen-reader users get these labels in their UI language. Queued as a "next proposal" by the last three loop iterations and re-verified in code this round.

Closes #897

## User value

A user in a non-English locale no longer sees English for: the toolbar's "Stop MCP Server" tooltip, the What's New dialog's "View changes on GitHub" link, the Codex node dialog's "Open documentation" link, the four canvas toggle switch aria-labels (edge animation, group highlight, interaction mode, scroll mode), the shared tag input's "Required" lock label, the wizard step navigation label, the Sub-Agent Flow editor dialog label, and the Claude API upload dialog's tooltips and input placeholders.

## Changes

- **`i18n/translation-keys.ts` + all 5 locale files** (`en/ja/ko/zh-CN/zh-TW.ts`): 18 new keys (`toolbar.*.label`, `toolbar.stopMcpServer`, `whatsNew.viewChangesOnGitHub`, `codex.openDocumentation`, `common.required`, `common.wizardSteps`, `subAgentFlow.dialog.ariaLabel`, `claudeApi.*`). Terminology matches existing translations (e.g. zh-CN 边动画, ja エッジアニメーション); product terms MCP, PulseMCP, Claude Platform, Sub-Agent Flow, and `access_token` stay English per `.claude/rules/translation.md`.
- **11 components** switched from hardcoded attributes to `t(...)`: `Toolbar`, `WhatsNewDialog`, `CodexNodeDialog`, `EdgeAnimationToggle`, `HighlightToggle`, `InteractionModeToggle`, `ScrollModeToggle`, `SelectTagInput` (+hook), `WizardStepIndicator` (+hook), `SubAgentFlowDialog`, `ClaudeApiUploadDialog` (`McpServerUrlForm` +hook; also the "Search on PulseMCP" and "Reset Conversation" button texts adjacent to their translated tooltips).

## Deliberately out of scope

- `McpServerSection.tsx` — discontinued chat panel, maintain-only per CLAUDE.md.
- `SkillCreationDialog`'s `placeholder="Read, Grep, Glob, Bash"` and `CommentaryOptionsDropdown`'s `placeholder="English"` — literal example values / technical identifiers.
- Full localization of `ClaudeApiUploadDialog` visible text: discovered this round to be almost entirely unlocalized (~3600 lines, a single `t()` call). Only its attribute-level strings are covered here; the full pass is filed as a follow-up proposal in the progress log, and the `claudeApi.*` namespace started here is the landing zone.

## Changeset

`.changeset/localize-active-ui-sweep.md` — `cc-wf-studio`: patch.

## Testing

- `pnpm build` and `pnpm check` pass from the repo root (locale-file completeness is type-checked against `WebviewTranslationKeys`).
- No behavior changes; attribute/text swaps only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF7w1evdv1VfHShCL5Q4q3)_