### PR TITLE
improvement(mcp): let validate_workflow preflight several agents at once

### DIFF
--- a/.changeset/mcp-validate-workflow-multi-agent.md
+++ b/.changeset/mcp-validate-workflow-multi-agent.md
@@ -1,0 +1,7 @@
+---
+'@cc-wf-studio/mcp': patch
+'@cc-wf-studio/cli': patch
+'cc-wf-studio': patch
+---
+
+The `validate_workflow` MCP tool now preflights several targets in one call: its `agent` parameter accepts a single agent name (unchanged result shape), an array of names, or `"all"` for every supported target — mirroring `ccwf validate --agent all`. With one agent the result keeps the stable `warnings: string[]` shape; with several it carries `warningsByAgent: { <agent>: string[] }` (de-duped, first-mention order). Docs for the MCP server, the ccwf-cli skill, and the AI-editing skill template mention the new forms.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-23 — MCP `validate_workflow` preflights several agents at once
+- **User value**: an AI agent editing a workflow via the MCP server can now
+  preflight target compatibility for every export target in a single
+  `validate_workflow` call — `agent: "all"` or `agent: ["codex", "gemini"]` —
+  matching `ccwf validate --agent all`, instead of one tool call per target.
+- **Issue/PR**: #913 / PR from `claude/sleepy-curie-x5rcx9`
+- **Outcome**: done — the `agent` param is now a union: single agent name
+  (result byte-identical to before, stable `warnings: string[]` shape),
+  `"all"` (expands to `WORKFLOW_TARGET_AGENTS`), or a non-empty array
+  (de-duped, first-mention order; a one-element array collapses to the
+  single-agent shape, same rule as the CLI). Several agents return
+  `warningsByAgent: { <agent>: string[] }`, the CLI's multi-agent JSON key.
+  Warnings still only collected for schema-valid drafts; invalid drafts
+  return `validationErrors` with no warning keys. Tool description text
+  updated in both canvas and file modes; docs: mcp README tool table,
+  ccwf-cli SKILL.md, ai-editing-skill-template.md. E2E: 11 cases through
+  the real MCP SDK stdio client against the built `ccwf-mcp` server
+  (baseline no-agent, legacy string, one-element array parity, duplicate
+  array dedupe + key order, `"all"` with all 7 targets, claude-code
+  self-check empty, invalid draft suppression, bad name / bad name in
+  array / empty array all rejected at the schema layer), plus CLI-parity
+  check that MCP and `ccwf validate --agent codex --json` emit identical
+  warning strings. Issue #913 could not be locked (no `gh`, no MCP lock
+  tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+  - Verify in a live webview whether arrow keys already move the focused
+    node (React Flow v11 keyboard a11y); only add grid-step nudging if
+    actually missing.
+
 ## 2026-07-23 — `ccwf validate --strict` gates CI on compatibility warnings
 - **User value**: a user can now make CI fail when a workflow carries
   target-compatibility warnings — `ccwf validate ./workflows --agent all

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -158,7 +158,7 @@ Typical `.mcp.json` snippet for Claude Code:
 }
 ```
 
