### PR TITLE
feat(vscode): add in-canvas node search (Ctrl/Cmd+F)

### DIFF
--- a/.changeset/canvas-node-search.md
+++ b/.changeset/canvas-node-search.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": minor
+---
+
+Add in-canvas node search: Ctrl/Cmd+F (or the toolbar Search button) opens a find widget that matches nodes by name, content, and type, lists the matches, and jumps to each one — selecting it and centering the viewport, including nodes nested in groups.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,40 @@ Entry format:
 
 ---
 
+## 2026-07-24 — In-canvas node search (Ctrl/Cmd+F)
+- **User value**: a user editing a large workflow can now press Ctrl/Cmd+F
+  (or click the toolbar Search button), type part of a node's name, and jump
+  straight to it — the viewport centers on the match and selects it, with
+  Enter/↑↓ cycling matches and a clickable result list — instead of panning
+  across a big graph to find one node.
+- **Issue/PR**: #929 / PR from `claude/sleepy-curie-evbv0a`
+- **Outcome**: done — new `NodeSearchPanel` (top-center React Flow `Panel`)
+  + `SearchNodesButton` in `CanvasToolbar` (button hidden in the sub-agent
+  flow dialog, which shares the toolbar but has no search). Matching is
+  case-insensitive over display-name fields (`label`, `name`,
+  `questionText`, `toolName`, `description`), free text (`prompt`,
+  `executionPrompt`), and the node type; the result row shows the same
+  display name the node header renders. Jump selects only the match
+  (selection is excluded from undo/canvas-revision, so search never dirties
+  the workflow, verified in store partialize), syncs `selectedNodeId`
+  without force-opening the property overlay, and `setCenter`s on
+  `positionAbsolute` so group children land correctly. Ctrl/Cmd+F re-focuses
+  the open widget via a nonce; Esc closes; Delete/Backspace in the input is
+  safe (global handler skips editable targets, verified). i18n keys
+  (`canvasSearch.*`) added to all 5 locales per translation rules.
+  `pnpm build` + `pnpm check` green. Manual E2E not possible in this
+  unattended session — queued below. Issue #929 could not be locked (no
+  `gh`, no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - `ccwf export -` / `ccwf run -` stdin input for symmetry, if piped
+    generate-then-materialise proves to be a real flow — judge value first.
+  - Node search in the sub-agent flow dialog if users ask for it (same
+    panel, dialog-scoped ReactFlow instance).
+  - Manual E2E queue (carried): node search (Ctrl/Cmd+F, cycling, group
+    children centering) in a real webview; align/distribute + context menu
+    + copy/cut/paste; localized Claude API dialog in ja/ko/zh;
+    `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-24 — MCP `patch_workflow` tool for structural edits
 - **User value**: an AI agent editing a workflow via MCP (canvas or file
   mode) can now add or remove individual nodes and connections in one small

--- a/packages/vscode/src/webview/src/components/CanvasToolbar.tsx
+++ b/packages/vscode/src/webview/src/components/CanvasToolbar.tsx
@@ -11,17 +11,22 @@ import { HighlightToggle } from './HighlightToggle';
 import { InteractionModeToggle } from './InteractionModeToggle';
 import { MinimapToggle } from './MinimapToggle';
 import { ScrollModeToggle } from './ScrollModeToggle';
+import { SearchNodesButton } from './SearchNodesButton';
 import { StartTourButton } from './StartTourButton';
 import { UndoRedoControls } from './UndoRedoControls';
 
 interface CanvasToolbarProps {
   isEdgeAnimationEnabled: boolean;
   onToggleEdgeAnimation: () => void;
+  /** Opens the node search panel; omitted where search is unavailable
+   *  (e.g. the sub-agent flow dialog), which hides the button. */
+  onOpenSearch?: () => void;
 }
 
 export const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   isEdgeAnimationEnabled,
   onToggleEdgeAnimation,
+  onOpenSearch,
 }) => {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -31,6 +36,7 @@ export const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
       <EdgeAnimationToggle isEnabled={isEdgeAnimationEnabled} onToggle={onToggleEdgeAnimation} />
       <HighlightToggle />
       <MinimapToggle />
+      {onOpenSearch && <SearchNodesButton onClick={onOpenSearch} />}
       <StartTourButton />
     </div>
   );

--- a/packages/vscode/src/webview/src/components/NodeSearchPanel.tsx
+++ b/packages/vscode/src/webview/src/components/NodeSearchPanel.tsx
@@ -1,0 +1,313 @@
+/**
+ * Node Search Panel (canvas find widget)
+ *
+ * Opened with Ctrl/Cmd+F or the toolbar Search button. Matches nodes by
+ * their display name (label / name / question / tool), free-text content
+ * (prompt, description) and node type; the current match is selected on
+ * the canvas and the viewport centers on it. Enter / ↓ cycles forward,
+ * Shift+Enter / ↑ backward, Esc closes.
+ *
+ * Selection state is excluded from undo history and canvas-revision
+ * tracking (see workflow-store partialize), so searching never dirties
+ * the workflow.
+ */
+
+import { ChevronDown, ChevronUp, X } from 'lucide-react';
+import type React from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { type Node, useReactFlow } from 'reactflow';
+import { useTranslation } from '../i18n/i18n-context';
+import { useWorkflowStore } from '../stores/workflow-store';
+
+interface NodeSearchPanelProps {
+  /** Re-focus the input when this changes (Ctrl/Cmd+F while already open) */
+  focusNonce: number;
+  onClose: () => void;
+}
+
+/** Mirror of the node headers' display-name resolution, in priority order */
+function nodeDisplayName(node: Node): string {
+  const data = (node.data ?? {}) as Record<string, unknown>;
+  const str = (value: unknown): string | null =>
+    typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  return (
+    str(data.label) ??
+    str(data.name) ??
+    str(data.questionText) ??
+    str(data.toolName) ??
+    str(data.description) ??
+    node.type ??
+    node.id
+  );
+}
+
+/** Free-text fields worth searching beyond the display name */
+const CONTENT_FIELDS = [
+  'label',
+  'name',
+  'questionText',
+  'toolName',
+  'description',
+  'prompt',
+  'executionPrompt',
+] as const;
+
+function nodeSearchText(node: Node): string {
+  const data = (node.data ?? {}) as Record<string, unknown>;
+  const parts: string[] = [node.type ?? ''];
+  for (const field of CONTENT_FIELDS) {
+    const value = data[field];
+    if (typeof value === 'string') parts.push(value);
+  }
+  return parts.join('\n').toLowerCase();
+}
+
+const ICON_BUTTON_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '22px',
+  height: '22px',
+  padding: 0,
+  border: 'none',
+  borderRadius: '4px',
+  backgroundColor: 'transparent',
+  color: 'var(--vscode-foreground)',
+  cursor: 'pointer',
+};
+
+export const NodeSearchPanel: React.FC<NodeSearchPanelProps> = ({ focusNonce, onClose }) => {
+  const { t } = useTranslation();
+  const reactFlow = useReactFlow();
+  const nodes = useWorkflowStore((s) => s.nodes);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus (and select) the input on open and on repeated Ctrl/Cmd+F
+  // biome-ignore lint/correctness/useExhaustiveDependencies: focusNonce is the re-focus trigger, not read inside
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [focusNonce]);
+
+  const matches = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (trimmed.length === 0) return [];
+    return nodes.filter((node) => nodeSearchText(node).includes(trimmed));
+  }, [nodes, query]);
+
+  // Nodes can change while the panel is open (e.g. undo) — keep index valid
+  const safeIndex = matches.length === 0 ? 0 : Math.min(activeIndex, matches.length - 1);
+
+  /** Select the match on the canvas and center the viewport on it */
+  const jumpTo = (nodeId: string) => {
+    const { nodes: currentNodes, setNodes, syncSelectedNodeId } = useWorkflowStore.getState();
+    setNodes(currentNodes.map((n) => ({ ...n, selected: n.id === nodeId })));
+    syncSelectedNodeId(nodeId);
+    // getNode returns the internal node: positionAbsolute resolves group
+    // children, width/height are the measured dimensions
+    const internal = reactFlow.getNode(nodeId);
+    if (!internal) return;
+    const x = (internal.positionAbsolute?.x ?? internal.position.x) + (internal.width ?? 200) / 2;
+    const y = (internal.positionAbsolute?.y ?? internal.position.y) + (internal.height ?? 80) / 2;
+    reactFlow.setCenter(x, y, { zoom: Math.max(reactFlow.getZoom(), 0.8), duration: 300 });
+  };
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    setActiveIndex(0);
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed.length === 0) return;
+    const first = nodes.find((node) => nodeSearchText(node).includes(trimmed));
+    if (first) jumpTo(first.id);
+  };
+
+  const step = (delta: number) => {
+    if (matches.length === 0) return;
+    const next = (safeIndex + delta + matches.length) % matches.length;
+    setActiveIndex(next);
+    jumpTo(matches[next].id);
+  };
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key === 'Enter' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      step(event.key === 'Enter' && event.shiftKey ? -1 : 1);
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      step(-1);
+      return;
+    }
+    // Ctrl/Cmd+F while the input is focused: keep our widget, skip the
+    // browser's find (the global shortcut handler ignores editable targets)
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+      event.preventDefault();
+      inputRef.current?.select();
+    }
+  };
+
+  const showList = query.trim().length > 0 && matches.length > 0;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minWidth: '260px',
+        maxWidth: '320px',
+        backgroundColor: 'var(--vscode-editor-background)',
+        border: '1px solid var(--vscode-panel-border)',
+        borderRadius: '6px',
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.25)',
+        padding: '4px',
+        boxSizing: 'border-box',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          onKeyDown={handleInputKeyDown}
+          placeholder={t('canvasSearch.placeholder')}
+          aria-label={t('canvasSearch.tooltip')}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            height: '24px',
+            padding: '0 6px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border, transparent)',
+            borderRadius: '4px',
+            outline: 'none',
+            fontSize: '12px',
+            boxSizing: 'border-box',
+          }}
+        />
+        <span
+          aria-live="polite"
+          style={{
+            fontSize: '11px',
+            color: 'var(--vscode-descriptionForeground)',
+            whiteSpace: 'nowrap',
+            padding: '0 2px',
+          }}
+        >
+          {query.trim().length === 0
+            ? ''
+            : matches.length === 0
+              ? t('canvasSearch.noResults')
+              : `${safeIndex + 1} / ${matches.length}`}
+        </span>
+        <button
+          type="button"
+          onClick={() => step(-1)}
+          disabled={matches.length === 0}
+          aria-label={t('canvasSearch.previous')}
+          title={t('canvasSearch.previous')}
+          style={{ ...ICON_BUTTON_STYLE, opacity: matches.length === 0 ? 0.4 : 1 }}
+        >
+          <ChevronUp size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={() => step(1)}
+          disabled={matches.length === 0}
+          aria-label={t('canvasSearch.next')}
+          title={t('canvasSearch.next')}
+          style={{ ...ICON_BUTTON_STYLE, opacity: matches.length === 0 ? 0.4 : 1 }}
+        >
+          <ChevronDown size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('canvasSearch.close')}
+          title={t('canvasSearch.close')}
+          style={ICON_BUTTON_STYLE}
+        >
+          <X size={14} />
+        </button>
+      </div>
+      {showList && (
+        <div
+          style={{
+            marginTop: '4px',
+            maxHeight: '192px',
+            overflowY: 'auto',
+            borderTop: '1px solid var(--vscode-panel-border)',
+            paddingTop: '4px',
+          }}
+        >
+          {matches.map((node, index) => {
+            const isActive = index === safeIndex;
+            return (
+              <div
+                key={node.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  setActiveIndex(index);
+                  jumpTo(node.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setActiveIndex(index);
+                    jumpTo(node.id);
+                  }
+                }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '8px',
+                  padding: '3px 6px',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  backgroundColor: isActive
+                    ? 'var(--vscode-list-activeSelectionBackground)'
+                    : 'transparent',
+                  color: isActive
+                    ? 'var(--vscode-list-activeSelectionForeground)'
+                    : 'var(--vscode-foreground)',
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: '12px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {nodeDisplayName(node)}
+                </span>
+                <span
+                  style={{
+                    fontSize: '10px',
+                    opacity: 0.7,
+                    whiteSpace: 'nowrap',
+                    fontFamily: 'var(--vscode-editor-font-family, monospace)',
+                  }}
+                >
+                  {node.type}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/vscode/src/webview/src/components/SearchNodesButton.tsx
+++ b/packages/vscode/src/webview/src/components/SearchNodesButton.tsx
@@ -1,0 +1,59 @@
+/**
+ * Search Nodes Button (canvas toolbar)
+ *
+ * Opens the node search panel (same as Ctrl/Cmd+F). Kept as a visible
+ * toolbar entry so the search feature is discoverable without knowing
+ * the shortcut.
+ */
+
+import { Search } from 'lucide-react';
+import type React from 'react';
+import { useTranslation } from '../i18n/i18n-context';
+import { StyledTooltipItem, StyledTooltipProvider } from './common/StyledTooltip';
+
+const ROUND_BUTTON_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: 'var(--vscode-editor-background)',
+  border: '1px solid var(--vscode-panel-border)',
+  borderRadius: '20px',
+  width: '34px',
+  height: '34px',
+  opacity: 0.85,
+  cursor: 'pointer',
+  boxSizing: 'border-box',
+};
+
+interface SearchNodesButtonProps {
+  onClick: () => void;
+}
+
+export const SearchNodesButton: React.FC<SearchNodesButtonProps> = ({ onClick }) => {
+  const { t } = useTranslation();
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+  const shortcut = isMac ? '⌘F' : 'Ctrl+F';
+  const tooltip = `${t('canvasSearch.tooltip')} (${shortcut})`;
+
+  return (
+    <StyledTooltipProvider>
+      <StyledTooltipItem content={tooltip}>
+        <div
+          onClick={onClick}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onClick();
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label={tooltip}
+          style={ROUND_BUTTON_STYLE}
+        >
+          <Search size={14} style={{ color: 'var(--vscode-foreground)' }} />
+        </div>
+      </StyledTooltipItem>
+    </StyledTooltipProvider>
+  );
+};

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -56,6 +56,7 @@ import { DescriptionPanel } from './DescriptionPanel';
 // Custom edge with delete button
 import { DeletableEdge } from './edges/DeletableEdge';
 import { MinimapContainer } from './MinimapContainer';
+import { NodeSearchPanel } from './NodeSearchPanel';
 import { AskUserQuestionNodeComponent } from './nodes/AskUserQuestionNode';
 import { BranchNodeComponent } from './nodes/BranchNode';
 import { BranchSessionNode } from './nodes/BranchSessionNode';
@@ -507,6 +508,15 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   // Track Ctrl/Cmd key state for temporary mode switching
   const [isModifierKeyPressed, setIsModifierKeyPressed] = useState(false);
 
+  // Node search panel (Ctrl/Cmd+F). The nonce re-focuses the input when
+  // the shortcut fires while the panel is already open.
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchFocusNonce, setSearchFocusNonce] = useState(0);
+  const openSearch = useCallback(() => {
+    setIsSearchOpen(true);
+    setSearchFocusNonce((nonce) => nonce + 1);
+  }, []);
+
   // Keyboard event handlers for modifier key and undo/redo
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -567,6 +577,10 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         if (key === 'a' && !event.shiftKey && !event.altKey) {
           event.preventDefault();
           selectAllOnCanvas();
+        }
+        if (key === 'f' && !event.shiftKey && !event.altKey) {
+          event.preventDefault();
+          openSearch();
         }
         if (key === 'z' && !event.shiftKey) {
           event.preventDefault();
@@ -676,7 +690,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       document.removeEventListener('cut', handleCut);
       document.removeEventListener('paste', handlePaste);
     };
-  }, []);
+  }, [openSearch]);
 
   // Minimap auto-show on scroll/pan/zoom (only for 'auto' mode)
   const minimapHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -996,8 +1010,19 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             <CanvasToolbar
               isEdgeAnimationEnabled={isEdgeAnimationEnabled}
               onToggleEdgeAnimation={() => setIsEdgeAnimationEnabled((prev) => !prev)}
+              onOpenSearch={openSearch}
             />
           </Panel>
+
+          {/* Node Search Panel (Ctrl/Cmd+F) */}
+          {isSearchOpen && (
+            <Panel position="top-center">
+              <NodeSearchPanel
+                focusNonce={searchFocusNonce}
+                onClose={() => setIsSearchOpen(false)}
+              />
+            </Panel>
+          )}
 
           {/* Description Panel for workflow description */}
           <Panel position="top-right">

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -406,6 +406,14 @@ export interface WebviewTranslationKeys {
   'contextMenu.distributeVertical': string;
   'announcement.dismiss': string;
 
+  // Canvas node search (Ctrl/Cmd+F)
+  'canvasSearch.tooltip': string;
+  'canvasSearch.placeholder': string;
+  'canvasSearch.noResults': string;
+  'canvasSearch.previous': string;
+  'canvasSearch.next': string;
+  'canvasSearch.close': string;
+
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': string;
   'dialog.deleteNode.message': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -426,6 +426,14 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.distributeVertical': 'Distribute vertically',
   'announcement.dismiss': 'Dismiss announcement',
 
+  // Canvas node search (Ctrl/Cmd+F)
+  'canvasSearch.tooltip': 'Search nodes',
+  'canvasSearch.placeholder': 'Search nodes…',
+  'canvasSearch.noResults': 'No results',
+  'canvasSearch.previous': 'Previous match',
+  'canvasSearch.next': 'Next match',
+  'canvasSearch.close': 'Close search',
+
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': 'Delete Node',
   'dialog.deleteNode.message': 'Are you sure you want to delete this node?',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -424,6 +424,14 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.distributeVertical': '上下に等間隔配置',
   'announcement.dismiss': 'お知らせを閉じる',
 
+  // Canvas node search (Ctrl/Cmd+F)
+  'canvasSearch.tooltip': 'ノードを検索',
+  'canvasSearch.placeholder': 'ノードを検索…',
+  'canvasSearch.noResults': '一致なし',
+  'canvasSearch.previous': '前の一致',
+  'canvasSearch.next': '次の一致',
+  'canvasSearch.close': '検索を閉じる',
+
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': 'ノードを削除',
   'dialog.deleteNode.message': 'このノードを削除してもよろしいですか？',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -423,6 +423,14 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.distributeVertical': '세로 균등 배치',
   'announcement.dismiss': '공지 닫기',
 
+  // Canvas node search (Ctrl/Cmd+F)
+  'canvasSearch.tooltip': '노드 검색',
+  'canvasSearch.placeholder': '노드 검색…',
+  'canvasSearch.noResults': '일치 항목 없음',
+  'canvasSearch.previous': '이전 일치 항목',
+  'canvasSearch.next': '다음 일치 항목',
+  'canvasSearch.close': '검색 닫기',
+
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '노드 삭제',
   'dialog.deleteNode.message': '이 노드를 삭제하시겠습니까?',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -410,6 +410,14 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.distributeVertical': '垂直均匀分布',
   'announcement.dismiss': '关闭公告',
 
+  // Canvas node search (Ctrl/Cmd+F)
+  'canvasSearch.tooltip': '搜索节点',
+  'canvasSearch.placeholder': '搜索节点…',
+  'canvasSearch.noResults': '无匹配项',
+  'canvasSearch.previous': '上一个匹配项',
+  'canvasSearch.next': '下一个匹配项',
+  'canvasSearch.close': '关闭搜索',
+
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '删除节点',
   'dialog.deleteNode.message': '确定要删除此节点吗？',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -412,6 +412,14 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'contextMenu.distributeVertical': '垂直均分',
   'announcement.dismiss': '關閉公告',
 
+  // Canvas node search (Ctrl/Cmd+F)
+  'canvasSearch.tooltip': '搜尋節點',
+  'canvasSearch.placeholder': '搜尋節點…',
+  'canvasSearch.noResults': '無符合項目',
+  'canvasSearch.previous': '上一個符合項目',
+  'canvasSearch.next': '下一個符合項目',
+  'canvasSearch.close': '關閉搜尋',
+
   // Delete Confirmation Dialog
   'dialog.deleteNode.title': '刪除節點',
   'dialog.deleteNode.message': '確定要刪除此節點嗎？',


### PR DESCRIPTION
## Summary

Adds a find widget to the workflow canvas: Ctrl/Cmd+F (or a new toolbar Search button) opens a search panel that matches nodes by display name, free-text content, and node type, lists the matches, and jumps to the current match — selecting it and centering the viewport on it, including nodes nested inside groups.

Closes #929

## User value

A user editing a large workflow no longer has to pan and scan the graph to find one node: type part of its name, hit Enter to cycle matches (Shift+Enter / ↑↓ backwards), or click a row in the result list to jump straight to it.

## Implementation notes

- **`NodeSearchPanel.tsx`** (new): rendered as a top-center React Flow `Panel`. Case-insensitive matching over the display-name fields the node headers render (`label`, `name`, `questionText`, `toolName`, `description`), free text (`prompt`, `executionPrompt`), and the node type. Counter (`n / m`), prev/next buttons, scrollable clickable result list showing display name + type.
- **Jump** selects only the match and centers via `setCenter` on the internal node's `positionAbsolute` (group children land correctly). Selection state is excluded from undo history and canvas-revision tracking (store `partialize`), so searching never dirties the workflow or pollutes undo. `syncSelectedNodeId` is used instead of `setSelectedNodeId` so the property overlay is not force-opened while cycling.
- **`SearchNodesButton.tsx`** (new): round toolbar button (same pattern as `StartTourButton`) with platform-aware shortcut in the tooltip, so the feature is discoverable without knowing the shortcut.
- **`WorkflowEditor.tsx`**: Ctrl/Cmd+F in the existing centralized keydown handler (skips editable targets like the other mod shortcuts); a focus nonce re-focuses/selects the input when the shortcut fires while the widget is already open; the input's own handler swallows Ctrl/Cmd+F so the browser find never appears. Esc closes. Delete/Backspace while typing is safe — the global delete handler already skips editable targets.
- **`CanvasToolbar.tsx`**: `onOpenSearch` is optional; the sub-agent flow dialog shares the toolbar but has no search, so the button is hidden there (out of scope for this PR).
- **i18n**: `canvasSearch.*` keys added to `translation-keys.ts` and all 5 locales (en/ja/ko/zh-CN/zh-TW) per `.claude/rules/translation.md`.
- Changeset: `cc-wf-studio` minor (`.changeset/canvas-node-search.md`).

## Verification

- `pnpm build` and `pnpm check` green from the repo root.
- Manual E2E in a real webview queued in `docs/progress-log.md` (unattended session): shortcut open/re-focus, match cycling, group-child centering, Esc/Backspace safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jt9nGdHdoEPPomLuA8bto

---
_Generated by [Claude Code](https://claude.ai/code/session_014jt9nGdHdoEPPomLuA8bto)_