### PR TITLE
feat(mcp): add validate_workflow tool for side-effect-free draft checks

### DIFF
--- a/.changeset/mcp-validate-workflow-tool.md
+++ b/.changeset/mcp-validate-workflow-tool.md
@@ -1,0 +1,8 @@
+---
+'@cc-wf-studio/core': minor
+'@cc-wf-studio/mcp': minor
+'@cc-wf-studio/cli': patch
+'cc-wf-studio': minor
+---
+
+Add a `validate_workflow` MCP tool: AI agents can now validate a workflow draft (schema check plus optional per-agent target-compatibility warnings via the new `agent` parameter) without applying it to the canvas or writing the workflow file — no review dialog, no auto-created sub-agent files. The warning logic is shared with `ccwf export/run/validate --agent` through the new core exports `collectAgentCompatibilityWarnings` / `WORKFLOW_TARGET_AGENTS`, and the AI-editing skill now instructs agents to validate before applying.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,41 @@ Entry format:
 
 ---
 
+## 2026-07-23 — Add a validate_workflow MCP tool (side-effect-free draft check)
+- **User value**: an AI agent editing a workflow through the MCP server can
+  now check a draft — schema validity plus, with the new optional `agent`
+  param, the same target-compatibility warnings `ccwf validate --agent`
+  prints — without touching the user's canvas or workflow file; previously
+  the only way to discover validation errors was attempting `apply_workflow`,
+  which in canvas mode auto-creates sub-agent `.md` files *before*
+  validation runs, so a failed apply could leave stray files behind.
+- **Issue/PR**: #905 / PR from `claude/sleepy-curie-1zwq4u`
+- **Outcome**: done — new `validate_workflow` tool in
+  `packages/mcp/src/tools.ts` (registered in both canvas and file modes with
+  mode-specific descriptions; pure function, no adapter IO). Invalid drafts
+  return a normal `{valid: false, validationErrors}` result (not `isError`)
+  so agents iterate cheaply. The warning logic moved to core as
+  `collectAgentCompatibilityWarnings` + `WORKFLOW_TARGET_AGENTS`
+  (`schema/warnings.ts`); `ccwf export/run/validate --agent` now consume the
+  shared helper (CLI re-exports it, byte-identical warnings). Discoverability:
+  `cc-workflow-ai-editor` skill template gained a validate-before-apply step,
+  `ccwf-cli` SKILL.md and the mcp README tool lists updated to 7 tools.
+  Supersedes the parked "apply_workflow compat warnings" proposal — that was
+  judged too thin because `apply_workflow` has no target parameter; the
+  explicit `agent` param here is what makes ignored-field warnings usable.
+  Issue #905 could not be locked (no `gh`, no MCP lock tool — known
+  limitation, noted in the issue).
+- **Next proposals**:
+  - `ccwf validate` accepting multiple files / a directory (per-file report,
+    single exit code) so CI can validate a workflows folder without a shell
+    loop.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in ja/ko/zh;
+    now also `validate_workflow` via MCP Inspector in both modes.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — Align and distribute selected nodes from the context menu
 - **User value**: a user can now tidy a messy workflow layout in one click —
   align the selected nodes to an edge or center (left / horizontal centers /

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -150,7 +150,7 @@ Typical `.mcp.json` snippet for Claude Code:
 }
 ```
 
-The MCP server exposes 6 tools: `get_workflow_schema`, `get_current_workflow`, `apply_workflow`, `update_nodes`, `list_available_agents`, `highlight_group_node`. Use these when the user wants AI-driven editing of the workflow itself (not just rendering / running it).
+The MCP server exposes 7 tools: `get_workflow_schema`, `get_current_workflow`, `validate_workflow`, `apply_workflow`, `update_nodes`, `list_available_agents`, `highlight_group_node`. Use these when the user wants AI-driven editing of the workflow itself (not just rendering / running it). `validate_workflow` checks a draft (schema validity + optional `--agent`-style target-compatibility warnings) without writing the file — prefer it before `apply_workflow`.
 
 ### `ccwf samples list` / `ccwf samples copy <id>`
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -14,12 +14,10 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {
   type AgentSkillProvider,
-  type ExportTarget,
   type PlannedExportFile,
-  type Workflow,
-  agentSkillProviderToTarget,
-  collectIgnoredFieldWarnings,
-  describeClaudeCodeOnlyNodes,
+  WORKFLOW_TARGET_AGENTS,
+  type WorkflowTargetAgent,
+  collectAgentCompatibilityWarnings,
   nodeNameToFileName,
   planAgentSkillFiles,
   planWorkflowExportFiles,
@@ -28,16 +26,9 @@ import { Command, InvalidArgumentError } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
 
 const CLAUDE_CODE_AGENT = 'claude-code' as const;
-export const SUPPORTED_AGENTS = [
-  CLAUDE_CODE_AGENT,
-  'antigravity',
-  'codex',
-  'copilot',
-  'cursor',
-  'gemini',
-  'roo-code',
-] as const;
-export type SupportedAgent = (typeof SUPPORTED_AGENTS)[number];
+export const SUPPORTED_AGENTS = WORKFLOW_TARGET_AGENTS;
+export type SupportedAgent = WorkflowTargetAgent;
+export { collectAgentCompatibilityWarnings };
 
 export interface ExportRunOptions {
   /** Path to the workflow JSON. */
@@ -82,32 +73,6 @@ async function pathExists(target: string): Promise<boolean> {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
     throw error;
   }
-}
-
-/**
- * Target-compatibility warnings for exporting `workflow` to `agent`:
- * Claude Code-only nodes the agent cannot execute, plus every configured
- * node field the target ignores. Shared by `ccwf export` / `ccwf run`
- * (printed before writing files) and `ccwf validate --agent` (preflight,
- * no files written).
- */
-export function collectAgentCompatibilityWarnings(
-  workflow: Workflow,
-  agent: SupportedAgent
-): string[] {
-  const warnings: string[] = [];
-  const claudeOnlyNodes = describeClaudeCodeOnlyNodes(workflow);
-  if (agent !== CLAUDE_CODE_AGENT && claudeOnlyNodes.length > 0) {
-    warnings.push(
-      `this workflow contains Claude Code-only node(s) that ${agent} cannot execute: ${claudeOnlyNodes.join(', ')}.`
-    );
-  }
-  const target: ExportTarget =
-    agent === CLAUDE_CODE_AGENT
-      ? 'claudeCode'
-      : agentSkillProviderToTarget(agent as AgentSkillProvider);
-  warnings.push(...collectIgnoredFieldWarnings(workflow, target));
-  return warnings;
 }
 
 /**

--- a/packages/core/src/schema/warnings.ts
+++ b/packages/core/src/schema/warnings.ts
@@ -13,10 +13,55 @@
  * `agentSkillProviderToTarget`.
  */
 
+import type { AgentSkillProvider } from '../services/agent-skill-export.js';
 import { NodeType, type Workflow } from '../types/workflow-definition.js';
+import { describeClaudeCodeOnlyNodes } from './claude-code-only.js';
 import { NODE_PROPERTY_SCHEMAS } from './node-schema-registry.js';
 import { getIgnoredFields } from './queries.js';
-import type { ExportTarget } from './targets.js';
+import { type ExportTarget, agentSkillProviderToTarget } from './targets.js';
+
+/**
+ * Agent names a workflow can be preflighted/exported for: Claude Code plus
+ * every {@link AgentSkillProvider}. This is the user-facing vocabulary used
+ * by `ccwf export --agent` / `ccwf validate --agent` and the MCP
+ * `validate_workflow` tool.
+ */
+export const WORKFLOW_TARGET_AGENTS = [
+  'claude-code',
+  'antigravity',
+  'codex',
+  'copilot',
+  'cursor',
+  'gemini',
+  'roo-code',
+] as const;
+
+export type WorkflowTargetAgent = (typeof WORKFLOW_TARGET_AGENTS)[number];
+
+/**
+ * Target-compatibility warnings for exporting `workflow` to `agent`:
+ * Claude Code-only nodes the agent cannot execute, plus every configured
+ * node field the target ignores. Callers should only pass schema-valid
+ * workflows — malformed node data would produce garbage reports.
+ */
+export function collectAgentCompatibilityWarnings(
+  workflow: Workflow,
+  agent: WorkflowTargetAgent
+): string[] {
+  const warnings: string[] = [];
+  const claudeOnlyNodes = describeClaudeCodeOnlyNodes(workflow);
+  if (agent !== 'claude-code' && claudeOnlyNodes.length > 0) {
+    warnings.push(
+      `this workflow contains Claude Code-only node(s) that ${agent} cannot execute: ${claudeOnlyNodes.join(', ')}.`
+    );
+  }
+  const target: ExportTarget =
+    agent === 'claude-code'
+      ? 'claudeCode'
+      : agentSkillProviderToTarget(agent satisfies AgentSkillProvider);
+  warnings.push(...collectIgnoredFieldWarnings(workflow, target));
+  return warnings;
+}
 
 /** One human-readable warning per set-but-ignored field of every node whose
  *  type has a registered property schema. */

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) server toolkit for [cc-wf-studio](https://github.co
 
 > One of the three interfaces sharing a workflow file: this MCP server, the [`@cc-wf-studio/cli`](https://www.npmjs.com/package/@cc-wf-studio/cli), and the [`cc-wf-studio` VSCode extension](https://marketplace.visualstudio.com/items?itemName=breaking-brake.cc-wf-studio). See the [monorepo README](https://github.com/breaking-brake/cc-wf-studio#readme) for the bigger picture.
 
-The package is the deduplicated home of the 6 cc-wf-studio MCP tools. Both the VSCode extension (canvas mode, HTTP transport) and the standalone bin (file mode, stdio transport) configure the same tool registrations through a shared factory.
+The package is the deduplicated home of the 7 cc-wf-studio MCP tools. Both the VSCode extension (canvas mode, HTTP transport) and the standalone bin (file mode, stdio transport) configure the same tool registrations through a shared factory.
 
 ## Install
 
@@ -50,6 +50,7 @@ The bin speaks stdio MCP â€” point an MCP client (Claude Code, MCP Inspector, â€
 |---|---|
 | `get_workflow_schema` | Return the workflow schema in TOON format. |
 | `get_current_workflow` | Return the current workflow + revision. |
+| `validate_workflow` | Validate a workflow draft without persisting anything; optional `agent` adds target-compatibility warnings. |
 | `apply_workflow` | Validate + persist a workflow. Honours `expectedRevision` for optimistic locking. |
 | `update_nodes` | Partial node updates (more token-efficient than `apply_workflow`). |
 | `list_available_agents` | Enumerate `~/.claude/agents/*.md` (user) and `<project>/.claude/agents/*.md` (project). |

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -13,6 +13,8 @@
 import {
   type BaseNode,
   NodeType,
+  WORKFLOW_TARGET_AGENTS,
+  collectAgentCompatibilityWarnings,
   validateAIGeneratedWorkflow,
   type Workflow,
   type WorkflowNode,
@@ -57,6 +59,7 @@ interface ToolText {
   applyWorkflowParamDescription: string;
   applyChangeDescriptionParam: string;
   applyRevisionParamDescription: string;
+  validateWorkflowDescription: string;
   updateNodesDescription: string;
   updateNodesChangeDescriptionParam: string;
   highlightGroupNodeDescription: string;
@@ -75,6 +78,8 @@ const TOOL_TEXT: Record<WorkflowMcpMode, ToolText> = {
       'A brief description of the changes being made (e.g., "Added error handling step after API call"). Shown to the user in the review dialog.',
     applyRevisionParamDescription:
       'Workflow revision from get_current_workflow for conflict detection. If provided and the workflow has been modified since, the apply will be rejected or a warning shown.',
+    validateWorkflowDescription:
+      'Validate a workflow JSON draft WITHOUT applying it to the canvas. Checks schema validity and, when "agent" is provided, also reports target-compatibility warnings (Claude Code-only nodes the agent cannot execute, configured fields that target ignores). No side effects: nothing is applied, no review dialog is shown, and no sub-agent files are created. Use this to check a draft before apply_workflow.',
     updateNodesDescription:
       'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and applies to the canvas. Only updates existing nodes — use apply_workflow to add or remove nodes.',
     updateNodesChangeDescriptionParam:
@@ -94,6 +99,8 @@ const TOOL_TEXT: Record<WorkflowMcpMode, ToolText> = {
       'A brief description of the changes being made (e.g., "Added error handling step after API call"). Not displayed in file mode; safe to omit.',
     applyRevisionParamDescription:
       'Workflow revision from get_current_workflow for conflict detection. If provided and the file has changed since it was read, the write is rejected with a revision-conflict error.',
+    validateWorkflowDescription:
+      'Validate a workflow JSON draft WITHOUT writing the workflow file. Checks schema validity and, when "agent" is provided, also reports target-compatibility warnings (Claude Code-only nodes the agent cannot execute, configured fields that target ignores). No side effects: the file is not touched. Use this to check a draft before apply_workflow.',
     updateNodesDescription:
       'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and writes it back to the workflow file. Only updates existing nodes — use apply_workflow to add or remove nodes.',
     updateNodesChangeDescriptionParam:
@@ -112,6 +119,7 @@ export function registerWorkflowTools(
   registerGetCurrentWorkflow(server, adapter, text);
   registerGetWorkflowSchema(server, adapter);
   registerApplyWorkflow(server, adapter, text);
+  registerValidateWorkflow(server, text);
   registerListAvailableAgents(server, adapter);
   registerUpdateNodes(server, adapter, text);
   registerHighlightGroupNode(server, adapter, text);
@@ -225,6 +233,54 @@ function registerApplyWorkflow(
           ...(plannedFiles.length > 0
             ? { autoCreatedFiles: plannedFiles.map((f) => f.filePath) }
             : {}),
+        });
+      } catch (error) {
+        return fail({ success: false, error: errorMessage(error) });
+      }
+    }
+  );
+}
+
+function registerValidateWorkflow(server: McpServer, text: ToolText): void {
+  server.tool(
+    'validate_workflow',
+    text.validateWorkflowDescription,
+    {
+      workflow: z.string().describe('The workflow JSON string to validate'),
+      agent: z
+        .enum(WORKFLOW_TARGET_AGENTS)
+        .optional()
+        .describe(
+          'Optional target agent to preflight compatibility for. When set (and the workflow is schema-valid), the result includes the same warnings `ccwf validate --agent` reports: Claude Code-only nodes the agent cannot execute, plus configured node fields that target ignores. Warnings never make the workflow invalid.'
+        ),
+    },
+    async ({ workflow: workflowJson, agent }) => {
+      try {
+        let parsedWorkflow: unknown;
+        try {
+          parsedWorkflow = JSON.parse(workflowJson);
+        } catch {
+          return fail({
+            success: false,
+            error: 'Invalid JSON: Failed to parse workflow string',
+          });
+        }
+
+        const validation = validateAIGeneratedWorkflow(parsedWorkflow);
+        // Compatibility warnings only for a schema-valid workflow —
+        // malformed node data would produce garbage reports.
+        const warnings =
+          agent && validation.valid
+            ? collectAgentCompatibilityWarnings(parsedWorkflow as Workflow, agent)
+            : undefined;
+
+        // An invalid draft is still a successful validation run: return a
+        // normal result so the agent can read the errors and iterate.
+        return ok({
+          success: true,
+          valid: validation.valid,
+          ...(validation.valid ? {} : { validationErrors: validation.errors }),
+          ...(warnings ? { warnings } : {}),
         });
       } catch (error) {
         return fail({ success: false, error: errorMessage(error) });

--- a/packages/vscode/resources/ai-editing-skill-template.md
+++ b/packages/vscode/resources/ai-editing-skill-template.md
@@ -1,6 +1,6 @@
 ---
 name: cc-workflow-ai-editor
-description: AI workflow editor for CC Workflow Studio. Create and edit visual AI agent workflows through interactive conversation using MCP tools (get_workflow_schema, get_current_workflow, apply_workflow, update_nodes). Use when the user wants to create a new workflow, modify an existing workflow, or edit the workflow canvas in CC Workflow Studio via the built-in MCP server.
+description: AI workflow editor for CC Workflow Studio. Create and edit visual AI agent workflows through interactive conversation using MCP tools (get_workflow_schema, get_current_workflow, validate_workflow, apply_workflow, update_nodes). Use when the user wants to create a new workflow, modify an existing workflow, or edit the workflow canvas in CC Workflow Studio via the built-in MCP server.
 ---
 
 1. Call `get_workflow_schema` via `cc-workflow-studio` MCP server
@@ -8,6 +8,7 @@ description: AI workflow editor for CC Workflow Studio. Create and edit visual A
 3. Ask the user what to create or modify
 4. Generate workflow JSON: choose each node type based on its role description in the schema. When a `subAgent` is the right choice, use a built-in `builtInType` (explore/plan/general-purpose). Only call `list_available_agents` when the user explicitly asks to use an existing custom sub-agent.
 5. Apply changes via `cc-workflow-studio` MCP server:
+   - **Check the draft first**: call `validate_workflow` with the workflow JSON — it validates without touching the canvas or creating any files. Fix reported errors and re-validate before applying. If the user plans to export/run the workflow on a non-Claude agent (codex, copilot, cursor, gemini, antigravity, roo-code), pass `agent` to also get target-compatibility warnings and mention them to the user.
    - **New workflow or structural changes** (add/remove nodes/connections): use `apply_workflow`
    - **Partial updates to existing nodes** (change name, position, or data): use `update_nodes` (more token-efficient)
    - Fix errors if any


### PR DESCRIPTION
## Summary

Adds a `validate_workflow` tool to the cc-wf-studio MCP server (both canvas and file modes): AI agents can now check a workflow draft — schema validity plus optional per-agent target-compatibility warnings — **without** applying it to the canvas or writing the workflow file.

Closes #905

## Why

- The only way for an agent to discover validation errors today is attempting `apply_workflow`. In canvas mode that calls `planAndPersistSubAgentFiles(...)` **before** validation, so a failed apply can leave stray auto-created `.claude/agents/*.md` files behind.
- No MCP surface exposed the target-compatibility warnings core already computes (`describeClaudeCodeOnlyNodes`, `collectIgnoredFieldWarnings`), so agents could not preflight "will this workflow survive export to codex/copilot/…?".
- A previous iteration parked "make `apply_workflow` return compat warnings" as too thin because `apply_workflow` has no target parameter; the explicit optional `agent` parameter here is what makes ignored-field warnings meaningful.

## Changes

- **`@cc-wf-studio/mcp`**: new `validate_workflow` tool (registered in both modes with mode-specific descriptions). Params: `workflow` (JSON string), optional `agent` (`claude-code | antigravity | codex | copilot | cursor | gemini | roo-code`). Invalid drafts return a normal `{success: true, valid: false, validationErrors}` result (not `isError`) so agents iterate cheaply; unparseable JSON returns the same error envelope as `apply_workflow`. Warnings are only computed for schema-valid drafts (matching `ccwf validate --agent`).
- **`@cc-wf-studio/core`**: moved `collectAgentCompatibilityWarnings` from the CLI into `schema/warnings.ts` and added the `WORKFLOW_TARGET_AGENTS` vocabulary, so the CLI and MCP surfaces share one implementation and can never drift.
- **`@cc-wf-studio/cli`**: `export.ts` now re-exports the core helper (byte-identical warnings; `SUPPORTED_AGENTS`/`SupportedAgent` preserved for `validate.ts`). `ccwf-cli` SKILL.md tool list updated to 7 tools.
- **`cc-wf-studio` (VSCode)**: `cc-workflow-ai-editor` skill template now instructs agents to validate before applying and mentions the new tool in its description.
- Changeset: `core` minor, `mcp` minor, `cli` patch, `cc-wf-studio` minor.

## Verification

E2E against the built stdio server (`ccwf mcp --file`) via raw JSON-RPC:

- `tools/list` shows the 7 tools including `validate_workflow`.
- Valid workflow containing a `branchSession` node + `agent: "codex"` → `{"valid":true,"warnings":["this workflow contains Claude Code-only node(s) that codex cannot execute: \"branch-here\" (branchSession)."]}` — byte-identical to `ccwf validate --agent codex` output on the same file.
- Same workflow, no `agent` → `{"valid":true}`; `agent: "claude-code"` → `{"valid":true,"warnings":[]}`.
- Invalid draft → `{"valid":false,"validationErrors":[…]}` with `isError` unset; malformed JSON → `Invalid JSON` error envelope; unknown `agent` → clean zod enum rejection listing valid values.
- `pnpm build && pnpm check` pass across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNhqKv2t147mAN5ub7fYbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNhqKv2t147mAN5ub7fYbZ)_