### PR TITLE
feat(cli): let ccwf export materialise several agents in one run

### DIFF
--- a/.changeset/export-multi-agent.md
+++ b/.changeset/export-multi-agent.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": minor
+---
+
+`ccwf export --agent` is now repeatable and accepts `all`, materialising a workflow for several agents in one atomic run (any conflict aborts before writing). Multi-agent human output uses `[agent]` prefixes; `--json` and `--dry-run --json` report per agent via `agents` + `resultsByAgent`. Single-agent output is unchanged.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,45 @@ Entry format:
 
 ---
 
+## 2026-07-23 — `ccwf export` materialises several agents in one run
+- **User value**: a user exporting a workflow to several AI agents can now
+  materialise files for all of them in one command — `ccwf export wf.json
+  --agent all` (or `--agent codex --agent gemini`) — with a single atomic
+  conflict check, instead of re-running export once per target.
+- **Issue/PR**: #919 / PR from `claude/sleepy-curie-805uax`
+- **Outcome**: done — `--agent` is now the same repeatable/`all` accumulator
+  as `ccwf validate` (de-duped, first-mention order; parser moved to
+  `export.ts` and shared, behavior byte-identical). With exactly one agent
+  every output — human, `--json`, `--dry-run` — is unchanged. With several:
+  the run is atomic (every agent's plan is classified before any write, so
+  a conflict without `--overwrite` aborts with zero files touched — verified:
+  conflicting gemini blocked codex from being written), human output uses
+  `[agent]` prefixes (warnings follow validate's `warning: [agent] …`
+  convention) plus a total summary line, and JSON payloads replace the
+  single-agent keys with `agents` + `resultsByAgent: { <agent>: {written,
+  upToDate, warnings} }` (`conflicts` per agent on failure with every
+  requested agent present, `files: [{path, status}]` per agent with
+  `--dry-run`; `ok` mirrors the exit code, stderr stays at 0 bytes in JSON
+  mode). Cross-agent collisions impossible — each provider plans under its
+  own root. `ccwf run` keeps its single-agent contract. Docs: cli README
+  (subcommand table, export section, JSON shapes) + ccwf-cli SKILL.md
+  (incl. phrasing table row for "export for all my agents"). E2E: 17 cases
+  against the built CLI (single-agent human/JSON parity, multi fresh /
+  idempotent rerun, `--agent all` writing all 7 targets incl. cursor's 3
+  files, atomic conflict human+JSON, dry-run mixed statuses human/JSON with
+  disk untouched, `--dry-run --overwrite` exit 0, `--overwrite` repair,
+  dedupe `codex codex all` order, bad agent name exit 1, default-agent JSON
+  keeps `agent` key, `ccwf run` regression, missing file exit 2, validate
+  regression after the shared-parser refactor). Issue #919 could not be
+  locked (no `gh`, no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - A multi-agent-aware follow-up for `ccwf run`: after export, print
+    per-agent next-step hints (run itself stays single-launch) — judge value
+    first.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-23 — `ccwf export --json` for machine-readable export results
 - **User value**: a user can now script `ccwf export` in CI or wrapper
   tooling by parsing stable JSON — which files were written / already up to

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ pnpm add -D @cc-wf-studio/cli
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
 | `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
-| `ccwf export <file>` | Materialise the workflow as agent-skill files for a target agent (`--agent <name>`, default `claude-code`). `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
+| `ccwf export <file>` | Materialise the workflow as agent-skill files for one or more target agents (`--agent <name>`, repeatable, or `--agent all`; default `claude-code`). Multi-agent runs are atomic: any conflict aborts before anything is written. `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
 | `ccwf preview <file>` | Open a read-only viewer (Mermaid + per-node Markdown panes) in a local browser. Auto-reloads when the file changes. |
 | `ccwf canvas <file>` | (Experimental) Open the **full editable** cc-wf-studio canvas in a local browser. Saves write back to the same file. |
@@ -89,6 +89,8 @@ Example `.mcp.json`:
 ccwf export ./my-workflow.json                                # --agent claude-code (default)
 ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex into a different root
+ccwf export ./my-workflow.json --agent codex --agent gemini    # several agents in one run
+ccwf export ./my-workflow.json --agent all                     # every supported target at once
 ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
 ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
 ccwf export ./my-workflow.json --json                          # machine-readable result on stdout
@@ -97,6 +99,8 @@ ccwf export ./my-workflow.json --dry-run --json                # machine-readabl
 
 Re-running an export is idempotent: existing files whose content already matches are reported as up to date and skipped. Only files with *different* content are conflicts that require `--overwrite`.
 
+`--agent` is repeatable (de-duped, first-mention order) and accepts `all` to expand to every supported target. With more than one agent the run is **atomic**: every agent's plan is checked against the disk first, and any conflict (without `--overwrite`) aborts the whole export before a single file is written (conflict lines are prefixed `[agent]`). Per-agent summaries are `[agent]`-prefixed, followed by a total line; target-compatibility warnings print as `warning: [agent] …`. With exactly one agent, all output is identical to earlier single-agent versions.
+
 `--dry-run` prints every planned file with its status — `new`, `up to date`, or `conflict: exists with different content` (shown as `would overwrite` when combined with `--overwrite`) — and writes nothing. The exit code mirrors what a real run would do: 0 means the export would succeed, 1 means it would stop on conflicts.
 
 `--json` prints a machine-readable result to stdout for CI scripting (exit codes unchanged; target-compatibility warnings move into the payload instead of stderr; file paths are relative to `root`):
@@ -104,6 +108,12 @@ Re-running an export is idempotent: existing files whose content already matches
 - Real run, success (exit 0): `{ "ok": true, "root", "agent", "written": [...], "upToDate": [...], "slashName", "warnings": [...] }`
 - Real run, conflict without `--overwrite` (exit 1): `{ "ok": false, "root", "agent", "conflicts": [...], "warnings": [...] }`
 - With `--dry-run`: `{ "ok", "dryRun": true, "root", "agent", "files": [{ "path", "status": "new" | "up-to-date" | "conflict" }], "warnings": [...] }` — statuses are the raw classification (a `conflict` stays `conflict` even with `--overwrite`); `ok` mirrors the exit code, i.e. whether a real run would succeed.
+
+With more than one agent, the single-agent keys are replaced by an `agents` array plus a `resultsByAgent` map (same exit-code rules):
+
+- Real run, success: `{ "ok": true, "root", "agents": [...], "resultsByAgent": { "<agent>": { "written", "upToDate", "warnings" } }, "slashName" }`
+- Real run, conflict: `{ "ok": false, "root", "agents": [...], "resultsByAgent": { "<agent>": { "conflicts", "warnings" } } }` — every requested agent appears, non-conflicting ones with an empty `conflicts` array.
+- With `--dry-run`: `{ "ok", "dryRun": true, "root", "agents": [...], "resultsByAgent": { "<agent>": { "files": [{ "path", "status" }], "warnings" } } }`
 
 Load errors (missing/unparseable `<file>`) keep their usual stderr message and exit codes in `--json` mode.
 

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -104,6 +104,8 @@ Materialise the workflow as **Agent Skill files** for a target agent. Pure file 
 ccwf export ./my-workflow.json                                 # --agent claude-code (default)
 ccwf export ./my-workflow.json --agent cursor                  # cursor
 ccwf export ./my-workflow.json --agent codex --cwd /tmp/proj   # codex, custom output root
+ccwf export ./my-workflow.json --agent codex --agent gemini    # several agents in one run
+ccwf export ./my-workflow.json --agent all                     # every supported target at once
 ccwf export ./my-workflow.json --overwrite                     # replace files whose content changed
 ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
 ccwf export ./my-workflow.json --json                          # machine-readable result on stdout
@@ -111,6 +113,8 @@ ccwf export ./my-workflow.json --dry-run --json                # machine-readabl
 ```
 
 Re-running an export is idempotent: existing files whose content already matches are skipped as up to date; only files with different content require `--overwrite`.
+
+`--agent` is repeatable (de-duped) and accepts `all` for every supported target. Multi-agent runs are atomic: every agent's plan is preflighted first and any conflict (without `--overwrite`) aborts before anything is written; human output uses `[agent]` prefixes and `--json` payloads replace the single-agent keys with `agents` + `resultsByAgent: { <agent>: { written, upToDate, warnings } }` (`conflicts` per agent on failure, `files` per agent with `--dry-run`). One agent keeps the exact single-agent output.
 
 `--dry-run` lists every planned file with its status — `new`, `up to date`, or `conflict: exists with different content` (`would overwrite` when combined with `--overwrite`) — and writes nothing. The exit code mirrors a real run: 0 means the export would succeed, 1 means it would stop on conflicts. Use it to check what an export touches before running it for real.
 
@@ -213,6 +217,7 @@ Use this as a lookup when the user describes intent in natural language. If the 
 | "Is this workflow valid?", "壊れてない?", "schema 確認して"                          | `ccwf validate <file>`                       |
 | "Export as a Claude Skill / agent file", "skills 化して"                            | `ccwf export <file>` (default agent)         |
 | "Convert for Cursor / Codex / Gemini …"                                            | `ccwf export <file> --agent <name>`          |
+| "Export for all my agents / every target at once"                                   | `ccwf export <file> --agent all`             |
 | "Run this workflow", "動かして", "実行して"                                          | `ccwf run <file> --launch`                   |
 | "Edit the canvas without VSCode", "editor を browser で開いて"                       | `ccwf canvas <file>` (mention experimental)  |
 | "Let an MCP client edit this workflow"                                              | `ccwf mcp --file <file>` and configure `.mcp.json` |

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -8,6 +8,13 @@
  * copilot / cursor / gemini / roo-code) use `planAgentSkillFiles`, which
  * emits the provider's own `<root>/skills/<workflow>/SKILL.md` (plus
  * `.cursor/agents/*.md` for Cursor).
