### PR TITLE
feat(vscode): insert a node into an existing connection (edge splice)

### DIFF
--- a/.changeset/edge-insert-node-splice.md
+++ b/.changeset/edge-insert-node-splice.md
@@ -1,0 +1,6 @@
+---
+'cc-wf-studio': patch
+'@cc-wf-studio/cli': patch
+---
+
+Selected edges now show a ⊕ insert button: pick a node type from the picker and it is spliced into the connection (source→new→target) as a single undo entry, instead of deleting the edge and re-wiring by hand

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,55 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Insert a node into an existing connection (edge splice)
+- **User value**: a user can now insert a node into the middle of an existing
+  connection in two clicks — select the edge, click its new ⊕ button, pick a
+  node type from the same picker the edge-drop create uses — and the edge is
+  replaced by source→new→target as a single undo entry; previously this took
+  delete edge → palette add → drag into place → wire two edges by hand (top
+  carried proposal from the previous iteration, re-verified: the palette is
+  click-to-add, so the "drop a palette node onto an edge" phrasing was
+  re-shaped into an explicit edge affordance).
+- **Issue/PR**: #967
+- **Outcome**: done — DeletableEdge shows ⊕ (insert) beside ✕ (delete) while
+  the edge is selected; ⊕ requests the picker via a new transient
+  `edgeInsertRequest` store field (the `paletteDialogRequest` pattern —
+  DeletableEdge renders in a separate tree). WorkflowEditor consumes it and
+  opens the shared picker (`buildNodePickerEntries`, extracted from the
+  edge-drop menu; same gating, End excluded — a spliced node must re-wire to
+  the original target). New store action `insertNodeOnEdge(node, edgeId)`
+  replaces the edge with source→node and node→target in one `set()` (outer
+  handles preserved, addEdge id generation), selection + property overlay
+  as addNodeWithConnection; falls back to a plain add if the edge vanished.
+  Dialog-based types ride `pendingConnection` extended with
+  `splice: { edgeId }`, consumed by addNode; dialog cancel already clears
+  it. 1 new string in all 5 locales. No schema or persistence change.
+  Browser E2E via `ccwf canvas` + headless Chromium on the 29-node sample:
+  picker entries + gating correct (no End); Esc cancel leaves canvas
+  unchanged; Prompt insert splices (edge count net +1, original edge gone,
+  both new edges correctly wired) and ONE Ctrl+Z restores everything;
+  Skill dialog cancel leaves canvas unchanged; Sub-Agent built-in preset
+  confirm (nested form → Save) splices correctly and single-undo restores;
+  zero page errors. `pnpm build` + `pnpm check` green. Issue #967 could
+  not be locked (no `gh`, no MCP lock tool — known limitation, noted in
+  the issue).
+- **Next proposals**:
+  - Drag an existing (unwired) node onto an edge to splice it in on drop
+    (needs accidental-trigger guard — likely only when the dragged node has
+    no edges on the relevant handles).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): edge ⊕ insert in the VSCode extension host
+    (simple + dialog types, cancel paths, undo, ja locale tooltip);
+    edge-drop dialog create (all four dialogs, cancel path, collapsed
+    palette auto-expand, sub-agent-flow and Codex-beta gating); palette
+    filter; arrow-key nudge; Esc panel dismissal; F8 / Shift+F8 problem
+    cycling; inline group rename; Ungroup; Group selection; Save as Image
+    from the VSCode extension host; Copy as Markdown; `render_workflow`
+    via MCP Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search
+    cycling; align/distribute + context menu + copy/cut/paste; localized
+    Claude API dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Edge-drop create for dialog-based node types
 - **User value**: a user who drags a connection into empty canvas can now
   finish it with any node type — the picker gained Sub-Agent, Skill, and

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -64,7 +64,7 @@ import {
   useWorkflowStore,
 } from '../stores/workflow-store';
 import { jumpToNode } from '../utils/canvas-navigation';
-import { createDefaultNode, type SimpleNodeType } from '../utils/node-defaults';
+import { createDefaultNode, type SimpleNodeType, type TranslateFn } from '../utils/node-defaults';
 import { collectWorkflowIssues } from '../utils/workflow-issues';
 import { CanvasContextMenu, type CanvasContextMenuEntry } from './CanvasContextMenu';
 import { CanvasToolbar } from './CanvasToolbar';
@@ -130,6 +130,108 @@ const defaultEdgeOptions: DefaultEdgeOptions = {
  */
 const edgeTypes: EdgeTypes = {
   default: DeletableEdge,
+};
+
+/**
+ * Picker entries shared by the edge-drop create and edge-insert menus:
+ * dialog-free node types are created directly (`pick`); dialog-based types
+ * (Sub-Agent, Skill, MCP, Codex) go through `pickDialog`, which stashes the
+ * pending connection in the store and asks NodePalette to open the matching
+ * creation dialog. Gating mirrors the palette: interactive/session and
+ * Sub-Agent types are hidden while editing a sub-agent flow, Codex requires
+ * the beta toggle. End is only offered where the new node needs no output
+ * (edge-drop create) — a node spliced into an edge must re-wire to the
+ * original target.
+ */
+const buildNodePickerEntries = (opts: {
+  t: TranslateFn;
+  activeSubAgentFlowId: string | null;
+  isCodexEnabled: boolean;
+  includeEnd: boolean;
+  pick: (type: SimpleNodeType) => () => void;
+  pickDialog: (dialog: 'subAgent' | 'skill' | 'mcp' | 'codex') => () => void;
+}): CanvasContextMenuEntry[] => {
+  const { t, activeSubAgentFlowId, isCodexEnabled, includeEnd, pick, pickDialog } = opts;
+  return [
+    {
+      key: 'prompt',
+      label: t('node.prompt.title'),
+      icon: <MessageSquare size={14} />,
+      onSelect: pick('prompt'),
+    },
+    ...(activeSubAgentFlowId === null
+      ? ([
+          {
+            key: 'subAgent',
+            label: t('node.subAgent.title'),
+            icon: <Bot size={14} />,
+            onSelect: pickDialog('subAgent'),
+          },
+        ] satisfies CanvasContextMenuEntry[])
+      : []),
+    {
+      key: 'skill',
+      label: t('node.skill.title'),
+      icon: <Zap size={14} />,
+      onSelect: pickDialog('skill'),
+    },
+    {
+      key: 'mcp',
+      label: t('node.mcp.title'),
+      icon: <Plug size={14} />,
+      onSelect: pickDialog('mcp'),
+    },
+    ...(isCodexEnabled
+      ? ([
+          {
+            key: 'codex',
+            label: t('node.codex.title'),
+            icon: <Terminal size={14} />,
+            onSelect: pickDialog('codex'),
+          },
+        ] satisfies CanvasContextMenuEntry[])
+      : []),
+    'separator',
+    {
+      key: 'ifElse',
+      label: t('node.ifElse.title'),
+      icon: <GitBranch size={14} />,
+      onSelect: pick('ifElse'),
+    },
+    {
+      key: 'switch',
+      label: t('node.switch.title'),
+      icon: <GitFork size={14} />,
+      onSelect: pick('switch'),
+    },
+    ...(activeSubAgentFlowId === null
+      ? ([
+          {
+            key: 'askUserQuestion',
+            label: t('node.askUserQuestion.title'),
+            icon: <ShieldQuestion size={14} />,
+            onSelect: pick('askUserQuestion'),
+          },
+          {
+            key: 'branchSession',
+            label: t('node.branchSession.title'),
+            icon: <GitBranchPlus size={14} />,
+            onSelect: pick('branchSession'),
+          },
+        ] satisfies CanvasContextMenuEntry[])
+      : []),
+    ...(includeEnd
+      ? ([
+          'separator',
+          {
+            key: 'end',
+            label: t('node.end.title'),
+            icon: <Square size={14} />,
+            onSelect: pick('end'),
+          },
+        ] satisfies CanvasContextMenuEntry[])
+      : []),
+  ];
 };
 
 /** In-window mirror of the last copied/cut selection. The context menu's
@@ -612,6 +714,17 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
 
   const closeEdgeDropMenu = useCallback(() => setEdgeDropMenu(null), []);
 
+  // Edge insert picker (⊕ button on a selected edge) — request consumed and
+  // entries built below, after the edge-drop entries they share a builder with
+  const [edgeInsertMenu, setEdgeInsertMenu] = useState<{
+    x: number;
+    y: number;
+    flowPosition: { x: number; y: number };
+    edgeId: string;
+  } | null>(null);
+
+  const closeEdgeInsertMenu = useCallback(() => setEdgeInsertMenu(null), []);
+
   // Memoize snap grid
   const snapGrid = useMemo<[number, number]>(() => [15, 15], []);
 
@@ -635,7 +748,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const escTargetsRef = useRef({ isSearchOpen: false, isMenuOpen: false });
   escTargetsRef.current = {
     isSearchOpen,
-    isMenuOpen: contextMenu !== null || edgeDropMenu !== null,
+    isMenuOpen: contextMenu !== null || edgeDropMenu !== null || edgeInsertMenu !== null,
   };
 
   // Auto layout — tidy the whole canvas, then re-fit the view so the
@@ -661,111 +774,85 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   }, []);
   const isProblemsPanelVisible = isProblemsPanelOpen && activeSubAgentFlowId === null;
 
-  // Picker entries for the edge-drop menu: dialog-free node types are
-  // created directly; dialog-based types (Sub-Agent, Skill, MCP, Codex)
-  // stash the pending connection in the store and ask NodePalette to open
-  // the matching creation dialog — the created node then lands at the drop
-  // point pre-wired (addNode consumes the pending connection). Gating
-  // mirrors the palette: interactive/session and Sub-Agent types are hidden
-  // while editing a sub-agent flow, Codex requires the beta toggle.
+  // Picker entries for the edge-drop menu — the created node lands at the
+  // drop point pre-wired to the dragged-from source (addNode consumes the
+  // pending connection for the dialog-based types).
   const isCodexEnabled = useRefinementStore((state) => state.isCodexEnabled);
   const edgeDropEntries = useMemo<CanvasContextMenuEntry[]>(() => {
     if (!edgeDropMenu) return [];
-    const pick = (type: SimpleNodeType) => () => {
-      const node = createDefaultNode(type, edgeDropMenu.flowPosition, t);
-      useWorkflowStore.getState().addNodeWithConnection(node, {
-        source: edgeDropMenu.source.nodeId,
-        sourceHandle: edgeDropMenu.source.handleId,
-        target: node.id,
-        targetHandle: null,
-      });
-    };
-    const pickDialog = (dialog: 'subAgent' | 'skill' | 'mcp' | 'codex') => () => {
-      const store = useWorkflowStore.getState();
-      store.setPendingConnection({
-        source: edgeDropMenu.source.nodeId,
-        sourceHandle: edgeDropMenu.source.handleId,
-        position: edgeDropMenu.flowPosition,
-      });
-      store.setPaletteDialogRequest(dialog);
-    };
-    return [
-      {
-        key: 'prompt',
-        label: t('node.prompt.title'),
-        icon: <MessageSquare size={14} />,
-        onSelect: pick('prompt'),
+    return buildNodePickerEntries({
+      t,
+      activeSubAgentFlowId,
+      isCodexEnabled,
+      includeEnd: true,
+      pick: (type) => () => {
+        const node = createDefaultNode(type, edgeDropMenu.flowPosition, t);
+        useWorkflowStore.getState().addNodeWithConnection(node, {
+          source: edgeDropMenu.source.nodeId,
+          sourceHandle: edgeDropMenu.source.handleId,
+          target: node.id,
+          targetHandle: null,
+        });
       },
-      ...(activeSubAgentFlowId === null
-        ? ([
-            {
-              key: 'subAgent',
-              label: t('node.subAgent.title'),
-              icon: <Bot size={14} />,
-              onSelect: pickDialog('subAgent'),
-            },
-          ] satisfies CanvasContextMenuEntry[])
-        : []),
-      {
-        key: 'skill',
-        label: t('node.skill.title'),
-        icon: <Zap size={14} />,
-        onSelect: pickDialog('skill'),
+      pickDialog: (dialog) => () => {
+        const store = useWorkflowStore.getState();
+        store.setPendingConnection({
+          source: edgeDropMenu.source.nodeId,
+          sourceHandle: edgeDropMenu.source.handleId,
+          position: edgeDropMenu.flowPosition,
+        });
+        store.setPaletteDialogRequest(dialog);
       },
-      {
-        key: 'mcp',
-        label: t('node.mcp.title'),
-        icon: <Plug size={14} />,
-        onSelect: pickDialog('mcp'),
-      },
-      ...(isCodexEnabled
-        ? ([
-            {
-              key: 'codex',
-              label: t('node.codex.title'),
-              icon: <Terminal size={14} />,
-              onSelect: pickDialog('codex'),
-            },
-          ] satisfies CanvasContextMenuEntry[])
-        : []),
-      'separator',
-      {
-        key: 'ifElse',
-        label: t('node.ifElse.title'),
-        icon: <GitBranch size={14} />,
-        onSelect: pick('ifElse'),
-      },
-      {
-        key: 'switch',
-        label: t('node.switch.title'),
-        icon: <GitFork size={14} />,
-        onSelect: pick('switch'),
-      },
-      ...(activeSubAgentFlowId === null
-        ? ([
-            {
-              key: 'askUserQuestion',
-              label: t('node.askUserQuestion.title'),
-              icon: <ShieldQuestion size={14} />,
-              onSelect: pick('askUserQuestion'),
-            },
-            {
-              key: 'branchSession',
-              label: t('node.branchSession.title'),
-              icon: <GitBranchPlus size={14} />,
-              onSelect: pick('branchSession'),
-            },
-          ] satisfies CanvasContextMenuEntry[])
-        : []),
-      'separator',
-      {
-        key: 'end',
-        label: t('node.end.title'),
-        icon: <Square size={14} />,
-        onSelect: pick('end'),
-      },
-    ];
+    });
   }, [edgeDropMenu, t, activeSubAgentFlowId, isCodexEnabled]);
+
+  // ---------------------------------------------------------------------
+  // Edge insert: the ⊕ button on a selected edge (DeletableEdge) requests
+  // the picker via the store — convert the click's screen position to
+  // container coordinates and open the same picker menu there. The chosen
+  // node replaces the edge with source→node→target in one undo entry.
+  // ---------------------------------------------------------------------
+  const edgeInsertRequest = useWorkflowStore((state) => state.edgeInsertRequest);
+
+  useEffect(() => {
+    if (!edgeInsertRequest) return;
+    useWorkflowStore.getState().setEdgeInsertRequest(null);
+    const container = canvasContainerRef.current;
+    if (!container) return;
+    const bounds = container.getBoundingClientRect();
+    setEdgeInsertMenu({
+      x: edgeInsertRequest.clientX - bounds.left,
+      y: edgeInsertRequest.clientY - bounds.top,
+      flowPosition: edgeInsertRequest.flowPosition,
+      edgeId: edgeInsertRequest.edgeId,
+    });
+  }, [edgeInsertRequest]);
+
+  const edgeInsertEntries = useMemo<CanvasContextMenuEntry[]>(() => {
+    if (!edgeInsertMenu) return [];
+    return buildNodePickerEntries({
+      t,
+      activeSubAgentFlowId,
+      isCodexEnabled,
+      includeEnd: false,
+      pick: (type) => () => {
+        const node = createDefaultNode(type, edgeInsertMenu.flowPosition, t);
+        useWorkflowStore.getState().insertNodeOnEdge(node, edgeInsertMenu.edgeId);
+      },
+      pickDialog: (dialog) => () => {
+        const store = useWorkflowStore.getState();
+        const edge = store.edges.find((e) => e.id === edgeInsertMenu.edgeId);
+        if (!edge) return;
+        store.setPendingConnection({
+          source: edge.source,
+          sourceHandle: edge.sourceHandle ?? null,
+          position: edgeInsertMenu.flowPosition,
+          splice: { edgeId: edge.id },
+        });
+        store.setPaletteDialogRequest(dialog);
+      },
+    });
+  }, [edgeInsertMenu, t, activeSubAgentFlowId, isCodexEnabled]);
 
   // Validation issues for the problems panel and the on-canvas node markers.
   // Computed here (not in the panel) so a single validation pass feeds both;
@@ -1625,6 +1712,14 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
             y={edgeDropMenu.y}
             entries={edgeDropEntries}
             onClose={closeEdgeDropMenu}
+          />
+        )}
+        {edgeInsertMenu && (
+          <CanvasContextMenu
+            x={edgeInsertMenu.x}
+            y={edgeInsertMenu.y}
+            entries={edgeInsertEntries}
+            onClose={closeEdgeInsertMenu}
           />
         )}
         <KeyboardShortcutsDialog

--- a/packages/vscode/src/webview/src/components/edges/DeletableEdge.tsx
+++ b/packages/vscode/src/webview/src/components/edges/DeletableEdge.tsx
@@ -1,11 +1,11 @@
 /**
  * DeletableEdge Component
  *
- * Custom edge component with delete button.
- * Shows delete button only when edge is selected.
+ * Custom edge component with insert and delete buttons.
+ * Shows the buttons only when the edge is selected.
  */
 
-import { X } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import type React from 'react';
 import {
   BaseEdge,
@@ -15,11 +15,26 @@ import {
   useReactFlow,
 } from 'reactflow';
 import { useTranslation } from '../../i18n/i18n-context';
+import { useWorkflowStore } from '../../stores/workflow-store';
+
+const edgeButtonStyle: React.CSSProperties = {
+  width: '18px',
+  height: '18px',
+  borderRadius: '3px',
+  color: 'white',
+  border: 'none',
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+};
 
 /**
  * Deletable edge component
  *
- * Extends React Flow's default edge to show delete button when selected.
+ * Extends React Flow's default edge to show insert (splice a node into the
+ * connection) and delete buttons when selected.
  */
 export const DeletableEdge: React.FC<EdgeProps> = ({
   id,
@@ -52,44 +67,77 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
     setEdges((edges) => edges.filter((edge) => edge.id !== id));
   };
 
+  // Insert button click handler - ask WorkflowEditor (which owns the picker
+  // menu) to open the insert-node picker for this edge. The inserted node
+  // lands at the grid-snapped edge midpoint.
+  const handleInsertClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    useWorkflowStore.getState().setEdgeInsertRequest({
+      edgeId: id,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      flowPosition: {
+        x: Math.round(labelX / 15) * 15,
+        y: Math.round(labelY / 15) * 15,
+      },
+    });
+  };
+
   return (
     <>
       {/* Base edge */}
       <BaseEdge path={edgePath} style={style} markerEnd={markerEnd} />
 
-      {/* Delete button rendered in HTML layer (outside SVG) to avoid animation flicker */}
+      {/* Buttons rendered in HTML layer (outside SVG) to avoid animation flicker */}
       {selected && (
         <EdgeLabelRenderer>
-          <button
-            type="button"
-            onClick={handleDeleteClick}
+          <div
             className="nodrag nopan"
             style={{
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
               pointerEvents: 'all',
-              width: '18px',
-              height: '18px',
-              borderRadius: '3px',
-              backgroundColor: 'var(--vscode-errorForeground)',
-              color: 'white',
-              border: 'none',
-              cursor: 'pointer',
               display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: 0,
+              gap: '4px',
             }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.opacity = '0.8';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.opacity = '1';
-            }}
-            title={t('canvas.deleteEdge.tooltip')}
           >
-            <X size={12} strokeWidth={2.5} />
-          </button>
+            <button
+              type="button"
+              onClick={handleInsertClick}
+              style={{
+                ...edgeButtonStyle,
+                backgroundColor: 'var(--vscode-button-background)',
+                color: 'var(--vscode-button-foreground)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = '0.8';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = '1';
+              }}
+              title={t('canvas.insertNodeOnEdge.tooltip')}
+              aria-label={t('canvas.insertNodeOnEdge.tooltip')}
+            >
+              <Plus size={12} strokeWidth={2.5} />
+            </button>
+            <button
+              type="button"
+              onClick={handleDeleteClick}
+              style={{
+                ...edgeButtonStyle,
+                backgroundColor: 'var(--vscode-errorForeground)',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.opacity = '0.8';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = '1';
+              }}
+              title={t('canvas.deleteEdge.tooltip')}
+            >
+              <X size={12} strokeWidth={2.5} />
+            </button>
+          </div>
         </EdgeLabelRenderer>
       )}
     </>

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -390,6 +390,7 @@ export interface WebviewTranslationKeys {
   // Canvas action tooltips / a11y labels
   'canvas.deleteNode.tooltip': string;
   'canvas.deleteEdge.tooltip': string;
+  'canvas.insertNodeOnEdge.tooltip': string;
   'canvas.groupRename.tooltip': string;
   'canvas.groupRename.inputAria': string;
   'canvas.resizeSidebar': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -410,6 +410,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': 'Regenerating…',
   'canvas.deleteNode.tooltip': 'Delete node',
   'canvas.deleteEdge.tooltip': 'Delete connection',
+  'canvas.insertNodeOnEdge.tooltip': 'Insert node into this connection',
   'canvas.groupRename.tooltip': 'Double-click to rename',
   'canvas.groupRename.inputAria': 'Group name',
   'canvas.resizeSidebar': 'Resize sidebar',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -408,6 +408,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '再生成中…',
   'canvas.deleteNode.tooltip': 'ノードを削除',
   'canvas.deleteEdge.tooltip': '接続を削除',
+  'canvas.insertNodeOnEdge.tooltip': 'この接続にノードを挿入',
   'canvas.groupRename.tooltip': 'ダブルクリックで名前を変更',
   'canvas.groupRename.inputAria': 'グループ名',
   'canvas.resizeSidebar': 'サイドバーのサイズを変更',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -407,6 +407,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '재생성 중…',
   'canvas.deleteNode.tooltip': '노드 삭제',
   'canvas.deleteEdge.tooltip': '연결 삭제',
+  'canvas.insertNodeOnEdge.tooltip': '이 연결에 노드 삽입',
   'canvas.groupRename.tooltip': '더블 클릭으로 이름 변경',
   'canvas.groupRename.inputAria': '그룹 이름',
   'canvas.resizeSidebar': '사이드바 크기 조절',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -394,6 +394,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '重新生成中…',
   'canvas.deleteNode.tooltip': '删除节点',
   'canvas.deleteEdge.tooltip': '删除连接',
+  'canvas.insertNodeOnEdge.tooltip': '在此连接中插入节点',
   'canvas.groupRename.tooltip': '双击重命名',
   'canvas.groupRename.inputAria': '编组名称',
   'canvas.resizeSidebar': '调整侧边栏大小',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -396,6 +396,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'workflowTour.popover.regenerating': '重新產生中…',
   'canvas.deleteNode.tooltip': '刪除節點',
   'canvas.deleteEdge.tooltip': '刪除連線',
+  'canvas.insertNodeOnEdge.tooltip': '在此連線中插入節點',
   'canvas.groupRename.tooltip': '雙擊重新命名',
   'canvas.groupRename.inputAria': '群組名稱',
   'canvas.resizeSidebar': '調整側邊欄大小',

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -180,16 +180,32 @@ interface WorkflowStore {
   /** Edge-drop create for dialog-based node types: the connection (and drop
    *  position) to complete when the next node is added. Consumed by addNode;
    *  cleared by the palette dialogs' close handlers when the dialog is
-   *  cancelled instead. Transient UI state — not tracked in undo history. */
+   *  cancelled instead. When `splice` is set the add is an edge insert:
+   *  addNode routes to insertNodeOnEdge with the stored edge id instead of
+   *  appending a plain connection. Transient UI state — not tracked in undo
+   *  history. */
   pendingConnection: {
     source: string;
     sourceHandle: string | null;
     position: { x: number; y: number };
+    splice?: { edgeId: string };
   } | null;
   /** Asks NodePalette to open one of its node-creation dialogs (the
    *  edge-drop picker lives outside the palette, which owns the dialogs).
    *  Cleared by the palette once the dialog opens. */
   paletteDialogRequest: 'subAgent' | 'skill' | 'mcp' | 'codex' | null;
+  /** Asks WorkflowEditor (which owns the picker menu) to open the insert-node
+   *  picker for an edge — set by the edge's ⊕ button, which lives in a
+   *  separate component tree (DeletableEdge). Screen coordinates come from
+   *  the button's click event; flowPosition is the grid-snapped edge midpoint
+   *  where the inserted node will land. Cleared by the editor once the menu
+   *  opens. Transient UI state — not tracked in undo history. */
+  edgeInsertRequest: {
+    edgeId: string;
+    clientX: number;
+    clientY: number;
+    flowPosition: { x: number; y: number };
+  } | null;
 
   // Guided Tour player state (reads steps from activeWorkflow.tour)
   isTourActive: boolean;
@@ -267,13 +283,30 @@ interface WorkflowStore {
       source: string;
       sourceHandle: string | null;
       position: { x: number; y: number };
+      splice?: { edgeId: string };
     } | null
   ) => void;
   setPaletteDialogRequest: (dialog: 'subAgent' | 'skill' | 'mcp' | 'codex' | null) => void;
+  setEdgeInsertRequest: (
+    request: {
+      edgeId: string;
+      clientX: number;
+      clientY: number;
+      flowPosition: { x: number; y: number };
+    } | null
+  ) => void;
   /** Add a node together with the edge that connects it (edge-drop create):
    *  one set() → one undo entry. The new node becomes the selection and the
    *  property overlay opens, same as addNode. */
   addNodeWithConnection: (node: Node, connection: Connection) => void;
+  /** Insert a node into an existing edge (splice): the edge is replaced by
+   *  source→node and node→target — the outer handles of the original edge are
+   *  preserved, the node's own handles resolve to React Flow's first-handle
+   *  default — all in one set() → one undo entry. Selection and property
+   *  overlay behave like addNodeWithConnection. Falls back to a plain add
+   *  when the edge no longer exists (e.g. the canvas changed while a
+   *  creation dialog was open). */
+  insertNodeOnEdge: (node: Node, edgeId: string) => void;
   /** Duplicate a configured node (fresh id, +40/+40 offset, same parent group,
    *  deep-copied data; edges are not copied). Duplicating a group also copies
    *  its child nodes and the edges fully inside the group. Start/End excluded. */
@@ -591,6 +624,7 @@ export const useWorkflowStore = create<WorkflowStore>()(
       requestedFocusNodeId: null,
       pendingConnection: null,
       paletteDialogRequest: null,
+      edgeInsertRequest: null,
       isTourActive: false,
       tourStepIndex: 0,
       highlightedGroupNodeId: null,
@@ -909,6 +943,10 @@ export const useWorkflowStore = create<WorkflowStore>()(
         const pending = get().pendingConnection;
         if (pending) {
           const placed = { ...node, position: pending.position };
+          if (pending.splice) {
+            get().insertNodeOnEdge(placed, pending.splice.edgeId);
+            return;
+          }
           get().addNodeWithConnection(placed, {
             source: pending.source,
             sourceHandle: pending.sourceHandle,
@@ -938,8 +976,47 @@ export const useWorkflowStore = create<WorkflowStore>()(
         });
       },
 
+      insertNodeOnEdge: (node: Node, edgeId: string) => {
+        const edge = get().edges.find((e) => e.id === edgeId);
+        const currentNodes = get().nodes.map((n) => (n.selected ? { ...n, selected: false } : n));
+        const currentEdges = get()
+          .edges.filter((e) => e.id !== edgeId)
+          .map((e) => (e.selected ? { ...e, selected: false } : e));
+        const splicedEdges = edge
+          ? addEdge(
+              {
+                source: node.id,
+                sourceHandle: null,
+                target: edge.target,
+                targetHandle: edge.targetHandle ?? null,
+              },
+              addEdge(
+                {
+                  source: edge.source,
+                  sourceHandle: edge.sourceHandle ?? null,
+                  target: node.id,
+                  targetHandle: null,
+                },
+                currentEdges
+              )
+            )
+          : currentEdges;
+        set({
+          nodes: [...currentNodes, node],
+          edges: splicedEdges,
+          pendingConnection: null,
+          lastAddedNodeId: node.id,
+          selectedNodeId: node.id,
+          isPropertyOverlayOpen: true,
+        });
+      },
+
       setPendingConnection: (pending) => {
         set({ pendingConnection: pending });
+      },
+
+      setEdgeInsertRequest: (request) => {
+        set({ edgeInsertRequest: request });
       },
 
       setPaletteDialogRequest: (dialog) => {


### PR DESCRIPTION
## Summary

A user can now insert a node into the middle of an existing connection in two clicks: select the edge, click its new ⊕ button, and pick a node type from the picker. The edge is replaced by `source → new node → target` as a **single undo entry** — previously this took delete edge → palette add → drag into place → wire two edges by hand.

Closes #967

## Changes

- **`DeletableEdge`**: shows a ⊕ insert button beside the existing ✕ delete button while the edge is selected. Clicking it requests the picker via a new transient `edgeInsertRequest` store field (the `paletteDialogRequest` cross-tree pattern), carrying the click position and the grid-snapped edge midpoint.
- **`WorkflowEditor`**: consumes the request and opens the node picker at the button. The entries are extracted into a shared `buildNodePickerEntries` used by both the edge-drop create menu and the new insert menu — same gating (Sub-Agent hidden while editing a sub-agent flow, Codex behind the beta toggle), with End excluded from the insert menu (a spliced-in node must re-wire to the original target, and End has no output).
- **`workflow-store`**: new `insertNodeOnEdge(node, edgeId)` action — removes the original edge and adds `source→node` and `node→target` (outer handles preserved, React Flow `addEdge` id generation) in one `set()` → one undo entry; selection + property overlay behave like `addNodeWithConnection`; falls back to a plain add if the edge no longer exists. Dialog-based types (Sub-Agent, Skill, MCP, Codex) ride the existing `pendingConnection` flow extended with a `splice: { edgeId }` marker consumed by `addNode`; dialog cancel already clears it.
- **i18n**: 1 new tooltip string (`canvas.insertNodeOnEdge.tooltip`) in all 5 locales.
- No schema or persistence change — nodes/edges only. Serves both hosts of the shared webview bundle (VSCode extension + `ccwf canvas`).

## Verification

- `pnpm build` + `pnpm check` green from the repo root.
- Browser E2E against the real webview (`ccwf canvas` + headless Chromium, 29-node sample):
  - picker entries and gating correct; End absent from the insert menu
  - Esc cancel closes the menu, canvas unchanged
  - Prompt insert splices correctly (original edge removed, both new edges wired `start-1 → new → prompt-ticketinput`), and **one** Ctrl+Z restores everything
  - Skill dialog cancel leaves the canvas unchanged
  - Sub-Agent built-in preset confirm (nested form → Save) splices correctly through the `pendingConnection.splice` path; single undo restores
  - zero page errors

## Changeset

`.changeset/edge-insert-node-splice.md` — `cc-wf-studio` + `@cc-wf-studio/cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hj4B1uai1Cw3CvMJdDWSDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hj4B1uai1Cw3CvMJdDWSDw)_