### PR TITLE
feat(vscode): add "Copy as Markdown" action to the canvas More Actions menu

### DIFF
--- a/.changeset/copy-as-markdown-canvas-action.md
+++ b/.changeset/copy-as-markdown-canvas-action.md
@@ -1,0 +1,6 @@
+---
+"cc-wf-studio": patch
+"@cc-wf-studio/cli": patch
+---
+
+Add a "Copy as Markdown" action to the canvas More Actions menu — copies the current workflow as a paste-ready Markdown document (title, description, Mermaid diagram, execution instructions), the same bundle `ccwf render` prints, for sharing in PRs, issues, or READMEs.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,38 @@ Entry format:
 
 ---
 
+## 2026-07-24 — "Copy as Markdown" canvas action
+- **User value**: a user who built a workflow on the canvas can now copy a
+  paste-ready Markdown document of it — title, description, fenced Mermaid
+  diagram (rendered natively by GitHub), and execution instructions, the
+  same bundle `ccwf render` prints — from the More Actions menu, instead of
+  installing the `ccwf` CLI or hand-assembling a doc to describe the
+  workflow in a PR, issue, or README (carried proposal from the
+  `render_workflow` iteration).
+- **Issue/PR**: #947 / PR from `claude/sleepy-curie-63ljp4`
+- **Outcome**: done — new "Copy as Markdown" item in `MoreActionsDropdown`
+  (after Share to Slack, `ClipboardCopy` icon), wired from `Toolbar.tsx`:
+  serializes the current canvas via the established `serializeWorkflow`
+  path and assembles the doc with `generateMermaidFlowchart` +
+  `generateExecutionInstructions` from `@cc-wf-studio/core` (byte-identical
+  to `ccwf render --format=md`'s stdout), then writes it with
+  `navigator.clipboard`. The item preventDefaults so the menu stays open
+  and shows a transient localized "Copied!" + check confirmation (2 s);
+  disabled on an empty canvas. Two new strings in all 5 locales
+  ("Markdown" kept untranslated per the translation rule). Serves both
+  hosts of the shared webview bundle (VSCode editor + `ccwf canvas`).
+  `pnpm build` + `pnpm check` green. Issue #947 could not be locked (no
+  `gh`, no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Mirror the shortcut cheat sheet in the README/docs.
+  - Manual E2E queue (carried): Copy as Markdown (menu item feedback,
+    disabled on empty canvas, pasted doc renders on GitHub);
+    `render_workflow` via MCP Inspector (both formats); problems badge;
+    shortcut cheat sheet (`?`, toolbar button, ja locale); problem-node
+    markers; problems panel click-to-jump; auto layout; node search
+    cycling; align/distribute + context menu + copy/cut/paste; localized
+    Claude API dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — `render_workflow` MCP tool (show the workflow as a diagram)
 - **User value**: a user editing a workflow through an AI agent (canvas skill
   or `ccwf-mcp` file mode) can now ask "show me the workflow" and the agent

--- a/packages/vscode/src/webview/src/components/Toolbar.tsx
+++ b/packages/vscode/src/webview/src/components/Toolbar.tsx
@@ -4,7 +4,12 @@
  * Provides Save and Load functionality for workflows
  */
 
-import { CLAUDE_CODE_ONLY_NODE_TYPES, type NodeType } from '@cc-wf-studio/core';
+import {
+  CLAUDE_CODE_ONLY_NODE_TYPES,
+  generateExecutionInstructions,
+  generateMermaidFlowchart,
+  type NodeType,
+} from '@cc-wf-studio/core';
 import type { Workflow } from '@shared/types/messages';
 import {
   BookOpen,
@@ -162,6 +167,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   const [isGeneratingName, setIsGeneratingName] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [workflowNameError, setWorkflowNameError] = useState<string | null>(null);
+  const [isMarkdownCopied, setIsMarkdownCopied] = useState(false);
+  const markdownCopiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Copilot Chat integration
   const [isCopilotChatExporting, setIsCopilotChatExporting] = useState(false);
   const [isCopilotChatRunning, setIsCopilotChatRunning] = useState(false);
@@ -326,6 +333,47 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       setIsSaving(false);
     }
   };
