### PR TITLE
feat(vscode): edge-drop create for dialog-based node types

### DIFF
--- a/.changeset/edge-drop-dialog-node-types.md
+++ b/.changeset/edge-drop-dialog-node-types.md
@@ -1,0 +1,6 @@
+---
+'cc-wf-studio': patch
+'@cc-wf-studio/cli': patch
+---
+
+Edge-drop picker can now create dialog-based node types (Sub-Agent, Skill, MCP, Codex): the chosen dialog opens and the configured node lands at the drop point pre-wired to the source

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,48 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Edge-drop create for dialog-based node types
+- **User value**: a user who drags a connection into empty canvas can now
+  finish it with any node type — the picker gained Sub-Agent, Skill, and
+  MCP entries (plus Codex when the beta is enabled) that open the matching
+  creation dialog and land the configured node at the drop point already
+  connected to the source; previously only the six dialog-free types were
+  offered, so the workflow's most important node types forced cancel →
+  palette → drag into place → wire the edge by hand.
+- **Issue/PR**: #965 / PR from `claude/sleepy-curie-hfaly4`
+- **Outcome**: done — new `pendingConnection` + `paletteDialogRequest`
+  store fields (transient, outside undo tracking): the picker stashes the
+  drop connection and requests a dialog; NodePalette (dialog owner) opens
+  it via an effect, App expands a collapsed palette first (it unmounts
+  while collapsed); `addNode` consumes a pending connection by delegating
+  to `addNodeWithConnection` (one undo entry, drop-point position), so
+  every dialog confirm path works unchanged; dialog `onClose` clears the
+  pending connection on cancel. Gating mirrors the palette (Sub-Agent
+  hidden in sub-agent-flow editing, Codex behind the beta toggle). Reuses
+  existing `node.<type>.title` strings — no new locale strings. Browser
+  E2E via `ccwf canvas` + headless Chromium: picker shows the new
+  entries; Skill dialog opens; Esc cancel leaves no stray edge and a
+  later palette add is unaffected; simple-type edge-drop regression
+  passes; built-in Sub-Agent preset confirm creates the node pre-wired at
+  the drop point (nodes 8→9, edges 8→9, property overlay open); zero page
+  errors. `pnpm build` + `pnpm check` green. Issue #965 could not be
+  locked (no `gh`, no MCP lock tool — known limitation, noted in the
+  issue).
+- **Next proposals**:
+  - Drop a palette node onto an existing edge to splice it in
+    (insert-between: rewire source→new→target in one undo entry).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): edge-drop dialog create in the VSCode
+    extension host (all four dialogs, cancel path, collapsed palette
+    auto-expand, sub-agent-flow and Codex-beta gating); palette filter;
+    arrow-key nudge; Esc panel dismissal; F8 / Shift+F8 problem cycling;
+    inline group rename; Ungroup; Group selection; Save as Image from the
+    VSCode extension host; Copy as Markdown; `render_workflow` via MCP
+    Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search
+    cycling; align/distribute + context menu + copy/cut/paste; localized
+    Claude API dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Type-to-filter the node palette
 - **User value**: a user can now type in a filter box at the top of the
   Node Palette to instantly narrow the list to matching node types —

--- a/packages/vscode/src/webview/src/App.tsx
+++ b/packages/vscode/src/webview/src/App.tsx
@@ -258,6 +258,16 @@ const App: React.FC = () => {
   } = useCollapsiblePanel();
   const isCompact = useIsCompactMode();
 
