### PR TITLE
feat(cli): add --strict to ccwf validate to gate CI on compatibility warnings

### DIFF
--- a/.changeset/strict-validate-warnings.md
+++ b/.changeset/strict-validate-warnings.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': minor
+---
+
+Add `--strict` to `ccwf validate`: combined with `--agent`, any target-compatibility warning now exits 1 so CI can gate on warnings, not just schema validity. `--strict` without `--agent` is a usage error (exit 2). `--json` output shapes are unchanged — the exit code carries the verdict.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,39 @@ Entry format:
 
 ---
 
+## 2026-07-23 — `ccwf validate --strict` gates CI on compatibility warnings
+- **User value**: a user can now make CI fail when a workflow carries
+  target-compatibility warnings — `ccwf validate ./workflows --agent all
+  --strict` — instead of warnings scrolling past with exit 0 and only
+  schema validity gating the pipeline.
+- **Issue/PR**: #911 / PR from `claude/sleepy-curie-q7n03u`
+- **Outcome**: done — `--strict` turns any collected warning into exit 1
+  (schema-invalid still 1, unreadable files still win with 2). `--strict`
+  without `--agent` would collect no warnings and silently pass, so it
+  aborts with a usage error (exit 2), matching validate's "a typo can
+  never produce a false-green CI" philosophy. A final
+  `error: N target-compatibility warning(s) treated as errors (--strict).`
+  stderr line explains the nonzero exit in both human and `--json` mode;
+  JSON stdout shapes (single-file stable contract, multi-file
+  `{valid, files}`) are byte-identical — the multi-file top-level `valid`
+  already mirrors the exit code, so it reflects strict failures
+  automatically. Docs: cli README + ccwf-cli SKILL.md. E2E: 12 cases
+  against the built CLI (baseline no-strict exit 0, strict-without-agent
+  usage error, warning/clean single agent, `--agent all`, JSON shape +
+  stderr notice, schema-invalid suppression (empty warnings, no notice),
+  directory batch human/JSON, unreadable-beats-strict exit 2). Issue #911
+  could not be locked (no `gh`, no MCP lock tool — known limitation,
+  noted in the issue).
+- **Next proposals**:
+  - MCP `validate_workflow` parity: accept `agent: "all"` (or an array)
+    so AI agents can preflight every target in one call like the CLI.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — `ccwf validate --agent` repeatable + `--agent all`
 - **User value**: a user exporting a workflow to several AI agents can now
   preflight target compatibility for all of them in one command —

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ pnpm add -D @cc-wf-studio/cli
 | Command | Description |
 |---|---|
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
-| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility. |
+| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
@@ -55,6 +55,10 @@ ccwf validate ./.vscode/workflows/my-workflow.json --agent all
 # ^ preflight every supported target in one run; --agent is also repeatable
 #   (--agent codex --agent gemini). With several agents, warning lines are
 #   prefixed [agent] and --json reports warningsByAgent: { <agent>: [...] }
+ccwf validate ./.vscode/workflows --agent all --strict
+# ^ CI gate: exit 1 when any target-compatibility warning is reported
+#   (requires --agent; without it --strict is a usage error, exit 2).
+#   JSON output shapes are unchanged — the exit code carries the verdict.
 ```
 
 ### `ccwf mcp`

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -60,9 +60,10 @@ ccwf validate ./.vscode/workflows/my-workflow.json --json    # prints { valid, e
 ccwf validate ./.vscode/workflows                            # every *.json under the dir, per-file report + summary
 ccwf validate ./my-workflow.json --agent codex               # + target-compatibility warnings for codex
 ccwf validate ./my-workflow.json --agent all                 # + warnings for every supported target at once
+ccwf validate ./workflows --agent all --strict               # CI gate: warnings become exit 1
 ```
 
-Exit 0 only if every file passes; 1 = schema errors, 2 = an unreadable/unparseable file or path. With `--json` and multiple inputs the output is `{ valid, files: [...] }` (a single file keeps the plain `{ valid, errors[] }` shape).
+Exit 0 only if every file passes; 1 = schema errors, 2 = an unreadable/unparseable file or path. With `--json` and multiple inputs the output is `{ valid, files: [...] }` (a single file keeps the plain `{ valid, errors[] }` shape). Target-compatibility warnings from `--agent` never affect the exit code unless `--strict` is passed, which turns any warning into exit 1 (`--strict` requires `--agent`; alone it is a usage error, exit 2). `--strict` never changes the `--json` output shape — the exit code carries the verdict.
 
 `--agent <name>` additionally reports which configured fields that target would ignore on export (same warnings as `ccwf export`), without writing files. It is repeatable (`--agent codex --agent gemini`) and accepts `all` for every supported target; with several agents, warning lines are prefixed `[agent]` and `--json` reports carry `warningsByAgent: { <agent>: [...] }` instead of `warnings`. Warnings never change the exit code.
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -17,7 +17,12 @@
  * to expand to every supported target; with more than one agent, human
  * warning lines are prefixed `[agent]` and the JSON report carries
  * `warningsByAgent` instead of `warnings`. Warnings never affect the exit
- * code — only schema validity does.
+ * code — only schema validity does — unless `--strict` is passed, which
+ * turns any target-compatibility warning into exit 1 so CI can gate on
+ * them. `--strict` requires `--agent` (warnings are only collected for a
+ * target agent, so `--strict` alone would be a silent no-op — that's a
+ * usage error, exit 2). JSON output shapes are unchanged by `--strict`;
+ * the exit code carries the verdict.
  */
 
 import * as fs from 'node:fs/promises';