+
+  // Copy the current workflow as the same Markdown bundle `ccwf render`
+  // (format md) prints: title + description + Mermaid diagram + execution
+  // instructions — paste-ready for a PR, issue, or README.
+  const handleCopyAsMarkdown = useCallback(() => {
+    const { subAgentFlows, workflowDescription, slashCommandOptions } = useWorkflowStore.getState();
+    const workflow = serializeWorkflow(
+      nodes,
+      edges,
+      workflowName,
+      workflowDescription || undefined,
+      activeWorkflow?.conversationHistory,
+      subAgentFlows,
+      slashCommandOptions,
+      activeWorkflow?.tour
+    );
+    // generateMermaidFlowchart already returns a fenced ```mermaid block.
+    const mermaidBlock = generateMermaidFlowchart(workflow);
+    const execution = generateExecutionInstructions(workflow, { provider: 'claude-code' });
+    const title = `# ${workflow.name || 'Workflow'}`;
+    const descriptionBlock = workflow.description ? `\n${workflow.description}\n` : '\n';
+    const doc = `${title}\n${descriptionBlock}\n${mermaidBlock}\n\n${execution}\n`;
+    navigator.clipboard
+      ?.writeText(doc)
+      .then(() => {
+        setIsMarkdownCopied(true);
+        if (markdownCopiedTimeoutRef.current) {
+          clearTimeout(markdownCopiedTimeoutRef.current);
+        }
+        markdownCopiedTimeoutRef.current = setTimeout(() => setIsMarkdownCopied(false), 2000);
+      })
+      .catch(() => {});
+  }, [nodes, edges, workflowName, activeWorkflow]);
+
+  useEffect(() => {
+    return () => {
+      if (markdownCopiedTimeoutRef.current) {
+        clearTimeout(markdownCopiedTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Listen for messages from Extension
   useEffect(() => {
@@ -2605,6 +2653,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             <MoreActionsDropdown
               onOpenClaudeApi={() => setIsClaudeApiUploadDialogOpen(true)}
               onShareToSlack={onShareToSlack}
+              onCopyAsMarkdown={handleCopyAsMarkdown}
+              isMarkdownCopied={isMarkdownCopied}
+              isCopyAsMarkdownDisabled={nodes.length === 0}
               onResetWorkflow={() => setShowResetConfirm(true)}
               onStartTour={onStartTour}
               isFocusMode={isFocusMode}

--- a/packages/vscode/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
+++ b/packages/vscode/src/webview/src/components/toolbar/MoreActionsDropdown.tsx
@@ -13,6 +13,7 @@ import {
   Bot,
   Check,
   ChevronLeft,
+  ClipboardCopy,
   Cloud,
   Focus,
   HelpCircle,
@@ -35,6 +36,13 @@ const FONT_SIZES = {
 interface MoreActionsDropdownProps {
   onOpenClaudeApi: () => void;
   onShareToSlack: () => void;
+  /** Copies the current workflow as a Markdown doc (title + Mermaid diagram +
+   *  execution instructions) to the clipboard. */
+  onCopyAsMarkdown: () => void;
+  /** Shows the transient "Copied!" confirmation on the copy item. */
+  isMarkdownCopied: boolean;
+  /** Disables the copy item (e.g. empty canvas — nothing to document). */
+  isCopyAsMarkdownDisabled: boolean;
   onResetWorkflow: () => void;
   onStartTour: () => void;
   isFocusMode: boolean;
@@ -65,6 +73,9 @@ interface MoreActionsDropdownProps {
 export function MoreActionsDropdown({
   onOpenClaudeApi,
   onShareToSlack,
+  onCopyAsMarkdown,
+  isMarkdownCopied,
+  isCopyAsMarkdownDisabled,
   onResetWorkflow,
   onStartTour,
   isFocusMode,
@@ -192,6 +203,34 @@ export function MoreActionsDropdown({
           >
             <Share2 size={14} />
             <span>{t('slack.share.title')}</span>
+          </DropdownMenu.Item>
+
+          {/* Copy as Markdown — keeps the menu open so the "Copied!"
+              confirmation is visible where the user just clicked. */}
+          <DropdownMenu.Item
+            disabled={isCopyAsMarkdownDisabled}
+            onSelect={(event) => {
+              event.preventDefault();
+              onCopyAsMarkdown();
+            }}
+            style={{
+              padding: '8px 12px',
+              fontSize: `${FONT_SIZES.small}px`,
+              color: 'var(--vscode-foreground)',
+              cursor: isCopyAsMarkdownDisabled ? 'default' : 'pointer',
+              opacity: isCopyAsMarkdownDisabled ? 0.5 : 1,
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              outline: 'none',
+              borderRadius: '2px',
+            }}
+          >
+            <ClipboardCopy size={14} />
+            <span style={{ flex: 1 }}>
+              {isMarkdownCopied ? t('toolbar.copyAsMarkdownCopied') : t('toolbar.copyAsMarkdown')}
+            </span>
+            {isMarkdownCopied && <Check size={14} />}
           </DropdownMenu.Item>
 
           {/* Reset Workflow */}

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -485,6 +485,8 @@ export interface WebviewTranslationKeys {
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': string;
   'toolbar.focusMode': string;
+  'toolbar.copyAsMarkdown': string;
+  'toolbar.copyAsMarkdownCopied': string;
   'dialog.resetWorkflow.title': string;
   'dialog.resetWorkflow.message': string;
   'dialog.resetWorkflow.confirm': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -508,6 +508,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'Reset Workflow',
   'toolbar.focusMode': 'Focus Mode',
+  'toolbar.copyAsMarkdown': 'Copy as Markdown',
+  'toolbar.copyAsMarkdownCopied': 'Copied!',
   'dialog.resetWorkflow.title': 'Reset Workflow',
   'dialog.resetWorkflow.message':
     'Are you sure you want to reset the workflow? All nodes except Start and End will be removed.',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -506,6 +506,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': 'ワークフローをリセット',
   'toolbar.focusMode': '集中モード',
+  'toolbar.copyAsMarkdown': 'Markdownとしてコピー',
+  'toolbar.copyAsMarkdownCopied': 'コピーしました',
   'dialog.resetWorkflow.title': 'ワークフローをリセット',
   'dialog.resetWorkflow.message':
     'ワークフローをリセットしてもよろしいですか？Start と End 以外のすべてのノードが削除されます。',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -504,6 +504,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '워크플로우 초기화',
   'toolbar.focusMode': '집중 모드',
+  'toolbar.copyAsMarkdown': 'Markdown으로 복사',
+  'toolbar.copyAsMarkdownCopied': '복사했습니다',
   'dialog.resetWorkflow.title': '워크플로우 초기화',
   'dialog.resetWorkflow.message':
     '워크플로우를 초기화하시겠습니까? Start와 End를 제외한 모든 노드가 삭제됩니다.',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -490,6 +490,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重置工作流',
   'toolbar.focusMode': '专注模式',
+  'toolbar.copyAsMarkdown': '复制为 Markdown',
+  'toolbar.copyAsMarkdownCopied': '已复制',
   'dialog.resetWorkflow.title': '重置工作流',
   'dialog.resetWorkflow.message': '确定要重置工作流吗？除 Start 和 End 外的所有节点都将被删除。',
   'dialog.resetWorkflow.confirm': '重置',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -492,6 +492,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   // Reset Workflow Confirmation Dialog
   'toolbar.resetWorkflow': '重設工作流程',
   'toolbar.focusMode': '專注模式',
+  'toolbar.copyAsMarkdown': '複製為 Markdown',
+  'toolbar.copyAsMarkdownCopied': '已複製',
   'dialog.resetWorkflow.title': '重設工作流程',
   'dialog.resetWorkflow.message': '確定要重設工作流程嗎？除 Start 和 End 外的所有節點都將被刪除。',
   'dialog.resetWorkflow.confirm': '重設',


### PR DESCRIPTION
Closes #947

## Summary

A user who built a workflow on the canvas had no way to get a shareable document of it without installing the `ccwf` CLI and running `ccwf render`. The More Actions menu now has a **Copy as Markdown** item that copies the same bundle `ccwf render --format=md` prints — `# title`, description, fenced ```mermaid diagram (rendered natively by GitHub), and the execution instructions — so the workflow can be pasted straight into a PR description, issue, or README. Carried next-proposal from the `render_workflow` iteration (`docs/progress-log.md`).

## Changes

- `MoreActionsDropdown.tsx`: new item after Share to Slack (`ClipboardCopy` icon). It `preventDefault`s on select so the menu stays open and shows a transient localized "Copied!" + check confirmation (2 s, matching the existing toggle-item pattern); disabled with reduced opacity on an empty canvas.
- `Toolbar.tsx`: `handleCopyAsMarkdown` serializes the current canvas via the established `serializeWorkflow` path and assembles the doc with `generateMermaidFlowchart` + `generateExecutionInstructions` from `@cc-wf-studio/core` — the exact functions and string assembly `ccwf render` uses (`packages/cli/src/commands/render.ts`) — then writes it with `navigator.clipboard.writeText` (established permission-free webview pattern).
- i18n: `toolbar.copyAsMarkdown` / `toolbar.copyAsMarkdownCopied` added to `translation-keys.ts` and all 5 locales; "Markdown" kept untranslated per the translation rule.
- Changeset: patch for `cc-wf-studio` and `@cc-wf-studio/cli` (both bundle the shared webview, so the action ships in the VSCode editor and `ccwf canvas`).

## Verification

- `pnpm build` and `pnpm check` green from the repo root.
- Manual E2E queued in the progress log (menu feedback, empty-canvas disabled state, pasted doc rendering on GitHub).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmecUb1k1mqiHsbYrrAx6K)_