-The MCP server exposes 7 tools: `get_workflow_schema`, `get_current_workflow`, `validate_workflow`, `apply_workflow`, `update_nodes`, `list_available_agents`, `highlight_group_node`. Use these when the user wants AI-driven editing of the workflow itself (not just rendering / running it). `validate_workflow` checks a draft (schema validity + optional `--agent`-style target-compatibility warnings) without writing the file — prefer it before `apply_workflow`.
+The MCP server exposes 7 tools: `get_workflow_schema`, `get_current_workflow`, `validate_workflow`, `apply_workflow`, `update_nodes`, `list_available_agents`, `highlight_group_node`. Use these when the user wants AI-driven editing of the workflow itself (not just rendering / running it). `validate_workflow` checks a draft (schema validity + optional `--agent`-style target-compatibility warnings) without writing the file — prefer it before `apply_workflow`. Its `agent` param accepts a single agent name, an array of names, or `"all"`, mirroring `ccwf validate --agent all`: one agent returns `warnings`, several return `warningsByAgent: { <agent>: string[] }`.
 
 ### `ccwf samples list` / `ccwf samples copy <id>`
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -50,7 +50,7 @@ The bin speaks stdio MCP — point an MCP client (Claude Code, MCP Inspector, �
 |---|---|
 | `get_workflow_schema` | Return the workflow schema in TOON format. |
 | `get_current_workflow` | Return the current workflow + revision. |
-| `validate_workflow` | Validate a workflow draft without persisting anything; optional `agent` adds target-compatibility warnings. |
+| `validate_workflow` | Validate a workflow draft without persisting anything; optional `agent` (a name, an array of names, or `"all"`) adds target-compatibility warnings — one agent returns `warnings`, several return `warningsByAgent`. |
 | `apply_workflow` | Validate + persist a workflow. Honours `expectedRevision` for optimistic locking. |
 | `update_nodes` | Partial node updates (more token-efficient than `apply_workflow`). |
 | `list_available_agents` | Enumerate `~/.claude/agents/*.md` (user) and `<project>/.claude/agents/*.md` (project). |

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -18,6 +18,7 @@ import {
   validateAIGeneratedWorkflow,
   type Workflow,
   type WorkflowNode,
+  type WorkflowTargetAgent,
 } from '@cc-wf-studio/core';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -79,7 +80,7 @@ const TOOL_TEXT: Record<WorkflowMcpMode, ToolText> = {
     applyRevisionParamDescription:
       'Workflow revision from get_current_workflow for conflict detection. If provided and the workflow has been modified since, the apply will be rejected or a warning shown.',
     validateWorkflowDescription:
-      'Validate a workflow JSON draft WITHOUT applying it to the canvas. Checks schema validity and, when "agent" is provided, also reports target-compatibility warnings (Claude Code-only nodes the agent cannot execute, configured fields that target ignores). No side effects: nothing is applied, no review dialog is shown, and no sub-agent files are created. Use this to check a draft before apply_workflow.',
+      'Validate a workflow JSON draft WITHOUT applying it to the canvas. Checks schema validity and, when "agent" is provided, also reports target-compatibility warnings (Claude Code-only nodes the agent cannot execute, configured fields that target ignores) — pass "all" or an array of agents to preflight several targets in one call. No side effects: nothing is applied, no review dialog is shown, and no sub-agent files are created. Use this to check a draft before apply_workflow.',
     updateNodesDescription:
       'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and applies to the canvas. Only updates existing nodes — use apply_workflow to add or remove nodes.',
     updateNodesChangeDescriptionParam:
@@ -100,7 +101,7 @@ const TOOL_TEXT: Record<WorkflowMcpMode, ToolText> = {
     applyRevisionParamDescription:
       'Workflow revision from get_current_workflow for conflict detection. If provided and the file has changed since it was read, the write is rejected with a revision-conflict error.',
     validateWorkflowDescription:
-      'Validate a workflow JSON draft WITHOUT writing the workflow file. Checks schema validity and, when "agent" is provided, also reports target-compatibility warnings (Claude Code-only nodes the agent cannot execute, configured fields that target ignores). No side effects: the file is not touched. Use this to check a draft before apply_workflow.',
+      'Validate a workflow JSON draft WITHOUT writing the workflow file. Checks schema validity and, when "agent" is provided, also reports target-compatibility warnings (Claude Code-only nodes the agent cannot execute, configured fields that target ignores) — pass "all" or an array of agents to preflight several targets in one call. No side effects: the file is not touched. Use this to check a draft before apply_workflow.',
     updateNodesDescription:
       'Update specific nodes in the current workflow by ID. More efficient than apply_workflow for partial changes. Fetches the current workflow, merges the specified node changes, validates the result, and writes it back to the workflow file. Only updates existing nodes — use apply_workflow to add or remove nodes.',
     updateNodesChangeDescriptionParam:
@@ -241,6 +242,28 @@ function registerApplyWorkflow(
   );
 }
 
+/**
+ * Normalize the `agent` param to a de-duped list in first-mention order:
+ * a single agent name stays a one-element list, `'all'` expands to every
+ * supported target, and an array is de-duped. Mirrors the CLI's repeatable
+ * `--agent` accumulator so both surfaces agree on semantics.
+ */
+function resolveRequestedAgents(
+  agent: WorkflowTargetAgent | 'all' | WorkflowTargetAgent[] | undefined
+): WorkflowTargetAgent[] {
+  if (agent === undefined) {
+    return [];
+  }
+  const requested = agent === 'all' ? WORKFLOW_TARGET_AGENTS : Array.isArray(agent) ? agent : [agent];
+  const deduped: WorkflowTargetAgent[] = [];
+  for (const name of requested) {
+    if (!deduped.includes(name)) {
+      deduped.push(name);
+    }
+  }
+  return deduped;
+}
+
 function registerValidateWorkflow(server: McpServer, text: ToolText): void {
   server.tool(
     'validate_workflow',
@@ -248,10 +271,13 @@ function registerValidateWorkflow(server: McpServer, text: ToolText): void {
     {
       workflow: z.string().describe('The workflow JSON string to validate'),
       agent: z
-        .enum(WORKFLOW_TARGET_AGENTS)
+        .union([
+          z.enum([...WORKFLOW_TARGET_AGENTS, 'all'] as const),
+          z.array(z.enum(WORKFLOW_TARGET_AGENTS)).min(1),
+        ])
         .optional()
         .describe(
-          'Optional target agent to preflight compatibility for. When set (and the workflow is schema-valid), the result includes the same warnings `ccwf validate --agent` reports: Claude Code-only nodes the agent cannot execute, plus configured node fields that target ignores. Warnings never make the workflow invalid.'
+          'Optional target agent(s) to preflight compatibility for: a single agent name, an array of agent names, or "all" for every supported target. When set (and the workflow is schema-valid), the result includes the same warnings `ccwf validate --agent` reports: Claude Code-only nodes the agent cannot execute, plus configured node fields that target ignores. With exactly one agent the result carries `warnings: string[]`; with several it carries `warningsByAgent: { <agent>: string[] }`. Warnings never make the workflow invalid.'
         ),
     },
     async ({ workflow: workflowJson, agent }) => {
@@ -269,18 +295,26 @@ function registerValidateWorkflow(server: McpServer, text: ToolText): void {
         const validation = validateAIGeneratedWorkflow(parsedWorkflow);
         // Compatibility warnings only for a schema-valid workflow —
         // malformed node data would produce garbage reports.
-        const warnings =
-          agent && validation.valid
-            ? collectAgentCompatibilityWarnings(parsedWorkflow as Workflow, agent)
-            : undefined;
+        const agents = validation.valid ? resolveRequestedAgents(agent) : [];
+        const collect = (target: WorkflowTargetAgent): string[] =>
+          collectAgentCompatibilityWarnings(parsedWorkflow as Workflow, target);
 
         // An invalid draft is still a successful validation run: return a
         // normal result so the agent can read the errors and iterate.
+        // Exactly one agent keeps the stable single-agent `warnings` shape;
+        // several agents get a per-agent map instead (same split as the CLI).
         return ok({
           success: true,
           valid: validation.valid,
           ...(validation.valid ? {} : { validationErrors: validation.errors }),
-          ...(warnings ? { warnings } : {}),
+          ...(agents.length === 1 ? { warnings: collect(agents[0]) } : {}),
+          ...(agents.length > 1
+            ? {
+                warningsByAgent: Object.fromEntries(
+                  agents.map((target) => [target, collect(target)])
+                ),
+              }
+            : {}),
         });
       } catch (error) {
         return fail({ success: false, error: errorMessage(error) });

--- a/packages/vscode/resources/ai-editing-skill-template.md
+++ b/packages/vscode/resources/ai-editing-skill-template.md
@@ -8,7 +8,7 @@ description: AI workflow editor for CC Workflow Studio. Create and edit visual A
 3. Ask the user what to create or modify
 4. Generate workflow JSON: choose each node type based on its role description in the schema. When a `subAgent` is the right choice, use a built-in `builtInType` (explore/plan/general-purpose). Only call `list_available_agents` when the user explicitly asks to use an existing custom sub-agent.
 5. Apply changes via `cc-workflow-studio` MCP server:
-   - **Check the draft first**: call `validate_workflow` with the workflow JSON — it validates without touching the canvas or creating any files. Fix reported errors and re-validate before applying. If the user plans to export/run the workflow on a non-Claude agent (codex, copilot, cursor, gemini, antigravity, roo-code), pass `agent` to also get target-compatibility warnings and mention them to the user.
+   - **Check the draft first**: call `validate_workflow` with the workflow JSON — it validates without touching the canvas or creating any files. Fix reported errors and re-validate before applying. If the user plans to export/run the workflow on a non-Claude agent (codex, copilot, cursor, gemini, antigravity, roo-code), pass `agent` to also get target-compatibility warnings and mention them to the user — `agent` accepts a single name, an array of names, or `"all"` to preflight every target at once (one agent returns `warnings`, several return `warningsByAgent`).
    - **New workflow or structural changes** (add/remove nodes/connections): use `apply_workflow`
    - **Partial updates to existing nodes** (change name, position, or data): use `update_nodes` (more token-efficient)
    - Fix errors if any


### PR DESCRIPTION
## Summary

The `validate_workflow` MCP tool now preflights target compatibility for several agents in one call, matching what `ccwf validate --agent all` already does on the CLI (#910/#912). Its `agent` parameter accepts:

- a **single agent name** — result is byte-identical to before (stable `warnings: string[]` shape),
- an **array of names** — de-duped in first-mention order; a one-element array collapses to the single-agent shape (same rule as the CLI),
- **`"all"`** — expands to every supported target (`WORKFLOW_TARGET_AGENTS`).

With several effective agents the result carries `warningsByAgent: { <agent>: string[] }`, the same key the CLI's multi-agent `--json` report uses. Warnings are still only collected for schema-valid drafts; invalid drafts return `validationErrors` with no warning keys, exactly as before.

## Changes

- `packages/mcp/src/tools.ts`: widened the `agent` zod schema to a union (enum + `"all"` | non-empty enum array), added a `resolveRequestedAgents` normalizer mirroring the CLI's repeatable `--agent` accumulator, and updated the tool/param description text in both canvas and file modes.
- Docs: `packages/mcp/README.md` tool table, `packages/cli/skills/ccwf-cli/SKILL.md`, `packages/vscode/resources/ai-editing-skill-template.md`.
- Changeset: patch for `@cc-wf-studio/mcp` (+ `@cc-wf-studio/cli`, `cc-wf-studio` which bundle it).
- `docs/progress-log.md`: iteration entry.

## Testing

- `pnpm build && pnpm check` green from the repo root.
- E2E: 11 cases through the real MCP SDK stdio client against the built `ccwf-mcp --file` server — baseline no-agent, legacy single string, one-element-array parity with the string form, duplicate-array dedupe + key order, `"all"` returning all 7 targets in canonical order, `claude-code` self-check empty, invalid-draft warning suppression, and rejection of a bad name, a bad name inside an array, and an empty array at the schema layer.
- CLI parity: MCP output for `codex` is string-identical to `ccwf validate --agent codex --json` `warnings` on the same workflow.

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zUcsXnvZxEVBWV8JwRwkK

---
_Generated by [Claude Code](https://claude.ai/code/session_013zUcsXnvZxEVBWV8JwRwkK)_