### PR TITLE
improvement(vscode): type-to-filter the node palette

### DIFF
--- a/.changeset/palette-type-to-filter.md
+++ b/.changeset/palette-type-to-filter.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': patch
+---
+
+Add a type-to-filter box to the Node Palette: typing narrows the list to matching node types (by title or localized description), hides empty sections, and shows a "no matching nodes" empty state.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,40 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Type-to-filter the node palette
+- **User value**: a user can now type in a filter box at the top of the
+  Node Palette to instantly narrow the list to matching node types —
+  matching both the (always-English) node titles and the localized
+  descriptions — instead of visually scanning four sections of 11+
+  buttons; empty section headers disappear while filtering and a
+  localized "no matching nodes" state explains an over-narrow query
+  (top carried proposal from the previous iteration).
+- **Issue/PR**: #963
+- **Outcome**: done — filter input styled like the canvas
+  NodeSearchPanel's (VSCode input theme vars, inline clear ✕ button,
+  Esc clears then blurs); per-button visibility flags fold in the
+  existing sub-agent-flow-editing and Codex-beta gates, section headers
+  render only when a member node matches, and the Quick Start block
+  hides while a filter is active. Matching is case-insensitive
+  substring over `node.<type>.title` + `node.<type>.description`.
+  3 new strings in all 5 locales. UI-only — no schema or persistence
+  change. Issue #963 could not be locked (no `gh`, no MCP lock tool —
+  known limitation, noted in the issue).
+- **Next proposals**:
+  - Type-to-filter for the edge-drop add-node menu (reuse the palette's
+    matcher).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): palette filter (title/description match,
+    section hiding, clear button, Esc, compact mode, Codex-beta and
+    sub-agent-flow gating); arrow-key nudge; Esc panel dismissal; F8 /
+    Shift+F8 problem cycling; inline group rename; Ungroup; Group
+    selection; Save as Image from the VSCode extension host; Copy as
+    Markdown; `render_workflow` via MCP Inspector; problems badge;
+    shortcut cheat sheet; problem-node markers; problems panel
+    click-to-jump; auto layout; node search cycling; align/distribute +
+    context menu + copy/cut/paste; localized Claude API dialog in
+    ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Arrow-key nudge with single-undo bursts
 - **User value**: a user can now nudge the selected node(s) with the arrow
   keys — one 15px grid step per press, ×4 with Shift — from anywhere on the

--- a/packages/vscode/src/webview/src/components/NodePalette.tsx
+++ b/packages/vscode/src/webview/src/components/NodePalette.tsx
@@ -20,12 +20,14 @@ import {
   Square,
   SquareDashed,
   Terminal,
+  X,
   Zap,
 } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
+import type { WebviewTranslationKeys } from '../i18n/translation-keys';
 import { createSubAgent } from '../services/command-browser-service';
 import { useRefinementStore } from '../stores/refinement-store';
 import { useWorkflowStore } from '../stores/workflow-store';
@@ -71,6 +73,50 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
   const [isMcpDialogOpen, setIsMcpDialogOpen] = useState(false);
   const [isCodexDialogOpen, setIsCodexDialogOpen] = useState(false);
   const [isSubAgentDialogOpen, setIsSubAgentDialogOpen] = useState(false);