+ *
+ * `--agent` is repeatable and accepts `all` (every supported target). With
+ * exactly one agent, all output — human, `--json`, `--dry-run` — is
+ * byte-identical to the historical single-agent behaviour. With several,
+ * the run is atomic across agents (any conflict without `--overwrite`
+ * aborts before anything is written), human lines are `[agent]`-prefixed,
+ * and JSON payloads carry `resultsByAgent` instead of the single-agent keys.
  */
 
 import * as fs from 'node:fs/promises';
@@ -119,6 +126,28 @@ function parseAgentOption(value: string): SupportedAgent {
   throw new InvalidArgumentError(`Expected one of: ${SUPPORTED_AGENTS.join(', ')}.`);
 }
 
+/**
+ * Repeatable `--agent` accumulator shared by `ccwf export` and `ccwf
+ * validate`: each occurrence appends one agent, `all` appends every
+ * supported target. De-duped, first-mention order preserved.
+ */
+export function collectAgentListOption(
+  value: string,
+  previous: SupportedAgent[] | undefined
+): SupportedAgent[] {
+  if (value !== 'all' && !(SUPPORTED_AGENTS as readonly string[]).includes(value)) {
+    throw new InvalidArgumentError(`Expected one of: ${SUPPORTED_AGENTS.join(', ')}, all.`);
+  }
+  const parsed = value === 'all' ? SUPPORTED_AGENTS : [value as SupportedAgent];
+  const next = previous ? [...previous] : [];
+  for (const agent of parsed) {
+    if (!next.includes(agent)) {
+      next.push(agent);
+    }
+  }
+  return next;
+}
+
 function resolvePlanned(rootDir: string, file: PlannedExportFile): string {
   return path.join(rootDir, ...file.relativePath.split('/'));
 }
