### PR TITLE
feat(vscode): rename a group in place by double-clicking its header

### DIFF
--- a/.changeset/group-inline-rename.md
+++ b/.changeset/group-inline-rename.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Rename a group in place by double-clicking its header — Enter or clicking away commits, Esc cancels; the property panel remains an equivalent editor.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,39 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Inline group rename (double-click the group header)
+- **User value**: a user can now rename a group by double-clicking its
+  header and typing — Enter or clicking away commits, Esc cancels —
+  instead of selecting the group and editing the label in the property
+  panel (top carried proposal from the previous iteration; double-click
+  on the header previously just zoomed the canvas).
+- **Issue/PR**: #955 / PR from `claude/sleepy-curie-km0zc4`
+- **Outcome**: done — `GroupNode.tsx` swaps the header label span for a
+  pre-filled, auto-selected text input on double-click; commit goes
+  through the existing `updateNodeData` (single `set()` → one undo
+  entry), empty input falls back to the previous label, Esc discards.
+  `nodrag nodblclick` classNames keep typing from dragging the node and
+  the double-click from triggering React Flow's canvas zoom; the global
+  shortcut handlers already ignore INPUT targets, and the input resets
+  the header's uppercase text-transform so the real stored value is shown
+  while editing. Tooltip + input aria strings added in all 5 locales. No
+  schema change — the property panel remains an equivalent editor. Issue
+  #955 could not be locked (no `gh`, no MCP lock tool — known limitation,
+  noted in the issue).
+- **Next proposals**:
+  - F8-style "next problem" keyboard cycling for the problems panel
+    (jump through problem nodes without the mouse).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): inline group rename (double-click,
+    Enter/blur/Esc, undo restores old name); Ungroup (menu +
+    mod+Shift+G, undo restores parenting, mixed selection); Group
+    selection (menu + mod+G, undo as one step); Save as Image from the
+    VSCode extension host; Copy as Markdown; `render_workflow` via MCP
+    Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search
+    cycling; align/distribute + context menu + copy/cut/paste; localized
+    Claude API dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — "Ungroup" canvas action (context menu + Ctrl/Cmd+Shift+G)
 - **User value**: a user can now dissolve a selected group in place — its
   nodes keep their exact canvas positions and edges, only the container

--- a/packages/vscode/src/webview/src/components/nodes/GroupNode.tsx
+++ b/packages/vscode/src/webview/src/components/nodes/GroupNode.tsx
@@ -7,7 +7,9 @@
  */
 
 import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { type NodeProps, NodeResizer } from 'reactflow';
+import { useTranslation } from '../../i18n/i18n-context';
 import { useWorkflowStore } from '../../stores/workflow-store';
 import { DeleteButton } from './DeleteButton';
 import { DuplicateButton } from './DuplicateButton';
@@ -18,8 +20,35 @@ export interface GroupNodeData {
 
 export const GroupNodeComponent: React.FC<NodeProps<GroupNodeData>> = ({ id, data, selected }) => {
   const label = data.label || 'Group';
+  const { t } = useTranslation();
   const highlightedGroupNodeId = useWorkflowStore((s) => s.highlightedGroupNodeId);
+  const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
   const isHighlighted = highlightedGroupNodeId === id;
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(label);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const startEditing = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setDraft(label);
+    setIsEditing(true);
+  };
+
+  const commitEdit = () => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== label) {
+      updateNodeData(id, { label: trimmed });
+    }
+    setIsEditing(false);
+  };
 
   const borderColor = isHighlighted
     ? 'var(--vscode-focusBorder)'
@@ -84,7 +113,47 @@ export const GroupNodeComponent: React.FC<NodeProps<GroupNodeData>> = ({ id, dat
             justifyContent: 'space-between',
           }}
         >
