### PR TITLE
improvement(vscode): align and distribute selected nodes from the context menu

### DIFF
--- a/.changeset/align-distribute-selection.md
+++ b/.changeset/align-distribute-selection.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Align and distribute selected nodes from the canvas context menu: align to left/right/top/bottom edges or horizontal/vertical centers, and evenly space 3+ nodes, each as a single undoable operation

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,41 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Align and distribute selected nodes from the context menu
+- **User value**: a user can now tidy a messy workflow layout in one click —
+  align the selected nodes to an edge or center (left / horizontal centers /
+  right / top / vertical centers / bottom) or space 3+ nodes out evenly —
+  instead of pixel-dragging each node into line. The canvas previously had
+  no alignment or layout tooling at all.
+- **Issue/PR**: #903 / PR from `claude/sleepy-curie-j6xhnc`
+- **Outcome**: done — two new store actions (`alignSelection` with 6 modes,
+  `distributeSelection` with 2 axes), each a single `set()` → one undo
+  entry. Geometry runs in absolute coordinates (groups never nest, one
+  parent hop); deltas apply to `position` directly since a target's parent
+  never moves, so group-relative children stay correct. Children whose
+  selected group is also selected ride along and are excluded from the
+  math; sizes come from explicit `style` (groups) or React Flow's measured
+  `width`/`height` with fallbacks. Distribute keeps the outermost nodes
+  fixed and equalizes edge-to-edge gaps (ties broken by node id for a
+  deterministic order). Surface: `CanvasContextMenu` gained a generic
+  icon-row entry kind (icon-only buttons with tooltip + aria-label);
+  `WorkflowEditor` shows an align row (6 lucide icons) and a distribute
+  row (2 icons, disabled below 3 nodes) when ≥2 alignable nodes are
+  selected. 8 new `contextMenu.*` keys in all 5 locales. Guard step this
+  round closed #901 (merged as #902). Issue #903 could not be locked (no
+  `gh`, no MCP lock tool, API proxied — known limitation, noted in issue).
+- **Next proposals**:
+  - Manual E2E queue (carried): copy/cut/paste DOM events, canvas context
+    menu, localized Claude API dialog in ja/ko/zh — and now align/distribute
+    on mixed selections (incl. a group + loose nodes).
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+  - The model list in the API Test dialog is hardcoded in two `<select>`s
+    in `ClaudeApiUploadDialog.tsx` — extract to a single constant (and
+    consider sourcing from the shared model catalog) so new models appear
+    in both tabs consistently.
+
 ## 2026-07-23 — Localize the Claude API upload dialog
 - **User value**: a user running VSCode in Japanese, Korean, or Chinese no
   longer sees the entire Claude API skill upload & test flow in English —

--- a/packages/vscode/src/webview/src/components/CanvasContextMenu.tsx
+++ b/packages/vscode/src/webview/src/components/CanvasContextMenu.tsx
@@ -20,7 +20,24 @@ export interface CanvasContextMenuItem {
   onSelect: () => void;
 }
 