@@ -196,15 +225,9 @@ export function reportExportPreview(preview: ExportPreviewResult, overwrite: boo
   process.stdout.write('Dry run — no files were written.\n');
   process.stdout.write(`Would export ${preview.entries.length} file(s) into ${preview.rootDir}:\n`);
   for (const entry of preview.entries) {
-    const note =
-      entry.status === 'new'
-        ? 'new'
-        : entry.status === 'up-to-date'
-          ? 'up to date'
-          : overwrite
-            ? 'would overwrite'
-            : 'conflict: exists with different content';
-    process.stdout.write(`  - ${path.relative(preview.rootDir, entry.absPath)} (${note})\n`);
+    process.stdout.write(
+      `  - ${path.relative(preview.rootDir, entry.absPath)} (${previewNote(entry.status, overwrite)})\n`
+    );
   }
   if (conflictCount > 0 && !overwrite) {
     process.stderr.write(
@@ -212,6 +235,17 @@ export function reportExportPreview(preview: ExportPreviewResult, overwrite: boo
     );
     process.exit(1);
   }
+}
+
+/** Human annotation for one planned file in a `--dry-run` listing. */
+function previewNote(status: PlannedFileStatus, overwrite: boolean): string {
+  return status === 'new'
+    ? 'new'
+    : status === 'up-to-date'
+      ? 'up to date'
+      : overwrite
+        ? 'would overwrite'
+        : 'conflict: exists with different content';
 }
 
 /**
@@ -315,8 +349,252 @@ export function asSupportedAgent(value: string): SupportedAgent {
   return parseAgentOption(value);
 }
 
-interface CommanderExportOptions {
+/** One agent's slice of a multi-agent export: its warnings and planned files. */
+interface AgentPlanBundle {
   agent: SupportedAgent;
+  warnings: string[];
+  plan: PlannedExportFile[];
+}
+
+/**
+ * Load the workflow once and plan every requested agent's file set.
+ * Cross-agent path collisions cannot occur: each provider plans under its
+ * own root (`.claude/`, `.codex/`, `.github/skills/`, `.cursor/`,
+ * `.gemini/`, `.roo/`, `.agent/`).
+ */
+async function planForAgents(
+  file: string,
+  agents: SupportedAgent[],
+  cwd: string | undefined,
+  emitWarnings: boolean
+): Promise<{ slashName: string; rootDir: string; bundles: AgentPlanBundle[] }> {
+  const { workflow } = await loadWorkflowFromFile(file);
+  const rootDir = path.resolve(cwd ?? process.cwd());
+  const bundles: AgentPlanBundle[] = agents.map((agent) => ({
+    agent,
+    warnings: collectAgentCompatibilityWarnings(workflow, agent),
+    plan:
+      agent === CLAUDE_CODE_AGENT
+        ? planWorkflowExportFiles(workflow)
+        : planAgentSkillFiles(workflow, agent as AgentSkillProvider),
+  }));
+  if (emitWarnings) {
+    for (const bundle of bundles) {
+      for (const warning of bundle.warnings) {
+        process.stderr.write(`warning: [${bundle.agent}] ${warning}\n`);
+      }
+    }
+  }
+  return { slashName: nodeNameToFileName(workflow.name), rootDir, bundles };
+}
+
+/**
+ * `--dry-run` with several agents: per-agent file listing (human) or a
+ * per-agent `resultsByAgent` payload (`--json`). Exit code mirrors a real
+ * run, exactly like the single-agent preview.
+ */
+async function previewMultiExport(
+  file: string,
+  agents: SupportedAgent[],
+  options: CommanderExportOptions
+): Promise<void> {
+  const { rootDir, bundles } = await planForAgents(file, agents, options.cwd, !options.json);
+  const classified: { bundle: AgentPlanBundle; entries: ClassifiedPlanEntry[] }[] = [];
+  for (const bundle of bundles) {
+    classified.push({ bundle, entries: await classifyPlan(rootDir, bundle.plan) });
+  }
+  const conflictCount = classified.reduce(
+    (sum, c) => sum + c.entries.filter((e) => e.status === 'conflict').length,
+    0
+  );
+  const ok = conflictCount === 0 || options.overwrite;
+
+  if (options.json) {
+    printJson({
+      ok,
+      dryRun: true,
+      root: rootDir,
+      agents,
+      resultsByAgent: Object.fromEntries(
+        classified.map((c) => [
+          c.bundle.agent,
+          {
+            files: c.entries.map((entry) => ({
+              path: path.relative(rootDir, entry.absPath),
+              status: entry.status,
+            })),
+            warnings: c.bundle.warnings,
+          },
+        ])
+      ),
+    });
+    if (!ok) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  const totalFiles = classified.reduce((sum, c) => sum + c.entries.length, 0);
+  process.stdout.write('Dry run — no files were written.\n');
+  process.stdout.write(
+    `Would export ${totalFiles} file(s) for ${agents.length} agent(s) into ${rootDir}:\n`
+  );
+  for (const c of classified) {
+    process.stdout.write(`[${c.bundle.agent}]\n`);
+    for (const entry of c.entries) {
+      process.stdout.write(
+        `  - ${path.relative(rootDir, entry.absPath)} (${previewNote(entry.status, options.overwrite)})\n`
+      );
+    }
+  }
+  if (!ok) {
+    process.stderr.write(
+      `error: export would fail: ${conflictCount} file(s) already exist with different content. Pass --overwrite to replace them.\n`
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Real export for several agents. Atomic across agents: every agent's plan
+ * is classified before anything is written, so a conflict in any target
+ * (without `--overwrite`) aborts the whole run with zero files touched.
+ */
+async function runMultiExport(
+  file: string,
+  agents: SupportedAgent[],
+  options: CommanderExportOptions
+): Promise<void> {
+  const { slashName, rootDir, bundles } = await planForAgents(
+    file,
+    agents,
+    options.cwd,
+    !options.json
+  );
+
+  // Same contract as the single-agent run: --overwrite skips classification
+  // entirely and rewrites every planned file.
+  const unchangedByAgent = new Map<SupportedAgent, Set<string>>();
+  if (!options.overwrite) {
+    const conflicts: { agent: SupportedAgent; absPath: string }[] = [];
+    for (const bundle of bundles) {
+      const classified = await classifyPlan(rootDir, bundle.plan);
+      unchangedByAgent.set(
+        bundle.agent,
+        new Set(classified.filter((e) => e.status === 'up-to-date').map((e) => e.absPath))
+      );
+      for (const entry of classified) {
+        if (entry.status === 'conflict') {
+          conflicts.push({ agent: bundle.agent, absPath: entry.absPath });
+        }
+      }
+    }
+    if (conflicts.length > 0) {
+      if (options.json) {
+        printJson({
+          ok: false,
+          root: rootDir,
+          agents,
+          resultsByAgent: Object.fromEntries(
+            bundles.map((bundle) => [
+              bundle.agent,
+              {
+                conflicts: conflicts
+                  .filter((c) => c.agent === bundle.agent)
+                  .map((c) => path.relative(rootDir, c.absPath)),
+                warnings: bundle.warnings,
+              },
+            ])
+          ),
+        });
+        process.exit(1);
+      }
+      process.stderr.write(
+        `error: ${conflicts.length} file(s) already exist with different content. Pass --overwrite to replace them:\n`
+      );
+      for (const conflict of conflicts) {
+        process.stderr.write(`  - [${conflict.agent}] ${conflict.absPath}\n`);
+      }
+      process.exit(1);
+    }
+  }
+
+  const ensuredDirs = new Set<string>();
+  const perAgent: {
+    agent: SupportedAgent;
+    written: string[];
+    upToDate: string[];
+    warnings: string[];
+  }[] = [];
+  for (const bundle of bundles) {
+    const unchanged = unchangedByAgent.get(bundle.agent) ?? new Set<string>();
+    const written: string[] = [];
+    for (const planned of bundle.plan) {
+      const absPath = resolvePlanned(rootDir, planned);
+      if (unchanged.has(absPath)) continue;
+      const dir = path.dirname(absPath);
+      if (!ensuredDirs.has(dir)) {
+        await fs.mkdir(dir, { recursive: true });
+        ensuredDirs.add(dir);
+      }
+      await fs.writeFile(absPath, planned.contents, 'utf-8');
+      written.push(absPath);
+    }
+    perAgent.push({
+      agent: bundle.agent,
+      written,
+      upToDate: [...unchanged],
+      warnings: bundle.warnings,
+    });
+  }
+
+  if (options.json) {
+    printJson({
+      ok: true,
+      root: rootDir,
+      agents,
+      resultsByAgent: Object.fromEntries(
+        perAgent.map((result) => [
+          result.agent,
+          {
+            written: toRootRelative(rootDir, result.written),
+            upToDate: toRootRelative(rootDir, result.upToDate),
+            warnings: result.warnings,
+          },
+        ])
+      ),
+      slashName,
+    });
+    return;
+  }
+
+  let totalWritten = 0;
+  let totalUpToDate = 0;
+  for (const result of perAgent) {
+    totalWritten += result.written.length;
+    totalUpToDate += result.upToDate.length;
+    if (result.written.length > 0 || result.upToDate.length === 0) {
+      process.stdout.write(`[${result.agent}] ✓ Wrote ${result.written.length} file(s):\n`);
+      for (const writtenPath of result.written) {
+        process.stdout.write(`  - ${path.relative(rootDir, writtenPath)}\n`);
+      }
+      if (result.upToDate.length > 0) {
+        process.stdout.write(`  (${result.upToDate.length} file(s) already up to date)\n`);
+      }
+    } else {
+      process.stdout.write(
+        `[${result.agent}] ✓ All ${result.upToDate.length} file(s) already up to date; nothing to write.\n`
+      );
+    }
+  }
+  const upToDateSuffix = totalUpToDate > 0 ? `, ${totalUpToDate} already up to date` : '';
+  process.stdout.write(
+    `✓ Exported for ${agents.length} agent(s) into ${rootDir}: ${totalWritten} file(s) written${upToDateSuffix}.\n`
+  );
+}
+
+interface CommanderExportOptions {
+  agent?: SupportedAgent[];
   overwrite: boolean;
   dryRun: boolean;
   json: boolean;
@@ -366,11 +644,10 @@ export function registerExportCommand(program: Command): void {
       'Materialise a workflow as agent-skill files (.claude/agents + .claude/skills for Claude Code, <root>/skills for other agents).'
     )
     .argument('<file>', 'Path to a workflow JSON file.')
-    .option<SupportedAgent>(
+    .option<SupportedAgent[]>(
       '--agent <name>',
-      `Target agent. One of: ${SUPPORTED_AGENTS.join(', ')}. roo-code targets Zoo Code, the maintained fork of the sunset Roo Code.`,
-      parseAgentOption,
-      CLAUDE_CODE_AGENT
+      `Target agent(s) (repeatable; one of: ${SUPPORTED_AGENTS.join(', ')}, or 'all' for every target). Defaults to claude-code. roo-code targets Zoo Code, the maintained fork of the sunset Roo Code.`,
+      collectAgentListOption
     )
     .option('--overwrite', 'Overwrite existing files instead of erroring.', false)
     .option(
@@ -388,18 +665,31 @@ export function registerExportCommand(program: Command): void {
       'Output root. Defaults to process.cwd(). Useful for tests / scripted runs.'
     )
     .action(async (file: string, options: CommanderExportOptions) => {
+      const agents = options.agent ?? [CLAUDE_CODE_AGENT];
+      const singleAgent = agents.length === 1 ? agents[0] : undefined;
       try {
+        // More than one agent: dedicated per-agent reporting. Exactly one
+        // agent keeps the historical single-agent output, byte-identical.
+        if (singleAgent === undefined) {
+          if (options.dryRun) {
+            await previewMultiExport(file, agents, options);
+          } else {
+            await runMultiExport(file, agents, options);
+          }
+          return;
+        }
+
         if (options.dryRun) {
           const preview = await previewExport(
             {
               file,
-              agent: options.agent,
+              agent: singleAgent,
               cwd: options.cwd,
             },
             !options.json
           );
           if (options.json) {
-            reportExportPreviewJson(preview, options.agent, options.overwrite);
+            reportExportPreviewJson(preview, singleAgent, options.overwrite);
           } else {
             reportExportPreview(preview, options.overwrite);
           }
@@ -409,7 +699,7 @@ export function registerExportCommand(program: Command): void {
         const result = await runExport(
           {
             file,
-            agent: options.agent,
+            agent: singleAgent,
             overwrite: options.overwrite,
             cwd: options.cwd,
           },
@@ -420,7 +710,7 @@ export function registerExportCommand(program: Command): void {
           printJson({
             ok: true,
             root: result.rootDir,
-            agent: options.agent,
+            agent: singleAgent,
             written: toRootRelative(result.rootDir, result.writtenPaths),
             upToDate: toRootRelative(result.rootDir, result.unchangedPaths),
             slashName: result.slashName,
@@ -436,7 +726,7 @@ export function registerExportCommand(program: Command): void {
             printJson({
               ok: false,
               root: error.rootDir,
-              agent: options.agent,
+              agent: singleAgent,
               conflicts: toRootRelative(error.rootDir, error.conflictPaths),
               warnings: error.warnings,
             });

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -28,12 +28,13 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { type ValidationError, validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
-import { Command, InvalidArgumentError } from 'commander';
+import { Command } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
 import {
   SUPPORTED_AGENTS,
   type SupportedAgent,
   collectAgentCompatibilityWarnings,
+  collectAgentListOption,
 } from './export.js';
 
 interface ValidateOptions {
@@ -57,27 +58,6 @@ type FileReport =
       valid: false;
       loadError: string;
     };
-
-/**
- * Repeatable `--agent` accumulator: each occurrence appends one agent, `all`
- * appends every supported target. De-duped, first-mention order preserved.
- */
-function parseValidateAgent(
-  value: string,
-  previous: SupportedAgent[] | undefined
-): SupportedAgent[] {
-  if (value !== 'all' && !(SUPPORTED_AGENTS as readonly string[]).includes(value)) {
-    throw new InvalidArgumentError(`Expected one of: ${SUPPORTED_AGENTS.join(', ')}, all.`);
-  }
-  const parsed = value === 'all' ? SUPPORTED_AGENTS : [value as SupportedAgent];
-  const next = previous ? [...previous] : [];
-  for (const agent of parsed) {
-    if (!next.includes(agent)) {
-      next.push(agent);
-    }
-  }
-  return next;
-}
 
 function formatError(err: ValidationError): string {
   const fieldSuffix = err.field ? ` (field: ${err.field})` : '';
@@ -203,7 +183,7 @@ export function registerValidateCommand(program: Command): void {
     .option<SupportedAgent[]>(
       '--agent <name>',
       `Also preflight target compatibility for one or more agents (repeatable; one of: ${SUPPORTED_AGENTS.join(', ')}, or 'all' for every target): report which configured fields each target ignores, without writing files. Warnings do not affect the exit code unless --strict is passed.`,
-      parseValidateAgent
+      collectAgentListOption
     )
     .option(
       '--strict',


### PR DESCRIPTION
## Summary

`ccwf export --agent` is now repeatable and accepts `all`, so a user can materialise a workflow for several agents in one run — `ccwf export wf.json --agent all` or `--agent codex --agent gemini` — with a single **atomic** conflict check, instead of re-running export once per target.

Closes #919

## Changes

- `--agent` uses the same repeatable/`all` accumulator as `ccwf validate` (de-duped, first-mention order); the parser moved to `export.ts` as `collectAgentListOption` and validate now shares it (behavior byte-identical, same error message).
- **Single agent (incl. default `claude-code`): every output — human, `--json`, `--dry-run` — is byte-identical to before.**
- Multi-agent real run is atomic: every agent's plan is classified before any write, so a conflict without `--overwrite` aborts with zero files touched (conflict lines prefixed `[agent]`, exit 1). Cross-agent collisions are impossible — each provider plans under its own root.
- Multi-agent human output: `[agent]`-prefixed per-agent summaries plus a total line; warnings follow validate's `warning: [agent] …` convention.
- Multi-agent `--json`: single-agent keys are replaced by `agents` + `resultsByAgent: { <agent>: { written, upToDate, warnings } }` (success), `{ conflicts, warnings }` per agent on failure (all requested agents present), and `{ files: [{path, status}], warnings }` with `--dry-run`. `ok` mirrors the exit code; stderr stays at 0 bytes in JSON mode.
- `ccwf run` keeps its single-agent contract.
- Docs: cli README (subcommand table, export section, JSON shapes) and ccwf-cli SKILL.md (incl. a phrasing-table row for "export for all my agents").
- Changeset: minor bump for `@cc-wf-studio/cli` (`.changeset/export-multi-agent.md`).

## Testing

Manual E2E, 17 cases against the built CLI: single-agent human/JSON parity; multi fresh + idempotent rerun; `--agent all` writing all 7 targets (incl. cursor's 3 files); atomic conflict (human + JSON — conflicting gemini blocked codex from being written); dry-run mixed statuses human/JSON with disk untouched; `--dry-run --overwrite` exit 0; `--overwrite` repair; dedupe `codex codex all` order; bad agent name exit 1; default-agent JSON keeps the `agent` key; `ccwf run` regression; missing file exit 2; `ccwf validate` regression after the shared-parser refactor.

`pnpm build && pnpm check` pass from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuhdwnqWonpxi5EV1GYvhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuhdwnqWonpxi5EV1GYvhy)_