### PR TITLE
improvement(vscode): close the search/problems panels with Esc

### DIFF
--- a/.changeset/esc-dismisses-canvas-panels.md
+++ b/.changeset/esc-dismisses-canvas-panels.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Esc now closes the canvas search panel and the workflow problems panel from anywhere on the canvas (previously the search panel honored Esc only while its input had focus, and the problems panel had no Esc handling), with a new Esc row in the keyboard shortcut cheat sheet.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,40 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Esc dismisses the search / problems panel
+- **User value**: a user can now close the canvas search panel and the
+  workflow problems panel by pressing Esc from anywhere on the canvas —
+  completing the keyboard flow those panels start from the keyboard
+  (Ctrl/Cmd+F, F8) — and no longer has to reach for the mouse to click
+  the panel's ✕ button (the search panel previously honored Esc only
+  while its input still had focus; the problems panel not at all).
+- **Issue/PR**: #959
+- **Outcome**: done — Escape branch in WorkflowEditor's existing global
+  keydown handler, layered like VSCode's Esc: editable targets are
+  skipped (the search input and inline group rename own their Esc), open
+  Radix dialogs (`[role="dialog"]`) and canvas context menus are skipped
+  (they own their dismissal), then the search panel closes first, else
+  the problems panel (only when actually visible — not while a sub-agent
+  flow is being edited). Local panel/menu state reaches the stable
+  handler via a render-synced ref. New "Close search / problems panel"
+  cheat-sheet row (Esc), 1 new string in all 5 locales. UI-only — no
+  schema or persistence change. Issue #959 could not be locked (no `gh`,
+  no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Arrow-key nudge for selected nodes (needs an undo-coalescing design
+    first — every tracked change is one history entry today; file the
+    design as part of the idea).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): Esc panel dismissal (search unfocused,
+    problems panel, dialog/context-menu non-interference); F8/Shift+F8
+    problem cycling; inline group rename; Ungroup; Group selection; Save
+    as Image from the VSCode extension host; Copy as Markdown;
+    `render_workflow` via MCP Inspector; problems badge; shortcut cheat
+    sheet; problem-node markers; problems panel click-to-jump; auto
+    layout; node search cycling; align/distribute + context menu +
+    copy/cut/paste; localized Claude API dialog in ja/ko/zh;
+    `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Keyboard problem cycling (F8 / Shift+F8)
 - **User value**: a user can now step through every validation problem on
   the canvas from the keyboard — F8 selects and centers the next node with

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -597,6 +597,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     setSearchFocusNonce((nonce) => nonce + 1);
   }, []);
 
+  // Live mirror of transient-UI state for the global Esc handler — the
+  // keydown effect's deps are stable, so it cannot close over this state
+  const escTargetsRef = useRef({ isSearchOpen: false, isMenuOpen: false });
+  escTargetsRef.current = {
+    isSearchOpen,
+    isMenuOpen: contextMenu !== null || edgeDropMenu !== null,
+  };
+
   // Auto layout — tidy the whole canvas, then re-fit the view so the
   // freshly arranged graph is fully visible
   const autoLayoutCanvas = useCallback(() => {
@@ -873,6 +881,35 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             ? 0
             : currentIndex + 1;
         jumpToNode(instance, problemNodeIds[nextIndex]);
+        return;
+      }
+
+      // Esc — dismiss the search panel, then the problems panel (topmost
+      // transient UI first, VSCode's layered Esc). Editable targets keep
+      // their own Esc (search input, inline group rename); open dialogs
+      // and context menus own their dismissal and are skipped here.
+      if (event.key === 'Escape' && !mod && !event.altKey && !event.shiftKey) {
+        const target = event.target as HTMLElement | null;
+        if (
+          target &&
+          (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        ) {
+          return;
+        }
+        if (escTargetsRef.current.isMenuOpen) return;
+        if (document.querySelector('[role="dialog"]')) return;
+        if (escTargetsRef.current.isSearchOpen) {
+          event.preventDefault();
+          setIsSearchOpen(false);
+          return;
+        }
+        const state = useWorkflowStore.getState();
+        // Only when the panel is actually visible — while a sub-agent flow
+        // is being edited the open flag may be set but the panel is hidden
+        if (state.isProblemsPanelOpen && state.activeSubAgentFlowId === null) {
+          event.preventDefault();
+          state.closeProblemsPanel();
+        }
         return;
       }
 

--- a/packages/vscode/src/webview/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -89,6 +89,7 @@ export const KeyboardShortcutsDialog: React.FC<KeyboardShortcutsDialogProps> = (
         { label: t('shortcuts.search'), combos: [[mod, 'F']] },
         { label: t('shortcuts.nextProblem'), combos: [['F8']] },
         { label: t('shortcuts.prevProblem'), combos: [['Shift', 'F8']] },
+        { label: t('shortcuts.closePanel'), combos: [['Esc']] },
         { label: t('shortcuts.openCheatSheet'), combos: [['?']] },
       ],
     },

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -450,6 +450,7 @@ export interface WebviewTranslationKeys {
   'shortcuts.search': string;
   'shortcuts.nextProblem': string;
   'shortcuts.prevProblem': string;
+  'shortcuts.closePanel': string;
   'shortcuts.openCheatSheet': string;
   'shortcuts.contextMenu': string;
   'shortcuts.edgeDrop': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -470,6 +470,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.search': 'Search nodes',
   'shortcuts.nextProblem': 'Jump to next problem',
   'shortcuts.prevProblem': 'Jump to previous problem',
+  'shortcuts.closePanel': 'Close search / problems panel',
   'shortcuts.openCheatSheet': 'Show this cheat sheet',
   'shortcuts.contextMenu': 'Open the context menu',
   'shortcuts.edgeDrop': 'Create a connected node',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -468,6 +468,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.search': 'ノードを検索',
   'shortcuts.nextProblem': '次の問題へ移動',
   'shortcuts.prevProblem': '前の問題へ移動',
+  'shortcuts.closePanel': '検索／問題パネルを閉じる',
   'shortcuts.openCheatSheet': 'このチートシートを表示',
   'shortcuts.contextMenu': 'コンテキストメニューを開く',
   'shortcuts.edgeDrop': '接続済みノードを作成',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -467,6 +467,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.search': '노드 검색',
   'shortcuts.nextProblem': '다음 문제로 이동',
   'shortcuts.prevProblem': '이전 문제로 이동',
+  'shortcuts.closePanel': '검색/문제 패널 닫기',
   'shortcuts.openCheatSheet': '이 치트 시트 표시',
   'shortcuts.contextMenu': '컨텍스트 메뉴 열기',
   'shortcuts.edgeDrop': '연결된 노드 만들기',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -454,6 +454,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.search': '搜索节点',
   'shortcuts.nextProblem': '跳转到下一个问题',
   'shortcuts.prevProblem': '跳转到上一个问题',
+  'shortcuts.closePanel': '关闭搜索/问题面板',
   'shortcuts.openCheatSheet': '显示此快捷键列表',
   'shortcuts.contextMenu': '打开上下文菜单',
   'shortcuts.edgeDrop': '创建已连接的节点',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -456,6 +456,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.search': '搜尋節點',
   'shortcuts.nextProblem': '跳至下一個問題',
   'shortcuts.prevProblem': '跳至上一個問題',
+  'shortcuts.closePanel': '關閉搜尋/問題面板',
   'shortcuts.openCheatSheet': '顯示此快捷鍵列表',
   'shortcuts.contextMenu': '開啟操作選單',
   'shortcuts.edgeDrop': '建立已連接的節點',


### PR DESCRIPTION
## Summary

A user can now close the canvas search panel and the workflow problems panel by pressing **Esc from anywhere on the canvas** — completing the keyboard flow those panels already start from the keyboard (Ctrl/Cmd+F opens search, F8 auto-opens the problems panel) — instead of reaching for the mouse to click the panel's ✕. Previously the search panel honored Esc only while its input still had focus, and the problems panel had no Esc handling at all.

Closes #959

## Changes

- **`WorkflowEditor.tsx`**: Escape branch in the existing global keydown handler, layered like VSCode's Esc — editable targets are skipped (the search input and inline group rename own their Esc), open Radix dialogs (`[role="dialog"]`) and canvas context menus are skipped (they own their dismissal), then the search panel closes first, else the problems panel (only when actually visible, i.e. not while a sub-agent flow is being edited). Local panel/menu state reaches the stable handler via a render-synced ref.
- **`KeyboardShortcutsDialog.tsx`**: new "Close search / problems panel" row (Esc).
- **i18n**: `shortcuts.closePanel` in all 5 locales.
- **`docs/progress-log.md`**: iteration entry.

## Changeset

`.changeset/esc-dismisses-canvas-panels.md` — `cc-wf-studio` patch.

## Testing

- `pnpm build` and `pnpm check` green from the repo root.
- Manual E2E (queued in the progress log): Esc closes the search panel after focus has left its input; Esc closes the problems panel after an F8 jump; Esc inside the search input still closes via the input's own handler; Esc with a dialog open closes only the dialog; Esc with a context menu open closes only the menu; no-op while editing a sub-agent flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGuieLtFzvmbKvUWP8yHxk)_