### PR TITLE
improvement(vscode): add right-click context menu to the workflow canvas

### DIFF
--- a/.changeset/canvas-context-menu.md
+++ b/.changeset/canvas-context-menu.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+Add a right-click context menu to the workflow canvas exposing Copy, Cut, Paste, Duplicate, Delete, and Select All — with paste-at-cursor when pasting from the menu.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,41 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Right-click context menu on the canvas
+- **User value**: a user can now right-click a node, a multi-selection, or
+  the empty canvas to Copy, Cut, Paste, Duplicate, or Delete (plus Select
+  All) — the clipboard verbs shipped in #890–#896 were keyboard-only and
+  invisible to mouse-first users; pasting via the canvas menu now lands the
+  nodes at the click point instead of the fixed +40/+40 offset.
+- **Issue/PR**: #899 / PR from `claude/canvas-context-menu`
+- **Outcome**: done — new `CanvasContextMenu` component (VSCode dropdown
+  tokens, lucide icons, platform-aware shortcut hints, edge clamping,
+  closes on outside click/Escape/pan/zoom); `WorkflowEditor` wires React
+  Flow's `onNodeContextMenu`/`onSelectionContextMenu`/`onPaneContextMenu`
+  (right-click selects an unselected node exclusively, keeps a
+  multi-selection). Menu actions reuse the existing store verbs and
+  policies (Start/End exclusions, delete-confirm flow, pendingDelete
+  guard). Paste tries `navigator.clipboard.readText()` (menu click is a
+  user gesture) and falls back to an in-window mirror of the last
+  copied/cut payload — set by both keyboard and menu copy/cut — so
+  same-window right-click paste works even where webview clipboard read is
+  denied; system-clipboard non-payload text correctly no-ops. Ctrl+A logic
+  extracted to a shared `selectAllOnCanvas`. `pasteSelection` gained an
+  optional target position (top-left of the payload's bounding box lands
+  at the cursor). 6 new `contextMenu.*` keys in all 5 locales. Issue #899
+  could not be locked (no `gh`, no MCP lock tool, API proxied — known
+  limitation, noted in the issue body).
+- **Next proposals**:
+  - Full localization of `ClaudeApiUploadDialog` visible text — biggest
+    remaining unlocalized surface (~3600 lines, one `t()` call); the
+    `claudeApi.*` namespace from #897 is the landing zone.
+  - Manual E2E queue: verify copy/cut/paste DOM events and the new
+    context menu (incl. clipboard-read fallback path) in real webviews on
+    all three OSes.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — Localize remaining hardcoded English strings in active UI
 - **User value**: a user running VSCode in Japanese, Korean, or Chinese no
   longer hits stray English strings in otherwise-localized surfaces: the

