### PR TITLE
feat(cli): add --dry-run to ccwf export to preview planned files

### DIFF
--- a/.changeset/export-dry-run.md
+++ b/.changeset/export-dry-run.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': minor
+---
+
+Add `--dry-run` to `ccwf export`: preview every planned file (new / up to date / conflict) without writing anything. Exit 0 means the export would succeed; exit 1 means it would stop on conflicts (add `--overwrite` to see those files as `would overwrite` instead).

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,41 @@ Entry format:
 
 ---
 
+## 2026-07-23 — `ccwf export --dry-run` previews the plan without writing
+- **User value**: a user can now see exactly which files `ccwf export` would
+  create or overwrite — and whether the export would fail on conflicts —
+  before anything touches disk, instead of discovering conflicts by running
+  the export and hitting the error.
+- **Issue/PR**: #915 / PR from `claude/sleepy-curie-lq5l6o`
+- **Outcome**: done — `--dry-run` lists every planned file in plan order with
+  its status: `new`, `up to date`, or `conflict: exists with different
+  content` (`would overwrite` when combined with `--overwrite`). Exit code
+  mirrors a real run: 0 = export would succeed, 1 = it would stop on
+  conflicts (stderr `error: export would fail: …`); load errors keep their
+  usual exit codes. Target-compatibility warnings still print to stderr.
+  Internally the real run's conflict check and the preview share one
+  `classifyPlan` helper so they can never disagree; `ccwf run` is untouched.
+  Docs: cli README (subcommand table + export section) and ccwf-cli
+  SKILL.md. E2E: 9 cases against the built CLI (fresh-dir all-new with
+  zero files written, idempotent up-to-date, conflict exit 1 with disk
+  untouched, `--overwrite` preview exit 0, codex agent path + warnings
+  parity, bad agent name, missing file exit 2, real export still repairs
+  with `--overwrite`, 7-file cursor plan mixing new/conflict/up-to-date in
+  one listing). Also verified this round: canvas arrow-key node movement
+  already ships via React Flow v11 keyboard a11y (no `disableKeyboardA11y`
+  anywhere) — the carried nudge proposal is dropped as already-present.
+  Issue #915 could not be locked (no `gh`, no MCP lock tool — known
+  limitation, noted in the issue).
+- **Next proposals**:
+  - `ccwf export --agent all` (or repeatable `--agent`) to materialise a
+    workflow for several agents in one run — needs a per-agent
+    conflict/summary design now that dry-run exists.
+  - `--json` on `ccwf export` (incl. `--dry-run`) for scripting parity with
+    `ccwf validate --json`.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-23 — MCP `validate_workflow` preflights several agents at once
 - **User value**: an AI agent editing a workflow via the MCP server can now
   preflight target compatibility for every export target in a single

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ pnpm add -D @cc-wf-studio/cli
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
 | `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
-| `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). |
+| `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). `--dry-run` previews the planned files without writing. |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
 | `ccwf preview <file>` | Open a read-only viewer (Mermaid + per-node Markdown panes) in a local browser. Auto-reloads when the file changes. |
 | `ccwf canvas <file>` | (Experimental) Open the **full editable** cc-wf-studio canvas in a local browser. Saves write back to the same file. |
@@ -90,9 +90,12 @@ ccwf export ./my-workflow.json                                # --agent claude-c
 ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex into a different root
 ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
+ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
 ```
 
 Re-running an export is idempotent: existing files whose content already matches are reported as up to date and skipped. Only files with *different* content are conflicts that require `--overwrite`.
+
+`--dry-run` prints every planned file with its status — `new`, `up to date`, or `conflict: exists with different content` (shown as `would overwrite` when combined with `--overwrite`) — and writes nothing. The exit code mirrors what a real run would do: 0 means the export would succeed, 1 means it would stop on conflicts.
 
 Output layout by target agent:
 

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -105,9 +105,12 @@ ccwf export ./my-workflow.json                                 # --agent claude-
 ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex, custom output root
 ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
+ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
 ```
 
 Re-running an export is idempotent: existing files whose content already matches are skipped as up to date; only files with different content require `--overwrite`.
+
+`--dry-run` lists every planned file with its status — `new`, `up to date`, or `conflict: exists with different content` (`would overwrite` when combined with `--overwrite`) — and writes nothing. The exit code mirrors a real run: 0 means the export would succeed, 1 means it would stop on conflicts. Use it to check what an export touches before running it for real.
 
 Output by `--agent`:
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -52,6 +52,22 @@ export interface ExportRunResult {
   rootDir: string;
 }
 
+/** On-disk classification of a single planned export file. */
+export type PlannedFileStatus = 'new' | 'conflict' | 'up-to-date';
+
+export interface ClassifiedPlanEntry {
+  /** Absolute path the file would be written to. */
+  absPath: string;
+  status: PlannedFileStatus;
+}
+
+export interface ExportPreviewResult {
+  /** Every planned file in plan order with its on-disk classification. */
+  entries: ClassifiedPlanEntry[];
+  /** Project root used. */
+  rootDir: string;
+}
+
 function parseAgentOption(value: string): SupportedAgent {
   if ((SUPPORTED_AGENTS as readonly string[]).includes(value)) {
     return value as SupportedAgent;
@@ -72,6 +88,83 @@ async function pathExists(target: string): Promise<boolean> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
     throw error;
+  }
+}
+
+/**
+ * Sort every planned file into new / conflicting / already up to date,
+ * without writing anything. Shared by `runExport`'s conflict check and
+ * `--dry-run`'s preview so the two can never disagree.
+ */
+async function classifyPlan(
+  rootDir: string,
+  plan: PlannedExportFile[]
+): Promise<ClassifiedPlanEntry[]> {
+  const entries: ClassifiedPlanEntry[] = [];
+  for (const planned of plan) {
+    const absPath = resolvePlanned(rootDir, planned);
+    if (!(await pathExists(absPath))) {
+      entries.push({ absPath, status: 'new' });
+    } else if (await matchesPlannedContents(absPath, planned.contents)) {
+      entries.push({ absPath, status: 'up-to-date' });
+    } else {
+      entries.push({ absPath, status: 'conflict' });
+    }
+  }
+  return entries;
+}
+
+/**
+ * `--dry-run` implementation: load the workflow, emit the same
+ * target-compatibility warnings as a real export, and classify the planned
+ * files against the disk — but never write.
+ *
+ * Throws `WorkflowLoadError` for `<file>` issues, like `runExport`.
+ */
+export async function previewExport(
+  options: Omit<ExportRunOptions, 'overwrite'>
+): Promise<ExportPreviewResult> {
+  const { workflow } = await loadWorkflowFromFile(options.file);
+  const rootDir = path.resolve(options.cwd ?? process.cwd());
+
+  for (const warning of collectAgentCompatibilityWarnings(workflow, options.agent)) {
+    process.stderr.write(`warning: ${warning}\n`);
+  }
+
+  const plan =
+    options.agent === CLAUDE_CODE_AGENT
+      ? planWorkflowExportFiles(workflow)
+      : planAgentSkillFiles(workflow, options.agent as AgentSkillProvider);
+
+  return { entries: await classifyPlan(rootDir, plan), rootDir };
+}
+
+/**
+ * Print the `--dry-run` report. The exit code mirrors what a real run would
+ * do: exits 1 when the export would stop on conflicts (i.e. conflicting
+ * files present and no `--overwrite`), so exit 0 always means "the export
+ * would succeed".
+ */
+export function reportExportPreview(preview: ExportPreviewResult, overwrite: boolean): void {
+  const conflictCount = preview.entries.filter((e) => e.status === 'conflict').length;
+  process.stdout.write('Dry run — no files were written.\n');
+  process.stdout.write(`Would export ${preview.entries.length} file(s) into ${preview.rootDir}:\n`);
+  for (const entry of preview.entries) {
+    const note =
+      entry.status === 'new'
+        ? 'new'
+        : entry.status === 'up-to-date'
+          ? 'up to date'
+          : overwrite
+            ? 'would overwrite'
+            : 'conflict: exists with different content';
+    process.stdout.write(`  - ${path.relative(preview.rootDir, entry.absPath)} (${note})\n`);
+  }
+  if (conflictCount > 0 && !overwrite) {
+    process.stderr.write(
+      `error: export would fail: ${conflictCount} file(s) already exist with different content. Pass --overwrite to replace them.\n`
+    );
+    process.exit(1);
   }
 }
 
@@ -97,17 +190,11 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
 
   const unchangedPaths: string[] = [];
   if (!options.overwrite) {
-    const conflicts: string[] = [];
-    for (const planned of plan) {
-      const absPath = resolvePlanned(rootDir, planned);
-      if (await pathExists(absPath)) {
-        if (await matchesPlannedContents(absPath, planned.contents)) {
-          unchangedPaths.push(absPath);
-        } else {
-          conflicts.push(absPath);
-        }
-      }
-    }
+    const classified = await classifyPlan(rootDir, plan);
+    const conflicts = classified.filter((e) => e.status === 'conflict').map((e) => e.absPath);
+    unchangedPaths.push(
+      ...classified.filter((e) => e.status === 'up-to-date').map((e) => e.absPath)
+    );
     if (conflicts.length > 0) {
       process.stderr.write(
         `error: ${conflicts.length} file(s) already exist with different content. Pass --overwrite to replace them:\n`
@@ -183,6 +270,7 @@ export function asSupportedAgent(value: string): SupportedAgent {
 interface CommanderExportOptions {
   agent: SupportedAgent;
   overwrite: boolean;
+  dryRun: boolean;
   cwd?: string;
 }
 
@@ -201,11 +289,26 @@ export function registerExportCommand(program: Command): void {
     )
     .option('--overwrite', 'Overwrite existing files instead of erroring.', false)
     .option(
+      '--dry-run',
+      'Preview every planned file (new / up to date / conflict) without writing anything. Exit 1 if the export would fail on conflicts.',
+      false
+    )
+    .option(
       '--cwd <dir>',
       'Output root. Defaults to process.cwd(). Useful for tests / scripted runs.'
     )
     .action(async (file: string, options: CommanderExportOptions) => {
       try {
+        if (options.dryRun) {
+          const preview = await previewExport({
+            file,
+            agent: options.agent,
+            cwd: options.cwd,
+          });
+          reportExportPreview(preview, options.overwrite);
+          return;
+        }
+
         const result = await runExport({
           file,
           agent: options.agent,


### PR DESCRIPTION
Closes #915

## Summary

Adds a `--dry-run` flag to `ccwf export` so a user can see exactly which files an export would create or overwrite — and whether it would fail on conflicts — before anything touches disk.

```
$ ccwf export wf.json --agent cursor --dry-run
Dry run — no files were written.
Would export 7 file(s) into /path/to/project:
  - .cursor/skills/my-workflow/SKILL.md (up to date)
  - .cursor/agents/agent-3.md (new)
  - .cursor/agents/agent-retrospective.md (conflict: exists with different content)
  ...
