### PR TITLE
feat(vscode): create a connected node by dropping an edge on empty canvas

### DIFF
--- a/.changeset/edge-drop-node-create.md
+++ b/.changeset/edge-drop-node-create.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": minor
+---
+
+Create a connected node by dropping an edge on empty canvas: drag a connection from a node's output handle, release it on the pane, and pick a node type from a small menu — the node is created at the drop point already wired to the source. Node + edge land as a single undo step; Escape or clicking away cancels.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,44 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Edge-drop node creation (drag a connection to empty canvas)
+- **User value**: a user extending a workflow can now drag a connection from
+  a node's output handle, release it on empty canvas, and pick a node type
+  from a small menu — the node is created at the drop point already wired to
+  the source — instead of adding from the palette, dragging into place, and
+  drawing the connection by hand.
+- **Issue/PR**: #937 / PR from `claude/sleepy-curie-av4v0s`
+- **Outcome**: done — `onConnectStart` records the source handle;
+  `onConnectEnd` detects a pane drop (`react-flow__pane` class), projects
+  the point to flow coordinates (snapped to the 15px grid), and opens a
+  picker reusing `CanvasContextMenu` as-is. Picker offers the dialog-free
+  types with their palette icons and existing `node.<type>.title` keys
+  (zero new i18n keys): Prompt, If/Else, Switch, Ask User Question, Branch
+  Session, End — the latter three hidden while editing a sub-agent flow,
+  matching the palette gating. Node defaults extracted from `NodePalette`'s
+  inline handlers into `utils/node-defaults.ts` (palette behavior
+  unchanged); new store action `addNodeWithConnection` adds node + edge in
+  one `set()` → one undo entry, selects the node and opens the property
+  overlay like `addNode`. Forward drags only; connection valid by
+  construction (new node is the target). `pnpm build` + `pnpm check`
+  green. **Browser E2E against the real webview** via `ccwf canvas` +
+  headless Chromium: picker appears with all 6 entries, Prompt pick creates
+  node + edge, single Ctrl+Z removes both, Escape cancels cleanly, dropping
+  on a node does not open the picker — all passed. Issue #937 could not be
+  locked (no `gh`, no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Fix the `ccwf canvas` boot race found while E2E-testing: on fast
+    localhost the server answers `WEBVIEW_READY` (sent right after
+    `root.render()`) before React's message listener attaches, leaving an
+    eternal spinner — resend `INITIAL_STATE`/`LOAD_WORKFLOW` on listener
+    attach, or delay the ready signal until after mount effects.
+  - Keyboard-shortcut cheat sheet overlay (many shortcuts now exist:
+    Ctrl+F/A/D/Z/C/X/V, Delete, context menu) — discoverability gap.
+  - Manual E2E queue (carried): problem-node markers; problems panel
+    click-to-jump; auto layout on a real messy workflow; node search
+    cycling; align/distribute + context menu + copy/cut/paste; localized
+    Claude API dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — On-canvas markers for problem nodes
 - **User value**: a user triaging validation failures can now see every
   offending node marked with a red ring and a ⚠ badge directly on the

--- a/packages/vscode/src/webview/src/components/NodePalette.tsx
+++ b/packages/vscode/src/webview/src/components/NodePalette.tsx
@@ -6,12 +6,7 @@
  */
 
 import type { BuiltInSubAgentType, SubAgentFlow } from '@cc-wf-studio/core';
-import {
-  BUILT_IN_SUB_AGENTS,
-  generateBranchId,
-  generateOptionId,
-  NodeType,
-} from '@cc-wf-studio/core';
+import { BUILT_IN_SUB_AGENTS, generateBranchId, NodeType } from '@cc-wf-studio/core';
 import type { CommandReference } from '@shared/types/messages';
 import {
   Bot,
@@ -34,6 +29,7 @@ import { useTranslation } from '../i18n/i18n-context';
 import { createSubAgent } from '../services/command-browser-service';
 import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
+import { createDefaultNode } from '../utils/node-defaults';
 import { BetaBadge } from './common/BetaBadge';
 import { CodexNodeDialog } from './dialogs/CodexNodeDialog';
 import { McpNodeDialog } from './dialogs/McpNodeDialog';
@@ -225,71 +221,22 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
 
   const handleAddAskUserQuestion = () => {
     const position = calculateNonOverlappingPosition(250, 300);
-    const newNode = {
-      id: `question-${Date.now()}`,
-      type: 'askUserQuestion' as const,
-      position,
-      data: {
-        questionText: t('default.newQuestion'),
-        options: [
-          {
-            id: generateOptionId(),
-            label: `${t('default.option')} 1`,
-            description: t('default.firstOption'),
-          },
-          {
-            id: generateOptionId(),
-            label: `${t('default.option')} 2`,
-            description: t('default.secondOption'),
-          },
-        ],
-        outputPorts: 2,
-      },
-    };
-    addNode(newNode);
+    addNode(createDefaultNode('askUserQuestion', position, t));
   };
 
   const handleAddPromptNode = () => {
     const position = calculateNonOverlappingPosition(350, 200);
-    const newNode = {
-      id: `prompt-${Date.now()}`,
-      type: 'prompt' as const,
-      position,
-      data: {
-        label: t('default.newPrompt'),
-        prompt: t('default.prompt'),
-        variables: {},
-      },
-    };
-    addNode(newNode);
+    addNode(createDefaultNode('prompt', position, t));
   };
 
   const handleAddBranchSessionNode = () => {
     const position = calculateNonOverlappingPosition(350, 200);
-    const newNode = {
-      id: `branch-session-${Date.now()}`,
-      type: 'branchSession' as const,
-      position,
-      data: {
-        label: t('default.newBranchSession'),
-        workDescription: '',
-        outputPorts: 1 as const,
-      },
-    };
-    addNode(newNode);
+    addNode(createDefaultNode('branchSession', position, t));
   };
 
   const handleAddEndNode = () => {
     const position = calculateNonOverlappingPosition(600, 200);
-    const newNode = {
-      id: `end_${Date.now()}`,
-      type: 'end' as const,
-      position,
-      data: {
-        label: 'End',
-      },
-    };
-    addNode(newNode);
+    addNode(createDefaultNode('end', position, t));
   };
 
   const handleAddBranch = () => {
@@ -320,62 +267,12 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
 
   const handleAddIfElse = () => {
     const position = calculateNonOverlappingPosition(250, 250);
-    const newNode = {
-      id: `ifelse-${Date.now()}`,
-      type: 'ifElse' as const,
-      position,
-      data: {
-        evaluationTarget: '',
-        branches: [
-          {
-            id: generateBranchId(),
-            label: t('default.branchTrue'),
-            condition: t('default.branchTrueCondition'),
-          },
-          {
-            id: generateBranchId(),
-            label: t('default.branchFalse'),
-            condition: t('default.branchFalseCondition'),
-          },
-        ],
-        outputPorts: 2 as const,
-      },
-    };
-    addNode(newNode);
+    addNode(createDefaultNode('ifElse', position, t));
   };
 
   const handleAddSwitch = () => {
     const position = calculateNonOverlappingPosition(250, 280);
-    const newNode = {
-      id: `switch-${Date.now()}`,
-      type: 'switch' as const,
-      position,
-      data: {
-        evaluationTarget: '',
-        branches: [
-          {
-            id: generateBranchId(),
-            label: t('default.case1'),
-            condition: t('default.case1Condition'),
-            isDefault: false,
-          },
-          {
-            id: generateBranchId(),
-            label: t('default.case2'),
-            condition: t('default.case2Condition'),
-            isDefault: false,
-          },
-          {
-            id: generateBranchId(),
-            label: t('default.defaultBranch'),
-            condition: t('default.defaultBranchCondition'),
-            isDefault: true,
-          },
-        ],
-        outputPorts: 3,
-      },
-    };
-    addNode(newNode);
+    addNode(createDefaultNode('switch', position, t));
   };
 
   // Feature: 089-subworkflow - Create new Sub-Agent Flow and enter edit mode

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -17,8 +17,14 @@ import {
   ClipboardPaste,
   Copy,
   CopyPlus,
+  GitBranch,
+  GitBranchPlus,
+  GitFork,
+  MessageSquare,
   PanelLeftOpen,
   Scissors,
+  ShieldQuestion,
+  Square,
   SquareDashedMousePointer,
   Trash2,
 } from 'lucide-react';
@@ -34,6 +40,7 @@ import ReactFlow, {
   MiniMap,
   type Node,
   type NodeTypes,
+  type OnConnectStartParams,
   Panel,
   PanOnScrollMode,
   type ReactFlowInstance,
@@ -49,6 +56,7 @@ import {
   type SelectionClipboardPayload,
   useWorkflowStore,
 } from '../stores/workflow-store';
+import { createDefaultNode, type SimpleNodeType } from '../utils/node-defaults';
 import { collectWorkflowIssues } from '../utils/workflow-issues';
 import { CanvasContextMenu, type CanvasContextMenuEntry } from './CanvasContextMenu';
 import { CanvasToolbar } from './CanvasToolbar';
@@ -504,6 +512,57 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     }
   }, []);
 
+  // ---------------------------------------------------------------------
+  // Edge-drop create: drag a connection from a source handle, release on
+  // empty canvas → a picker menu creates the chosen node pre-wired there
+  // ---------------------------------------------------------------------
+  const connectStartRef = useRef<OnConnectStartParams | null>(null);
+  const [edgeDropMenu, setEdgeDropMenu] = useState<{
+    x: number;
+    y: number;
+    flowPosition: { x: number; y: number };
+    source: { nodeId: string; handleId: string | null };
+  } | null>(null);
+
+  const handleConnectStart = useCallback(
+    (_event: React.MouseEvent | React.TouchEvent, params: OnConnectStartParams) => {
+      connectStartRef.current = params;
+    },
+    []
+  );
+
+  const handleConnectEnd = useCallback((event: MouseEvent | TouchEvent) => {
+    const start = connectStartRef.current;
+    connectStartRef.current = null;
+    // Forward drags only — from a source handle; a valid drop on a node
+    // fires onConnect instead and the drop target is then not the pane
+    if (!start?.nodeId || start.handleType !== 'source') return;
+    const dropTarget = event.target as Element | null;
+    if (!dropTarget?.classList?.contains('react-flow__pane')) return;
+    const container = canvasContainerRef.current;
+    if (!container) return;
+    const point = 'changedTouches' in event ? event.changedTouches[0] : event;
+    if (!point) return;
+    const bounds = container.getBoundingClientRect();
+    const x = point.clientX - bounds.left;
+    const y = point.clientY - bounds.top;
+    const projected = reactFlowInstanceRef.current?.project({ x, y });
+    if (!projected) return;
+    // Land on the canvas grid, matching snapToGrid drag behavior
+    const flowPosition = {
+      x: Math.round(projected.x / 15) * 15,
+      y: Math.round(projected.y / 15) * 15,
+    };
+    setEdgeDropMenu({
+      x,
+      y,
+      flowPosition,
+      source: { nodeId: start.nodeId, handleId: start.handleId ?? null },
+    });
+  }, []);
+
+  const closeEdgeDropMenu = useCallback(() => setEdgeDropMenu(null), []);
+
   // Memoize snap grid
   const snapGrid = useMemo<[number, number]>(() => [15, 15], []);
 
@@ -541,6 +600,65 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     useWorkflowStore.getState().closeProblemsPanel();
   }, []);
   const isProblemsPanelVisible = isProblemsPanelOpen && activeSubAgentFlowId === null;
