### PR TITLE
feat(cli): let ccwf validate accept multiple files and directories

### DIFF
--- a/.changeset/ccwf-validate-multi-file.md
+++ b/.changeset/ccwf-validate-multi-file.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': minor
+---
+
+`ccwf validate` now accepts multiple files and directories: `ccwf validate ./workflows` validates every `*.json` under the directory (recursive, skipping `node_modules` and dot-directories) with a per-file report, a summary line, and a single exit code (0 all pass, 1 schema errors, 2 unreadable file). Multi-input `--json` prints `{ valid, files: [...] }`; single-file output and exit codes are unchanged.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-23 — ccwf validate accepts multiple files and directories
+- **User value**: a user can now validate an entire workflows folder in one
+  command — `ccwf validate ./workflows` or `ccwf validate a.json b.json` —
+  with a per-file report, a summary line, and a single exit code, instead of
+  writing a shell loop around single-file invocations in CI (which also
+  stopped at the first unreadable file instead of reporting them all).
+- **Issue/PR**: #907 / PR from `claude/sleepy-curie-dx1emm`
+- **Outcome**: done — `validate`'s argument is now variadic `<paths...>`;
+  directories expand recursively to `*.json` (skipping `node_modules` and
+  dot-directories, deterministic sort, de-duped). Nonexistent paths and
+  empty directory expansions abort the whole run (exit 2) so a typo can
+  never produce a false-green CI result. Every file is validated even when
+  earlier ones fail; load errors are reported per file. Exit code: 2 if any
+  file unreadable, else 1 if any invalid, else 0. Multi-input `--json`
+  prints `{ valid, files: [...] }`; the single-file shape (raw
+  ValidationResult + `warnings` with `--agent`) is byte-identical to
+  before, as is all single-file human output. `--agent` warnings print per
+  file. README and ccwf-cli SKILL.md updated. E2E: 10 cases against the
+  built CLI (legacy single-file ×4, mixed directory, aggregate JSON,
+  multi-file, empty dir, per-file `--agent codex` warnings, dedupe).
+  Guard step this round closed #905 (merged as #906). Issue #907 could not
+  be locked (no `gh`, no MCP lock tool — known limitation, noted in issue).
+- **Next proposals**:
+  - `--agent all` (or repeatable `--agent`) on `ccwf validate` to preflight
+    every target at once — natural follow-up now that multi-file works.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — Add a validate_workflow MCP tool (side-effect-free draft check)
 - **User value**: an AI agent editing a workflow through the MCP server can
   now check a draft — schema validity plus, with the new optional `agent`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ pnpm add -D @cc-wf-studio/cli
 | Command | Description |
 |---|---|
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
-| `ccwf validate <file>` | Schema-check the workflow JSON. Exit 0/1. `--json` for machine-readable output. `--agent <name>` also preflights target compatibility. |
+| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` also preflights target compatibility. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
@@ -42,6 +42,11 @@ ccwf render ./.vscode/workflows/my-workflow.json -o out.md  # write to a file in
 ```sh
 ccwf validate ./.vscode/workflows/my-workflow.json          # exit 0/1
 ccwf validate ./.vscode/workflows/my-workflow.json --json   # prints { valid, errors[] }
+ccwf validate ./.vscode/workflows                           # every *.json under the directory
+# ^ per-file report + summary line; also accepts several files/dirs at once.
+#   Exit 0 only if every file passes (1 = schema errors, 2 = unreadable file);
+#   with --json, multiple inputs print { valid, files: [...] } (one file keeps
+#   the plain { valid, errors[] } shape)
 ccwf validate ./.vscode/workflows/my-workflow.json --agent codex
 # ^ also reports which configured fields codex would ignore on export,
 #   without writing any files (warnings don't affect the exit code;

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -50,14 +50,17 @@ ccwf render ./.vscode/workflows/my-workflow.json -o out.md   # write to a file i
 
 Output is the same content `ccwf preview` shows in the right pane.
 
-### `ccwf validate <file>`
+### `ccwf validate <paths...>`
 
