### PR TITLE
improvement(vscode): show a live problems-count badge on the canvas Problems button

### DIFF
--- a/.changeset/problems-count-badge.md
+++ b/.changeset/problems-count-badge.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Show a live problems-count badge on the canvas Problems button: while the problems panel is closed, the current number of validation issues appears as a red badge on the toolbar button (debounced, hidden on an empty canvas), so broken workflows are visible before a save or export fails.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,35 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Problems-count badge on the toolbar Problems button
+- **User value**: a user can now see at a glance — via a red count badge on
+  the canvas Problems button — that the workflow currently has N validation
+  problems, instead of only finding out when a save/export fails or after
+  opening the panel by hand (carried proposal from two iterations, judged
+  shippable: the validator is a pure in-memory pass, debounced to ~1 run
+  per editing pause).
+- **Issue/PR**: #943 / PR from `claude/sleepy-curie-33m9bp`
+- **Outcome**: done — `WorkflowProblemsButton` grew an optional `issueCount`
+  prop rendering a top-right `--vscode-charts-red` badge (99+ cap, count-aware
+  localized tooltip/aria-label); `CanvasToolbar` passes it through via the
+  established optional-prop pattern; `WorkflowEditor` reuses the live
+  `workflowIssues` pass while the panel is open and otherwise recomputes the
+  count in a 400 ms-debounced effect, suppressed on an empty canvas so a
+  brand-new workflow isn't nagged. New `problemsPanel.tooltipWithCount`
+  string in all 5 locales. `pnpm build` + `pnpm check` green. Issue #943
+  could not be locked (no `gh`, no MCP lock tool — known limitation, noted
+  in the issue).
+- **Next proposals**:
+  - MCP: a `render_workflow` tool returning the Mermaid diagram of the
+    current workflow, so AI agents can show users what they just built.
+  - Mirror the shortcut cheat sheet in the README/docs.
+  - Manual E2E queue (carried): badge appears/clears while editing with the
+    panel closed and hides on empty canvas; shortcut cheat sheet (`?`,
+    toolbar button, ja locale); problem-node markers; problems panel
+    click-to-jump; auto layout on a messy workflow; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Keyboard shortcut cheat sheet on the canvas
 - **User value**: a user can now press `?` on the canvas (or click the new
   keyboard toolbar button) to see every shortcut and mouse gesture the

--- a/packages/vscode/src/webview/src/components/CanvasToolbar.tsx
+++ b/packages/vscode/src/webview/src/components/CanvasToolbar.tsx
@@ -30,6 +30,9 @@ interface CanvasToolbarProps {
   /** Opens the workflow problems panel; omitted where validation is
    *  unavailable (e.g. the sub-agent flow dialog), which hides the button. */
   onOpenProblems?: () => void;
+  /** Current number of validation issues, shown as a badge on the
+   *  Problems button while > 0. */
+  problemCount?: number;
   /** Opens the keyboard shortcut cheat sheet; omitted where the canvas
    *  shortcuts don't apply (e.g. the sub-agent flow dialog), which hides
    *  the button. */
@@ -42,6 +45,7 @@ export const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   onOpenSearch,
   onAutoLayout,
   onOpenProblems,
+  problemCount,
   onOpenShortcuts,
 }) => {
   return (
@@ -54,7 +58,9 @@ export const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
       <MinimapToggle />
       {onOpenSearch && <SearchNodesButton onClick={onOpenSearch} />}
       {onAutoLayout && <AutoLayoutButton onClick={onAutoLayout} />}
-      {onOpenProblems && <WorkflowProblemsButton onClick={onOpenProblems} />}
+      {onOpenProblems && (
+        <WorkflowProblemsButton onClick={onOpenProblems} issueCount={problemCount} />
+      )}
       {onOpenShortcuts && <KeyboardShortcutsButton onClick={onOpenShortcuts} />}
       <StartTourButton />
     </div>

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -694,6 +694,48 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     ]
   );
 