--- a/packages/vscode/src/webview/src/components/CanvasContextMenu.tsx
+++ b/packages/vscode/src/webview/src/components/CanvasContextMenu.tsx
@@ -1,0 +1,150 @@
+/**
+ * Canvas Context Menu
+ *
+ * Right-click menu for the workflow canvas exposing the clipboard verbs
+ * (Copy/Cut/Paste/Duplicate/Delete/Select All) that are otherwise
+ * keyboard-only. Positioned at the cursor inside the canvas container;
+ * closes on outside click, Escape, or pan/zoom (handled by the parent).
+ */
+
+import type React from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export interface CanvasContextMenuItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  /** Shortcut hint rendered right-aligned (e.g. "Ctrl+C" / "⌘C") */
+  shortcut?: string;
+  disabled?: boolean;
+  onSelect: () => void;
+}
+
+export type CanvasContextMenuEntry = CanvasContextMenuItem | 'separator';
+
+interface CanvasContextMenuProps {
+  /** Position relative to the canvas container (the menu's offset parent) */
+  x: number;
+  y: number;
+  entries: CanvasContextMenuEntry[];
+  onClose: () => void;
+}
+
+export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({ x, y, entries, onClose }) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ x, y });
+
+  // Keep the menu inside the canvas container (flip/clamp near edges)
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    const container = menu?.parentElement;
+    if (!menu || !container) {
+      setPosition({ x, y });
+      return;
+    }
+    const menuRect = menu.getBoundingClientRect();
+    const maxX = container.clientWidth - menuRect.width - 4;
+    const maxY = container.clientHeight - menuRect.height - 4;
+    setPosition({
+      x: Math.max(0, Math.min(x, maxX)),
+      y: Math.max(0, Math.min(y, maxY)),
+    });
+  }, [x, y]);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    // Capture phase so a click that opens another UI still closes the menu
+    window.addEventListener('mousedown', handleMouseDown, true);
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      window.removeEventListener('mousedown', handleMouseDown, true);
+      window.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      style={{
+        position: 'absolute',
+        left: position.x,
+        top: position.y,
+        zIndex: 9999,
+        backgroundColor: 'var(--vscode-dropdown-background)',
+        border: '1px solid var(--vscode-dropdown-border)',
+        borderRadius: '4px',
+        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.3)',
+        minWidth: '180px',
+        padding: '4px',
+      }}
+      // A right-click on the menu itself must not bubble into the canvas
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      {entries.map((entry, index) =>
+        entry === 'separator' ? (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: separators are positional
+            key={`separator-${index}`}
+            style={{
+              height: '1px',
+              backgroundColor: 'var(--vscode-panel-border)',
+              margin: '4px 0',
+            }}
+          />
+        ) : (
+          <button
+            key={entry.key}
+            type="button"
+            role="menuitem"
+            disabled={entry.disabled}
+            onClick={() => {
+              if (entry.disabled) return;
+              onClose();
+              entry.onSelect();
+            }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              width: '100%',
+              padding: '6px 12px',
+              backgroundColor: 'transparent',
+              border: 'none',
+              borderRadius: '2px',
+              color: 'var(--vscode-foreground)',
+              fontSize: '12px',
+              textAlign: 'left',
+              cursor: entry.disabled ? 'default' : 'pointer',
+              opacity: entry.disabled ? 0.45 : 1,
+            }}
+            onMouseEnter={(event) => {
+              if (!entry.disabled) {
+                event.currentTarget.style.backgroundColor = 'var(--vscode-list-hoverBackground)';
+              }
+            }}
+            onMouseLeave={(event) => {
+              event.currentTarget.style.backgroundColor = 'transparent';
+            }}
+          >
+            {entry.icon}
+            <span style={{ flex: 1 }}>{entry.label}</span>
+            {entry.shortcut && (
+              <span style={{ opacity: 0.6, fontSize: '11px' }}>{entry.shortcut}</span>
+            )}
+          </button>
+        )
+      )}
+    </div>
+  );
+};

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -5,7 +5,15 @@
  * Based on: /specs/001-cc-wf-studio/research.md section 3.4
  */
 
-import { PanelLeftOpen } from 'lucide-react';
+import {
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
+  PanelLeftOpen,
+  Scissors,
+  SquareDashedMousePointer,
+  Trash2,
+} from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
@@ -20,12 +28,18 @@ import ReactFlow, {
   type NodeTypes,
   Panel,
   PanOnScrollMode,
+  type ReactFlowInstance,
 } from 'reactflow';
 import { CURRENT_ANNOUNCEMENT, cleanupDismissedAnnouncements } from '../constants/announcements';
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
-import { parseSelectionClipboardPayload, useWorkflowStore } from '../stores/workflow-store';
+import {
+  parseSelectionClipboardPayload,
+  type SelectionClipboardPayload,
+  useWorkflowStore,
+} from '../stores/workflow-store';
+import { CanvasContextMenu, type CanvasContextMenuEntry } from './CanvasContextMenu';
 import { CanvasToolbar } from './CanvasToolbar';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
 import { DescriptionPanel } from './DescriptionPanel';
@@ -86,6 +100,37 @@ const defaultEdgeOptions: DefaultEdgeOptions = {
  */
 const edgeTypes: EdgeTypes = {
   default: DeletableEdge,
+};
+
+/** In-window mirror of the last copied/cut selection. The context menu's
+ *  Paste falls back to it when the webview denies clipboard read (the DOM
+ *  paste event path is unaffected — Ctrl/Cmd+V still reads the system
+ *  clipboard). */
+let selectionClipboardMirror: SelectionClipboardPayload | null = null;
+
+/** Mirror the payload and best-effort write it to the system clipboard
+ *  (context-menu clicks are user gestures, but webviews may still deny). */
+const writeSelectionToClipboard = (payload: SelectionClipboardPayload) => {
+  selectionClipboardMirror = payload;
+  navigator.clipboard?.writeText(JSON.stringify(payload, null, 2)).catch(() => {});
+};
+
+/** Select every node and edge. Selection state is excluded from undo
+ *  history and canvas-revision tracking, so this never dirties the
+ *  workflow or pollutes undo. */
+const selectAllOnCanvas = () => {
+  const {
+    nodes: currentNodes,
+    edges: currentEdges,
+    setNodes,
+    setEdges,
+    syncSelectedNodeId,
+  } = useWorkflowStore.getState();
+  if (currentNodes.length === 0 && currentEdges.length === 0) return;
+  setNodes(currentNodes.map((n) => (n.selected ? n : { ...n, selected: true })));
+  setEdges(currentEdges.map((e) => (e.selected ? e : { ...e, selected: true })));
+  // Same rule as handleNodesChange: exactly one selected node syncs its id
+  syncSelectedNodeId(currentNodes.length === 1 ? currentNodes[0].id : null);
 };
 
 /**
@@ -306,6 +351,134 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     syncSelectedNodeId(null);
   }, [syncSelectedNodeId]);
 
+  // ---------------------------------------------------------------------
+  // Canvas context menu (right-click): Copy/Cut/Paste/Duplicate/Delete
+  // ---------------------------------------------------------------------
+  const canvasContainerRef = useRef<HTMLDivElement>(null);
+  const reactFlowInstanceRef = useRef<ReactFlowInstance | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    flowPosition: { x: number; y: number } | null;
+    target: 'node' | 'pane';
+  } | null>(null);
+
+  const openContextMenu = useCallback(
+    (event: React.MouseEvent | MouseEvent, target: 'node' | 'pane') => {
+      // Suppress the webview's native context menu
+      event.preventDefault();
+      const container = canvasContainerRef.current;
+      if (!container) return;
+      const bounds = container.getBoundingClientRect();
+      const x = event.clientX - bounds.left;
+      const y = event.clientY - bounds.top;
+      // Flow coordinates of the click, so Paste can land the nodes there
+      const flowPosition = reactFlowInstanceRef.current?.project({ x, y }) ?? null;
+      setContextMenu({ x, y, flowPosition, target });
+    },
+    []
+  );
+
+  const handleNodeContextMenu = useCallback(
+    (event: React.MouseEvent, node: Node) => {
+      const {
+        nodes: currentNodes,
+        edges: currentEdges,
+        setNodes,
+        setEdges,
+        syncSelectedNodeId: syncId,
+      } = useWorkflowStore.getState();
+      // Right-clicking an unselected node selects it exclusively (standard
+      // editor behavior); a right-click inside a multi-selection keeps it
+      const clicked = currentNodes.find((n) => n.id === node.id);
+      if (clicked && !clicked.selected) {
+        setNodes(
+          currentNodes.map((n) =>
+            n.id === node.id ? { ...n, selected: true } : n.selected ? { ...n, selected: false } : n
+          )
+        );
+        if (currentEdges.some((e) => e.selected)) {
+          setEdges(currentEdges.map((e) => (e.selected ? { ...e, selected: false } : e)));
+        }
+        syncId(node.id);
+      }
+      openContextMenu(event, 'node');
+    },
+    [openContextMenu]
+  );
+
+  const handleSelectionContextMenu = useCallback(
+    (event: React.MouseEvent) => openContextMenu(event, 'node'),
+    [openContextMenu]
+  );
+
+  const handlePaneContextMenu = useCallback(
+    (event: React.MouseEvent | MouseEvent) => openContextMenu(event, 'pane'),
+    [openContextMenu]
+  );
+
+  const closeContextMenu = useCallback(() => setContextMenu(null), []);
+
+  const copySelectionFromMenu = useCallback(() => {
+    const { nodes: currentNodes, serializeSelection } = useWorkflowStore.getState();
+    const selectedIds = currentNodes.filter((n) => n.selected).map((n) => n.id);
+    if (selectedIds.length === 0) return;
+    const payload = serializeSelection(selectedIds);
+    if (payload) writeSelectionToClipboard(payload);
+  }, []);
+
+  const cutSelectionFromMenu = useCallback(() => {
+    const { nodes: currentNodes, pendingDeleteNodeIds, cutSelection } = useWorkflowStore.getState();
+    // Don't race the delete-confirmation dialog over the same selection
+    if (pendingDeleteNodeIds.length > 0) return;
+    const selectedIds = currentNodes.filter((n) => n.selected).map((n) => n.id);
+    if (selectedIds.length === 0) return;
+    const payload = cutSelection(selectedIds);
+    if (payload) writeSelectionToClipboard(payload);
+  }, []);
+
+  const pasteFromMenu = useCallback(async (position: { x: number; y: number } | null) => {
+    let payload: SelectionClipboardPayload | null = null;
+    try {
+      const text = await navigator.clipboard.readText();
+      payload = parseSelectionClipboardPayload(text);
+    } catch {
+      // Webview denied clipboard read — fall back to the in-window mirror
+      payload = selectionClipboardMirror;
+    }
+    if (payload) useWorkflowStore.getState().pasteSelection(payload, position ?? undefined);
+  }, []);
+
+  const duplicateSelectionFromMenu = useCallback(() => {
+    const { nodes: currentNodes, duplicateSelection } = useWorkflowStore.getState();
+    const selectedIds = currentNodes
+      .filter((n) => n.selected && n.type !== 'start' && n.type !== 'end')
+      .map((n) => n.id);
+    if (selectedIds.length > 0) duplicateSelection(selectedIds);
+  }, []);
+
+  const deleteSelectionFromMenu = useCallback(() => {
+    const {
+      nodes: currentNodes,
+      edges: currentEdges,
+      pendingDeleteNodeIds,
+      requestDeleteSelection,
+      setEdges,
+    } = useWorkflowStore.getState();
+    if (pendingDeleteNodeIds.length > 0) return;
+    const selectedNodeIds = currentNodes
+      .filter((n) => n.selected && n.type !== 'start')
+      .map((n) => n.id);
+    const selectedEdgeIds = currentEdges.filter((e) => e.selected).map((e) => e.id);
+    if (selectedNodeIds.length > 0) {
+      // Same confirm flow as the Delete key
+      requestDeleteSelection(selectedNodeIds, selectedEdgeIds);
+    } else if (selectedEdgeIds.length > 0) {
+      // Edge-only selection: delete immediately (parity with the edge ✕ button)
+      setEdges(currentEdges.filter((e) => !e.selected));
+    }
+  }, []);
+
   // Memoize snap grid
   const snapGrid = useMemo<[number, number]>(() => [15, 15], []);
 
@@ -370,22 +543,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         }
         const key = event.key.toLowerCase();
         if (key === 'a' && !event.shiftKey && !event.altKey) {
-          // Select all nodes and edges. Selection state is excluded from undo
-          // history and canvas-revision tracking, so this never dirties the
-          // workflow or pollutes undo.
           event.preventDefault();
-          const {
-            nodes: currentNodes,
-            edges: currentEdges,
-            setNodes,
-            setEdges,
-            syncSelectedNodeId,
-          } = useWorkflowStore.getState();
-          if (currentNodes.length === 0 && currentEdges.length === 0) return;
-          setNodes(currentNodes.map((n) => (n.selected ? n : { ...n, selected: true })));
-          setEdges(currentEdges.map((e) => (e.selected ? e : { ...e, selected: true })));
-          // Same rule as handleNodesChange: exactly one selected node syncs its id
-          syncSelectedNodeId(currentNodes.length === 1 ? currentNodes[0].id : null);
+          selectAllOnCanvas();
         }
         if (key === 'z' && !event.shiftKey) {
           event.preventDefault();
@@ -441,6 +600,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       if (selectedIds.length === 0) return;
       const payload = serializeSelection(selectedIds);
       if (!payload || !event.clipboardData) return;
+      selectionClipboardMirror = payload;
       event.preventDefault();
       event.clipboardData.setData('text/plain', JSON.stringify(payload, null, 2));
     };
@@ -465,6 +625,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       // lives on in the clipboard payload — standard editor semantics
       const payload = cutSelection(selectedIds);
       if (!payload) return;
+      selectionClipboardMirror = payload;
       event.preventDefault();
       event.clipboardData.setData('text/plain', JSON.stringify(payload, null, 2));
     };
@@ -499,6 +660,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const minimapHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleMoveStart = useCallback(() => {
+    // Pan/zoom invalidates the menu's position — dismiss it
+    setContextMenu(null);
     if (minimapDisplayMode !== 'auto') return;
     if (minimapHideTimerRef.current) {
       clearTimeout(minimapHideTimerRef.current);
@@ -536,6 +699,86 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const panOnDrag = effectiveMode === 'pan';
   const selectionOnDrag = effectiveMode === 'selection';
 
+  // Context-menu entries (built at render so disabled states track the
+  // live selection; Start/End follow the store's exclusion policies)
+  const contextMenuEntries = useMemo<CanvasContextMenuEntry[]>(() => {
+    if (!contextMenu) return [];
+    const isMac = navigator.platform.toUpperCase().includes('MAC');
+    const mod = isMac ? '⌘' : 'Ctrl+';
+    const pasteEntry: CanvasContextMenuEntry = {
+      key: 'paste',
+      label: t('contextMenu.paste'),
+      icon: <ClipboardPaste size={14} />,
+      shortcut: `${mod}V`,
+      onSelect: () => void pasteFromMenu(contextMenu.flowPosition),
+    };
+    if (contextMenu.target === 'pane') {
+      return [
+        pasteEntry,
+        'separator',
+        {
+          key: 'selectAll',
+          label: t('contextMenu.selectAll'),
+          icon: <SquareDashedMousePointer size={14} />,
+          shortcut: `${mod}A`,
+          disabled: nodes.length === 0 && edges.length === 0,
+          onSelect: selectAllOnCanvas,
+        },
+      ];
+    }
+    const hasCopyableSelection = nodes.some(
+      (n) => n.selected && n.type !== 'start' && n.type !== 'end'
+    );
+    const hasDeletableSelection =
+      nodes.some((n) => n.selected && n.type !== 'start') || edges.some((e) => e.selected);
+    return [
+      {
+        key: 'copy',
+        label: t('contextMenu.copy'),
+        icon: <Copy size={14} />,
+        shortcut: `${mod}C`,
+        disabled: !hasCopyableSelection,
+        onSelect: copySelectionFromMenu,
+      },
+      {
+        key: 'cut',
+        label: t('contextMenu.cut'),
+        icon: <Scissors size={14} />,
+        shortcut: `${mod}X`,
+        disabled: !hasCopyableSelection,
+        onSelect: cutSelectionFromMenu,
+      },
+      pasteEntry,
+      {
+        key: 'duplicate',
+        label: t('contextMenu.duplicate'),
+        icon: <CopyPlus size={14} />,
+        shortcut: `${mod}D`,
+        disabled: !hasCopyableSelection,
+        onSelect: duplicateSelectionFromMenu,
+      },
+      'separator',
+      {
+        key: 'delete',
+        label: t('contextMenu.delete'),
+        icon: <Trash2 size={14} />,
+        shortcut: 'Del',
+        disabled: !hasDeletableSelection,
+        onSelect: deleteSelectionFromMenu,
+      },
+    ];
+  }, [
+    contextMenu,
+    nodes,
+    edges,
+    t,
+    pasteFromMenu,
+    copySelectionFromMenu,
+    cutSelectionFromMenu,
+    duplicateSelectionFromMenu,
+    deleteSelectionFromMenu,
+  ]);
+
   return (
     <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* Feature Announcement Banner - displayed when CURRENT_ANNOUNCEMENT is set */}