+  const [filterText, setFilterText] = useState('');
+
+  const paletteFilter = filterText.trim().toLowerCase();
+
+  /** Case-insensitive match against the palette title and localized description */
+  const matchesFilter = (
+    titleKey: keyof WebviewTranslationKeys,
+    descKey: keyof WebviewTranslationKeys
+  ): boolean =>
+    paletteFilter === '' ||
+    t(titleKey).toLowerCase().includes(paletteFilter) ||
+    t(descKey).toLowerCase().includes(paletteFilter);
+
+  const showPrompt = matchesFilter('node.prompt.title', 'node.prompt.description');
+  const showSubAgent =
+    !isEditingSubAgentFlow && matchesFilter('node.subAgent.title', 'node.subAgent.description');
+  const showSubAgentFlow =
+    !isEditingSubAgentFlow &&
+    matchesFilter('node.subAgentFlow.title', 'node.subAgentFlow.description');
+  const showSkill = matchesFilter('node.skill.title', 'node.skill.description');
+  const showMcp = matchesFilter('node.mcp.title', 'node.mcp.description');
+  const showCodex = isCodexEnabled && matchesFilter('node.codex.title', 'node.codex.description');
+  const showGroup = matchesFilter('node.group.title', 'node.group.description');
+  const showIfElse = matchesFilter('node.ifElse.title', 'node.ifElse.description');
+  const showSwitch = matchesFilter('node.switch.title', 'node.switch.description');
+  const showAskUserQuestion =
+    !isEditingSubAgentFlow &&
+    matchesFilter('node.askUserQuestion.title', 'node.askUserQuestion.description');
+  const showBranchSession =
+    !isEditingSubAgentFlow &&
+    matchesFilter('node.branchSession.title', 'node.branchSession.description');
+  const showEnd = matchesFilter('node.end.title', 'node.end.description');
+  const showBranch =
+    !isEditingSubAgentFlow && matchesFilter('node.branch.title', 'node.branch.description');
+
+  const showBasicSection = showPrompt || showSubAgent || showSubAgentFlow || showSkill || showMcp;
+  const showControlFlowSection =
+    showIfElse || showSwitch || showAskUserQuestion || showBranchSession || showEnd || showBranch;
+  const noFilterResults =
+    paletteFilter !== '' &&
+    !showBasicSection &&
+    !showCodex &&
+    !showGroup &&
+    !showControlFlowSection;
 
   /**
    * 既存のノードと重ならない位置を計算する
@@ -372,68 +418,132 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
         )}
       </div>
 
-      {/* Section: Basic Nodes */}
-      <div
-        style={{
-          fontSize: isCompact ? '10px' : '11px',
-          fontWeight: 600,
-          color: 'var(--vscode-descriptionForeground)',
-          marginBottom: isCompact ? '4px' : '8px',
-          marginTop: isCompact ? '4px' : '8px',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-        }}
-      >
-        {t('palette.basicNodes')}
-      </div>
-
-      {/* Prompt Node Button */}
-      <button
-        type="button"
-        onClick={handleAddPromptNode}
-        data-tour="add-prompt-button"
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <MessageSquare size={14} />
-          {t('node.prompt.title')}
-        </div>
-        {!isCompact && (
-          <div
+      {/* Filter input */}
+      <div style={{ position: 'relative', marginBottom: isCompact ? '8px' : '12px' }}>
+        <input
+          type="text"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              if (filterText !== '') {
+                setFilterText('');
+              } else {
+                e.currentTarget.blur();
+              }
+            }
+          }}
+          placeholder={t('palette.filter.placeholder')}
+          aria-label={t('palette.filter.placeholder')}
+          style={{
+            width: '100%',
+            height: '24px',
+            padding: filterText !== '' ? '0 24px 0 6px' : '0 6px',
+            backgroundColor: 'var(--vscode-input-background)',
+            color: 'var(--vscode-input-foreground)',
+            border: '1px solid var(--vscode-input-border, transparent)',
+            borderRadius: '4px',
+            outline: 'none',
+            fontSize: '12px',
+            boxSizing: 'border-box',
+          }}
+        />
+        {filterText !== '' && (
+          <button
+            type="button"
+            onClick={() => setFilterText('')}
+            aria-label={t('palette.filter.clear')}
+            title={t('palette.filter.clear')}
             style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
+              position: 'absolute',
+              right: '2px',
+              top: '50%',
+              transform: 'translateY(-50%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '20px',
+              height: '20px',
+              padding: 0,
+              border: 'none',
+              borderRadius: '4px',
+              backgroundColor: 'transparent',
+              color: 'var(--vscode-foreground)',
+              cursor: 'pointer',
             }}
           >
-            {t('node.prompt.description')}
-          </div>
+            <X size={12} />
+          </button>
         )}