+  // Edge-drop create for dialog-based node types: the palette owns the
+  // creation dialogs but unmounts while collapsed — expand it so it can
+  // pick up the pending dialog request from the store.
+  const paletteDialogRequest = useWorkflowStore((state) => state.paletteDialogRequest);
+  useEffect(() => {
+    if (paletteDialogRequest !== null && isNodePaletteCollapsed) {
+      expandNodePalette();
+    }
+  }, [paletteDialogRequest, isNodePaletteCollapsed, expandNodePalette]);
+
   // Reset emptyStateDismissed when a workflow is loaded (so empty state reappears after reset)
   const prevActiveWorkflowRef = useRef(activeWorkflow);
   useEffect(() => {

--- a/packages/vscode/src/webview/src/components/NodePalette.tsx
+++ b/packages/vscode/src/webview/src/components/NodePalette.tsx
@@ -24,7 +24,7 @@ import {
   Zap,
 } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
 import type { WebviewTranslationKeys } from '../i18n/translation-keys';
@@ -63,6 +63,9 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
     addSubAgentFlow,
     setActiveSubAgentFlowId,
     activeSubAgentFlowId,
+    paletteDialogRequest,
+    setPaletteDialogRequest,
+    setPendingConnection,
   } = useWorkflowStore();
 
   // サブエージェントフロー編集中はネスト不可のノードを非活性にする
@@ -74,6 +77,29 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
   const [isCodexDialogOpen, setIsCodexDialogOpen] = useState(false);
   const [isSubAgentDialogOpen, setIsSubAgentDialogOpen] = useState(false);
   const [filterText, setFilterText] = useState('');
+
+  // Edge-drop create for dialog-based node types: the canvas picker asks for
+  // a creation dialog through the store (the palette owns the dialogs). The
+  // pending connection stays set — addNode consumes it on confirm; the
+  // dialogs' close handlers clear it on cancel.
+  useEffect(() => {
+    if (!paletteDialogRequest) return;
+    setPaletteDialogRequest(null);
+    switch (paletteDialogRequest) {
+      case 'subAgent':
+        setIsSubAgentDialogOpen(true);
+        break;
+      case 'skill':
+        setIsSkillBrowserOpen(true);
+        break;
+      case 'mcp':
+        setIsMcpDialogOpen(true);
+        break;
+      case 'codex':
+        setIsCodexDialogOpen(true);
+        break;
+    }
+  }, [paletteDialogRequest, setPaletteDialogRequest]);
 
   const paletteFilter = filterText.trim().toLowerCase();
 
@@ -1220,19 +1246,37 @@ export const NodePalette: React.FC<NodePaletteProps> = ({ onCollapse }) => {
       {/* Skill Browser Dialog */}
       <SkillBrowserDialog
         isOpen={isSkillBrowserOpen}
-        onClose={() => setIsSkillBrowserOpen(false)}
+        onClose={() => {
+          setIsSkillBrowserOpen(false);
+          setPendingConnection(null);
+        }}
       />
 
       {/* MCP Node Dialog (Feature: 001-mcp-node) */}
-      <McpNodeDialog isOpen={isMcpDialogOpen} onClose={() => setIsMcpDialogOpen(false)} />
+      <McpNodeDialog
+        isOpen={isMcpDialogOpen}
+        onClose={() => {
+          setIsMcpDialogOpen(false);
+          setPendingConnection(null);
+        }}
+      />
 
       {/* Codex Node Dialog (Feature: 518-codex-agent-node) */}
-      <CodexNodeDialog isOpen={isCodexDialogOpen} onClose={() => setIsCodexDialogOpen(false)} />
+      <CodexNodeDialog
+        isOpen={isCodexDialogOpen}
+        onClose={() => {
+          setIsCodexDialogOpen(false);
+          setPendingConnection(null);
+        }}
+      />
 
       {/* Sub-Agent Creation Dialog (Feature: 636) */}
       <SubAgentCreationDialog
         isOpen={isSubAgentDialogOpen}
-        onClose={() => setIsSubAgentDialogOpen(false)}
+        onClose={() => {
+          setIsSubAgentDialogOpen(false);
+          setPendingConnection(null);
+        }}
         onCreateWithForm={handleCreateNewSubAgent}
         onSelectCommand={handleSelectCommand}
         onSelectBuiltInPreset={handleSelectBuiltInPreset}

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -14,6 +14,7 @@ import {
   AlignStartHorizontal,
   AlignStartVertical,
   AlignVerticalDistributeCenter,
+  Bot,
   ClipboardPaste,
   Copy,
   CopyPlus,
@@ -23,12 +24,15 @@ import {
   Group,
   MessageSquare,
   PanelLeftOpen,
+  Plug,
   Scissors,
   ShieldQuestion,
   Square,
   SquareDashedMousePointer,
+  Terminal,
   Trash2,
   Ungroup,
+  Zap,
 } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -51,6 +55,7 @@ import { CURRENT_ANNOUNCEMENT, cleanupDismissedAnnouncements } from '../constant
 import { useAutoFocusNode } from '../hooks/useAutoFocusNode';
 import { useIsCompactMode } from '../hooks/useWindowWidth';
 import { useTranslation } from '../i18n/i18n-context';
+import { useRefinementStore } from '../stores/refinement-store';
 import {
   type AlignMode,
   type DistributeAxis,
@@ -656,9 +661,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   }, []);
   const isProblemsPanelVisible = isProblemsPanelOpen && activeSubAgentFlowId === null;
 
-  // Picker entries for the edge-drop menu: the dialog-free node types with
-  // their palette icons and labels. Interactive/session types are hidden
-  // while editing a sub-agent flow, matching the palette's gating.
+  // Picker entries for the edge-drop menu: dialog-free node types are
+  // created directly; dialog-based types (Sub-Agent, Skill, MCP, Codex)
+  // stash the pending connection in the store and ask NodePalette to open
+  // the matching creation dialog — the created node then lands at the drop
+  // point pre-wired (addNode consumes the pending connection). Gating
+  // mirrors the palette: interactive/session and Sub-Agent types are hidden
+  // while editing a sub-agent flow, Codex requires the beta toggle.
+  const isCodexEnabled = useRefinementStore((state) => state.isCodexEnabled);
   const edgeDropEntries = useMemo<CanvasContextMenuEntry[]>(() => {
     if (!edgeDropMenu) return [];
     const pick = (type: SimpleNodeType) => () => {
@@ -670,6 +680,15 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         targetHandle: null,
       });
     };
+    const pickDialog = (dialog: 'subAgent' | 'skill' | 'mcp' | 'codex') => () => {
+      const store = useWorkflowStore.getState();
+      store.setPendingConnection({
+        source: edgeDropMenu.source.nodeId,
+        sourceHandle: edgeDropMenu.source.handleId,
+        position: edgeDropMenu.flowPosition,
+      });
+      store.setPaletteDialogRequest(dialog);
+    };
     return [
       {
         key: 'prompt',
@@ -677,6 +696,39 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         icon: <MessageSquare size={14} />,
         onSelect: pick('prompt'),
       },
+      ...(activeSubAgentFlowId === null
+        ? ([
+            {
+              key: 'subAgent',
+              label: t('node.subAgent.title'),
+              icon: <Bot size={14} />,
+              onSelect: pickDialog('subAgent'),
+            },
+          ] satisfies CanvasContextMenuEntry[])
+        : []),
+      {
+        key: 'skill',
+        label: t('node.skill.title'),
+        icon: <Zap size={14} />,
+        onSelect: pickDialog('skill'),
+      },
+      {
+        key: 'mcp',
+        label: t('node.mcp.title'),
+        icon: <Plug size={14} />,
+        onSelect: pickDialog('mcp'),
+      },
+      ...(isCodexEnabled
+        ? ([
+            {
+              key: 'codex',
+              label: t('node.codex.title'),
+              icon: <Terminal size={14} />,
+              onSelect: pickDialog('codex'),
+            },
+          ] satisfies CanvasContextMenuEntry[])
+        : []),
+      'separator',
       {
         key: 'ifElse',
         label: t('node.ifElse.title'),
@@ -713,7 +765,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         onSelect: pick('end'),
       },
     ];
-  }, [edgeDropMenu, t, activeSubAgentFlowId]);
+  }, [edgeDropMenu, t, activeSubAgentFlowId, isCodexEnabled]);
 
   // Validation issues for the problems panel and the on-canvas node markers.
   // Computed here (not in the panel) so a single validation pass feeds both;

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -177,6 +177,19 @@ interface WorkflowStore {
   /** When set, the Edit-mode canvas should pan to centre this node and clear the
    *  request. Used by the Overview mode "Edit on canvas" links. */
   requestedFocusNodeId: string | null;
+  /** Edge-drop create for dialog-based node types: the connection (and drop
+   *  position) to complete when the next node is added. Consumed by addNode;
+   *  cleared by the palette dialogs' close handlers when the dialog is
+   *  cancelled instead. Transient UI state — not tracked in undo history. */
+  pendingConnection: {
+    source: string;
+    sourceHandle: string | null;
+    position: { x: number; y: number };
+  } | null;
+  /** Asks NodePalette to open one of its node-creation dialogs (the
+   *  edge-drop picker lives outside the palette, which owns the dialogs).
+   *  Cleared by the palette once the dialog opens. */
+  paletteDialogRequest: 'subAgent' | 'skill' | 'mcp' | 'codex' | null;
 
   // Guided Tour player state (reads steps from activeWorkflow.tour)
   isTourActive: boolean;
@@ -244,7 +257,19 @@ interface WorkflowStore {
 
   // Custom Actions
   updateNodeData: (nodeId: string, data: Partial<unknown>) => void;
+  /** Add a node. When a pendingConnection is set (edge-drop → dialog create),
+   *  the node is placed at the stored drop position and connected to the
+   *  stored source in the same set() — one undo entry, then the pending
+   *  connection is consumed. */
   addNode: (node: Node) => void;
+  setPendingConnection: (
+    pending: {
+      source: string;
+      sourceHandle: string | null;
+      position: { x: number; y: number };
+    } | null
+  ) => void;
+  setPaletteDialogRequest: (dialog: 'subAgent' | 'skill' | 'mcp' | 'codex' | null) => void;
   /** Add a node together with the edge that connects it (edge-drop create):
    *  one set() → one undo entry. The new node becomes the selection and the
    *  property overlay opens, same as addNode. */
@@ -564,6 +589,8 @@ export const useWorkflowStore = create<WorkflowStore>()(
       },
       lastAddedNodeId: null,
       requestedFocusNodeId: null,
+      pendingConnection: null,
+      paletteDialogRequest: null,
       isTourActive: false,
       tourStepIndex: 0,
       highlightedGroupNodeId: null,
@@ -879,6 +906,17 @@ export const useWorkflowStore = create<WorkflowStore>()(
       },
 
       addNode: (node: Node) => {
+        const pending = get().pendingConnection;
+        if (pending) {
+          const placed = { ...node, position: pending.position };
+          get().addNodeWithConnection(placed, {
+            source: pending.source,
+            sourceHandle: pending.sourceHandle,
+            target: placed.id,
+            targetHandle: null,
+          });
+          return;
+        }
         set({
           nodes: [...get().nodes, node],
           lastAddedNodeId: node.id,
@@ -893,10 +931,19 @@ export const useWorkflowStore = create<WorkflowStore>()(
         set({
           nodes: [...currentNodes, node],
           edges: addEdge(connection, currentEdges),
+          pendingConnection: null,
           lastAddedNodeId: node.id,
           selectedNodeId: node.id,
           isPropertyOverlayOpen: true,
         });
+      },
+
+      setPendingConnection: (pending) => {
+        set({ pendingConnection: pending });
+      },
+
+      setPaletteDialogRequest: (dialog) => {
+        set({ paletteDialogRequest: dialog });
       },
 
       clearLastAddedNodeId: () => {


### PR DESCRIPTION
## Summary

The edge-drop picker (drag a connection from a source handle, release on empty canvas) previously offered only the six dialog-free node types. It now also offers **Sub-Agent, Skill, MCP** — and **Codex** when the beta toggle is on. Picking one opens the matching creation dialog, and the configured node lands at the drop point already connected to the source, with the property overlay open and a single undo entry.

Closes #965

## Changes

- **`workflow-store`**: new transient fields `pendingConnection` (`{ source, sourceHandle, position }`) and `paletteDialogRequest`, with setters. `addNode` consumes a pending connection by delegating to `addNodeWithConnection` (drop-point position, one `set()` → one undo entry), so every existing dialog confirm path works unchanged. `addNodeWithConnection` clears the pending connection. Both fields are outside the zundo `partialize`, so undo history is unaffected.
- **`WorkflowEditor`**: the edge-drop menu gains dialog-based entries that stash the pending connection and request the dialog. Gating mirrors the palette: Sub-Agent hidden while editing a sub-agent flow, Codex behind the beta toggle.
- **`NodePalette`** (dialog owner): an effect opens the requested dialog and clears the request; every dialog `onClose` clears any leftover pending connection (cancel path).
- **`App`**: expands a collapsed palette when a dialog request arrives (the palette unmounts while collapsed).
- Reuses existing `node.<type>.title` strings — no new locale strings. No schema or persistence change.

## Verification

- `pnpm build` + `pnpm check` green from the repo root.
- Browser E2E against the built webview (`ccwf canvas` + headless Chromium, 8-node sample):
  - picker shows the new Sub-Agent / Skill / MCP entries alongside the simple types
  - clicking **Skill** opens the Skill browser dialog from the canvas picker
  - **Esc cancel** leaves no stray edge, and a later palette add creates an unconnected node as before
  - simple-type edge-drop regression (Prompt) still creates node + edge
  - **confirm path**: built-in Sub-Agent preset → Save creates the node pre-wired at the drop point (nodes 8→9, edges 8→9, property overlay open)
  - zero page errors throughout
- Manual E2E in the VSCode extension host queued in `docs/progress-log.md` (all four dialogs, collapsed-palette auto-expand, gating).

## Changeset

`patch` for `cc-wf-studio` and `@cc-wf-studio/cli` (the webview bundle ships in both).