### PR TITLE
feat(cli): add stdin input ('-') to ccwf validate and ccwf render

### DIFF
--- a/.changeset/stdin-input-validate-render.md
+++ b/.changeset/stdin-input-validate-render.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": minor
+---
+
+`ccwf validate` and `ccwf render` now accept `-` to read the workflow JSON from stdin (reported as `<stdin>`), so generated workflows can be checked or rendered in a pipe without a temp file. Works alongside regular files/dirs and all existing flags; an interactive TTY fails fast instead of hanging.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,39 @@ Entry format:
 
 ---
 
+## 2026-07-23 — stdin input (`-`) for `ccwf validate` and `ccwf render`
+- **User value**: a user — or a script/AI agent that just generated workflow
+  JSON — can now pipe it straight into `ccwf validate -` / `ccwf render -`
+  (standard Unix `-` convention) instead of writing a temp file first.
+- **Issue/PR**: #923 / PR from `claude/sleepy-curie-vli55d`
+- **Outcome**: done — `-` reads one workflow JSON document from stdin,
+  reported as `<stdin>` everywhere a path would appear; the `{ meta,
+  workflow }` wrapper is honoured, exit codes are unchanged (2 on invalid
+  JSON / empty stream / not-a-workflow, 1 on schema errors), and an
+  interactive TTY fails fast with a friendly error instead of hanging.
+  `validate` accepts `-` mixed with files/dirs (repeated `-` de-dupes to a
+  single stdin read) and composes with `--json` / `--agent` / `--strict`;
+  `render` composes with `-f mermaid`, `--agent`, `-o`. Loader logic shared
+  via `parseWorkflowSource` + `loadWorkflowFromStdin` in
+  `packages/cli/src/utils/load-workflow.ts` — file behavior byte-identical.
+  Docs: cli README (subcommand table + render/validate sections) and
+  ccwf-cli SKILL.md (sections + phrasing-table row). E2E: 14 cases against
+  the built CLI (stdin/file parity for validate `--json` and render md,
+  invalid/empty/non-workflow stdin, wrapper unwrap, mixed `- file -`
+  dedupe, `--agent codex` and `--agent all --strict`, mermaid + `-o`
+  variants, schema-invalid exit 1, missing-file regressions). `ccwf
+  export` / `run` intentionally out of scope (they write files). Issue #923
+  could not be locked (no `gh`, no MCP lock tool — known limitation, noted
+  in the issue).
+- **Next proposals**:
+  - MCP `export_workflow` tool for file-mode servers (design needed: write
+    safety, root resolution) — parity with `ccwf export`.
+  - `ccwf export -` / `ccwf run -` stdin input for symmetry, if piped
+    generate-then-materialise proves to be a real flow — judge value first.
+  - Manual E2E queue (carried): align/distribute + context menu +
+    copy/cut/paste in real webviews; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-23 — `ccwf render --agent` phrases instructions per target agent
 - **User value**: a user rendering a workflow bundle for a non-Claude agent
   (codex, cursor, gemini, copilot, antigravity, roo-code) now gets execution

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,8 +18,8 @@ pnpm add -D @cc-wf-studio/cli
 
 | Command | Description |
 |---|---|
-| `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). `--agent <name>` phrases the execution instructions for that target agent and reports its target-compatibility warnings. |
-| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`). Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
+| `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). `<file>` may be `-` to read the workflow JSON from stdin. `--agent <name>` phrases the execution instructions for that target agent and reports its target-compatibility warnings. |
+| `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`); `-` reads workflow JSON from stdin. Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
 | `ccwf export <file>` | Materialise the workflow as agent-skill files for one or more target agents (`--agent <name>`, repeatable, or `--agent all`; default `claude-code`). Multi-agent runs are atomic: any conflict aborts before anything is written. `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
 | `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
@@ -36,7 +36,10 @@ ccwf render ./.vscode/workflows/my-workflow.json            # Markdown (default)
 ccwf render ./.vscode/workflows/my-workflow.json -f mermaid # ```mermaid block only
 ccwf render ./.vscode/workflows/my-workflow.json -o out.md  # write to a file instead of stdout
 ccwf render ./.vscode/workflows/my-workflow.json --agent codex # instructions phrased for Codex
