### PR TITLE
improvement(cli): let ccwf validate preflight several agents at once (--agent all)

### DIFF
--- a/.changeset/validate-agent-all.md
+++ b/.changeset/validate-agent-all.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": patch
+---
+
+`ccwf validate --agent` is now repeatable and accepts `all`, preflighting target compatibility for several agents in one run: per-agent `[agent]`-prefixed warning lines, and `warningsByAgent` in multi-agent `--json` reports. Single-agent output is unchanged.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-23 — `ccwf validate --agent` repeatable + `--agent all`
+- **User value**: a user exporting a workflow to several AI agents can now
+  preflight target compatibility for all of them in one command —
+  `ccwf validate wf.json --agent all` (or `--agent codex --agent gemini`) —
+  instead of re-running validate once per target.
+- **Issue/PR**: #909 / PR from `claude/sleepy-curie-mgigph`
+- **Outcome**: done — `--agent` uses a commander accumulator: repeatable,
+  de-duped, first-mention order; `all` expands to `WORKFLOW_TARGET_AGENTS`
+  (7 targets). With exactly one agent every output — human lines and the
+  single-file `--json` `warnings` array — is byte-identical to before.
+  With several agents, warning lines gain a `[agent]` prefix, each clean
+  target still prints `✓ No target-compatibility warnings for <agent>.`,
+  and `--json` reports carry `warningsByAgent: { <agent>: string[] }`
+  instead of `warnings`. Warnings still never affect the exit code; invalid
+  workflows suppress warning collection (empty arrays per agent). Bad agent
+  names get a clean commander error listing the vocabulary plus `all`.
+  Docs: cli README + ccwf-cli SKILL.md (which had never documented
+  `validate --agent`). E2E: 11 cases against the built CLI (legacy
+  single-agent human/JSON, `all`, repeat+dedupe, no-agent, bad name,
+  directory batch with unreadable file, multi-agent JSON, invalid-schema
+  suppression, exit codes 0/1/2). Issue #909 could not be locked (no `gh`,
+  no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - `ccwf validate --strict` (or `--fail-on-warnings`) so CI can gate on
+    target-compatibility warnings, not just schema validity.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — ccwf validate accepts multiple files and directories
 - **User value**: a user can now validate an entire workflows folder in one
   command — `ccwf validate ./workflows` or `ccwf validate a.json b.json` —

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ pnpm add -D @cc-wf-studio/cli
 | Command | Description |
 |---|---|
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
-| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` also preflights target compatibility. |
+| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
@@ -51,6 +51,10 @@ ccwf validate ./.vscode/workflows/my-workflow.json --agent codex
 # ^ also reports which configured fields codex would ignore on export,
 #   without writing any files (warnings don't affect the exit code;
 #   with --json they land in a `warnings` array)
+ccwf validate ./.vscode/workflows/my-workflow.json --agent all
+# ^ preflight every supported target in one run; --agent is also repeatable
+#   (--agent codex --agent gemini). With several agents, warning lines are
+#   prefixed [agent] and --json reports warningsByAgent: { <agent>: [...] }
 ```
 
 ### `ccwf mcp`

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -58,9 +58,13 @@ Schema-check workflow JSON files — any mix of files and directories (directori
 ccwf validate ./.vscode/workflows/my-workflow.json           # exit 0/1, human-readable errors on stderr
 ccwf validate ./.vscode/workflows/my-workflow.json --json    # prints { valid, errors[] }
 ccwf validate ./.vscode/workflows                            # every *.json under the dir, per-file report + summary
+ccwf validate ./my-workflow.json --agent codex               # + target-compatibility warnings for codex
+ccwf validate ./my-workflow.json --agent all                 # + warnings for every supported target at once
 ```
 
 Exit 0 only if every file passes; 1 = schema errors, 2 = an unreadable/unparseable file or path. With `--json` and multiple inputs the output is `{ valid, files: [...] }` (a single file keeps the plain `{ valid, errors[] }` shape).
+
+`--agent <name>` additionally reports which configured fields that target would ignore on export (same warnings as `ccwf export`), without writing files. It is repeatable (`--agent codex --agent gemini`) and accepts `all` for every supported target; with several agents, warning lines are prefixed `[agent]` and `--json` reports carry `warningsByAgent: { <agent>: [...] }` instead of `warnings`. Warnings never change the exit code.
 
 Use this:
 - Before `ccwf run` / `ccwf export` if the file is hand-edited or AI-generated

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -13,24 +13,27 @@
  * `--agent <name>` additionally preflights target compatibility: it reports
  * the same warnings `ccwf export --agent <name>` would print (Claude
  * Code-only nodes, fields the target ignores) without writing any files.
- * Warnings never affect the exit code — only schema validity does.
+ * The flag is repeatable (`--agent codex --agent gemini`) and accepts `all`
+ * to expand to every supported target; with more than one agent, human
+ * warning lines are prefixed `[agent]` and the JSON report carries
+ * `warningsByAgent` instead of `warnings`. Warnings never affect the exit
+ * code — only schema validity does.
  */
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { type ValidationError, validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
 import {
   SUPPORTED_AGENTS,
   type SupportedAgent,
-  asSupportedAgent,
   collectAgentCompatibilityWarnings,
 } from './export.js';
 
 interface ValidateOptions {
   json?: boolean;
-  agent?: SupportedAgent;
+  agent?: SupportedAgent[];
 }
 
 type FileReport =
@@ -38,13 +41,37 @@ type FileReport =
       file: string;
       valid: boolean;
       errors: ValidationError[];
+      /** Present when exactly one agent was requested (stable single-agent shape). */
       warnings?: string[];
+      /** Present when more than one agent was requested. */
+      warningsByAgent?: Record<string, string[]>;
     }
   | {
       file: string;
       valid: false;
       loadError: string;
     };
+
+/**
+ * Repeatable `--agent` accumulator: each occurrence appends one agent, `all`
+ * appends every supported target. De-duped, first-mention order preserved.
+ */
+function parseValidateAgent(
+  value: string,
+  previous: SupportedAgent[] | undefined
+): SupportedAgent[] {
+  if (value !== 'all' && !(SUPPORTED_AGENTS as readonly string[]).includes(value)) {
+    throw new InvalidArgumentError(`Expected one of: ${SUPPORTED_AGENTS.join(', ')}, all.`);
+  }
+  const parsed = value === 'all' ? SUPPORTED_AGENTS : [value as SupportedAgent];
+  const next = previous ? [...previous] : [];
+  for (const agent of parsed) {
+    if (!next.includes(agent)) {
+      next.push(agent);
+    }
+  }
+  return next;
+}
 
 function formatError(err: ValidationError): string {
   const fieldSuffix = err.field ? ` (field: ${err.field})` : '';
@@ -102,7 +129,7 @@ async function expandPaths(inputs: string[]): Promise<string[]> {
   return [...new Set(files)];
 }
 
-async function validateFile(file: string, agent: SupportedAgent | undefined): Promise<FileReport> {
+async function validateFile(file: string, agents: SupportedAgent[]): Promise<FileReport> {
   let workflow: Awaited<ReturnType<typeof loadWorkflowFromFile>>['workflow'];
   try {
     ({ workflow } = await loadWorkflowFromFile(file));
@@ -115,30 +142,39 @@ async function validateFile(file: string, agent: SupportedAgent | undefined): Pr
   const result = validateAIGeneratedWorkflow(workflow);
   // Compatibility warnings only for a schema-valid workflow —
   // malformed node data would produce garbage reports.
-  const warnings =
-    agent && result.valid ? collectAgentCompatibilityWarnings(workflow, agent) : undefined;
+  const collect = (agent: SupportedAgent): string[] =>
+    result.valid ? collectAgentCompatibilityWarnings(workflow, agent) : [];
   return {
     file,
     valid: result.valid,
     errors: result.errors,
-    ...(agent ? { warnings: warnings ?? [] } : {}),
+    // Exactly one agent keeps the stable single-agent `warnings` shape;
+    // several agents get a per-agent map instead.
+    ...(agents.length === 1 ? { warnings: collect(agents[0]) } : {}),
+    ...(agents.length > 1
+      ? { warningsByAgent: Object.fromEntries(agents.map((agent) => [agent, collect(agent)])) }
+      : {}),
   };
 }
 
-function printHumanReport(report: FileReport, agent: SupportedAgent | undefined): void {
+function printHumanReport(report: FileReport, agents: SupportedAgent[]): void {
   if ('loadError' in report) {
     process.stderr.write(`error: ${report.loadError}\n`);
     return;
   }
   if (report.valid) {
     process.stdout.write(`✓ ${report.file} is valid.\n`);
-    if (agent) {
-      const warnings = report.warnings ?? [];
+    for (const agent of agents) {
+      // Single-agent lines are the historical format; with several agents
+      // each warning is prefixed so the target stays identifiable.
+      const warnings =
+        (agents.length === 1 ? report.warnings : report.warningsByAgent?.[agent]) ?? [];
       if (warnings.length === 0) {
         process.stdout.write(`✓ No target-compatibility warnings for ${agent}.\n`);
       } else {
+        const prefix = agents.length > 1 ? `[${agent}] ` : '';
         for (const warning of warnings) {
-          process.stderr.write(`warning: ${warning}\n`);
+          process.stderr.write(`warning: ${prefix}${warning}\n`);
         }
       }
     }
@@ -158,10 +194,10 @@ export function registerValidateCommand(program: Command): void {
     )
     .argument('<paths...>', 'Workflow JSON files and/or directories containing them.')
     .option('--json', 'Print the machine-readable result JSON to stdout.', false)
-    .option<SupportedAgent>(
+    .option<SupportedAgent[]>(
       '--agent <name>',
-      `Also preflight target compatibility for an agent (one of: ${SUPPORTED_AGENTS.join(', ')}): report which configured fields that target ignores, without writing files. Warnings do not affect the exit code.`,
-      (value) => asSupportedAgent(value)
+      `Also preflight target compatibility for one or more agents (repeatable; one of: ${SUPPORTED_AGENTS.join(', ')}, or 'all' for every target): report which configured fields each target ignores, without writing files. Warnings do not affect the exit code.`,
+      parseValidateAgent
     )
     .action(async (paths: string[], options: ValidateOptions) => {
       let files: string[];
@@ -175,9 +211,10 @@ export function registerValidateCommand(program: Command): void {
         throw error;
       }
 
+      const agents = options.agent ?? [];
       const reports: FileReport[] = [];
       for (const file of files) {
-        reports.push(await validateFile(file, options.agent));
+        reports.push(await validateFile(file, agents));
       }
 
       const unreadable = reports.filter((r) => 'loadError' in r).length;
@@ -204,7 +241,7 @@ export function registerValidateCommand(program: Command): void {
       }
 
       for (const report of reports) {
-        printHumanReport(report, options.agent);
+        printHumanReport(report, agents);
       }
       if (files.length > 1) {
         const parts = [`${passed} passed`, `${failed} failed`];


### PR DESCRIPTION
Closes #909

## What

`ccwf validate --agent` is now repeatable and accepts the special value `all`, so a user targeting several AI agents can preflight target compatibility for every one of them in a single command:

```sh
ccwf validate wf.json --agent all                 # all 7 supported targets
ccwf validate wf.json --agent codex --agent gemini
```

## How

- `--agent` uses a commander accumulator (`parseValidateAgent`): repeatable, de-duped, first-mention order preserved; `all` expands to `WORKFLOW_TARGET_AGENTS`. Unknown names get a clean `InvalidArgumentError` listing the vocabulary plus `all`.
- **Single-agent behavior is a stable contract and is unchanged** — human lines and the single-file `--json` `warnings` array are byte-identical to before.
- With several agents: warning lines are prefixed `[agent]`, each clean target still prints `✓ No target-compatibility warnings for <agent>.`, and `--json` reports carry `warningsByAgent: { <agent>: string[] }` instead of `warnings`.
- Warnings still never affect the exit code (0/1/2 semantics untouched); schema-invalid workflows suppress warning collection (empty arrays per agent).
- Scope kept to `ccwf validate` — `export`/`run` write files for one target, and the MCP `validate_workflow` tool keeps its single `agent` param.

## Docs

- `packages/cli/README.md`: command table + validate examples (`--agent all`, repeatability, `warningsByAgent`).
- `packages/cli/skills/ccwf-cli/SKILL.md`: the validate section had never documented `--agent`; now covers it including repeat/`all`.

## Changeset

`.changeset/validate-agent-all.md` — patch for `@cc-wf-studio/cli`.

## Manual E2E (built CLI, bundled sample workflow)

11 cases: legacy single-agent human/JSON output, `--agent all` (7 targets), repeat + dedupe order, no `--agent` unchanged, bad agent name error, directory batch with an unreadable file (summary + exit 2), multi-agent multi-file `--json` per-file reports, invalid-schema warning suppression (exit 1), exit codes 0/1/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187yH2bFQcibhGvxd5pprWN

---
_Generated by [Claude Code](https://claude.ai/code/session_0187yH2bFQcibhGvxd5pprWN)_