-      </button>
+      </div>
+
+      {/* Section: Basic Nodes */}
+      {showBasicSection && (
+        <div
+          style={{
+            fontSize: isCompact ? '10px' : '11px',
+            fontWeight: 600,
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: isCompact ? '4px' : '8px',
+            marginTop: isCompact ? '4px' : '8px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {t('palette.basicNodes')}
+        </div>
+      )}
+
+      {/* Prompt Node Button */}
+      {showPrompt && (
+        <button
+          type="button"
+          onClick={handleAddPromptNode}
+          data-tour="add-prompt-button"
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <MessageSquare size={14} />
+            {t('node.prompt.title')}
+          </div>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.prompt.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* Sub-Agent Node Button - hidden in SubAgentFlow edit mode */}
-      {!isEditingSubAgentFlow && (
+      {showSubAgent && (
         <button
           type="button"
           onClick={handleAddSubAgent}
@@ -480,7 +590,7 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       )}
 
       {/* Sub-Agent Flow Ref Node Button (Feature: 089-subworkflow) - hidden in SubAgentFlow edit mode */}
-      {!isEditingSubAgentFlow && (
+      {showSubAgentFlow && (
         <button
           type="button"
           onClick={handleAddSubAgentFlowRef}
@@ -527,97 +637,101 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       )}
 
       {/* Skill Node Button */}
-      <button
-        type="button"
-        onClick={() => setIsSkillBrowserOpen(true)}
-        data-tour="add-skill-button"
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <Zap size={14} />
-          {t('node.skill.title')}
-        </div>
-        {!isCompact && (
-          <div
-            style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
-            }}
-          >
-            {t('node.skill.description')}
+      {showSkill && (
+        <button
+          type="button"
+          onClick={() => setIsSkillBrowserOpen(true)}
+          data-tour="add-skill-button"
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <Zap size={14} />
+            {t('node.skill.title')}
           </div>
-        )}
-      </button>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.skill.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* MCP Tool Node Button (Feature: 001-mcp-node) */}
-      <button
-        type="button"
-        onClick={() => setIsMcpDialogOpen(true)}
-        data-tour="add-mcp-button"
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <Plug size={14} />
-          {t('node.mcp.title')}
-        </div>
-        {!isCompact && (
-          <div
-            style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
-            }}
-          >
-            {t('node.mcp.description')}
+      {showMcp && (
+        <button
+          type="button"
+          onClick={() => setIsMcpDialogOpen(true)}
+          data-tour="add-mcp-button"
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <Plug size={14} />
+            {t('node.mcp.title')}
           </div>
-        )}
-      </button>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.mcp.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* Section: Special Nodes - only shown when Codex Beta is enabled */}
-      {isCodexEnabled && (
+      {showCodex && (
         <>
           <div
             style={{
@@ -690,172 +804,182 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       )}
 
       {/* Section: Layout */}
-      <div
-        style={{
-          fontSize: isCompact ? '10px' : '11px',
-          fontWeight: 600,
-          color: 'var(--vscode-descriptionForeground)',
-          marginBottom: isCompact ? '4px' : '8px',
-          marginTop: isCompact ? '8px' : '16px',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-        }}
-      >
-        {t('palette.layout')}
-      </div>
+      {showGroup && (
+        <div
+          style={{
+            fontSize: isCompact ? '10px' : '11px',
+            fontWeight: 600,
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: isCompact ? '4px' : '8px',
+            marginTop: isCompact ? '8px' : '16px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {t('palette.layout')}
+        </div>
+      )}
 
       {/* Group Node Button */}
-      <button
-        type="button"
-        onClick={handleAddGroup}
-        data-tour="add-group-button"
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <SquareDashed size={14} />
-          {t('node.group.title')}
-        </div>
-        {!isCompact && (
-          <div
-            style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
-            }}
-          >
-            {t('node.group.description')}
+      {showGroup && (
+        <button
+          type="button"
+          onClick={handleAddGroup}
+          data-tour="add-group-button"
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <SquareDashed size={14} />
+            {t('node.group.title')}
           </div>
-        )}
-      </button>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.group.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* Section: Control Flow */}
-      <div
-        style={{
-          fontSize: isCompact ? '10px' : '11px',
-          fontWeight: 600,
-          color: 'var(--vscode-descriptionForeground)',
-          marginBottom: isCompact ? '4px' : '8px',
-          marginTop: isCompact ? '8px' : '16px',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-        }}
-      >
-        {t('palette.controlFlow')}
-      </div>
+      {showControlFlowSection && (
+        <div
+          style={{
+            fontSize: isCompact ? '10px' : '11px',
+            fontWeight: 600,
+            color: 'var(--vscode-descriptionForeground)',
+            marginBottom: isCompact ? '4px' : '8px',
+            marginTop: isCompact ? '8px' : '16px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {t('palette.controlFlow')}
+        </div>
+      )}
 
       {/* IfElse Node Button */}
-      <button
-        type="button"
-        data-tour="add-ifelse-button"
-        onClick={handleAddIfElse}
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <GitBranch size={14} />
-          {t('node.ifElse.title')}
-        </div>
-        {!isCompact && (
-          <div
-            style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
-            }}
-          >
-            {t('node.ifElse.description')}
+      {showIfElse && (
+        <button
+          type="button"
+          data-tour="add-ifelse-button"
+          onClick={handleAddIfElse}
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <GitBranch size={14} />
+            {t('node.ifElse.title')}
           </div>
-        )}
-      </button>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.ifElse.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* Switch Node Button */}
-      <button
-        type="button"
-        data-tour="add-switch-button"
-        onClick={handleAddSwitch}
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <GitFork size={14} />
-          {t('node.switch.title')}
-        </div>
-        {!isCompact && (
-          <div
-            style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
-            }}
-          >
-            {t('node.switch.description')}
+      {showSwitch && (
+        <button
+          type="button"
+          data-tour="add-switch-button"
+          onClick={handleAddSwitch}
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <GitFork size={14} />
+            {t('node.switch.title')}
           </div>
-        )}
-      </button>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.switch.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* AskUserQuestion Node Button - hidden in SubAgentFlow edit mode */}
-      {!isEditingSubAgentFlow && (
+      {showAskUserQuestion && (
         <button
           type="button"
           onClick={handleAddAskUserQuestion}
@@ -902,7 +1026,7 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       )}
 
       {/* Branch Session Node Button - hidden in SubAgentFlow edit mode (Claude Code only) */}
-      {!isEditingSubAgentFlow && (
+      {showBranchSession && (
         <button
           type="button"
           onClick={handleAddBranchSessionNode}
@@ -949,52 +1073,54 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       )}
 
       {/* End Node Button */}
-      <button
-        type="button"
-        onClick={handleAddEndNode}
-        data-tour="add-end-button"
-        style={{
-          width: '100%',
-          padding: isCompact ? '8px' : '12px',
-          marginBottom: isCompact ? '8px' : '12px',
-          backgroundColor: 'var(--vscode-button-background)',
-          color: 'var(--vscode-button-foreground)',
-          border: '1px solid var(--vscode-button-border)',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontSize: isCompact ? '11px' : '13px',
-          fontWeight: 500,
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
-          <Square size={14} />
-          {t('node.end.title')}
-        </div>
-        {!isCompact && (
-          <div
-            style={{
-              fontSize: '11px',
-              color: 'var(--vscode-button-foreground)',
-              opacity: 0.8,
-            }}
-          >
-            {t('node.end.description')}
+      {showEnd && (
+        <button
+          type="button"
+          onClick={handleAddEndNode}
+          data-tour="add-end-button"
+          style={{
+            width: '100%',
+            padding: isCompact ? '8px' : '12px',
+            marginBottom: isCompact ? '8px' : '12px',
+            backgroundColor: 'var(--vscode-button-background)',
+            color: 'var(--vscode-button-foreground)',
+            border: '1px solid var(--vscode-button-border)',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: isCompact ? '11px' : '13px',
+            fontWeight: 500,
+            textAlign: 'left',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontWeight: 600 }}>
+            <Square size={14} />
+            {t('node.end.title')}
           </div>
-        )}
-      </button>
+          {!isCompact && (
+            <div
+              style={{
+                fontSize: '11px',
+                color: 'var(--vscode-button-foreground)',
+                opacity: 0.8,
+              }}
+            >
+              {t('node.end.description')}
+            </div>
+          )}
+        </button>
+      )}
 
       {/* Branch Node Button (Legacy) - hidden in SubAgentFlow edit mode */}
-      {!isEditingSubAgentFlow && (
+      {showBranch && (
         <button
           type="button"
           onClick={handleAddBranch}
@@ -1053,8 +1179,22 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
         </button>
       )}
 
-      {/* Instructions - hidden in compact mode and SubAgentFlow edit mode */}
-      {!isCompact && !isEditingSubAgentFlow && (
+      {/* Empty state when the filter matches nothing */}
+      {noFilterResults && (
+        <div
+          style={{
+            padding: isCompact ? '8px' : '12px',
+            fontSize: isCompact ? '11px' : '12px',
+            color: 'var(--vscode-descriptionForeground)',
+            textAlign: 'center',
+          }}
+        >
+          {t('palette.filter.noResults')}
+        </div>
+      )}
+
+      {/* Instructions - hidden in compact mode, SubAgentFlow edit mode, and while filtering */}
+      {!isCompact && !isEditingSubAgentFlow && paletteFilter === '' && (
         <div
           style={{
             marginTop: '24px',

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -142,6 +142,9 @@ export interface WebviewTranslationKeys {
   'palette.controlFlow': string;
   'palette.layout': string;
   'palette.quickStart': string;
+  'palette.filter.placeholder': string;
+  'palette.filter.clear': string;
+  'palette.filter.noResults': string;
 
   // Node types
   'node.prompt.title': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -146,6 +146,9 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'palette.controlFlow': 'Control Flow',
   'palette.layout': 'Layout',
   'palette.quickStart': '💡 Quick Start',
+  'palette.filter.placeholder': 'Filter nodes…',
+  'palette.filter.clear': 'Clear filter',
+  'palette.filter.noResults': 'No matching nodes',
 
   // Node types
   'node.prompt.title': 'Prompt',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -146,6 +146,9 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'palette.controlFlow': '制御フロー',
   'palette.layout': 'レイアウト',
   'palette.quickStart': '💡 クイックスタート',
+  'palette.filter.placeholder': 'ノードを絞り込み…',
+  'palette.filter.clear': 'フィルターをクリア',
+  'palette.filter.noResults': '一致するノードがありません',
 
   // Node types
   'node.prompt.title': 'Prompt',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -145,6 +145,9 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'palette.controlFlow': '제어 흐름',
   'palette.layout': '레이아웃',
   'palette.quickStart': '💡 빠른 시작',
+  'palette.filter.placeholder': '노드 필터…',
+  'palette.filter.clear': '필터 지우기',
+  'palette.filter.noResults': '일치하는 노드가 없습니다',
 
   // Node types
   'node.prompt.title': 'Prompt',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -142,6 +142,9 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'palette.controlFlow': '控制流程',
   'palette.layout': '布局',
   'palette.quickStart': '💡 快速入门',
+  'palette.filter.placeholder': '筛选节点…',
+  'palette.filter.clear': '清除筛选',
+  'palette.filter.noResults': '没有匹配的节点',
 
   // Node types
   'node.prompt.title': 'Prompt',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -142,6 +142,9 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'palette.controlFlow': '控制流程',
   'palette.layout': '佈局',
   'palette.quickStart': '💡 快速入門',
+  'palette.filter.placeholder': '篩選節點…',
+  'palette.filter.clear': '清除篩選',
+  'palette.filter.noResults': '沒有符合的節點',
 
   // Node types
   'node.prompt.title': 'Prompt',


### PR DESCRIPTION
## Summary

Adds a type-to-filter box at the top of the Node Palette. Typing narrows the palette to matching node types instead of scanning four sections of 11+ buttons — especially helpful in compact mode, where node descriptions are hidden.

Closes #963

## Changes

- Filter input in `NodePalette.tsx`, styled after the canvas `NodeSearchPanel` input (VSCode input theme vars), with an inline clear ✕ button; Esc clears the filter (then blurs when already empty).
- Case-insensitive substring match against each entry's palette title (`node.<type>.title`, always English per translation rules) and its localized description (`node.<type>.description`), so both English node names and translated description terms match.
- Per-button visibility flags fold in the existing gates (sub-agent-flow editing hides nesting-incompatible nodes; Codex requires the beta toggle); section headers render only when at least one member matches; localized "no matching nodes" empty state; the Quick Start block hides while a filter is active.
- 3 new i18n strings (`palette.filter.placeholder` / `.clear` / `.noResults`) in all 5 locales.
- UI-only — no schema or persistence change.

## Changeset

`.changeset/palette-type-to-filter.md` — `cc-wf-studio` patch.

## Verification

- `pnpm build` and `pnpm check` green from the repo root.
- Manual E2E queued in `docs/progress-log.md` (filter matching, section hiding, clear/Esc, compact mode, beta/sub-agent-flow gating).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTnoJ3meDA5qT3RYGuXwZe)_