+
+  // Picker entries for the edge-drop menu: the dialog-free node types with
+  // their palette icons and labels. Interactive/session types are hidden
+  // while editing a sub-agent flow, matching the palette's gating.
+  const edgeDropEntries = useMemo<CanvasContextMenuEntry[]>(() => {
+    if (!edgeDropMenu) return [];
+    const pick = (type: SimpleNodeType) => () => {
+      const node = createDefaultNode(type, edgeDropMenu.flowPosition, t);
+      useWorkflowStore.getState().addNodeWithConnection(node, {
+        source: edgeDropMenu.source.nodeId,
+        sourceHandle: edgeDropMenu.source.handleId,
+        target: node.id,
+        targetHandle: null,
+      });
+    };
+    return [
+      {
+        key: 'prompt',
+        label: t('node.prompt.title'),
+        icon: <MessageSquare size={14} />,
+        onSelect: pick('prompt'),
+      },
+      {
+        key: 'ifElse',
+        label: t('node.ifElse.title'),
+        icon: <GitBranch size={14} />,
+        onSelect: pick('ifElse'),
+      },
+      {
+        key: 'switch',
+        label: t('node.switch.title'),
+        icon: <GitFork size={14} />,
+        onSelect: pick('switch'),
+      },
+      ...(activeSubAgentFlowId === null
+        ? ([
+            {
+              key: 'askUserQuestion',
+              label: t('node.askUserQuestion.title'),
+              icon: <ShieldQuestion size={14} />,
+              onSelect: pick('askUserQuestion'),
+            },
+            {
+              key: 'branchSession',
+              label: t('node.branchSession.title'),
+              icon: <GitBranchPlus size={14} />,
+              onSelect: pick('branchSession'),
+            },
+          ] satisfies CanvasContextMenuEntry[])
+        : []),
+      'separator',
+      {
+        key: 'end',
+        label: t('node.end.title'),
+        icon: <Square size={14} />,
+        onSelect: pick('end'),
+      },
+    ];
+  }, [edgeDropMenu, t, activeSubAgentFlowId]);
 
   // Validation issues for the problems panel and the on-canvas node markers.
   // Computed here (not in the panel) so a single validation pass feeds both;
