### PR TITLE
feat(cli): add --agent to ccwf render for target-phrased instructions

### DIFF
--- a/.changeset/render-agent-instructions.md
+++ b/.changeset/render-agent-instructions.md
@@ -1,0 +1,11 @@
+---
+'@cc-wf-studio/core': minor
+'@cc-wf-studio/cli': minor
+---
+
+`ccwf render --agent <name>` phrases the execution instructions for the chosen
+target agent (codex, cursor, gemini, copilot, antigravity, roo-code) — the same
+wording `ccwf export --agent <name>` writes into that agent's SKILL.md — and
+reports the agent's target-compatibility warnings on stderr. Default output is
+unchanged. Core now exports `generateAgentExecutionInstructions` (the
+instructions section of `generateAgentSkillContent`, extracted).

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,42 @@ Entry format:
 
 ---
 
+## 2026-07-23 — `ccwf render --agent` phrases instructions per target agent
+- **User value**: a user rendering a workflow bundle for a non-Claude agent
+  (codex, cursor, gemini, copilot, antigravity, roo-code) now gets execution
+  instructions phrased for that agent's tools — identical to the instructions
+  section of the SKILL.md `ccwf export --agent <name>` would write — plus the
+  same target-compatibility warnings, instead of always Claude Code wording.
+- **Issue/PR**: #921 / PR from `claude/render-agent-instructions`
+- **Outcome**: done — `--agent <name>` (single value, same vocabulary as
+  validate/export, default `claude-code`) selects the provider for the md
+  format's execution-instructions section. Core gained
+  `generateAgentExecutionInstructions(workflow, agent, options)` — the
+  provider/options selection extracted from `generateAgentSkillContent`
+  (which now calls it; SKILL.md output byte-identical, cursor's
+  sub-agent-flow options preserved). When the flag is passed explicitly
+  (`getOptionValueSource === 'cli'`), the same warnings `ccwf validate
+  --agent` reports print to stderr in any format (never affecting exit code
+  or stdout); a plain `ccwf render` stays byte-identical on both streams.
+  `-f mermaid` stdout is agent-agnostic and unchanged by `--agent`. Docs:
+  cli README (subcommand table + render section) and ccwf-cli SKILL.md
+  (render section + phrasing-table row). E2E: 12 cases against the built
+  CLI (default stderr-empty, `--agent claude-code` stdout identical to
+  default, codex output differs with `spawn_agent`/`ask_user_question`
+  wording, codex + cursor instruction parity vs exported SKILL.md sections,
+  warnings byte-parity with `ccwf validate --agent codex`, mermaid stdout
+  identical with/without `--agent`, bad agent name clean exit 1, `-o` with
+  `--agent`, missing file exit 2). Issue #921 could not be locked (no `gh`,
+  no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - `-` / stdin input for `ccwf validate` and `ccwf render` so generators can
+    pipe workflow JSON without temp files.
+  - MCP `export_workflow` tool for file-mode servers (design needed: write
+    safety, root resolution) — parity with `ccwf export`.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-23 — `ccwf export` materialises several agents in one run
 - **User value**: a user exporting a workflow to several AI agents can now
   materialise files for all of them in one command — `ccwf export wf.json

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ pnpm add -D @cc-wf-studio/cli
 
 | Command | Description |
 |---|---|
-| `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). |
+| `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). `--agent <name>` phrases the execution instructions for that target agent and reports its target-compatibility warnings. |
 | `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for one or more target agents (`--agent <name>`, repeatable, or `--agent all`; default `claude-code`). Multi-agent runs are atomic: any conflict aborts before anything is written. `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
@@ -35,7 +35,10 @@ pnpm add -D @cc-wf-studio/cli
 ccwf render ./.vscode/workflows/my-workflow.json            # Markdown (default)
 ccwf render ./.vscode/workflows/my-workflow.json -f mermaid # ```mermaid block only
 ccwf render ./.vscode/workflows/my-workflow.json -o out.md  # write to a file instead of stdout
+ccwf render ./.vscode/workflows/my-workflow.json --agent codex # instructions phrased for Codex
 ```
+
+`--agent <name>` (one of `claude-code`, `antigravity`, `codex`, `copilot`, `cursor`, `gemini`, `roo-code`; default `claude-code`) phrases the execution-instructions section for that agent's tools — the same wording `ccwf export --agent <name>` writes into the agent's `SKILL.md`. When the flag is passed it also prints the target-compatibility warnings `ccwf validate --agent <name>` would report (stderr only; never affects the exit code or the rendered stdout). The Mermaid diagram is agent-agnostic, so `-f mermaid` output is unchanged by `--agent`.
 
 ### `ccwf validate`
 

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -46,9 +46,12 @@ Print a Markdown bundle (Mermaid flowchart + per-node execution instructions) to
 ccwf render ./.vscode/workflows/my-workflow.json             # Markdown (default)
 ccwf render ./.vscode/workflows/my-workflow.json -f mermaid  # ```mermaid block only
 ccwf render ./.vscode/workflows/my-workflow.json -o out.md   # write to a file instead of stdout
