### PR TITLE
feat(cli): add --json output to ccwf export

### DIFF
--- a/.changeset/export-json-output.md
+++ b/.changeset/export-json-output.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': minor
+---
+
+Add `--json` to `ccwf export` (works with `--dry-run` too): prints a machine-readable result to stdout — written/up-to-date/conflict files, slash name, and target-compatibility warnings — for CI scripting, with exit codes and human output unchanged.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,41 @@ Entry format:
 
 ---
 
+## 2026-07-23 — `ccwf export --json` for machine-readable export results
+- **User value**: a user can now script `ccwf export` in CI or wrapper
+  tooling by parsing stable JSON — which files were written / already up to
+  date / in conflict, the slash-command name, and target-compatibility
+  warnings — instead of scraping human-formatted text; parity with
+  `ccwf validate --json`.
+- **Issue/PR**: #917 / PR from `claude/sleepy-curie-8gdi3g`
+- **Outcome**: done — `--json` works in both modes: a real run prints
+  `{ok: true, root, agent, written, upToDate, slashName, warnings}` (exit 0)
+  or `{ok: false, …, conflicts, warnings}` (exit 1) on conflict without
+  `--overwrite`; `--dry-run --json` prints `{ok, dryRun: true, root, agent,
+  files: [{path, status}], warnings}` where `status` is the raw
+  new/up-to-date/conflict classification and `ok` mirrors the exit code
+  (honouring `--overwrite`). Paths are root-relative. In JSON mode warnings
+  move into the payload instead of stderr (validate's convention); human
+  mode is byte-identical, including `ccwf run` — internally the conflict
+  `process.exit` in `runExport` became a typed `ExportConflictError` that
+  export (human/JSON) and run render via a shared `reportExportConflict`.
+  Load errors keep their stderr + exit-code contract in `--json` mode.
+  Docs: cli README (subcommand table + export section) and ccwf-cli
+  SKILL.md. E2E: 14 cases against the built CLI (fresh/idempotent JSON
+  runs, conflict JSON exit 1 with clean stderr, human conflict text
+  unchanged, dry-run JSON with/without `--overwrite`, warnings in payload
+  with 0 stderr bytes + parity diff against human warning lines, codex
+  real-run JSON, `--overwrite` repair, missing-file exit 2, human
+  export/run success output unchanged). Issue #917 could not be locked
+  (no `gh`, no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - `ccwf export --agent all` (or repeatable `--agent`) to materialise a
+    workflow for several agents in one run — per-agent conflict/summary
+    design needed; JSON shape now has a natural per-agent extension.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-23 — `ccwf export --dry-run` previews the plan without writing
 - **User value**: a user can now see exactly which files `ccwf export` would
   create or overwrite — and whether the export would fail on conflicts —

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ pnpm add -D @cc-wf-studio/cli
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
 | `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
-| `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). `--dry-run` previews the planned files without writing. |
+| `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
 | `ccwf preview <file>` | Open a read-only viewer (Mermaid + per-node Markdown panes) in a local browser. Auto-reloads when the file changes. |
 | `ccwf canvas <file>` | (Experimental) Open the **full editable** cc-wf-studio canvas in a local browser. Saves write back to the same file. |
@@ -91,11 +91,21 @@ ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex into a different root
 ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
 ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
+ccwf export ./my-workflow.json --json                          # machine-readable result on stdout
+ccwf export ./my-workflow.json --dry-run --json                # machine-readable plan preview
 ```
 
 Re-running an export is idempotent: existing files whose content already matches are reported as up to date and skipped. Only files with *different* content are conflicts that require `--overwrite`.
 
 `--dry-run` prints every planned file with its status — `new`, `up to date`, or `conflict: exists with different content` (shown as `would overwrite` when combined with `--overwrite`) — and writes nothing. The exit code mirrors what a real run would do: 0 means the export would succeed, 1 means it would stop on conflicts.
+
+`--json` prints a machine-readable result to stdout for CI scripting (exit codes unchanged; target-compatibility warnings move into the payload instead of stderr; file paths are relative to `root`):
+
+- Real run, success (exit 0): `{ "ok": true, "root", "agent", "written": [...], "upToDate": [...], "slashName", "warnings": [...] }`
+- Real run, conflict without `--overwrite` (exit 1): `{ "ok": false, "root", "agent", "conflicts": [...], "warnings": [...] }`
+- With `--dry-run`: `{ "ok", "dryRun": true, "root", "agent", "files": [{ "path", "status": "new" | "up-to-date" | "conflict" }], "warnings": [...] }` — statuses are the raw classification (a `conflict` stays `conflict` even with `--overwrite`); `ok` mirrors the exit code, i.e. whether a real run would succeed.
+
+Load errors (missing/unparseable `<file>`) keep their usual stderr message and exit codes in `--json` mode.
 
 Output layout by target agent:
 

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -106,11 +106,15 @@ ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex, custom output root
 ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
 ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
+ccwf export ./my-workflow.json --json                          # machine-readable result on stdout
+ccwf export ./my-workflow.json --dry-run --json                # machine-readable plan preview
 ```
 
 Re-running an export is idempotent: existing files whose content already matches are skipped as up to date; only files with different content require `--overwrite`.
 
 `--dry-run` lists every planned file with its status — `new`, `up to date`, or `conflict: exists with different content` (`would overwrite` when combined with `--overwrite`) — and writes nothing. The exit code mirrors a real run: 0 means the export would succeed, 1 means it would stop on conflicts. Use it to check what an export touches before running it for real.
+
+`--json` prints a machine-readable result to stdout (exit codes unchanged; warnings move into the payload instead of stderr; paths relative to `root`): a real run prints `{ ok: true, root, agent, written, upToDate, slashName, warnings }` on success or `{ ok: false, root, agent, conflicts, warnings }` with exit 1 on conflict; `--dry-run --json` prints `{ ok, dryRun: true, root, agent, files: [{ path, status }], warnings }` where `status` is `new` / `up-to-date` / `conflict` (raw classification — `ok` reflects whether the export would succeed, honouring `--overwrite`). Prefer it when scripting exports.
 
 Output by `--agent`:
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -50,6 +50,46 @@ export interface ExportRunResult {
   slashName: string;
   /** Project root used. */
   rootDir: string;
+  /** Target-compatibility warnings collected for the requested agent. */
+  warnings: string[];
+}
+
+/**
+ * Thrown by `runExport` when planned files already exist with different
+ * content and `--overwrite` was not passed. Carries everything a caller
+ * needs to render the failure (human or JSON) and exit 1.
+ */
+export class ExportConflictError extends Error {
+  /** Absolute paths of the conflicting files, in plan order. */
+  readonly conflictPaths: string[];
+  /** Project root used. */
+  readonly rootDir: string;
+  /** Target-compatibility warnings collected before the conflict check. */
+  readonly warnings: string[];
+
+  constructor(conflictPaths: string[], rootDir: string, warnings: string[]) {
+    super(
+      `${conflictPaths.length} file(s) already exist with different content. Pass --overwrite to replace them.`
+    );
+    this.name = 'ExportConflictError';
+    this.conflictPaths = conflictPaths;
+    this.rootDir = rootDir;
+    this.warnings = warnings;
+  }
+}
+
+/**
+ * Print `runExport`'s conflict failure exactly as it has always appeared on
+ * stderr, then exit 1. Shared by `ccwf export` and `ccwf run`.
+ */
+export function reportExportConflict(error: ExportConflictError): never {
+  process.stderr.write(
+    `error: ${error.conflictPaths.length} file(s) already exist with different content. Pass --overwrite to replace them:\n`
+  );
+  for (const absPath of error.conflictPaths) {
+    process.stderr.write(`  - ${absPath}\n`);
+  }
+  process.exit(1);
 }
 
 /** On-disk classification of a single planned export file. */
@@ -66,6 +106,8 @@ export interface ExportPreviewResult {
   entries: ClassifiedPlanEntry[];
   /** Project root used. */
   rootDir: string;
+  /** Target-compatibility warnings collected for the requested agent. */
+  warnings: string[];
 }
 
 function parseAgentOption(value: string): SupportedAgent {
@@ -122,13 +164,17 @@ async function classifyPlan(
  * Throws `WorkflowLoadError` for `<file>` issues, like `runExport`.
  */
 export async function previewExport(
-  options: Omit<ExportRunOptions, 'overwrite'>
+  options: Omit<ExportRunOptions, 'overwrite'>,
+  emitWarnings = true
 ): Promise<ExportPreviewResult> {
   const { workflow } = await loadWorkflowFromFile(options.file);
   const rootDir = path.resolve(options.cwd ?? process.cwd());
 
-  for (const warning of collectAgentCompatibilityWarnings(workflow, options.agent)) {
-    process.stderr.write(`warning: ${warning}\n`);
+  const warnings = collectAgentCompatibilityWarnings(workflow, options.agent);
+  if (emitWarnings) {
+    for (const warning of warnings) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
   }
 
   const plan =
@@ -136,7 +182,7 @@ export async function previewExport(
       ? planWorkflowExportFiles(workflow)
       : planAgentSkillFiles(workflow, options.agent as AgentSkillProvider);
 
-  return { entries: await classifyPlan(rootDir, plan), rootDir };
+  return { entries: await classifyPlan(rootDir, plan), rootDir, warnings };
 }
 
 /**
@@ -171,16 +217,23 @@ export function reportExportPreview(preview: ExportPreviewResult, overwrite: boo
 /**
  * Shared implementation invoked by both `ccwf export` and `ccwf run`.
  *
- * Throws `WorkflowLoadError` for `<file>` issues. Calls `process.exit(1)` on
- * a write conflict (without `--overwrite`) — the caller doesn't need to
- * handle either case explicitly.
+ * Throws `WorkflowLoadError` for `<file>` issues and `ExportConflictError`
+ * on a write conflict (without `--overwrite`) — callers render those via
+ * their usual error paths (`reportExportConflict` for the historical
+ * stderr + exit 1 behaviour).
  */
-export async function runExport(options: ExportRunOptions): Promise<ExportRunResult> {
+export async function runExport(
+  options: ExportRunOptions,
+  emitWarnings = true
+): Promise<ExportRunResult> {
   const { workflow } = await loadWorkflowFromFile(options.file);
   const rootDir = path.resolve(options.cwd ?? process.cwd());
 
-  for (const warning of collectAgentCompatibilityWarnings(workflow, options.agent)) {
-    process.stderr.write(`warning: ${warning}\n`);
+  const warnings = collectAgentCompatibilityWarnings(workflow, options.agent);
+  if (emitWarnings) {
+    for (const warning of warnings) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
   }
 
   const plan =
@@ -196,13 +249,7 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
       ...classified.filter((e) => e.status === 'up-to-date').map((e) => e.absPath)
     );
     if (conflicts.length > 0) {
-      process.stderr.write(
-        `error: ${conflicts.length} file(s) already exist with different content. Pass --overwrite to replace them:\n`
-      );
-      for (const absPath of conflicts) {
-        process.stderr.write(`  - ${absPath}\n`);
-      }
-      process.exit(1);
+      throw new ExportConflictError(conflicts, rootDir, warnings);
     }
   }
 
@@ -226,6 +273,7 @@ export async function runExport(options: ExportRunOptions): Promise<ExportRunRes
     unchangedPaths,
     slashName: nodeNameToFileName(workflow.name),
     rootDir,
+    warnings,
   };
 }
 
@@ -271,7 +319,44 @@ interface CommanderExportOptions {
   agent: SupportedAgent;
   overwrite: boolean;
   dryRun: boolean;
+  json: boolean;
   cwd?: string;
+}
+
+function toRootRelative(rootDir: string, absPaths: string[]): string[] {
+  return absPaths.map((absPath) => path.relative(rootDir, absPath));
+}
+
+function printJson(payload: unknown): void {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+/**
+ * `--dry-run --json` report. Statuses are the raw classification
+ * (`conflict` stays `conflict` even with `--overwrite`); `ok` mirrors the
+ * exit code, i.e. whether a real export would succeed.
+ */
+function reportExportPreviewJson(
+  preview: ExportPreviewResult,
+  agent: SupportedAgent,
+  overwrite: boolean
+): void {
+  const conflictCount = preview.entries.filter((e) => e.status === 'conflict').length;
+  const ok = conflictCount === 0 || overwrite;
+  printJson({
+    ok,
+    dryRun: true,
+    root: preview.rootDir,
+    agent,
+    files: preview.entries.map((entry) => ({
+      path: path.relative(preview.rootDir, entry.absPath),
+      status: entry.status,
+    })),
+    warnings: preview.warnings,
+  });
+  if (!ok) {
+    process.exit(1);
+  }
 }
 
 export function registerExportCommand(program: Command): void {
@@ -294,30 +379,71 @@ export function registerExportCommand(program: Command): void {
       false
     )
     .option(
+      '--json',
+      'Print the machine-readable result JSON to stdout (works with --dry-run too). Warnings move into the payload instead of stderr.',
+      false
+    )
+    .option(
       '--cwd <dir>',
       'Output root. Defaults to process.cwd(). Useful for tests / scripted runs.'
     )
     .action(async (file: string, options: CommanderExportOptions) => {
       try {
         if (options.dryRun) {
-          const preview = await previewExport({
-            file,
-            agent: options.agent,
-            cwd: options.cwd,
-          });
-          reportExportPreview(preview, options.overwrite);
+          const preview = await previewExport(
+            {
+              file,
+              agent: options.agent,
+              cwd: options.cwd,
+            },
+            !options.json
+          );
+          if (options.json) {
+            reportExportPreviewJson(preview, options.agent, options.overwrite);
+          } else {
+            reportExportPreview(preview, options.overwrite);
+          }
           return;
         }
 
-        const result = await runExport({
-          file,
-          agent: options.agent,
-          overwrite: options.overwrite,
-          cwd: options.cwd,
-        });
+        const result = await runExport(
+          {
+            file,
+            agent: options.agent,
+            overwrite: options.overwrite,
+            cwd: options.cwd,
+          },
+          !options.json
+        );
+
+        if (options.json) {
+          printJson({
+            ok: true,
+            root: result.rootDir,
+            agent: options.agent,
+            written: toRootRelative(result.rootDir, result.writtenPaths),
+            upToDate: toRootRelative(result.rootDir, result.unchangedPaths),
+            slashName: result.slashName,
+            warnings: result.warnings,
+          });
+          return;
+        }
 
         reportExportOutcome(result);
       } catch (error) {
+        if (error instanceof ExportConflictError) {
+          if (options.json) {
+            printJson({
+              ok: false,
+              root: error.rootDir,
+              agent: options.agent,
+              conflicts: toRootRelative(error.rootDir, error.conflictPaths),
+              warnings: error.warnings,
+            });
+            process.exit(1);
+          }
+          reportExportConflict(error);
+        }
         if (error instanceof WorkflowLoadError) {
           process.stderr.write(`error: ${error.message}\n`);
           process.exit(error.exitCode);

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -14,7 +14,13 @@ import { Command } from 'commander';
 import { LAUNCHABLE_AGENTS } from '../utils/agent-launchers.js';
 import { findBinaryInPath } from '../utils/find-binary.js';
 import { WorkflowLoadError } from '../utils/load-workflow.js';
-import { asSupportedAgent, reportExportOutcome, runExport } from './export.js';
+import {
+  ExportConflictError,
+  asSupportedAgent,
+  reportExportConflict,
+  reportExportOutcome,
+  runExport,
+} from './export.js';
 
 interface CommanderRunOptions {
   agent: string;
@@ -126,6 +132,9 @@ export function registerRunCommand(program: Command): void {
           });
         }
       } catch (error) {
+        if (error instanceof ExportConflictError) {
+          reportExportConflict(error);
+        }
         if (error instanceof WorkflowLoadError) {
           process.stderr.write(`error: ${error.message}\n`);
           process.exit(error.exitCode);


### PR DESCRIPTION
## Summary

Adds a `--json` flag to `ccwf export`, honored in both the real run and `--dry-run` mode, so exports can be scripted in CI and wrapper tooling by parsing stable JSON instead of scraping human-formatted text — parity with the `--json` flag `ccwf validate` already has.

Closes #917

## What changed

- **Real run** (`ccwf export wf.json --json`): stdout JSON `{ ok: true, root, agent, written, upToDate, slashName, warnings }` on success (exit 0); `{ ok: false, root, agent, conflicts, warnings }` with exit 1 when planned files conflict and `--overwrite` was not passed. File paths are root-relative.
- **Dry run** (`--dry-run --json`): `{ ok, dryRun: true, root, agent, files: [{ path, status }], warnings }` where `status` is the raw `new` / `up-to-date` / `conflict` classification and `ok` mirrors the exit code (honoring `--overwrite`).
- **Warnings**: in JSON mode, target-compatibility warnings move into the payload instead of stderr (same convention as `ccwf validate --json`); human mode still prints them to stderr, byte-identical to before.
- **Internals**: `runExport`'s conflict-path `process.exit(1)` became a typed `ExportConflictError`; `ccwf export` (human + JSON) and `ccwf run` render it via a shared `reportExportConflict`, keeping the historical stderr text and exit code exactly.
- **Docs**: cli README (subcommand table + export section) and the bundled `ccwf-cli` SKILL.md.
- **Changeset**: minor bump for `@cc-wf-studio/cli` (`.changeset/export-json-output.md`).

## Verification

`pnpm build && pnpm check` pass from the repo root. 14 E2E cases against the built CLI (`dist/cli.js`):

1. Fresh export `--json` (exit 0, `written` populated)
2. Idempotent re-run (`upToDate` populated, `written` empty)
3. Conflict `--json` → `ok: false`, `conflicts`, exit 1, **0 bytes on stderr**
4. Conflict human mode → stderr text byte-identical to before, exit 1
5. `--dry-run --json` with conflict → `ok: false`, exit 1
6. `--dry-run --json --overwrite` → `ok: true`, exit 0, status stays `conflict`
7. Warnings: human mode prints to stderr; JSON mode has clean stderr with warnings in payload
8. Real codex export `--json` with 3 warnings in payload
9. Parity diff: JSON `warnings` array identical to human `warning:` lines
10. `ccwf run` conflict → unchanged human text, exit 1
11. `--json --overwrite` repairs a conflict (exit 0)
12. Missing file with `--json` → usual stderr error, exit 2
13. Human export success output unchanged
14. `ccwf run` success output + next-step hint unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U52RDXXtdnjJUi7S2GzBie

---
_Generated by [Claude Code](https://claude.ai/code/session_01U52RDXXtdnjJUi7S2GzBie)_