+cat my-workflow.json | ccwf render -                        # read the workflow from stdin
 ```
+
+`<file>` may be `-` to read the workflow JSON from stdin — handy when another tool generates the workflow and you want to see it without a temp file. Errors are reported against `<stdin>` with the usual exit codes.
 
 `--agent <name>` (one of `claude-code`, `antigravity`, `codex`, `copilot`, `cursor`, `gemini`, `roo-code`; default `claude-code`) phrases the execution-instructions section for that agent's tools — the same wording `ccwf export --agent <name>` writes into the agent's `SKILL.md`. When the flag is passed it also prints the target-compatibility warnings `ccwf validate --agent <name>` would report (stderr only; never affects the exit code or the rendered stdout). The Mermaid diagram is agent-agnostic, so `-f mermaid` output is unchanged by `--agent`.
 
@@ -45,6 +48,9 @@ ccwf render ./.vscode/workflows/my-workflow.json --agent codex # instructions ph
 ```sh
 ccwf validate ./.vscode/workflows/my-workflow.json          # exit 0/1
 ccwf validate ./.vscode/workflows/my-workflow.json --json   # prints { valid, errors[] }
+cat my-workflow.json | ccwf validate -                      # read workflow JSON from stdin
+# ^ '-' reads a single workflow from stdin (reported as <stdin>); it can be
+#   mixed with regular files/dirs and works with --json / --agent / --strict
 ccwf validate ./.vscode/workflows                           # every *.json under the directory
 # ^ per-file report + summary line; also accepts several files/dirs at once.
 #   Exit 0 only if every file passes (1 = schema errors, 2 = unreadable file);

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -47,19 +47,21 @@ ccwf render ./.vscode/workflows/my-workflow.json             # Markdown (default
 ccwf render ./.vscode/workflows/my-workflow.json -f mermaid  # ```mermaid block only
 ccwf render ./.vscode/workflows/my-workflow.json -o out.md   # write to a file instead of stdout
 ccwf render ./.vscode/workflows/my-workflow.json --agent codex # instructions phrased for Codex
+cat my-workflow.json | ccwf render -                         # read the workflow from stdin
 ```
 
-Output is the same content `ccwf preview` shows in the right pane.
+Output is the same content `ccwf preview` shows in the right pane. `<file>` may be `-` to read the workflow JSON from stdin — useful when generating a workflow and rendering it in one pipe, no temp file needed (errors are reported against `<stdin>`).
 
 `--agent <name>` (one of `claude-code`, `antigravity`, `codex`, `copilot`, `cursor`, `gemini`, `roo-code`; default `claude-code`) phrases the execution instructions for that agent — the same wording `ccwf export --agent <name>` puts in the agent's `SKILL.md` — and prints that agent's target-compatibility warnings to stderr (exit code unaffected). `-f mermaid` output is agent-agnostic.
 
 ### `ccwf validate <paths...>`
 
-Schema-check workflow JSON files — any mix of files and directories (directories are searched recursively for `*.json`, skipping `node_modules` and dot-directories).
+Schema-check workflow JSON files — any mix of files and directories (directories are searched recursively for `*.json`, skipping `node_modules` and dot-directories). `-` reads a single workflow JSON document from stdin (reported as `<stdin>`), so a freshly generated workflow can be checked without writing a temp file.
 
 ```bash
 ccwf validate ./.vscode/workflows/my-workflow.json           # exit 0/1, human-readable errors on stderr
 ccwf validate ./.vscode/workflows/my-workflow.json --json    # prints { valid, errors[] }
+cat my-workflow.json | ccwf validate -                       # read workflow JSON from stdin
 ccwf validate ./.vscode/workflows                            # every *.json under the dir, per-file report + summary
 ccwf validate ./my-workflow.json --agent codex               # + target-compatibility warnings for codex
 ccwf validate ./my-workflow.json --agent all                 # + warnings for every supported target at once