@@ -989,6 +1107,8 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           onNodesChange={handleNodesChange}
           onEdgesChange={handleEdgesChange}
           onConnect={handleConnect}
+          onConnectStart={handleConnectStart}
+          onConnectEnd={handleConnectEnd}
           onNodeDragStart={handleNodeDragStart}
           onNodeDragStop={handleNodeDragStop}
           onNodeClick={handleNodeClick}
@@ -1144,6 +1264,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             y={contextMenu.y}
             entries={contextMenuEntries}
             onClose={closeContextMenu}
+          />
+        )}
+        {edgeDropMenu && (
+          <CanvasContextMenu
+            x={edgeDropMenu.x}
+            y={edgeDropMenu.y}
+            entries={edgeDropEntries}
+            onClose={closeEdgeDropMenu}
           />
         )}
         {onOpenSample && onDismissEmptyState && onLoadWorkflow && (

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -19,7 +19,7 @@ import { NodeType } from '@cc-wf-studio/core';
 import type { McpNodeData } from '@cc-wf-studio/core/mcp';
 import { normalizeMcpNodeData } from '@cc-wf-studio/core/mcp';
 import type { Workflow } from '@shared/types/messages';
-import type { Edge, Node, OnConnect, OnEdgesChange, OnNodesChange } from 'reactflow';
+import type { Connection, Edge, Node, OnConnect, OnEdgesChange, OnNodesChange } from 'reactflow';
 import { addEdge, applyEdgeChanges, applyNodeChanges } from 'reactflow';
 import { temporal } from 'zundo';
 import { create } from 'zustand';
@@ -240,6 +240,10 @@ interface WorkflowStore {
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
   addNode: (node: Node) => void;
+  /** Add a node together with the edge that connects it (edge-drop create):
+   *  one set() → one undo entry. The new node becomes the selection and the
+   *  property overlay opens, same as addNode. */
+  addNodeWithConnection: (node: Node, connection: Connection) => void;
   /** Duplicate a configured node (fresh id, +40/+40 offset, same parent group,
    *  deep-copied data; edges are not copied). Duplicating a group also copies
    *  its child nodes and the edges fully inside the group. Start/End excluded. */
@@ -851,6 +855,18 @@ export const useWorkflowStore = create<WorkflowStore>()(
       addNode: (node: Node) => {
         set({
           nodes: [...get().nodes, node],
+          lastAddedNodeId: node.id,
+          selectedNodeId: node.id,
+          isPropertyOverlayOpen: true,
+        });
+      },
+
+      addNodeWithConnection: (node: Node, connection: Connection) => {
+        const currentNodes = get().nodes.map((n) => (n.selected ? { ...n, selected: false } : n));
+        const currentEdges = get().edges.map((e) => (e.selected ? { ...e, selected: false } : e));
+        set({
+          nodes: [...currentNodes, node],
+          edges: addEdge(connection, currentEdges),
           lastAddedNodeId: node.id,
           selectedNodeId: node.id,
           isPropertyOverlayOpen: true,

--- a/packages/vscode/src/webview/src/utils/node-defaults.ts
+++ b/packages/vscode/src/webview/src/utils/node-defaults.ts
@@ -1,0 +1,141 @@
+/**
+ * Default node construction shared by the Node Palette buttons and the
+ * edge-drop picker, so a node created either way starts identical.
+ *
+ * Only covers node types that need no configuration dialog — dialog-based
+ * types (Sub-Agent, Skill, MCP, Codex, Sub-Agent Flow) and layout-only
+ * types (Group) are created by their own palette flows.
+ */
+
+import { generateBranchId, generateOptionId } from '@cc-wf-studio/core';
+import type { Node } from 'reactflow';
+import type { WebviewTranslationKeys } from '../i18n/translation-keys';
+
+/** Subset of the i18n `t` accepted here (assignable from useTranslation's t) */
+export type TranslateFn = (
+  key: keyof WebviewTranslationKeys,
+  params?: Record<string, string | number>
+) => string;
+
+/** Node types creatable without a configuration dialog */
+export type SimpleNodeType =
+  | 'prompt'
+  | 'askUserQuestion'
+  | 'ifElse'
+  | 'switch'
+  | 'branchSession'
+  | 'end';
+
+export function createDefaultNode(
+  type: SimpleNodeType,
+  position: { x: number; y: number },
+  t: TranslateFn
+): Node {
+  switch (type) {
+    case 'prompt':
+      return {
+        id: `prompt-${Date.now()}`,
+        type: 'prompt',
+        position,
+        data: {
+          label: t('default.newPrompt'),
+          prompt: t('default.prompt'),
+          variables: {},
+        },
+      };
+    case 'askUserQuestion':
+      return {
+        id: `question-${Date.now()}`,
+        type: 'askUserQuestion',
+        position,
+        data: {
+          questionText: t('default.newQuestion'),
+          options: [
+            {
+              id: generateOptionId(),
+              label: `${t('default.option')} 1`,
+              description: t('default.firstOption'),
+            },
+            {
+              id: generateOptionId(),
+              label: `${t('default.option')} 2`,
+              description: t('default.secondOption'),
+            },
+          ],
+          outputPorts: 2,
+        },
+      };
+    case 'ifElse':
+      return {
+        id: `ifelse-${Date.now()}`,
+        type: 'ifElse',
+        position,
+        data: {
+          evaluationTarget: '',
+          branches: [
+            {
+              id: generateBranchId(),
+              label: t('default.branchTrue'),
+              condition: t('default.branchTrueCondition'),
+            },
+            {
+              id: generateBranchId(),
+              label: t('default.branchFalse'),
+              condition: t('default.branchFalseCondition'),
+            },
+          ],
+          outputPorts: 2 as const,
+        },
+      };
+    case 'switch':
+      return {
+        id: `switch-${Date.now()}`,
+        type: 'switch',
+        position,
+        data: {
+          evaluationTarget: '',
+          branches: [
+            {
+              id: generateBranchId(),
+              label: t('default.case1'),
+              condition: t('default.case1Condition'),
+              isDefault: false,
+            },
+            {
+              id: generateBranchId(),
+              label: t('default.case2'),
+              condition: t('default.case2Condition'),
+              isDefault: false,
+            },
+            {
+              id: generateBranchId(),
+              label: t('default.defaultBranch'),
+              condition: t('default.defaultBranchCondition'),
+              isDefault: true,
+            },
+          ],
+          outputPorts: 3,
+        },
+      };
+    case 'branchSession':
+      return {
+        id: `branch-session-${Date.now()}`,
+        type: 'branchSession',
+        position,
+        data: {
+          label: t('default.newBranchSession'),
+          workDescription: '',
+          outputPorts: 1 as const,
+        },
+      };
+    case 'end':
+      return {
+        id: `end_${Date.now()}`,
+        type: 'end',
+        position,
+        data: {
+          label: 'End',
+        },
+      };
+  }
+}


### PR DESCRIPTION
## Summary

Drag a connection from a node's output handle and release it on empty canvas: a small picker menu opens at the drop point, and choosing a node type creates that node right there, already wired to the source. Node + edge land as a single undo step; Escape or clicking away cancels. This is the standard fast-authoring gesture in modern flow editors.

Closes #937

## User value

A user extending a workflow no longer needs three steps (click the palette, drag the new node into place, draw the connection by hand) for the most common editing action — one drag-and-pick does all of it.

## Implementation notes

- `onConnectStart` records the source node/handle; `onConnectEnd` detects a drop on the React Flow pane (`react-flow__pane` class check), projects the point via `project()` (snapped to the 15px canvas grid), and opens a picker rendered with the existing `CanvasContextMenu` component, reused as-is.
- Picker offers the dialog-free node types with their palette icons and existing `node.<type>.title` i18n keys (zero new translation keys): Prompt, If/Else, Switch, Ask User Question, Branch Session, End — the latter three hidden while editing a sub-agent flow, matching the palette's `isEditingSubAgentFlow` gating. Dialog-based types (Sub-Agent, Skill, MCP, Codex) stay palette-only.
- Node defaults are extracted from `NodePalette`'s inline handlers into a shared `utils/node-defaults.ts` factory so the palette and the picker create identical nodes (palette behavior unchanged).
- New store action `addNodeWithConnection` appends the node and adds the edge in a single `set()` → one undo entry (same single-entry policy as align/distribute/auto-layout), selects the new node, and opens the property overlay exactly like `addNode`.
- Forward drags only (from a source handle); the generated connection is valid by construction (the new node is the target, never Start/Group). Webview-only — no schema or API changes.

## Checks

- `pnpm build` + `pnpm check` green from the repo root.
- Browser E2E against the real webview (`ccwf canvas` + headless Chromium): picker appears with all 6 entries; picking Prompt creates the node and the wired edge; a single Ctrl+Z removes both; Escape cancels without creating anything; dropping onto a node does not open the picker — all passed.
- While E2E-testing, found a pre-existing `ccwf canvas` boot race (on fast localhost the server answers `WEBVIEW_READY` before React's message listener attaches → eternal spinner). Not touched here; queued as a next proposal in the progress log.
- Changeset: `cc-wf-studio` minor (`.changeset/edge-drop-node-create.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsMfYX4qzgknMbYNxpsWF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUsMfYX4qzgknMbYNxpsWF)_