### PR TITLE
improvement(vscode): mark problem nodes on the canvas while the Problems panel is open

### DIFF
--- a/.changeset/problem-node-canvas-markers.md
+++ b/.changeset/problem-node-canvas-markers.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Mark problem nodes directly on the canvas while the Workflow Problems panel is open: every node the panel points at gets a red ring and a ⚠ badge, cleared live as issues are fixed and removed entirely when the panel closes.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,42 @@ Entry format:
 
 ---
 
+## 2026-07-24 — On-canvas markers for problem nodes
+- **User value**: a user triaging validation failures can now see every
+  offending node marked with a red ring and a ⚠ badge directly on the
+  canvas while the Problems panel is open — instead of discovering broken
+  nodes one at a time by clicking Problems-panel rows; markers clear live
+  as issues are fixed and disappear when the panel closes (no permanent
+  visual noise — this answers the noise caveat the previous iteration
+  attached to this proposal).
+- **Issue/PR**: #935 / PR from `claude/sleepy-curie-aqjyio`
+- **Outcome**: done — the `collectWorkflowIssues` computation moved from
+  `WorkflowProblemsPanel` into `WorkflowEditor` (memoized, skipped entirely
+  while the panel is closed or a sub-agent flow is being edited), and the
+  panel now receives `issues` as a prop — one validation pass feeds both
+  the list and the markers. Nodes whose id appears in the issue list get a
+  `wf-problem-node` className injected into the React Flow node objects
+  (same display-mapping pattern as `animatedEdges`; store nodes carry no
+  className, verified). Marker styled in `styles/nodes.css` on the
+  `.react-flow__node` wrapper (red `--vscode-charts-red` outline + ⚠ badge
+  via `::after`, `pointer-events: none`), so every node type including
+  groups is covered without touching individual node components. No new
+  i18n keys (symbol-only badge). `pnpm build` + `pnpm check` green.
+  Manual E2E in a real webview queued below. Issue #935 could not be
+  locked (no `gh`, no MCP lock tool — known limitation, noted in the
+  issue).
+- **Next proposals**:
+  - Problems count badge on the toolbar Problems button while the panel is
+    closed — needs judging: it would cost a validation pass on every edit.
+  - `ccwf export -` / `ccwf run -` stdin input for symmetry, if piped
+    generate-then-materialise proves to be a real flow — judge value first.
+  - Manual E2E queue (carried): problem-node markers (open panel on failed
+    save → rings/badges on offending nodes incl. group children, live
+    clearing, close panel → markers gone); problems panel click-to-jump;
+    auto layout on a real messy workflow; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector in both modes.
+
 ## 2026-07-24 — Workflow Problems panel with click-to-jump
 - **User value**: a user whose save/export fails validation can now see
   every problem at once in a Problems panel on the canvas — and click any

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -49,6 +49,7 @@ import {
   type SelectionClipboardPayload,
   useWorkflowStore,
 } from '../stores/workflow-store';
+import { collectWorkflowIssues } from '../utils/workflow-issues';
 import { CanvasContextMenu, type CanvasContextMenuEntry } from './CanvasContextMenu';
 import { CanvasToolbar } from './CanvasToolbar';
 import { FeatureAnnouncementBanner } from './common/FeatureAnnouncementBanner';
@@ -539,6 +540,57 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const closeProblemsPanel = useCallback(() => {
     useWorkflowStore.getState().closeProblemsPanel();
   }, []);
