### PR TITLE
feat(vscode): cycle through workflow problems with F8 / Shift+F8

### DIFF
--- a/.changeset/problems-f8-keyboard-cycling.md
+++ b/.changeset/problems-f8-keyboard-cycling.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Cycle through workflow problems from the keyboard: F8 jumps to the next node with a validation problem (Shift+F8 to the previous one), selecting and centering it on the canvas and opening the problems panel, mirroring VSCode's "go to next problem" convention. Listed in the shortcut cheat sheet; the Problems toolbar button tooltip now shows the F8 hint.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,39 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Keyboard problem cycling (F8 / Shift+F8)
+- **User value**: a user can now step through every validation problem on
+  the canvas from the keyboard — F8 selects and centers the next node with
+  a problem, Shift+F8 the previous one (VSCode's own F8 convention) — and
+  no longer has to open the problems panel and click each entry with the
+  mouse (top carried proposal from the previous iteration).
+- **Issue/PR**: #957
+- **Outcome**: done — F8 block in WorkflowEditor's existing global keydown
+  handler: ignored in inputs/textareas/contentEditable and while a
+  sub-agent flow is being edited; computes issues on demand with
+  `collectWorkflowIssues` from live store state (the memoized list is
+  empty while the panel is closed), opens the problems panel so the list
+  and red node markers explain the jump, dedupes to distinct problem-node
+  ids in issue order, and cycles relative to the currently selected node
+  (wrap-around; Shift reverses) via the existing `jumpToNode` helper —
+  navigation-only, selection is excluded from undo history. Cheat-sheet
+  rows for F8 / Shift+F8, "(F8)" hint on the Problems toolbar button
+  tooltip, 2 new strings in all 5 locales. No schema change. Issue #957
+  could not be locked (no `gh`, no MCP lock tool — known limitation,
+  noted in the issue).
+- **Next proposals**:
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Esc closes the problems panel / search panel from the canvas (check
+    current behavior first).
+  - Manual E2E queue (carried): F8/Shift+F8 problem cycling (wrap-around,
+    panel auto-open, sub-agent flow ignored); inline group rename;
+    Ungroup; Group selection; Save as Image from the VSCode extension
+    host; Copy as Markdown; `render_workflow` via MCP Inspector; problems
+    badge; shortcut cheat sheet; problem-node markers; problems panel
+    click-to-jump; auto layout; node search cycling; align/distribute +
+    context menu + copy/cut/paste; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Inline group rename (double-click the group header)
 - **User value**: a user can now rename a group by double-clicking its
   header and typing — Enter or clicking away commits, Esc cancels —

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -58,6 +58,7 @@ import {
   type SelectionClipboardPayload,
   useWorkflowStore,
 } from '../stores/workflow-store';
+import { jumpToNode } from '../utils/canvas-navigation';
 import { createDefaultNode, type SimpleNodeType } from '../utils/node-defaults';
 import { collectWorkflowIssues } from '../utils/workflow-issues';
 import { CanvasContextMenu, type CanvasContextMenuEntry } from './CanvasContextMenu';
@@ -829,6 +830,49 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         }
         event.preventDefault();
         setIsShortcutsOpen(true);
+        return;
+      }
+
+      // F8 / Shift+F8 — jump to the next / previous node with a validation
+      // problem (VSCode's "go to next problem" convention). Opens the
+      // problems panel so the list and node markers explain the jump.
+      if (event.key === 'F8' && !mod && !event.altKey) {
+        const target = event.target as HTMLElement | null;
+        if (
+          target &&
+          (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        ) {
+          return;
+        }
+        const state = useWorkflowStore.getState();
+        // The panel and its issues describe the main workflow, not the
+        // sub-agent flow currently on the canvas
+        if (state.activeSubAgentFlowId !== null) return;
+        event.preventDefault();
+        if (!state.isProblemsPanelOpen) state.openProblemsPanel();
+        const issues = collectWorkflowIssues(
+          state.nodes,
+          state.edges,
+          state.workflowName,
+          state.workflowDescription || undefined,
+          state.subAgentFlows.length > 0 ? state.subAgentFlows : undefined,
+          state.slashCommandOptions
+        );
+        const problemNodeIds = [
+          ...new Set(issues.flatMap((issue) => (issue.nodeId !== null ? [issue.nodeId] : []))),
+        ].filter((id) => state.nodes.some((n) => n.id === id));
+        const instance = reactFlowInstanceRef.current;
+        if (problemNodeIds.length === 0 || !instance) return;
+        const selectedId = state.nodes.find((n) => n.selected)?.id;
+        const currentIndex = selectedId ? problemNodeIds.indexOf(selectedId) : -1;
+        const nextIndex = event.shiftKey
+          ? currentIndex <= 0
+            ? problemNodeIds.length - 1
+            : currentIndex - 1
+          : currentIndex === -1 || currentIndex === problemNodeIds.length - 1
+            ? 0
+            : currentIndex + 1;
+        jumpToNode(instance, problemNodeIds[nextIndex]);
         return;
       }
 

--- a/packages/vscode/src/webview/src/components/WorkflowProblemsButton.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowProblemsButton.tsx
@@ -59,10 +59,11 @@ export const WorkflowProblemsButton: React.FC<WorkflowProblemsButtonProps> = ({
   issueCount = 0,
 }) => {
   const { t } = useTranslation();
-  const tooltip =
+  const tooltip = `${
     issueCount > 0
       ? t('problemsPanel.tooltipWithCount', { count: issueCount })
-      : t('problemsPanel.tooltip');
+      : t('problemsPanel.tooltip')
+  } (F8)`;
 
   return (
     <StyledTooltipProvider>

--- a/packages/vscode/src/webview/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -87,6 +87,8 @@ export const KeyboardShortcutsDialog: React.FC<KeyboardShortcutsDialogProps> = (
       rows: [
         { label: t('shortcuts.selectAll'), combos: [[mod, 'A']] },
         { label: t('shortcuts.search'), combos: [[mod, 'F']] },
+        { label: t('shortcuts.nextProblem'), combos: [['F8']] },
+        { label: t('shortcuts.prevProblem'), combos: [['Shift', 'F8']] },
         { label: t('shortcuts.openCheatSheet'), combos: [['?']] },
       ],
     },

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -448,6 +448,8 @@ export interface WebviewTranslationKeys {
   'shortcuts.delete': string;
   'shortcuts.selectAll': string;
   'shortcuts.search': string;
+  'shortcuts.nextProblem': string;
+  'shortcuts.prevProblem': string;
   'shortcuts.openCheatSheet': string;
   'shortcuts.contextMenu': string;
   'shortcuts.edgeDrop': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -468,6 +468,8 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.delete': 'Delete selection',
   'shortcuts.selectAll': 'Select all nodes',
   'shortcuts.search': 'Search nodes',
+  'shortcuts.nextProblem': 'Jump to next problem',
+  'shortcuts.prevProblem': 'Jump to previous problem',
   'shortcuts.openCheatSheet': 'Show this cheat sheet',
   'shortcuts.contextMenu': 'Open the context menu',
   'shortcuts.edgeDrop': 'Create a connected node',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -466,6 +466,8 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.delete': '選択範囲を削除',
   'shortcuts.selectAll': 'すべてのノードを選択',
   'shortcuts.search': 'ノードを検索',
+  'shortcuts.nextProblem': '次の問題へ移動',
+  'shortcuts.prevProblem': '前の問題へ移動',
   'shortcuts.openCheatSheet': 'このチートシートを表示',
   'shortcuts.contextMenu': 'コンテキストメニューを開く',
   'shortcuts.edgeDrop': '接続済みノードを作成',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -465,6 +465,8 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.delete': '선택 항목 삭제',
   'shortcuts.selectAll': '모든 노드 선택',
   'shortcuts.search': '노드 검색',
+  'shortcuts.nextProblem': '다음 문제로 이동',
+  'shortcuts.prevProblem': '이전 문제로 이동',
   'shortcuts.openCheatSheet': '이 치트 시트 표시',
   'shortcuts.contextMenu': '컨텍스트 메뉴 열기',
   'shortcuts.edgeDrop': '연결된 노드 만들기',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -452,6 +452,8 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.delete': '删除所选内容',
   'shortcuts.selectAll': '选择所有节点',
   'shortcuts.search': '搜索节点',
+  'shortcuts.nextProblem': '跳转到下一个问题',
+  'shortcuts.prevProblem': '跳转到上一个问题',
   'shortcuts.openCheatSheet': '显示此快捷键列表',
   'shortcuts.contextMenu': '打开上下文菜单',
   'shortcuts.edgeDrop': '创建已连接的节点',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -454,6 +454,8 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.delete': '刪除所選內容',
   'shortcuts.selectAll': '選取所有節點',
   'shortcuts.search': '搜尋節點',
+  'shortcuts.nextProblem': '跳至下一個問題',
+  'shortcuts.prevProblem': '跳至上一個問題',
   'shortcuts.openCheatSheet': '顯示此快捷鍵列表',
   'shortcuts.contextMenu': '開啟操作選單',
   'shortcuts.edgeDrop': '建立已連接的節點',


### PR DESCRIPTION
## Summary

A user can now step through every validation problem on the canvas from the keyboard: **F8** selects and centers the next node with a problem, **Shift+F8** the previous one (wrap-around) — mirroring VSCode's own "go to next problem" convention — instead of opening the problems panel and clicking each entry with the mouse.

Closes #957

## Changes

- **`WorkflowEditor.tsx`**: F8 block in the existing global keydown handler. Ignored in inputs/textareas/contentEditable and while a sub-agent flow is being edited (the issues describe the main workflow). Computes issues on demand with `collectWorkflowIssues` from live store state (the memoized list is empty while the panel is closed), opens the problems panel so the list and red node markers explain the jump, dedupes to distinct problem-node ids in issue order, and cycles relative to the currently selected node via the existing `jumpToNode` helper. Navigation-only — selection is excluded from undo history.
- **`KeyboardShortcutsDialog.tsx`**: two new cheat-sheet rows (F8, Shift+F8).
- **`WorkflowProblemsButton.tsx`**: "(F8)" hint appended to the tooltip/aria-label.
- **i18n**: `shortcuts.nextProblem` / `shortcuts.prevProblem` in all 5 locales.
- **`docs/progress-log.md`**: iteration entry.

## Changeset

`.changeset/problems-f8-keyboard-cycling.md` — `cc-wf-studio` patch.

## Testing

- `pnpm build` and `pnpm check` green from the repo root.
- Manual E2E (queued in the progress log): F8 with panel closed opens it and jumps to the first problem node; repeated F8 cycles with wrap-around; Shift+F8 reverses; no-op in text inputs and while editing a sub-agent flow; no problems → panel just opens showing the "no problems" state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRYV5kfYbvoB6hkwukoF6G)_