@@ -550,10 +793,13 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       )}
 
       {/* Canvas area */}
-      <div style={{ flex: 1, position: 'relative' }}>
+      <div ref={canvasContainerRef} style={{ flex: 1, position: 'relative' }}>
         <ReactFlow
           nodes={nodes}
           edges={animatedEdges}
+          onInit={(instance) => {
+            reactFlowInstanceRef.current = instance;
+          }}
           onNodesChange={handleNodesChange}
           onEdgesChange={handleEdgesChange}
           onConnect={handleConnect}
@@ -562,6 +808,9 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           onNodeClick={handleNodeClick}
           onEdgeClick={() => syncSelectedNodeId(null)}
           onPaneClick={handlePaneClick}
+          onNodeContextMenu={handleNodeContextMenu}
+          onSelectionContextMenu={handleSelectionContextMenu}
+          onPaneContextMenu={handlePaneContextMenu}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           defaultEdgeOptions={defaultEdgeOptions}
@@ -683,6 +932,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             </Panel>
           )}
         </ReactFlow>
+        {contextMenu && (
+          <CanvasContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            entries={contextMenuEntries}
+            onClose={closeContextMenu}
+          />
+        )}
         {onOpenSample && onDismissEmptyState && onLoadWorkflow && (
           <StartMenu
             isOpen={showEmptyState}

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -388,6 +388,14 @@ export interface WebviewTranslationKeys {
   'canvas.deleteNode.tooltip': string;
   'canvas.deleteEdge.tooltip': string;
   'canvas.resizeSidebar': string;
+
+  // Canvas context menu
+  'contextMenu.copy': string;
+  'contextMenu.cut': string;
+  'contextMenu.paste': string;
+  'contextMenu.duplicate': string;
+  'contextMenu.delete': string;
+  'contextMenu.selectAll': string;
   'announcement.dismiss': string;
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -408,6 +408,14 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'canvas.deleteNode.tooltip': 'Delete node',
   'canvas.deleteEdge.tooltip': 'Delete connection',
   'canvas.resizeSidebar': 'Resize sidebar',
+
+  // Canvas context menu
+  'contextMenu.copy': 'Copy',
+  'contextMenu.cut': 'Cut',
+  'contextMenu.paste': 'Paste',
+  'contextMenu.duplicate': 'Duplicate',
+  'contextMenu.delete': 'Delete',
+  'contextMenu.selectAll': 'Select All',
   'announcement.dismiss': 'Dismiss announcement',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -406,6 +406,14 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'canvas.deleteNode.tooltip': 'ノードを削除',
   'canvas.deleteEdge.tooltip': '接続を削除',
   'canvas.resizeSidebar': 'サイドバーのサイズを変更',
+
+  // Canvas context menu
+  'contextMenu.copy': 'コピー',
+  'contextMenu.cut': '切り取り',
+  'contextMenu.paste': '貼り付け',
+  'contextMenu.duplicate': '複製',
+  'contextMenu.delete': '削除',
+  'contextMenu.selectAll': 'すべて選択',
   'announcement.dismiss': 'お知らせを閉じる',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -405,6 +405,14 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'canvas.deleteNode.tooltip': '노드 삭제',
   'canvas.deleteEdge.tooltip': '연결 삭제',
   'canvas.resizeSidebar': '사이드바 크기 조절',
+
+  // Canvas context menu
+  'contextMenu.copy': '복사',
+  'contextMenu.cut': '잘라내기',
+  'contextMenu.paste': '붙여넣기',
+  'contextMenu.duplicate': '복제',
+  'contextMenu.delete': '삭제',
+  'contextMenu.selectAll': '모두 선택',
   'announcement.dismiss': '공지 닫기',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -392,6 +392,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'canvas.deleteNode.tooltip': '删除节点',
   'canvas.deleteEdge.tooltip': '删除连接',
   'canvas.resizeSidebar': '调整侧边栏大小',
+
+  // Canvas context menu
+  'contextMenu.copy': '复制',
+  'contextMenu.cut': '剪切',
+  'contextMenu.paste': '粘贴',
+  'contextMenu.duplicate': '创建副本',
+  'contextMenu.delete': '删除',
+  'contextMenu.selectAll': '全选',
   'announcement.dismiss': '关闭公告',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -394,6 +394,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'canvas.deleteNode.tooltip': '刪除節點',
   'canvas.deleteEdge.tooltip': '刪除連線',
   'canvas.resizeSidebar': '調整側邊欄大小',
+
+  // Canvas context menu
+  'contextMenu.copy': '複製',
+  'contextMenu.cut': '剪下',
+  'contextMenu.paste': '貼上',
+  'contextMenu.duplicate': '建立複本',
+  'contextMenu.delete': '刪除',
+  'contextMenu.selectAll': '全選',
   'announcement.dismiss': '關閉公告',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -238,8 +238,10 @@ interface WorkflowStore {
   serializeSelection: (nodeIds: string[]) => SelectionClipboardPayload | null;
   /** Insert a clipboard payload as new nodes/edges: fresh ids, +40/+40
    *  offset, deep-copied data, one undo entry. The pasted nodes become the
-   *  new selection. Works with payloads copied from another workflow. */
-  pasteSelection: (payload: SelectionClipboardPayload) => void;
+   *  new selection. Works with payloads copied from another workflow.
+   *  When `position` is given (context-menu paste), the payload's top-left
+   *  corner lands there instead of the +40/+40 offset. */
+  pasteSelection: (payload: SelectionClipboardPayload, position?: { x: number; y: number }) => void;
   /** Cut a selection: serialize it (same policy as serializeSelection),
    *  then remove the serialized nodes plus every edge touching them in a
    *  single undo entry. No confirmation dialog — cut is undoable and the
@@ -980,7 +982,7 @@ export const useWorkflowStore = create<WorkflowStore>()(
         };
       },
 
-      pasteSelection: (payload: SelectionClipboardPayload) => {
+      pasteSelection: (payload: SelectionClipboardPayload, position?: { x: number; y: number }) => {
         const allNodes = get().nodes;
         // Defense in depth — serializeSelection never emits these, but the
         // clipboard is user-editable text
@@ -995,17 +997,29 @@ export const useWorkflowStore = create<WorkflowStore>()(
           idMap.set(node.id, makeUniqueNodeId(usedIds, node.id));
         }
 
+        // Top-level payload nodes (children of a pasted group keep their
+        // group-relative position and follow their parent instead)
+        const isTopLevel = (node: SelectionClipboardNode) =>
+          !(node.parentId && idMap.has(node.parentId));
+
+        // Default: +40/+40 (same offset as duplication). With a target
+        // position, translate so the payload's top-left corner lands there.
+        let offset = { x: 40, y: 40 };
+        if (position) {
+          const topLevel = incoming.filter(isTopLevel);
+          const minX = Math.min(...topLevel.map((node) => node.position.x));
+          const minY = Math.min(...topLevel.map((node) => node.position.y));
+          offset = { x: position.x - minX, y: position.y - minY };
+        }
+
         const copies: Node[] = incoming.map((node) => ({
           id: idMap.get(node.id) as string,
           type: node.type,
           // Deep copy so pasting twice never shares data between the copies
           data: JSON.parse(JSON.stringify(node.data ?? {})),
-          // Children of a pasted group keep their group-relative position;
-          // every other node shifts +40/+40 (same offset as duplication)
-          position:
-            node.parentId && idMap.has(node.parentId)
-              ? { ...node.position }
-              : { x: node.position.x + 40, y: node.position.y + 40 },
+          position: isTopLevel(node)
+            ? { x: node.position.x + offset.x, y: node.position.y + offset.y }
+            : { ...node.position },
           ...(node.parentId && idMap.has(node.parentId)
             ? { parentId: idMap.get(node.parentId) as string }
             : {}),


### PR DESCRIPTION
## Summary

Adds a right-click context menu to the workflow canvas, making the recently shipped clipboard verbs (select-all #890, duplicate #892, copy/paste #894, cut #896) discoverable for mouse-first users. Previously they were keyboard-only with no UI hint they existed.

Closes #899

## User value

A user can now right-click:
- **a node / a multi-selection** → Copy, Cut, Paste, Duplicate, Delete (with platform-aware shortcut hints teaching the keyboard equivalents)
- **the empty canvas** → Paste, Select All

Pasting from the canvas menu inserts the nodes at the click position (bounding-box top-left lands at the cursor) instead of the fixed +40/+40 offset; keyboard paste keeps the existing offset behavior.

## Implementation notes

- **`CanvasContextMenu.tsx`** (new): positioned menu styled with `--vscode-dropdown-*` tokens like the existing dropdowns; clamps to the canvas container near edges; closes on outside click (capture phase), Escape, pan/zoom, or action.
- **`WorkflowEditor.tsx`**: wires React Flow's `onNodeContextMenu` / `onSelectionContextMenu` / `onPaneContextMenu`. Right-clicking an unselected node selects it exclusively (standard editor behavior); right-clicking inside a multi-selection keeps it. Menu actions reuse the existing store verbs and their policies unchanged: Start/End exclusions, the delete-confirmation flow (Delete routes through `requestDeleteSelection`; edge-only selections delete immediately, parity with the edge ✕ button), and the `pendingDeleteNodeIds` guard for cut/delete. The Ctrl/Cmd+A handler body was extracted to a shared `selectAllOnCanvas` used by both paths.
- **Paste strategy**: the menu click is a user gesture, so `navigator.clipboard.readText()` is tried first; if the webview denies clipboard read, it falls back to an in-window mirror of the last copied/cut payload (kept up to date by both the keyboard DOM handlers and the menu actions). If clipboard read *succeeds* but contains ordinary text, paste correctly no-ops — the mirror is only used when read is denied, never to override newer clipboard content.
- **`workflow-store.ts`**: `pasteSelection(payload, position?)` — optional target position; children of a pasted group still keep their group-relative positions.
- **i18n**: 6 new `contextMenu.*` keys added to `translation-keys.ts` and all 5 locales (en/ja/ko/zh-CN/zh-TW) per `.claude/rules/translation.md`. Shortcut hints (`Ctrl+C` / `⌘C` / `Del`) are technical identifiers and stay untranslated.

## Quality gates

- `pnpm build` ✅
- `pnpm check` ✅ (Biome + tsc across all packages)
- Changeset: `cc-wf-studio` patch (`.changeset/canvas-context-menu.md`)
- Manual E2E: queued in the progress log — verify the menu (incl. the clipboard-read fallback path) in real webviews on all three OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xtUijDibPzNgeuLmbkNy9

---
_Generated by [Claude Code](https://claude.ai/code/session_015xtUijDibPzNgeuLmbkNy9)_