+  // Problems-count badge on the toolbar button. While the panel is open the
+  // live workflowIssues result is reused (same single validation pass);
+  // while it is closed the count is recomputed in a debounced effect so
+  // rapid edits/drags trigger at most one validation pass per pause.
+  // An empty canvas shows no badge — a brand-new workflow isn't nagged.
+  const [idleIssueCount, setIdleIssueCount] = useState(0);
+  useEffect(() => {
+    if (isProblemsPanelVisible) {
+      return undefined;
+    }
+    if (nodes.length === 0) {
+      setIdleIssueCount(0);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setIdleIssueCount(
+        collectWorkflowIssues(
+          nodes,
+          edges,
+          workflowName,
+          workflowDescription || undefined,
+          subAgentFlows.length > 0 ? subAgentFlows : undefined,
+          slashCommandOptions
+        ).length
+      );
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [
+    isProblemsPanelVisible,
+    nodes,
+    edges,
+    workflowName,
+    workflowDescription,
+    subAgentFlows,
+    slashCommandOptions,
+  ]);
+  const problemCount = isProblemsPanelVisible
+    ? workflowIssues.length
+    : nodes.length === 0
+      ? 0
+      : idleIssueCount;
+
   // Mark every node the problems panel points at with a red ring + badge
   // (styles/nodes.css `.wf-problem-node`), so the user can see all offending
   // nodes at a glance while the panel is open.
@@ -1227,6 +1269,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
               onOpenSearch={openSearch}
               onAutoLayout={autoLayoutCanvas}
               onOpenProblems={activeSubAgentFlowId === null ? openProblemsPanel : undefined}
+              problemCount={problemCount}
               onOpenShortcuts={() => setIsShortcutsOpen(true)}
             />
           </Panel>

--- a/packages/vscode/src/webview/src/components/WorkflowProblemsButton.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowProblemsButton.tsx
@@ -4,7 +4,9 @@
  * Opens the workflow problems panel, which lists every validation issue
  * and jumps to the offending node on click. The panel also opens
  * automatically when a save/export fails validation; this button makes
- * checking proactively possible before saving.
+ * checking proactively possible before saving. When the workflow currently
+ * has validation issues, a red count badge (matching the on-canvas
+ * `wf-problem-node` markers) surfaces them without opening the panel.
  */
 
 import { ListChecks } from 'lucide-react';
@@ -26,13 +28,41 @@ const ROUND_BUTTON_STYLE: React.CSSProperties = {
   boxSizing: 'border-box',
 };
 
+const COUNT_BADGE_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  top: '-5px',
+  right: '-5px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: '16px',
+  height: '16px',
+  padding: '0 4px',
+  borderRadius: '8px',
+  fontSize: '10px',
+  lineHeight: 1,
+  fontWeight: 600,
+  backgroundColor: 'var(--vscode-charts-red, #ef4444)',
+  color: '#ffffff',
+  pointerEvents: 'none',
+  boxSizing: 'border-box',
+};
+
 interface WorkflowProblemsButtonProps {
   onClick: () => void;
+  /** Current number of validation issues; > 0 shows a red count badge */
+  issueCount?: number;
 }
 
-export const WorkflowProblemsButton: React.FC<WorkflowProblemsButtonProps> = ({ onClick }) => {
+export const WorkflowProblemsButton: React.FC<WorkflowProblemsButtonProps> = ({
+  onClick,
+  issueCount = 0,
+}) => {
   const { t } = useTranslation();
-  const tooltip = t('problemsPanel.tooltip');
+  const tooltip =
+    issueCount > 0
+      ? t('problemsPanel.tooltipWithCount', { count: issueCount })
+      : t('problemsPanel.tooltip');
 
   return (
     <StyledTooltipProvider>
@@ -48,9 +78,14 @@ export const WorkflowProblemsButton: React.FC<WorkflowProblemsButtonProps> = ({ 
           role="button"
           tabIndex={0}
           aria-label={tooltip}
-          style={ROUND_BUTTON_STYLE}
+          style={{ ...ROUND_BUTTON_STYLE, position: 'relative' }}
         >
           <ListChecks size={14} style={{ color: 'var(--vscode-foreground)' }} />
+          {issueCount > 0 && (
+            <span aria-hidden="true" style={COUNT_BADGE_STYLE}>
+              {issueCount > 99 ? '99+' : issueCount}
+            </span>
+          )}
         </div>
       </StyledTooltipItem>
     </StyledTooltipProvider>

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -419,6 +419,7 @@ export interface WebviewTranslationKeys {
 
   // Workflow problems panel (canvas toolbar + auto-open on validation failure)
   'problemsPanel.tooltip': string;
+  'problemsPanel.tooltipWithCount': string;
   'problemsPanel.title': string;
   'problemsPanel.noProblems': string;
   'problemsPanel.close': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -439,6 +439,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
 
   // Workflow problems panel (canvas toolbar + auto-open on validation failure)
   'problemsPanel.tooltip': 'Check workflow problems',
+  'problemsPanel.tooltipWithCount': 'Check workflow problems ({count} found)',
   'problemsPanel.title': 'Workflow problems',
   'problemsPanel.noProblems': 'No problems found — this workflow passes validation',
   'problemsPanel.close': 'Close problems panel',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -437,6 +437,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
 
   // Workflow problems panel (canvas toolbar + auto-open on validation failure)
   'problemsPanel.tooltip': 'ワークフローの問題をチェック',
+  'problemsPanel.tooltipWithCount': 'ワークフローの問題をチェック（{count}件）',
   'problemsPanel.title': 'ワークフローの問題',
   'problemsPanel.noProblems': '問題は見つかりませんでした — このワークフローは検証に合格しています',
   'problemsPanel.close': '問題パネルを閉じる',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -436,6 +436,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
 
   // Workflow problems panel (canvas toolbar + auto-open on validation failure)
   'problemsPanel.tooltip': '워크플로 문제 확인',
+  'problemsPanel.tooltipWithCount': '워크플로 문제 확인 ({count}개)',
   'problemsPanel.title': '워크플로 문제',
   'problemsPanel.noProblems': '문제가 발견되지 않았습니다 — 이 워크플로는 검증을 통과했습니다',
   'problemsPanel.close': '문제 패널 닫기',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -423,6 +423,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
 
   // Workflow problems panel (canvas toolbar + auto-open on validation failure)
   'problemsPanel.tooltip': '检查工作流问题',
+  'problemsPanel.tooltipWithCount': '检查工作流问题（{count} 个）',
   'problemsPanel.title': '工作流问题',
   'problemsPanel.noProblems': '未发现问题 — 此工作流通过验证',
   'problemsPanel.close': '关闭问题面板',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -425,6 +425,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
 
   // Workflow problems panel (canvas toolbar + auto-open on validation failure)
   'problemsPanel.tooltip': '檢查工作流程問題',
+  'problemsPanel.tooltipWithCount': '檢查工作流程問題（{count} 個）',
   'problemsPanel.title': '工作流程問題',
   'problemsPanel.noProblems': '未發現問題 — 此工作流程通過驗證',
   'problemsPanel.close': '關閉問題面板',


### PR DESCRIPTION
Closes #943

## Summary

While the Workflow Problems panel is closed, the toolbar Problems button now shows a small red count badge with the workflow's current number of validation issues — so a broken workflow is visible at a glance instead of only when a save/export fails or after opening the panel by hand. This completes the problems-surfacing flow started by #934 (panel + click-to-jump) and #936 (on-canvas markers), and was carried as a next-proposal in `docs/progress-log.md` for two iterations.

## Changes

- `WorkflowProblemsButton`: optional `issueCount` prop rendering a top-right badge in `--vscode-charts-red` (matching the on-canvas `wf-problem-node` markers), capped at `99+`, with a count-aware localized tooltip/aria-label.
- `WorkflowEditor`: while the panel is open, the badge reuses the existing live `workflowIssues` result (still a single validation pass feeding panel + markers + badge). While it is closed, the count is recomputed in a 400 ms-debounced effect over the same inputs, so rapid edits/drags cost at most one in-memory validation pass per pause. Empty canvas → no badge, so a brand-new workflow isn't nagged.
- `CanvasToolbar`: `problemCount` pass-through via the established optional-prop pattern (button stays hidden in the sub-agent flow dialog).
- i18n: new `problemsPanel.tooltipWithCount` string in `translation-keys.ts` and all 5 locales per the translation rule.
- Changeset: `cc-wf-studio` patch.

## Verification

- `pnpm build` and `pnpm check` green from the repo root (biome + tsc across all packages).
- Manual E2E queued in the progress log: badge appears/clears while editing with the panel closed, hides on empty canvas, live count while the panel is open, ja locale tooltip.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SF1XRCZxBzaFEjxaf6uz3)_