-Schema-check the workflow JSON.
+Schema-check workflow JSON files — any mix of files and directories (directories are searched recursively for `*.json`, skipping `node_modules` and dot-directories).
 
 ```bash
 ccwf validate ./.vscode/workflows/my-workflow.json           # exit 0/1, human-readable errors on stderr
 ccwf validate ./.vscode/workflows/my-workflow.json --json    # prints { valid, errors[] }
+ccwf validate ./.vscode/workflows                            # every *.json under the dir, per-file report + summary
 ```
+
+Exit 0 only if every file passes; 1 = schema errors, 2 = an unreadable/unparseable file or path. With `--json` and multiple inputs the output is `{ valid, files: [...] }` (a single file keeps the plain `{ valid, errors[] }` shape).
 
 Use this:
 - Before `ccwf run` / `ccwf export` if the file is hand-edited or AI-generated

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,9 +1,14 @@
 /**
- * `ccwf validate <file>` — schema-check a workflow JSON file.
+ * `ccwf validate <paths...>` — schema-check one or more workflow JSON files.
  *
- * Default output is a human-readable error list on stderr; exit 0 on pass,
- * exit 1 on validation failure. `--json` prints the raw `ValidationResult`
- * to stdout for CI scripting (still exit 0/1 by `valid` flag).
+ * Accepts any mix of files and directories; a directory expands to every
+ * `*.json` under it (recursive, skipping `node_modules` and dot-directories).
+ * Default output is a per-file report (errors on stderr) plus a summary line
+ * when more than one file is checked; exit 0 when every file passes, 1 on
+ * validation failure, 2 when a file cannot be read/parsed. `--json` prints a
+ * machine-readable result to stdout for CI scripting (same exit codes). With
+ * a single file the output — including the `--json` shape — is identical to
+ * what earlier single-file versions printed.
  *
  * `--agent <name>` additionally preflights target compatibility: it reports
  * the same warnings `ccwf export --agent <name>` would print (Claude
@@ -11,6 +16,8 @@
  * Warnings never affect the exit code — only schema validity does.
  */
 
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { type ValidationError, validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
 import { Command } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
@@ -26,55 +33,140 @@ interface ValidateOptions {
   agent?: SupportedAgent;
 }
 
+type FileReport =
+  | {
+      file: string;
+      valid: boolean;
+      errors: ValidationError[];
+      warnings?: string[];
+    }
+  | {
+      file: string;
+      valid: false;
+      loadError: string;
+    };
+
 function formatError(err: ValidationError): string {
   const fieldSuffix = err.field ? ` (field: ${err.field})` : '';
   return `  - [${err.code}] ${err.message}${fieldSuffix}`;
 }
 
+const SKIPPED_DIR_NAMES = new Set(['node_modules']);
+
+async function collectJsonFiles(dir: string, out: string[]): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIR_NAMES.has(entry.name)) {
+        continue;
+      }
+      await collectJsonFiles(full, out);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.json')) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Resolve the command's path arguments to a concrete file list. Nonexistent
+ * paths and directories with no `*.json` under them are usage errors — they
+ * abort the whole run (exit 2) rather than shrink it, so a typo can never
+ * turn into a false-green CI result.
+ */
+async function expandPaths(inputs: string[]): Promise<string[]> {
+  const files: string[] = [];
+  for (const input of inputs) {
+    const absolute = path.resolve(input);
+    let stats: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stats = await fs.stat(absolute);
+    } catch {
+      throw new WorkflowLoadError(`File not found: ${absolute}`);
+    }
+    if (stats.isDirectory()) {
+      const found: string[] = [];
+      await collectJsonFiles(absolute, found);
+      if (found.length === 0) {
+        throw new WorkflowLoadError(`No .json files found under ${absolute}`);
+      }
+      files.push(...found);
+    } else {
+      files.push(absolute);
+    }
+  }
+  return [...new Set(files)];
+}
+
+async function validateFile(file: string, agent: SupportedAgent | undefined): Promise<FileReport> {
+  let workflow: Awaited<ReturnType<typeof loadWorkflowFromFile>>['workflow'];
+  try {
+    ({ workflow } = await loadWorkflowFromFile(file));
+  } catch (error) {
+    if (error instanceof WorkflowLoadError) {
+      return { file, valid: false, loadError: error.message };
+    }
+    throw error;
+  }
+  const result = validateAIGeneratedWorkflow(workflow);
+  // Compatibility warnings only for a schema-valid workflow —
+  // malformed node data would produce garbage reports.
+  const warnings =
+    agent && result.valid ? collectAgentCompatibilityWarnings(workflow, agent) : undefined;
+  return {
+    file,
+    valid: result.valid,
+    errors: result.errors,
+    ...(agent ? { warnings: warnings ?? [] } : {}),
+  };
+}
+
+function printHumanReport(report: FileReport, agent: SupportedAgent | undefined): void {
+  if ('loadError' in report) {
+    process.stderr.write(`error: ${report.loadError}\n`);
+    return;
+  }
+  if (report.valid) {
+    process.stdout.write(`✓ ${report.file} is valid.\n`);
+    if (agent) {
+      const warnings = report.warnings ?? [];
+      if (warnings.length === 0) {
+        process.stdout.write(`✓ No target-compatibility warnings for ${agent}.\n`);
+      } else {
+        for (const warning of warnings) {
+          process.stderr.write(`warning: ${warning}\n`);
+        }
+      }
+    }
+  } else {
+    process.stderr.write(`✗ ${report.file} has ${report.errors.length} error(s):\n`);
+    for (const err of report.errors) {
+      process.stderr.write(`${formatError(err)}\n`);
+    }
+  }
+}
+
 export function registerValidateCommand(program: Command): void {
   program
     .command('validate')
-    .description('Validate a workflow JSON file against the cc-wf-studio schema.')
-    .argument('<file>', 'Path to a workflow JSON file.')
-    .option('--json', 'Print the raw ValidationResult JSON to stdout.', false)
+    .description(
+      'Validate workflow JSON files against the cc-wf-studio schema. Accepts files and/or directories (directories are searched recursively for *.json).'
+    )
+    .argument('<paths...>', 'Workflow JSON files and/or directories containing them.')
+    .option('--json', 'Print the machine-readable result JSON to stdout.', false)
     .option<SupportedAgent>(
       '--agent <name>',
       `Also preflight target compatibility for an agent (one of: ${SUPPORTED_AGENTS.join(', ')}): report which configured fields that target ignores, without writing files. Warnings do not affect the exit code.`,
       (value) => asSupportedAgent(value)
     )
-    .action(async (file: string, options: ValidateOptions) => {
+    .action(async (paths: string[], options: ValidateOptions) => {
+      let files: string[];
       try {
-        const { workflow, absolutePath } = await loadWorkflowFromFile(file);
-        const result = validateAIGeneratedWorkflow(workflow);
-        // Compatibility warnings only for a schema-valid workflow —
-        // malformed node data would produce garbage reports.
-        const warnings =
-          options.agent && result.valid
-            ? collectAgentCompatibilityWarnings(workflow, options.agent)
-            : [];
-
-        if (options.json) {
-          const payload = options.agent ? { ...result, warnings } : result;
-          process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-        } else if (result.valid) {
-          process.stdout.write(`✓ ${absolutePath} is valid.\n`);
-          if (options.agent) {
-            if (warnings.length === 0) {
-              process.stdout.write(`✓ No target-compatibility warnings for ${options.agent}.\n`);
-            } else {
-              for (const warning of warnings) {
-                process.stderr.write(`warning: ${warning}\n`);
-              }
-            }
-          }
-        } else {
-          process.stderr.write(`✗ ${absolutePath} has ${result.errors.length} error(s):\n`);
-          for (const err of result.errors) {
-            process.stderr.write(`${formatError(err)}\n`);
-          }
-        }
-
-        process.exit(result.valid ? 0 : 1);
+        files = await expandPaths(paths);
       } catch (error) {
         if (error instanceof WorkflowLoadError) {
           process.stderr.write(`error: ${error.message}\n`);
@@ -82,5 +174,46 @@ export function registerValidateCommand(program: Command): void {
         }
         throw error;
       }
+
+      const reports: FileReport[] = [];
+      for (const file of files) {
+        reports.push(await validateFile(file, options.agent));
+      }
+
+      const unreadable = reports.filter((r) => 'loadError' in r).length;
+      const failed = reports.filter((r) => !('loadError' in r) && !r.valid).length;
+      const passed = reports.length - unreadable - failed;
+      const exitCode = unreadable > 0 ? 2 : failed > 0 ? 1 : 0;
+
+      if (options.json) {
+        if (files.length === 1) {
+          // Single-file shape is a stable contract: the raw ValidationResult
+          // (plus `warnings` with --agent), exactly as earlier versions printed.
+          const report = reports[0];
+          if ('loadError' in report) {
+            process.stderr.write(`error: ${report.loadError}\n`);
+          } else {
+            const { file: _file, ...payload } = report;
+            process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+          }
+        } else {
+          const payload = { valid: exitCode === 0, files: reports };
+          process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+        }
+        process.exit(exitCode);
+      }
+
+      for (const report of reports) {
+        printHumanReport(report, options.agent);
+      }
+      if (files.length > 1) {
+        const parts = [`${passed} passed`, `${failed} failed`];
+        if (unreadable > 0) {
+          parts.push(`${unreadable} unreadable`);
+        }
+        const summary = `${parts.join(', ')} (${files.length} files checked).\n`;
+        (exitCode === 0 ? process.stdout : process.stderr).write(summary);
+      }
+      process.exit(exitCode);
     });
 }


### PR DESCRIPTION
## Summary

`ccwf validate` now accepts any mix of files and directories: `ccwf validate ./workflows` validates every `*.json` under the directory with a per-file report, a summary line, and a single exit code — no more shell loops around single-file invocations in CI.

Closes #907

## Why

- The `validate` command took exactly one `<file>`; validating N files meant N processes plus manual exit-code aggregation.
- Even a wrapper loop stopped at the first unreadable/malformed file (`WorkflowLoadError` exits immediately), so a broken folder never got a full report.

## Changes

- **`@cc-wf-studio/cli`**: `validate` argument is now variadic `<paths...>`. Directories expand recursively to `*.json` (skipping `node_modules` and dot-directories; deterministic sort; de-duped). Nonexistent paths and empty directory expansions abort the run with exit 2, so a typo can never produce a false-green CI result.
- Every file is validated even when earlier ones fail; load errors are reported per file and validation continues. Exit code: 2 if any file is unreadable, else 1 if any is schema-invalid, else 0.
- Multi-input `--json` prints an aggregate `{ valid, files: [...] }`. The single-file `--json` shape (raw ValidationResult, plus `warnings` with `--agent`) and all single-file human output/exit codes are byte-identical to before.
- `--agent <name>` keeps working per file (warnings computed only for schema-valid files, as today).
- Docs: `packages/cli/README.md` subcommand table + examples, `ccwf-cli` SKILL.md section updated.
- Changeset: `@cc-wf-studio/cli` minor.

## Verification

10 E2E cases against the built CLI (`node packages/cli/dist/cli.js validate …`):

- Single valid / invalid / missing file and single-file `--json` — output and exit codes identical to the previous release.
- Mixed directory (valid ×2 incl. subdir, schema-invalid, malformed JSON, plus a `.txt`, a `node_modules/*.json`, and a dot-directory `*.json`) → 4 files checked (skips honored), per-file blocks, `2 passed, 1 failed, 1 unreadable (4 files checked).`, exit 2.
- Same directory with `--json` → `{valid: false, files: [...]}` with per-file `loadError`/`errors`.
- Multiple explicit files → summary + exit 0; duplicate path listed twice → de-duped to single-file mode.
- Empty directory → `No .json files found under …`, exit 2.
- Directory + `--agent codex` → per-file ignored-field warnings, exit 0.
- `pnpm build && pnpm check` pass across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHHjp9GXDMB3p7jboyB55p

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHHjp9GXDMB3p7jboyB55p)_