@@ -219,6 +221,7 @@ Use this as a lookup when the user describes intent in natural language. If the 
 | "Render this as Markdown", "Mermaid 図にして"                                       | `ccwf render <file>`                         |
 | "Show the instructions as Cursor / Codex would see them"                            | `ccwf render <file> --agent <name>`          |
 | "Is this workflow valid?", "壊れてない?", "schema 確認して"                          | `ccwf validate <file>`                       |
+| "Check / render this workflow I just generated" (no file yet)                       | pipe the JSON: `... \| ccwf validate -` / `... \| ccwf render -` |
 | "Export as a Claude Skill / agent file", "skills 化して"                            | `ccwf export <file>` (default agent)         |
 | "Convert for Cursor / Codex / Gemini …"                                            | `ccwf export <file> --agent <name>`          |
 | "Export for all my agents / every target at once"                                   | `ccwf export <file> --agent all`             |

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -4,7 +4,8 @@
  * Default format is `md` (Markdown bundle: title + Mermaid block + execution
  * guide), suitable for pasting into a PR description or README. `--format=mermaid`
  * outputs only the Mermaid `flowchart` source, intended for piping into
- * `mermaid-cli` or similar.
+ * `mermaid-cli` or similar. `<file>` may be `-` to read the workflow JSON
+ * from stdin (errors are then labelled `<stdin>`; exit codes unchanged).
  *
  * `--agent <name>` phrases the execution instructions for that target agent —
  * the same wording `ccwf export --agent <name>` writes into the agent's
@@ -22,7 +23,11 @@ import {
   generateExecutionInstructions,
   generateMermaidFlowchart,
 } from '@cc-wf-studio/core';