@@ -34,6 +39,7 @@ import {
 interface ValidateOptions {
   json?: boolean;
   agent?: SupportedAgent[];
+  strict?: boolean;
 }
 
 type FileReport =
@@ -196,10 +202,24 @@ export function registerValidateCommand(program: Command): void {
     .option('--json', 'Print the machine-readable result JSON to stdout.', false)
     .option<SupportedAgent[]>(
       '--agent <name>',
-      `Also preflight target compatibility for one or more agents (repeatable; one of: ${SUPPORTED_AGENTS.join(', ')}, or 'all' for every target): report which configured fields each target ignores, without writing files. Warnings do not affect the exit code.`,
+      `Also preflight target compatibility for one or more agents (repeatable; one of: ${SUPPORTED_AGENTS.join(', ')}, or 'all' for every target): report which configured fields each target ignores, without writing files. Warnings do not affect the exit code unless --strict is passed.`,
       parseValidateAgent
     )
+    .option(
+      '--strict',
+      'Exit 1 when any target-compatibility warning is reported (requires --agent). Lets CI gate on warnings, not just schema validity.',
+      false
+    )
     .action(async (paths: string[], options: ValidateOptions) => {
+      // --strict without --agent would collect no warnings and silently pass —
+      // abort instead, so a forgotten flag can never green-light a CI gate.
+      if (options.strict && !options.agent?.length) {
+        process.stderr.write(
+          'error: --strict requires --agent (target-compatibility warnings are only collected for a target agent).\n'
+        );
+        process.exit(2);
+      }
+
       let files: string[];
       try {
         files = await expandPaths(paths);
@@ -220,7 +240,22 @@ export function registerValidateCommand(program: Command): void {
       const unreadable = reports.filter((r) => 'loadError' in r).length;
       const failed = reports.filter((r) => !('loadError' in r) && !r.valid).length;
       const passed = reports.length - unreadable - failed;
-      const exitCode = unreadable > 0 ? 2 : failed > 0 ? 1 : 0;
+      const warningCount = reports.reduce((sum, report) => {
+        if ('loadError' in report) {
+          return sum;
+        }
+        const perFile =
+          report.warnings?.length ??
+          Object.values(report.warningsByAgent ?? {}).reduce((s, w) => s + w.length, 0);
+        return sum + perFile;
+      }, 0);
+      const strictFailed = Boolean(options.strict) && warningCount > 0;
+      const exitCode = unreadable > 0 ? 2 : failed > 0 || strictFailed ? 1 : 0;
+      // Explains the nonzero exit in both human and --json mode (stderr, so
+      // the stdout JSON contract is untouched).
+      const strictNotice = strictFailed
+        ? `error: ${warningCount} target-compatibility warning(s) treated as errors (--strict).\n`
+        : '';
 
       if (options.json) {
         if (files.length === 1) {
@@ -237,6 +272,7 @@ export function registerValidateCommand(program: Command): void {
           const payload = { valid: exitCode === 0, files: reports };
           process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
         }
+        process.stderr.write(strictNotice);
         process.exit(exitCode);
       }
 
@@ -251,6 +287,7 @@ export function registerValidateCommand(program: Command): void {
         const summary = `${parts.join(', ')} (${files.length} files checked).\n`;
         (exitCode === 0 ? process.stdout : process.stderr).write(summary);
       }
+      process.stderr.write(strictNotice);
       process.exit(exitCode);
     });
 }


### PR DESCRIPTION
## Summary

Adds a `--strict` flag to `ccwf validate` so CI pipelines can gate on target-compatibility warnings, not just schema validity. Closes #911.

**User value**: a user can now make CI fail when a workflow carries target-compatibility warnings — `ccwf validate ./workflows --agent all --strict` — instead of warnings scrolling past with exit 0.

## Changes

- `packages/cli/src/commands/validate.ts`:
  - New `--strict` option: any collected target-compatibility warning turns the exit code to 1 (schema-invalid stays 1; unreadable files still win with exit 2).
  - `--strict` without `--agent` aborts with a usage error (exit 2): warnings are only collected for a target agent, so `--strict` alone would be a silent no-op — consistent with validate's existing "a typo can never produce a false-green CI result" philosophy.
  - A final `error: N target-compatibility warning(s) treated as errors (--strict).` line on **stderr** explains the nonzero exit in both human and `--json` mode.
  - `--json` stdout shapes are byte-identical (single-file stable contract and multi-file `{ valid, files }`); the multi-file top-level `valid` already mirrors the exit code, so it reflects strict failures automatically. Schema-invalid files still suppress warning collection (empty arrays, no strict notice).
- Docs: `packages/cli/README.md` and `packages/cli/skills/ccwf-cli/SKILL.md` validate sections.
- Changeset: minor bump for `@cc-wf-studio/cli`.

## Testing

- `pnpm build && pnpm check` pass from the repo root.
- 12 manual E2E cases against the built CLI: baseline `--agent all` without strict (exit 0 regression), strict-without-agent usage error (exit 2), clean agent + strict (exit 0), warning agent + strict (exit 1, human and `--json`), JSON shape unchanged with stderr notice, schema-invalid + strict (exit 1, empty `warnings`, no notice), directory batch human/JSON, unreadable-file precedence (exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu8h8tXtpENFQ58nnquCrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu8h8tXtpENFQ58nnquCrJ)_