+  const isProblemsPanelVisible = isProblemsPanelOpen && activeSubAgentFlowId === null;
+
+  // Validation issues for the problems panel and the on-canvas node markers.
+  // Computed here (not in the panel) so a single validation pass feeds both;
+  // skipped entirely while the panel is closed.
+  const workflowName = useWorkflowStore((state) => state.workflowName);
+  const workflowDescription = useWorkflowStore((state) => state.workflowDescription);
+  const subAgentFlows = useWorkflowStore((state) => state.subAgentFlows);
+  const slashCommandOptions = useWorkflowStore((state) => state.slashCommandOptions);
+  const workflowIssues = useMemo(
+    () =>
+      isProblemsPanelVisible
+        ? collectWorkflowIssues(
+            nodes,
+            edges,
+            workflowName,
+            workflowDescription || undefined,
+            subAgentFlows.length > 0 ? subAgentFlows : undefined,
+            slashCommandOptions
+          )
+        : [],
+    [
+      isProblemsPanelVisible,
+      nodes,
+      edges,
+      workflowName,
+      workflowDescription,
+      subAgentFlows,
+      slashCommandOptions,
+    ]
+  );
+
+  // Mark every node the problems panel points at with a red ring + badge
+  // (styles/nodes.css `.wf-problem-node`), so the user can see all offending
+  // nodes at a glance while the panel is open.
+  const displayNodes = useMemo(() => {
+    const problemNodeIds = new Set(
+      workflowIssues.flatMap((issue) => (issue.nodeId !== null ? [issue.nodeId] : []))
+    );
+    if (problemNodeIds.size === 0) {
+      return nodes;
+    }
+    return nodes.map((node) =>
+      problemNodeIds.has(node.id)
+        ? {
+            ...node,
+            className: node.className ? `${node.className} wf-problem-node` : 'wf-problem-node',
+          }
+        : node
+    );
+  }, [nodes, workflowIssues]);
 
   // Keyboard event handlers for modifier key and undo/redo
   useEffect(() => {
@@ -929,7 +981,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       {/* Canvas area */}
       <div ref={canvasContainerRef} style={{ flex: 1, position: 'relative' }}>
         <ReactFlow
-          nodes={nodes}
+          nodes={displayNodes}
           edges={animatedEdges}
           onInit={(instance) => {
             reactFlowInstanceRef.current = instance;
@@ -1050,9 +1102,9 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           )}
 
           {/* Workflow Problems Panel (all validation issues, click-to-jump) */}
-          {isProblemsPanelOpen && activeSubAgentFlowId === null && (
+          {isProblemsPanelVisible && (
             <Panel position="bottom-center">
-              <WorkflowProblemsPanel onClose={closeProblemsPanel} />
+              <WorkflowProblemsPanel issues={workflowIssues} onClose={closeProblemsPanel} />
             </Panel>
           )}
 

--- a/packages/vscode/src/webview/src/components/WorkflowProblemsPanel.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowProblemsPanel.tsx
@@ -5,8 +5,9 @@
  * core validator the MCP server and `ccwf validate` use — and lets the user
  * click a node-scoped issue to jump straight to the offending node. Opens
  * automatically when a save/export fails validation, or manually from the
- * canvas toolbar Problems button. The list re-validates live as the
- * workflow is edited, so issues disappear as they are fixed.
+ * canvas toolbar Problems button. The issue list is computed live in
+ * WorkflowEditor (one validation pass shared with the on-canvas node
+ * markers), so issues disappear as they are fixed.
  */
 
 import { CheckCircle2, X, XCircle } from 'lucide-react';
@@ -16,34 +17,20 @@ import { useReactFlow } from 'reactflow';
 import { useTranslation } from '../i18n/i18n-context';
 import { useWorkflowStore } from '../stores/workflow-store';
 import { jumpToNode, nodeDisplayName } from '../utils/canvas-navigation';
-import { collectWorkflowIssues } from '../utils/workflow-issues';
+import type { WorkflowIssue } from '../utils/workflow-issues';
 
 interface WorkflowProblemsPanelProps {
+  issues: WorkflowIssue[];
   onClose: () => void;
 }
 
-export const WorkflowProblemsPanel: React.FC<WorkflowProblemsPanelProps> = ({ onClose }) => {
+export const WorkflowProblemsPanel: React.FC<WorkflowProblemsPanelProps> = ({
+  issues,
+  onClose,
+}) => {
   const { t } = useTranslation();
   const reactFlow = useReactFlow();
   const nodes = useWorkflowStore((s) => s.nodes);
-  const edges = useWorkflowStore((s) => s.edges);
-  const workflowName = useWorkflowStore((s) => s.workflowName);
-  const workflowDescription = useWorkflowStore((s) => s.workflowDescription);
-  const subAgentFlows = useWorkflowStore((s) => s.subAgentFlows);
-  const slashCommandOptions = useWorkflowStore((s) => s.slashCommandOptions);
-
-  const issues = useMemo(
-    () =>
-      collectWorkflowIssues(
-        nodes,
-        edges,
-        workflowName,
-        workflowDescription || undefined,
-        subAgentFlows.length > 0 ? subAgentFlows : undefined,
-        slashCommandOptions
-      ),
-    [nodes, edges, workflowName, workflowDescription, subAgentFlows, slashCommandOptions]
-  );
 
   const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
 

--- a/packages/vscode/src/webview/src/styles/nodes.css
+++ b/packages/vscode/src/webview/src/styles/nodes.css
@@ -204,3 +204,36 @@
   outline: 2px solid var(--vscode-focusBorder);
   outline-offset: 2px;
 }
+
+/* ============================================================================
+   Problem node marker
+   Applied by WorkflowEditor (`wf-problem-node` on the React Flow node
+   wrapper) to every node the Workflow Problems panel points at, while the
+   panel is open. Styled on the wrapper so it works for every node type,
+   including groups, without touching individual node components.
+   ============================================================================ */
+
+.react-flow__node.wf-problem-node {
+  outline: 2px solid var(--vscode-charts-red, #ef4444);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.react-flow__node.wf-problem-node::after {
+  content: "⚠";
+  position: absolute;
+  top: -9px;
+  right: -9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 11px;
+  line-height: 1;
+  border-radius: 50%;
+  background: var(--vscode-charts-red, #ef4444);
+  color: #ffffff;
+  z-index: 10;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary

While the Workflow Problems panel is open, every node it points at is now marked directly on the canvas with a red ring and a small ⚠ badge. Markers clear live as issues are fixed and disappear entirely when the panel closes, so there is no permanent visual noise.

Closes #935

## User value

A user triaging a failed save/export can now see every offending node at a glance on the canvas, instead of discovering broken nodes one at a time by clicking Problems-panel rows. (This was queued as a next proposal by the Problems-panel iteration, #933; the visual-noise caveat raised there is answered by scoping the markers to while the panel is open.)

## Implementation notes

- The `collectWorkflowIssues` computation moved from `WorkflowProblemsPanel` into `WorkflowEditor` (memoized, skipped entirely while the panel is closed or a sub-agent flow is being edited); the panel now receives `issues` as a prop, so one validation pass feeds both the list and the markers.
- Nodes whose id appears in the issue list get a `wf-problem-node` className injected into the React Flow node objects passed to `<ReactFlow>` — the same display-mapping pattern as the existing `animatedEdges`; store nodes carry no className of their own (verified), so the injection cannot clobber anything.
- The marker is styled in `styles/nodes.css` on the `.react-flow__node` wrapper (red `--vscode-charts-red` outline + ⚠ badge via `::after`, `pointer-events: none`), covering every node type including groups without touching individual node components.
- No new i18n keys (symbol-only badge), no schema/API changes; webview-only.

## Checks

- `pnpm build` + `pnpm check` green from the repo root; the built webview bundles (extension and CLI-embedded) contain the new marker styles.
- Changeset: `cc-wf-studio` patch (`.changeset/problem-node-canvas-markers.md`).
- Manual E2E in a real webview queued in the progress log (open panel on failed save → rings/badges incl. group children, live clearing, markers gone on close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsHUHjTwym8VTZ56PhBhqj

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsHUHjTwym8VTZ56PhBhqj)_