-import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import {
+  WorkflowLoadError,
+  loadWorkflowFromFile,
+  loadWorkflowFromStdin,
+} from '../utils/load-workflow.js';
 import {
   SUPPORTED_AGENTS,
   type SupportedAgent,
@@ -41,8 +46,10 @@ interface RenderOptions {
 export function registerRenderCommand(program: Command): void {
   program
     .command('render')
-    .description('Render a workflow JSON as Mermaid + execution Markdown to stdout.')
-    .argument('<file>', 'Path to a workflow JSON file.')
+    .description(
+      "Render a workflow JSON as Mermaid + execution Markdown to stdout. '-' reads the workflow from stdin."
+    )
+    .argument('<file>', "Path to a workflow JSON file, or '-' to read from stdin.")
     .option<RenderFormat>(
       '-f, --format <format>',
       'Output format: "md" (default) or "mermaid".',
@@ -63,7 +70,8 @@ export function registerRenderCommand(program: Command): void {
     .option('-o, --output <file>', 'Write output to this file instead of stdout.')
     .action(async (file: string, options: RenderOptions, command: Command) => {
       try {
-        const { workflow } = await loadWorkflowFromFile(file);
+        const { workflow } =
+          file === '-' ? await loadWorkflowFromStdin() : await loadWorkflowFromFile(file);
         const agent = options.agent;
 
         // Warnings only when --agent was passed explicitly: a plain

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -3,6 +3,9 @@
  *
  * Accepts any mix of files and directories; a directory expands to every
  * `*.json` under it (recursive, skipping `node_modules` and dot-directories).
+ * `-` reads a single workflow JSON document from stdin (reported as
+ * `<stdin>`), so generators can pipe output straight in without a temp file;
+ * repeated `-` arguments collapse to one stdin read.
  * Default output is a per-file report (errors on stderr) plus a summary line
  * when more than one file is checked; exit 0 when every file passes, 1 on
  * validation failure, 2 when a file cannot be read/parsed. `--json` prints a
@@ -29,7 +32,12 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { type ValidationError, validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
 import { Command } from 'commander';
-import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import {
+  STDIN_LABEL,
+  WorkflowLoadError,
+  loadWorkflowFromFile,
+  loadWorkflowFromStdin,
+} from '../utils/load-workflow.js';
 import {
   SUPPORTED_AGENTS,
   type SupportedAgent,
@@ -94,6 +102,12 @@ async function collectJsonFiles(dir: string, out: string[]): Promise<void> {
 async function expandPaths(inputs: string[]): Promise<string[]> {
   const files: string[] = [];
   for (const input of inputs) {
+    // '-' is stdin, not a filesystem path; keep it verbatim (the final
+    // de-dup collapses repeated '-' so stdin is only consumed once).
+    if (input === '-') {
+      files.push(input);
+      continue;
+    }
     const absolute = path.resolve(input);
     let stats: Awaited<ReturnType<typeof fs.stat>>;
     try {
@@ -117,11 +131,12 @@ async function expandPaths(inputs: string[]): Promise<string[]> {
 
 async function validateFile(file: string, agents: SupportedAgent[]): Promise<FileReport> {
   let workflow: Awaited<ReturnType<typeof loadWorkflowFromFile>>['workflow'];
+  const label = file === '-' ? STDIN_LABEL : file;
   try {
-    ({ workflow } = await loadWorkflowFromFile(file));
+    ({ workflow } = file === '-' ? await loadWorkflowFromStdin() : await loadWorkflowFromFile(file));
   } catch (error) {
     if (error instanceof WorkflowLoadError) {
-      return { file, valid: false, loadError: error.message };
+      return { file: label, valid: false, loadError: error.message };
     }
     throw error;
   }
@@ -131,7 +146,7 @@ async function validateFile(file: string, agents: SupportedAgent[]): Promise<Fil
   const collect = (agent: SupportedAgent): string[] =>
     result.valid ? collectAgentCompatibilityWarnings(workflow, agent) : [];
   return {
-    file,
+    file: label,
     valid: result.valid,
     errors: result.errors,
     // Exactly one agent keeps the stable single-agent `warnings` shape;
@@ -176,9 +191,12 @@ export function registerValidateCommand(program: Command): void {
   program
     .command('validate')
     .description(
-      'Validate workflow JSON files against the cc-wf-studio schema. Accepts files and/or directories (directories are searched recursively for *.json).'
+      "Validate workflow JSON files against the cc-wf-studio schema. Accepts files and/or directories (directories are searched recursively for *.json); '-' reads workflow JSON from stdin."
     )
-    .argument('<paths...>', 'Workflow JSON files and/or directories containing them.')
+    .argument(
+      '<paths...>',
+      "Workflow JSON files and/or directories containing them; '-' reads from stdin."
+    )
     .option('--json', 'Print the machine-readable result JSON to stdout.', false)
     .option<SupportedAgent[]>(
       '--agent <name>',

--- a/packages/cli/src/utils/load-workflow.ts
+++ b/packages/cli/src/utils/load-workflow.ts
@@ -1,5 +1,5 @@
 /**
- * Read a workflow JSON file from disk and parse it.
+ * Read a workflow JSON file from disk (or stdin) and parse it.
  *
  * Used by every subcommand that takes a `<file>` argument. Errors are wrapped
  * so commander can surface a stable exit code (2) with a friendly stderr line
@@ -31,6 +31,31 @@ function looksLikeWorkflow(value: unknown): value is Workflow {
   );
 }
 
+function parseWorkflowSource(raw: string, sourceLabel: string): Workflow {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new WorkflowLoadError(
+      `Invalid JSON in ${sourceLabel}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (looksLikeWorkflow(parsed)) {
+    return parsed;
+  }
+  // Sample/share files wrap the workflow: { meta: {...}, workflow: {...} }
+  const wrapped =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as { workflow?: unknown }).workflow
+      : undefined;
+  if (looksLikeWorkflow(wrapped)) {
+    return wrapped;
+  }
+  throw new WorkflowLoadError(
+    `${sourceLabel} does not look like a workflow file: expected a top-level "nodes" array or a { meta, workflow } wrapper`
+  );
+}
+
 export async function loadWorkflowFromFile(filePath: string): Promise<{
   workflow: Workflow;
   absolutePath: string;
@@ -48,26 +73,40 @@ export async function loadWorkflowFromFile(filePath: string): Promise<{
       `Failed to read ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`
     );
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
+  return { workflow: parseWorkflowSource(raw, absolutePath), absolutePath };
+}
+
+/** Label used wherever a file path would appear in reports and error messages. */
+export const STDIN_LABEL = '<stdin>';
+
+/**
+ * Read a workflow JSON document from stdin (the `-` argument convention).
+ *
+ * Refuses to read from an interactive terminal — a bare `ccwf validate -`
+ * with nothing piped in would otherwise hang waiting for input forever.
+ */
+export async function loadWorkflowFromStdin(): Promise<{
+  workflow: Workflow;
+  absolutePath: string;
+}> {
+  if (process.stdin.isTTY) {
     throw new WorkflowLoadError(
-      `Invalid JSON in ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`
+      `No input on stdin: '-' expects workflow JSON piped in (e.g. \`cat wf.json | ccwf validate -\`).`
     );
   }
-  if (looksLikeWorkflow(parsed)) {
-    return { workflow: parsed, absolutePath };
+  const chunks: Buffer[] = [];
+  try {
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+  } catch (error) {
+    throw new WorkflowLoadError(
+      `Failed to read stdin: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
-  // Sample/share files wrap the workflow: { meta: {...}, workflow: {...} }
-  const wrapped =
-    typeof parsed === 'object' && parsed !== null
-      ? (parsed as { workflow?: unknown }).workflow
-      : undefined;
-  if (looksLikeWorkflow(wrapped)) {
-    return { workflow: wrapped, absolutePath };
+  const raw = Buffer.concat(chunks).toString('utf-8');
+  if (raw.trim() === '') {
+    throw new WorkflowLoadError('No input on stdin: received an empty stream.');
   }
-  throw new WorkflowLoadError(
-    `${absolutePath} does not look like a workflow file: expected a top-level "nodes" array or a { meta, workflow } wrapper`
-  );
+  return { workflow: parseWorkflowSource(raw, STDIN_LABEL), absolutePath: STDIN_LABEL };
 }


### PR DESCRIPTION
## Summary

`ccwf validate` and `ccwf render` now accept `-` as an input argument, reading the workflow JSON from stdin — so a script or AI agent that just generated a workflow can check or render it in one pipe, without writing a temp file:

```sh
some-generator | ccwf validate -
cat wf.json | ccwf render - --agent codex
```

Closes #923

## Changes

- `packages/cli/src/utils/load-workflow.ts`: extracted the JSON-parse + `{ meta, workflow }` unwrap logic into `parseWorkflowSource`, added `loadWorkflowFromStdin()` (label `<stdin>`, exit-code contract unchanged: 2 on invalid JSON / empty stream / not-a-workflow). An interactive TTY fails fast with a friendly `error:` line instead of hanging forever. File loading is byte-identical to before.
- `packages/cli/src/commands/validate.ts`: `-` is accepted among `<paths...>`, kept out of filesystem resolution, de-duplicated (repeated `-` reads stdin once), and reported as `<stdin>` in human and `--json` output. Composes with files/dirs, `--json`, `--agent` (incl. `all`), and `--strict`.
- `packages/cli/src/commands/render.ts`: `<file>` may be `-`; `-f mermaid`, `--agent`, `-o` all unchanged.
- Docs: cli README (subcommand table + render/validate sections), bundled ccwf-cli SKILL.md (sections + phrasing-table row).
- Changeset: minor bump for `@cc-wf-studio/cli`.

`ccwf export` / `ccwf run` are intentionally out of scope (they write files; possible follow-up noted in the idea issue).

## Testing

- `pnpm build && pnpm check` from the repo root — green.
- Manual E2E, 14 cases against the built CLI: stdin/file byte-parity for `validate --json` and `render` md output; invalid JSON / empty stream / non-workflow stdin (exit 2, `<stdin>` label); `{ meta, workflow }` wrapper unwrap; mixed `- file -` run with de-dupe and summary line; `--agent codex`, `--agent all --strict` (exit 0 with no warnings); `render - -f mermaid`, `render - --agent codex`, `render - -o out.md`; schema-invalid stdin workflow → exit 1; missing-file regressions for both commands unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPksGi5KsWqmdSxcsBRit

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtPksGi5KsWqmdSxcsBRit)_