+ccwf render ./.vscode/workflows/my-workflow.json --agent codex # instructions phrased for Codex
 ```
 
 Output is the same content `ccwf preview` shows in the right pane.
+
+`--agent <name>` (one of `claude-code`, `antigravity`, `codex`, `copilot`, `cursor`, `gemini`, `roo-code`; default `claude-code`) phrases the execution instructions for that agent — the same wording `ccwf export --agent <name>` puts in the agent's `SKILL.md` — and prints that agent's target-compatibility warnings to stderr (exit code unaffected). `-f mermaid` output is agent-agnostic.
 
 ### `ccwf validate <paths...>`
 
@@ -214,6 +217,7 @@ Use this as a lookup when the user describes intent in natural language. If the 
 |------------------------------------------------------------------------------------|----------------------------------------------|
 | "Show me / preview this workflow", "見せて", "可視化して"                          | `ccwf preview <file>`                        |
 | "Render this as Markdown", "Mermaid 図にして"                                       | `ccwf render <file>`                         |
+| "Show the instructions as Cursor / Codex would see them"                            | `ccwf render <file> --agent <name>`          |
 | "Is this workflow valid?", "壊れてない?", "schema 確認して"                          | `ccwf validate <file>`                       |
 | "Export as a Claude Skill / agent file", "skills 化して"                            | `ccwf export <file>` (default agent)         |
 | "Convert for Cursor / Codex / Gemini …"                                            | `ccwf export <file> --agent <name>`          |

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -5,20 +5,36 @@
  * guide), suitable for pasting into a PR description or README. `--format=mermaid`
  * outputs only the Mermaid `flowchart` source, intended for piping into
  * `mermaid-cli` or similar.
+ *
+ * `--agent <name>` phrases the execution instructions for that target agent —
+ * the same wording `ccwf export --agent <name>` writes into the agent's
+ * SKILL.md — instead of the default Claude Code phrasing. When the flag is
+ * passed explicitly, the same target-compatibility warnings `ccwf validate
+ * --agent` reports are printed to stderr (they never affect the exit code or
+ * the stdout render). The Mermaid diagram itself is agent-agnostic, so
+ * `--format=mermaid` output is unaffected by `--agent`.
  */
 
 import * as fs from 'node:fs/promises';
 import { Command, InvalidArgumentError } from 'commander';
 import {
+  generateAgentExecutionInstructions,
   generateExecutionInstructions,
   generateMermaidFlowchart,
 } from '@cc-wf-studio/core';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import {
+  SUPPORTED_AGENTS,
+  type SupportedAgent,
+  asSupportedAgent,
+  collectAgentCompatibilityWarnings,
+} from './export.js';
 
 type RenderFormat = 'mermaid' | 'md';
 
 interface RenderOptions {
   format: RenderFormat;
+  agent: SupportedAgent;
   output?: string;
 }
 
@@ -38,10 +54,26 @@ export function registerRenderCommand(program: Command): void {
       },
       'md'
     )
+    .option<SupportedAgent>(
+      '--agent <name>',
+      `Phrase the execution instructions for this target agent (one of: ${SUPPORTED_AGENTS.join(', ')}). Defaults to claude-code. Also reports the same target-compatibility warnings as ccwf validate --agent (stderr, never affects the exit code). The Mermaid diagram is agent-agnostic.`,
+      (value) => asSupportedAgent(value),
+      'claude-code'
+    )
     .option('-o, --output <file>', 'Write output to this file instead of stdout.')
-    .action(async (file: string, options: RenderOptions) => {
+    .action(async (file: string, options: RenderOptions, command: Command) => {
       try {
         const { workflow } = await loadWorkflowFromFile(file);
+        const agent = options.agent;
+
+        // Warnings only when --agent was passed explicitly: a plain
+        // `ccwf render` keeps its historical stdout/stderr byte-for-byte.
+        if (command.getOptionValueSource('agent') === 'cli') {
+          for (const warning of collectAgentCompatibilityWarnings(workflow, agent)) {
+            process.stderr.write(`warning: ${warning}\n`);
+          }
+        }
+
         // generateMermaidFlowchart already returns a fenced ```mermaid block.
         const mermaidBlock = generateMermaidFlowchart(workflow);
 