-export type CanvasContextMenuEntry = CanvasContextMenuItem | 'separator';
+/** Icon-only action in a compact row (e.g. the align/distribute buttons) */
+export interface CanvasContextMenuIconItem {
+  key: string;
+  /** Tooltip and accessible name — the button renders only the icon */
+  label: string;
+  icon: React.ReactNode;
+  disabled?: boolean;
+  onSelect: () => void;
+}
+
+/** A horizontal row of icon-only buttons rendered as one menu line */
+export interface CanvasContextMenuIconRow {
+  kind: 'iconRow';
+  key: string;
+  items: CanvasContextMenuIconItem[];
+}
+
+export type CanvasContextMenuEntry = CanvasContextMenuItem | CanvasContextMenuIconRow | 'separator';
 
 interface CanvasContextMenuProps {
   /** Position relative to the canvas container (the menu's offset parent) */
@@ -102,6 +119,52 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({ x, y, entr
               margin: '4px 0',
             }}
           />
+        ) : 'kind' in entry ? (
+          <div
+            key={entry.key}
+            role="group"
+            style={{ display: 'flex', alignItems: 'center', gap: '2px', padding: '2px 8px' }}
+          >
+            {entry.items.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                role="menuitem"
+                title={item.label}
+                aria-label={item.label}
+                disabled={item.disabled}
+                onClick={() => {
+                  if (item.disabled) return;
+                  onClose();
+                  item.onSelect();
+                }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '26px',
+                  height: '24px',
+                  backgroundColor: 'transparent',
+                  border: 'none',
+                  borderRadius: '2px',
+                  color: 'var(--vscode-foreground)',
+                  cursor: item.disabled ? 'default' : 'pointer',
+                  opacity: item.disabled ? 0.45 : 1,
+                }}
+                onMouseEnter={(event) => {
+                  if (!item.disabled) {
+                    event.currentTarget.style.backgroundColor =
+                      'var(--vscode-list-hoverBackground)';
+                  }
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.style.backgroundColor = 'transparent';
+                }}
+              >
+                {item.icon}
+              </button>
+            ))}
+          </div>
         ) : (
           <button
             key={entry.key}

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -6,6 +6,14 @@
  */
 
 import {
+  AlignCenterHorizontal,
+  AlignCenterVertical,
+  AlignEndHorizontal,
+  AlignEndVertical,
+  AlignHorizontalDistributeCenter,
+  AlignStartHorizontal,
+  AlignStartVertical,
+  AlignVerticalDistributeCenter,
   ClipboardPaste,
   Copy,
   CopyPlus,
@@ -35,6 +43,8 @@ import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
 import {
+  type AlignMode,
+  type DistributeAxis,
   parseSelectionClipboardPayload,
   type SelectionClipboardPayload,
   useWorkflowStore,
@@ -457,6 +467,18 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     if (selectedIds.length > 0) duplicateSelection(selectedIds);
   }, []);
 
+  const alignSelectionFromMenu = useCallback((mode: AlignMode) => {
+    const { nodes: currentNodes, alignSelection } = useWorkflowStore.getState();
+    const selectedIds = currentNodes.filter((n) => n.selected).map((n) => n.id);
+    if (selectedIds.length > 0) alignSelection(selectedIds, mode);
+  }, []);
+
+  const distributeSelectionFromMenu = useCallback((axis: DistributeAxis) => {
+    const { nodes: currentNodes, distributeSelection } = useWorkflowStore.getState();
+    const selectedIds = currentNodes.filter((n) => n.selected).map((n) => n.id);
+    if (selectedIds.length > 0) distributeSelection(selectedIds, axis);
+  }, []);
+
   const deleteSelectionFromMenu = useCallback(() => {
     const {
       nodes: currentNodes,
@@ -731,6 +753,12 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     );
     const hasDeletableSelection =
       nodes.some((n) => n.selected && n.type !== 'start') || edges.some((e) => e.selected);
+    // Same ride-along policy as the store's alignSelection: children whose
+    // group is also selected move with the group and don't count
+    const selectedIds = new Set(nodes.filter((n) => n.selected).map((n) => n.id));
+    const alignableCount = nodes.filter(
+      (n) => n.selected && !(n.parentId && selectedIds.has(n.parentId))
+    ).length;
     return [
       {
         key: 'copy',
@@ -757,6 +785,73 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         disabled: !hasCopyableSelection,
         onSelect: duplicateSelectionFromMenu,
       },
+      ...(alignableCount >= 2
+        ? ([
+            'separator',
+            {
+              kind: 'iconRow',
+              key: 'align',
+              items: [
+                {
+                  key: 'alignLeft',
+                  label: t('contextMenu.alignLeft'),
+                  icon: <AlignStartVertical size={14} />,
+                  onSelect: () => alignSelectionFromMenu('left'),
+                },
+                {
+                  key: 'alignCenterH',
+                  label: t('contextMenu.alignCenterHorizontal'),
+                  icon: <AlignCenterVertical size={14} />,
+                  onSelect: () => alignSelectionFromMenu('centerH'),
+                },
+                {
+                  key: 'alignRight',
+                  label: t('contextMenu.alignRight'),
+                  icon: <AlignEndVertical size={14} />,
+                  onSelect: () => alignSelectionFromMenu('right'),
+                },
+                {
+                  key: 'alignTop',
+                  label: t('contextMenu.alignTop'),
+                  icon: <AlignStartHorizontal size={14} />,
+                  onSelect: () => alignSelectionFromMenu('top'),
+                },
+                {
+                  key: 'alignMiddle',
+                  label: t('contextMenu.alignMiddle'),
+                  icon: <AlignCenterHorizontal size={14} />,
+                  onSelect: () => alignSelectionFromMenu('middle'),
+                },
+                {
+                  key: 'alignBottom',
+                  label: t('contextMenu.alignBottom'),
+                  icon: <AlignEndHorizontal size={14} />,
+                  onSelect: () => alignSelectionFromMenu('bottom'),
+                },
+              ],
+            },
+            {
+              kind: 'iconRow',
+              key: 'distribute',
+              items: [
+                {
+                  key: 'distributeH',
+                  label: t('contextMenu.distributeHorizontal'),
+                  icon: <AlignHorizontalDistributeCenter size={14} />,
+                  disabled: alignableCount < 3,
+                  onSelect: () => distributeSelectionFromMenu('horizontal'),
+                },
+                {
+                  key: 'distributeV',
+                  label: t('contextMenu.distributeVertical'),
+                  icon: <AlignVerticalDistributeCenter size={14} />,
+                  disabled: alignableCount < 3,
+                  onSelect: () => distributeSelectionFromMenu('vertical'),
+                },
+              ],
+            },
+          ] satisfies CanvasContextMenuEntry[])
+        : []),
       'separator',
       {
         key: 'delete',
@@ -776,6 +871,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     copySelectionFromMenu,
     cutSelectionFromMenu,
     duplicateSelectionFromMenu,
+    alignSelectionFromMenu,
+    distributeSelectionFromMenu,
     deleteSelectionFromMenu,
   ]);
 

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -396,6 +396,14 @@ export interface WebviewTranslationKeys {
   'contextMenu.duplicate': string;
   'contextMenu.delete': string;
   'contextMenu.selectAll': string;
+  'contextMenu.alignLeft': string;
+  'contextMenu.alignCenterHorizontal': string;
+  'contextMenu.alignRight': string;
+  'contextMenu.alignTop': string;
+  'contextMenu.alignMiddle': string;
+  'contextMenu.alignBottom': string;
+  'contextMenu.distributeHorizontal': string;
+  'contextMenu.distributeVertical': string;
   'announcement.dismiss': string;
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -416,6 +416,14 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.duplicate': 'Duplicate',
   'contextMenu.delete': 'Delete',
   'contextMenu.selectAll': 'Select All',
+  'contextMenu.alignLeft': 'Align left',
+  'contextMenu.alignCenterHorizontal': 'Align horizontal centers',
+  'contextMenu.alignRight': 'Align right',
+  'contextMenu.alignTop': 'Align top',
+  'contextMenu.alignMiddle': 'Align vertical centers',
+  'contextMenu.alignBottom': 'Align bottom',
+  'contextMenu.distributeHorizontal': 'Distribute horizontally',
+  'contextMenu.distributeVertical': 'Distribute vertically',
   'announcement.dismiss': 'Dismiss announcement',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -414,6 +414,14 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.duplicate': '複製',
   'contextMenu.delete': '削除',
   'contextMenu.selectAll': 'すべて選択',
+  'contextMenu.alignLeft': '左揃え',
+  'contextMenu.alignCenterHorizontal': '左右中央揃え',
+  'contextMenu.alignRight': '右揃え',
+  'contextMenu.alignTop': '上揃え',
+  'contextMenu.alignMiddle': '上下中央揃え',
+  'contextMenu.alignBottom': '下揃え',
+  'contextMenu.distributeHorizontal': '左右に等間隔配置',
+  'contextMenu.distributeVertical': '上下に等間隔配置',
   'announcement.dismiss': 'お知らせを閉じる',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -413,6 +413,14 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.duplicate': '복제',
   'contextMenu.delete': '삭제',
   'contextMenu.selectAll': '모두 선택',
+  'contextMenu.alignLeft': '왼쪽 정렬',
+  'contextMenu.alignCenterHorizontal': '가로 가운데 정렬',
+  'contextMenu.alignRight': '오른쪽 정렬',
+  'contextMenu.alignTop': '위쪽 정렬',
+  'contextMenu.alignMiddle': '세로 가운데 정렬',
+  'contextMenu.alignBottom': '아래쪽 정렬',
+  'contextMenu.distributeHorizontal': '가로 균등 배치',
+  'contextMenu.distributeVertical': '세로 균등 배치',
   'announcement.dismiss': '공지 닫기',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -400,6 +400,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.duplicate': '创建副本',
   'contextMenu.delete': '删除',
   'contextMenu.selectAll': '全选',
+  'contextMenu.alignLeft': '左对齐',
+  'contextMenu.alignCenterHorizontal': '水平居中对齐',
+  'contextMenu.alignRight': '右对齐',
+  'contextMenu.alignTop': '顶部对齐',
+  'contextMenu.alignMiddle': '垂直居中对齐',
+  'contextMenu.alignBottom': '底部对齐',
+  'contextMenu.distributeHorizontal': '水平均匀分布',
+  'contextMenu.distributeVertical': '垂直均匀分布',
   'announcement.dismiss': '关闭公告',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -402,6 +402,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.duplicate': '建立複本',
   'contextMenu.delete': '刪除',
   'contextMenu.selectAll': '全選',
+  'contextMenu.alignLeft': '靠左對齊',
+  'contextMenu.alignCenterHorizontal': '水平置中對齊',
+  'contextMenu.alignRight': '靠右對齊',
+  'contextMenu.alignTop': '靠上對齊',
+  'contextMenu.alignMiddle': '垂直置中對齊',
+  'contextMenu.alignBottom': '靠下對齊',
+  'contextMenu.distributeHorizontal': '水平均分',
+  'contextMenu.distributeVertical': '垂直均分',
   'announcement.dismiss': '關閉公告',
 
   // Delete Confirmation Dialog

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -122,6 +122,16 @@ export function parseSelectionClipboardPayload(text: string): SelectionClipboard
   return parsed as SelectionClipboardPayload;
 }
 
+// ============================================================================
+// Selection Alignment (context menu: align / distribute)
+// ============================================================================
+
+/** Edge or center line the selection is aligned to */
+export type AlignMode = 'left' | 'centerH' | 'right' | 'top' | 'middle' | 'bottom';
+
+/** Axis along which the selection is evenly spaced */
+export type DistributeAxis = 'horizontal' | 'vertical';
+
 /**
  * Snapshot of main workflow state for restoration after Sub-Agent Flow editing
  */
@@ -248,6 +258,16 @@ interface WorkflowStore {
    *  content lives on in the returned clipboard payload. Returns null (and
    *  removes nothing) when nothing serializable is selected. */
   cutSelection: (nodeIds: string[]) => SelectionClipboardPayload | null;
+  /** Align the selection to an edge or center line of its bounding box.
+   *  Children whose group is also selected ride along with the group and are
+   *  skipped; geometry is compared in absolute coordinates (groups never
+   *  nest). No-op with fewer than two alignable nodes. Single undo entry. */
+  alignSelection: (nodeIds: string[], mode: AlignMode) => void;
+  /** Space the selection evenly along one axis: the outermost nodes stay
+   *  fixed and the gaps between node edges are equalized. Same ride-along
+   *  policy as alignSelection. No-op with fewer than three alignable nodes.
+   *  Single undo entry. */
+  distributeSelection: (nodeIds: string[], axis: DistributeAxis) => void;
   clearLastAddedNodeId: () => void;
   /** Request the canvas to pan to a specific node (e.g. when jumping in from
    *  Overview mode). The canvas-side hook clears it after centring. */
@@ -300,6 +320,26 @@ function sortNodesParentFirst(nodes: Node[]): Node[] {
   const parents = nodes.filter((n) => parentIds.has(n.id));
   const others = nodes.filter((n) => !parentIds.has(n.id));
   return [...parents, ...others];
+}
+
+/** Absolute canvas position of a node (groups never nest — one parent hop). */
+function absoluteNodePosition(node: Node, allNodes: Node[]): { x: number; y: number } {
+  if (!node.parentId) return { x: node.position.x, y: node.position.y };
+  const parent = allNodes.find((n) => n.id === node.parentId);
+  return parent
+    ? { x: node.position.x + parent.position.x, y: node.position.y + parent.position.y }
+    : { x: node.position.x, y: node.position.y };
+}
+
+/** Rendered node size: explicit style size (groups) over React Flow's
+ *  measured size, with fallbacks for nodes not yet measured. */
+function nodeBoxSize(node: Node): { width: number; height: number } {
+  const styleWidth = typeof node.style?.width === 'number' ? node.style.width : undefined;
+  const styleHeight = typeof node.style?.height === 'number' ? node.style.height : undefined;
+  return {
+    width: styleWidth ?? node.width ?? (node.type === 'group' ? 400 : 200),
+    height: styleHeight ?? node.height ?? (node.type === 'group' ? 300 : 80),
+  };
 }
 
 /**
@@ -1103,6 +1143,125 @@ export const useWorkflowStore = create<WorkflowStore>()(
         });
 
         return payload;
+      },
+
+      alignSelection: (nodeIds: string[], mode: AlignMode) => {
+        const allNodes = get().nodes;
+        const requested = new Set(nodeIds);
+        // Children whose group is also selected ride along with the group
+        const targets = allNodes.filter(
+          (node) => requested.has(node.id) && !(node.parentId && requested.has(node.parentId))
+        );
+        if (targets.length < 2) return;
+
+        const boxes = targets.map((node) => {
+          const { x, y } = absoluteNodePosition(node, allNodes);
+          const { width, height } = nodeBoxSize(node);
+          return { id: node.id, left: x, top: y, width, height };
+        });
+        const minLeft = Math.min(...boxes.map((box) => box.left));
+        const maxRight = Math.max(...boxes.map((box) => box.left + box.width));
+        const minTop = Math.min(...boxes.map((box) => box.top));
+        const maxBottom = Math.max(...boxes.map((box) => box.top + box.height));
+
+        // Deltas are identical in absolute and group-relative coordinates
+        // (a target's parent never moves), so they apply to position directly
+        const deltas = new Map<string, { dx: number; dy: number }>();
+        for (const box of boxes) {
+          let dx = 0;
+          let dy = 0;
+          switch (mode) {
+            case 'left':
+              dx = minLeft - box.left;
+              break;
+            case 'centerH':
+              dx = (minLeft + maxRight) / 2 - (box.left + box.width / 2);
+              break;
+            case 'right':
+              dx = maxRight - (box.left + box.width);
+              break;
+            case 'top':
+              dy = minTop - box.top;
+              break;
+            case 'middle':
+              dy = (minTop + maxBottom) / 2 - (box.top + box.height / 2);
+              break;
+            case 'bottom':
+              dy = maxBottom - (box.top + box.height);
+              break;
+          }
+          if (dx !== 0 || dy !== 0) deltas.set(box.id, { dx, dy });
+        }
+        if (deltas.size === 0) return;
+
+        // Single set() call → single undo/redo history entry
+        set({
+          nodes: allNodes.map((node) => {
+            const delta = deltas.get(node.id);
+            return delta
+              ? {
+                  ...node,
+                  position: { x: node.position.x + delta.dx, y: node.position.y + delta.dy },
+                }
+              : node;
+          }),
+        });
+      },
+
+      distributeSelection: (nodeIds: string[], axis: DistributeAxis) => {
+        const allNodes = get().nodes;
+        const requested = new Set(nodeIds);
+        // Same ride-along policy as alignSelection
+        const targets = allNodes.filter(
+          (node) => requested.has(node.id) && !(node.parentId && requested.has(node.parentId))
+        );
+        if (targets.length < 3) return;
+
+        const horizontal = axis === 'horizontal';
+        const boxes = targets
+          .map((node) => {
+            const position = absoluteNodePosition(node, allNodes);
+            const size = nodeBoxSize(node);
+            return {
+              id: node.id,
+              start: horizontal ? position.x : position.y,
+              extent: horizontal ? size.width : size.height,
+            };
+          })
+          .sort((a, b) => a.start - b.start || a.id.localeCompare(b.id));
+
+        // The outermost nodes stay fixed; the gaps between node edges in
+        // between are equalized (negative gaps mean overlapping nodes and
+        // distribute evenly all the same)
+        const first = boxes[0];
+        const last = boxes[boxes.length - 1];
+        const span = last.start + last.extent - first.start;
+        const totalExtent = boxes.reduce((sum, box) => sum + box.extent, 0);
+        const gap = (span - totalExtent) / (boxes.length - 1);
+
+        const deltas = new Map<string, number>();
+        let cursor = first.start;
+        for (const box of boxes) {
+          const delta = cursor - box.start;
+          if (delta !== 0) deltas.set(box.id, delta);
+          cursor += box.extent + gap;
+        }
+        if (deltas.size === 0) return;
+
+        // Single set() call → single undo/redo history entry
+        set({
+          nodes: allNodes.map((node) => {
+            const delta = deltas.get(node.id);
+            return delta !== undefined
+              ? {
+                  ...node,
+                  position: horizontal
+                    ? { x: node.position.x + delta, y: node.position.y }
+                    : { x: node.position.x, y: node.position.y + delta },
+                }
+              : node;
+          }),
+        });
       },
 
       requestFocusNode: (nodeId: string) => {


### PR DESCRIPTION
## Summary

A user can now tidy a messy workflow layout in one click: right-click a multi-selection and align the nodes to an edge or center line (left / horizontal centers / right / top / vertical centers / bottom), or space 3+ nodes out evenly along an axis — instead of pixel-dragging each node into line. The canvas previously had no alignment or layout tooling at all.

Closes #903

## Changes

- Two new store actions in `workflow-store.ts`: `alignSelection(nodeIds, mode)` (6 modes) and `distributeSelection(nodeIds, axis)` (horizontal/vertical), each a single `set()` call → one undo/redo entry (zundo already tracks nodes)
- Geometry runs in absolute coordinates: groups never nest, so absolute position is one parent hop; deltas apply to `node.position` directly (translation is parent-invariant), so group-relative children stay correct
- Children whose selected group is also selected ride along with the group and are excluded from the math; node sizes come from explicit `style` (groups) or React Flow's measured `width`/`height` with fallbacks — same pattern as the group-bounds check in `onNodeDragStop`
- Distribute keeps the outermost nodes fixed and equalizes edge-to-edge gaps (deterministic ordering: position, then node id)
- `CanvasContextMenu` gains a generic `iconRow` entry kind: a compact row of icon-only buttons with tooltip + `aria-label`
- `WorkflowEditor` shows an align row (6 lucide icons) and a distribute row (2 icons, disabled below 3 alignable nodes) when ≥2 alignable nodes are selected
- 8 new `contextMenu.*` keys in `translation-keys.ts` and all 5 locales (en/ja/ko/zh-CN/zh-TW) per `.claude/rules/translation.md`
- No schema changes, no behavior changes outside the canvas

## Release

Changeset added: `cc-wf-studio` patch (`.changeset/align-distribute-selection.md`).

## Verification

- `pnpm build` — all packages compile
- `pnpm check` — Biome + tsc clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8CaRbbYdkDBW6AtPyM3bF)_