error: export would fail: 1 file(s) already exist with different content. Pass --overwrite to replace them.
```

## Behavior

- Every planned file is listed in plan order with its status: `new`, `up to date`, or `conflict: exists with different content` (`would overwrite` when combined with `--overwrite`).
- The exit code mirrors a real run: 0 means the export would succeed, 1 means it would stop on conflicts. Load errors keep their usual codes (missing file → 2).
- Target-compatibility warnings print to stderr exactly like a real export.
- Nothing is ever written in dry-run mode.
- The real run's conflict check and the preview share a single `classifyPlan` helper, so the two can never disagree. `ccwf run` is untouched.

## Docs

- `packages/cli/README.md`: subcommand table + export section
- `packages/cli/skills/ccwf-cli/SKILL.md`: export section

## Changeset

`.changeset/export-dry-run.md` — minor bump for `@cc-wf-studio/cli`.

## Verification

`pnpm build && pnpm check` pass. Manual E2E against the built CLI, 9 cases: fresh-dir all-new dry run with zero files written; idempotent re-run all up to date; conflict without `--overwrite` (exit 1, disk untouched); conflict with `--overwrite` (exit 0 preview, disk untouched); `--agent codex` path + warnings parity; bad agent name (clean commander error); missing workflow file (exit 2); real export still repairs with `--overwrite`; 7-file cursor plan mixing new / conflict / up to date in one listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Be1SJSYUYPiyDAi7uQA5hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Be1SJSYUYPiyDAi7uQA5hy)_