@@ -49,9 +81,10 @@ export function registerRenderCommand(program: Command): void {
         if (options.format === 'mermaid') {
           rendered = `${mermaidBlock}\n`;
         } else {
-          const execution = generateExecutionInstructions(workflow, {
-            provider: 'claude-code',
-          });
+          const execution =
+            agent === 'claude-code'
+              ? generateExecutionInstructions(workflow, { provider: 'claude-code' })
+              : generateAgentExecutionInstructions(workflow, agent);
           const title = `# ${workflow.name || 'Workflow'}`;
           const descriptionBlock = workflow.description ? `\n${workflow.description}\n` : '\n';
           rendered = `${title}\n${descriptionBlock}\n${mermaidBlock}\n\n${execution}\n`;

--- a/packages/core/src/services/agent-skill-export.ts
+++ b/packages/core/src/services/agent-skill-export.ts
@@ -83,6 +83,26 @@ function defaultSkillDescription(workflow: Workflow): string {
 }
 
 /**
+ * Generate the execution-instructions Markdown for a given non-Claude agent,
+ * phrased for that agent's tools — exactly the instructions section that
+ * `generateAgentSkillContent` embeds in the exported SKILL.md.
+ */
+export function generateAgentExecutionInstructions(
+  workflow: Workflow,
+  agent: AgentSkillProvider,
+  options?: AgentSkillExportOptions
+): string {
+  const spec = AGENT_SKILL_SPECS[agent];
+  return generateExecutionInstructions(workflow, {
+    provider: spec.exportProvider,
+    highlightEnabled: options?.highlightEnabled,
+    ...(spec.passSubAgentFlowsToInstructions
+      ? { parentWorkflowName: nodeNameToFileName(workflow.name), subAgentFlows: workflow.subAgentFlows }
+      : {}),
+  });
+}
+
+/**
  * Generate the `SKILL.md` body for a given non-Claude agent.
  *
  * Identical structure across providers (YAML frontmatter + Mermaid +
@@ -94,7 +114,6 @@ export function generateAgentSkillContent(
   agent: AgentSkillProvider,
   options?: AgentSkillExportOptions
 ): string {
-  const spec = AGENT_SKILL_SPECS[agent];
   const skillName = nodeNameToFileName(workflow.name);
   const description = workflow.metadata?.description || defaultSkillDescription(workflow);
 
@@ -108,13 +127,7 @@ description: ${description}
     connections: workflow.connections,
   });
 
-  const instructions = generateExecutionInstructions(workflow, {
-    provider: spec.exportProvider,
-    highlightEnabled: options?.highlightEnabled,
-    ...(spec.passSubAgentFlowsToInstructions
-      ? { parentWorkflowName: skillName, subAgentFlows: workflow.subAgentFlows }
-      : {}),
-  });
+  const instructions = generateAgentExecutionInstructions(workflow, agent, options);
 
   const body = `# ${workflow.name}
 


### PR DESCRIPTION
## Summary

`ccwf render` always phrased its execution-instructions section for Claude Code (`provider: 'claude-code'` hard-coded), even when the user is targeting another agent. This PR adds `--agent <name>` — the same flag vocabulary `ccwf validate` and `ccwf export` already use — so the rendered instructions match what the chosen agent's exported SKILL.md would contain.

Closes #921

## Changes

- **cli**: `ccwf render --agent <name>` (single value, one of `claude-code`, `antigravity`, `codex`, `copilot`, `cursor`, `gemini`, `roo-code`; default `claude-code`). In `md` format the execution instructions are phrased for that agent's tools. When the flag is passed explicitly, the same target-compatibility warnings `ccwf validate --agent` reports are printed to stderr (any format, never affecting exit code or stdout). A plain `ccwf render` stays byte-identical on both streams; `-f mermaid` stdout is agent-agnostic and unchanged.
- **core**: extracted `generateAgentExecutionInstructions(workflow, agent, options)` from `generateAgentSkillContent`, which now calls it — exported SKILL.md output is byte-identical, including cursor's sub-agent-flow instruction options.
- **docs**: cli README (subcommand table + render section) and ccwf-cli SKILL.md (render section + phrasing-table row).
- **changeset**: minor for `@cc-wf-studio/core` and `@cc-wf-studio/cli`.

## E2E (built CLI, 12 cases)

- default render: exit 0, stderr empty (byte-identical default preserved)
- `--agent claude-code`: stdout identical to default
- `--agent codex`: output differs with codex wording (`spawn_agent`, `ask_user_question`)
- codex instruction parity: render section == exported `.codex/.../SKILL.md` "Execution Instructions" section (worktree sample)
- cursor instruction parity: same check, exercising `passSubAgentFlowsToInstructions`
- warnings byte-parity with `ccwf validate --agent codex` (3 warnings on the worktree sample)
- `-f mermaid` stdout identical with/without `--agent`; warnings still on stderr
- bad agent name: clean commander error, exit 1
- `-o` with `--agent gemini`: file written, exit 0
- missing file: exit 2

`pnpm build && pnpm check` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_015DDHpTrKKeSyqCkpF34xzk)_