-          <span>{label}</span>
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              className="nodrag nodblclick"
+              value={draft}
+              aria-label={t('canvas.groupRename.inputAria')}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') {
+                  commitEdit();
+                } else if (e.key === 'Escape') {
+                  setIsEditing(false);
+                }
+              }}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                font: 'inherit',
+                fontWeight: 600,
+                textTransform: 'none',
+                letterSpacing: 'inherit',
+                color: 'var(--vscode-input-foreground)',
+                backgroundColor: 'var(--vscode-input-background)',
+                border: '1px solid var(--vscode-focusBorder)',
+                borderRadius: '2px',
+                padding: '0 4px',
+                margin: '-1px 0',
+              }}
+            />
+          ) : (
+            <span
+              className="nodblclick"
+              title={t('canvas.groupRename.tooltip')}
+              onDoubleClick={startEditing}
+              style={{ flex: 1, minWidth: 0 }}
+            >
+              {label}
+            </span>
+          )}
           <DuplicateButton nodeId={id} selected={selected} />
           <DeleteButton nodeId={id} selected={selected} />
         </div>

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -387,6 +387,8 @@ export interface WebviewTranslationKeys {
   // Canvas action tooltips / a11y labels
   'canvas.deleteNode.tooltip': string;
   'canvas.deleteEdge.tooltip': string;
+  'canvas.groupRename.tooltip': string;
+  'canvas.groupRename.inputAria': string;
   'canvas.resizeSidebar': string;
 
   // Canvas context menu

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -407,6 +407,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': 'Regenerating…',
   'canvas.deleteNode.tooltip': 'Delete node',
   'canvas.deleteEdge.tooltip': 'Delete connection',
+  'canvas.groupRename.tooltip': 'Double-click to rename',
+  'canvas.groupRename.inputAria': 'Group name',
   'canvas.resizeSidebar': 'Resize sidebar',
 
   // Canvas context menu

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -405,6 +405,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '再生成中…',
   'canvas.deleteNode.tooltip': 'ノードを削除',
   'canvas.deleteEdge.tooltip': '接続を削除',
+  'canvas.groupRename.tooltip': 'ダブルクリックで名前を変更',
+  'canvas.groupRename.inputAria': 'グループ名',
   'canvas.resizeSidebar': 'サイドバーのサイズを変更',
 
   // Canvas context menu

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -404,6 +404,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '재생성 중…',
   'canvas.deleteNode.tooltip': '노드 삭제',
   'canvas.deleteEdge.tooltip': '연결 삭제',
+  'canvas.groupRename.tooltip': '더블 클릭으로 이름 변경',
+  'canvas.groupRename.inputAria': '그룹 이름',
   'canvas.resizeSidebar': '사이드바 크기 조절',
 
   // Canvas context menu

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -391,6 +391,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '重新生成中…',
   'canvas.deleteNode.tooltip': '删除节点',
   'canvas.deleteEdge.tooltip': '删除连接',
+  'canvas.groupRename.tooltip': '双击重命名',
+  'canvas.groupRename.inputAria': '编组名称',
   'canvas.resizeSidebar': '调整侧边栏大小',
 
   // Canvas context menu

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -393,6 +393,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '重新產生中…',
   'canvas.deleteNode.tooltip': '刪除節點',
   'canvas.deleteEdge.tooltip': '刪除連線',
+  'canvas.groupRename.tooltip': '雙擊重新命名',
+  'canvas.groupRename.inputAria': '群組名稱',
   'canvas.resizeSidebar': '調整側邊欄大小',
 
   // Canvas context menu


### PR DESCRIPTION
## Summary

A user can now rename a group by double-clicking its header and typing — Enter (or clicking away) commits, Esc cancels — instead of selecting the group and editing the label through the property panel. Previously double-clicking a group header just zoomed the canvas.

Closes #955

## Changes

- `GroupNode.tsx`: the header label `<span>` swaps to a pre-filled, auto-focused/selected text input on double-click. Commit goes through the existing `updateNodeData` store action (single `set()` → one undo entry); an empty/whitespace input falls back to the previous label; Esc discards without a store write.
- `nodrag nodblclick` classNames on the input/label so typing doesn't drag the node and the double-click doesn't trigger React Flow's double-click zoom; the input overrides the header's `text-transform: uppercase` so the real stored value is shown while editing. Global shortcut handlers already ignore `INPUT` targets.
- Tooltip ("Double-click to rename") and input aria-label strings added to `translation-keys.ts` and all 5 locales.
- Progress-log entry appended; changeset added (`cc-wf-studio` patch).

## Why

Inline rename on double-click is the standard canvas idiom (Figma, Miro, draw.io); the property panel remains an equivalent editor, so nothing changes for existing flows. No schema change — `label` already round-trips through persistence.

## Verification

- `pnpm build` and `pnpm check` green from the repo root.
- Manual E2E queued in the progress log (double-click → type → Enter/blur/Esc, undo restores the old name).

---
_Generated by [Claude Code](https://claude.ai/code/session_012URW2ioEh8ac3U1wdFM2t9)_