### PR TITLE
fix(webview): post WEBVIEW_READY after the message listener attaches

### DIFF
--- a/.changeset/canvas-boot-race-fix.md
+++ b/.changeset/canvas-boot-race-fix.md
@@ -1,0 +1,6 @@
+---
+"@cc-wf-studio/cli": patch
+"cc-wf-studio": patch
+---
+
+Fix a webview boot race that could leave `ccwf canvas` stuck on the loading spinner forever: `WEBVIEW_READY` is now posted only after the webview's message listener is attached, so a fast host can no longer reply with `INITIAL_STATE`/`LOAD_WORKFLOW` before anyone is listening. The same ordering guarantee hardens the VSCode editor's boot handshake.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,37 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Fix `ccwf canvas` boot race (eternal spinner)
+- **User value**: a user opening `ccwf canvas` no longer risks a page stuck
+  on the loading spinner forever — on fast localhost the server could answer
+  `WEBVIEW_READY` with `INITIAL_STATE`/`LOAD_WORKFLOW` before React attached
+  the webview's message listener, silently dropping the boot messages.
+- **Issue/PR**: #939 / PR from `claude/canvas-boot-race`
+- **Outcome**: done — `WEBVIEW_READY` moved from `main.tsx` (posted
+  synchronously right after `root.render()`, i.e. before any effect ran)
+  into an `App` mount effect declared after the message-listener effect;
+  React runs mount effects in declaration order, so the listener now
+  provably exists before the host is invited to reply. Ref-guarded to post
+  exactly once (StrictMode-safe). Same bundle serves the VSCode editor, so
+  the extension's own #396 handshake is hardened by the same change; the
+  overview custom editor ignores unknown message types (verified). **Bug
+  reproduced deterministically**: headless-Chromium E2E against the
+  unfixed build hangs at the spinner (`.react-flow__node` never appears);
+  with the fix, 5/5 fresh page loads boot fully — all 8 sample nodes
+  render, zero page errors. `pnpm build` + `pnpm check` green. Changeset
+  bumps `@cc-wf-studio/cli` + `cc-wf-studio` (patch). Issue #939 could not
+  be locked (no `gh`, no MCP lock tool — known limitation, noted in the
+  issue).
+- **Next proposals**:
+  - Keyboard-shortcut cheat sheet overlay (Ctrl+F/A/D/Z/C/X/V, Delete,
+    context menu, edge-drop…) — discoverability gap keeps growing.
+  - Problems count badge on the toolbar Problems button while the panel is
+    closed — needs judging: costs a validation pass on every edit.
+  - Manual E2E queue (carried): problem-node markers; problems panel
+    click-to-jump; auto layout on a real messy workflow; node search
+    cycling; align/distribute + context menu + copy/cut/paste; localized
+    Claude API dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Edge-drop node creation (drag a connection to empty canvas)
 - **User value**: a user extending a workflow can now drag a connection from
   a node's output handle, release it on empty canvas, and pick a node type

--- a/packages/vscode/src/webview/src/App.tsx
+++ b/packages/vscode/src/webview/src/App.tsx
@@ -665,6 +665,18 @@ const App: React.FC = () => {
     handleStartTour,
   ]);
 
+  // Announce readiness only after the message listener above is attached —
+  // mount effects run in declaration order, so this must stay below that
+  // useEffect. A fast host (`ccwf canvas` on localhost) answers WEBVIEW_READY
+  // immediately; posting before the listener exists loses INITIAL_STATE /
+  // LOAD_WORKFLOW and the spinner never resolves. (Issues #396, #939)
+  const hasAnnouncedReadyRef = useRef(false);
+  useEffect(() => {
+    if (hasAnnouncedReadyRef.current) return;
+    hasAnnouncedReadyRef.current = true;
+    vscode.postMessage({ type: 'WEBVIEW_READY' });
+  }, []);
+
   // Render loading state (waiting for mode to be determined)
   // Shows spinner while waiting for INITIAL_STATE or OVERVIEW_MODE_INIT from Extension Host
   if (mode === null) {

--- a/packages/vscode/src/webview/src/main.tsx
+++ b/packages/vscode/src/webview/src/main.tsx
@@ -67,7 +67,8 @@ root.render(
   </React.StrictMode>
 );
 
-// Notify Extension Host that Webview is ready to receive messages
-// This ensures INITIAL_STATE is sent only after React is fully initialized
-// Fixes: Issue #396 - blank page when Webview loads slowly
-vscode.postMessage({ type: 'WEBVIEW_READY' });
+// WEBVIEW_READY is posted by <App /> after its message listener is attached
+// (see App.tsx). Posting it here — synchronously after root.render() — raced
+// fast hosts: `ccwf canvas` on localhost could answer with INITIAL_STATE /
+// LOAD_WORKFLOW before React committed App's effects, and the dropped boot
+// messages left the spinner up forever. (Issues #396, #939)


### PR DESCRIPTION
## Summary

Fixes a webview boot race that could leave `ccwf canvas` stuck on the loading spinner forever. Closes #939.

`main.tsx` posted `WEBVIEW_READY` synchronously right after `root.render()` — but the only handler for `INITIAL_STATE` / `LOAD_WORKFLOW` is attached in `App`'s `useEffect`, which React commits after paint. A fast host (the `ccwf canvas` server on localhost) answers immediately over the WebSocket, so its replies could be dispatched on `window` before the listener existed; the dropped boot messages left `mode === null` and the spinner never resolved.

## Changes

- `WEBVIEW_READY` is now posted from an `App` mount effect declared **after** the message-listener effect — React runs mount effects in declaration order, so the listener provably exists before the host is invited to reply. Ref-guarded to fire exactly once (StrictMode-safe).
- `main.tsx` keeps a comment pointing at the new location.
- The same bundle serves the VSCode editor, so this also hardens the extension's original Issue-#396 handshake (which intended exactly this ordering). The overview custom editor uses the same bundle and ignores unknown message types — unaffected (verified).

## Verification

- **Bug reproduced deterministically**: a headless-Chromium E2E (`ccwf canvas` + Playwright against the built CLI) hangs at the spinner on the unfixed build — `.react-flow__node` never appears.
- With the fix: 5/5 fresh page loads boot fully; all 8 nodes of the bundled sample workflow render, spinner gone, zero page errors.
- `pnpm build` + `pnpm check` green from the repo root.

## Changeset

`.changeset/canvas-boot-race-fix.md` — patch bump for `@cc-wf-studio/cli` and `cc-wf-studio` (webview is bundled into both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhZbWziHPiLYdHC5K66D9B

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhZbWziHPiLYdHC5K66D9B)_