### PR TITLE
feat(vscode): drag an unwired node onto a connection to splice it in

### DIFF
--- a/.changeset/drag-splice-node-onto-edge.md
+++ b/.changeset/drag-splice-node-onto-edge.md
@@ -1,0 +1,5 @@
+---
+'cc-wf-studio': minor
+---
+
+Drag an unwired node onto an existing connection to splice it in — the edge highlights while the node hovers over it and is replaced by source→node→target on drop, undoable together with the move as a single Ctrl+Z step

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,56 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Drag an unwired node onto a connection to splice it in
+- **User value**: a user who click-adds a node from the palette (which lands
+  unwired) can now wire it into the flow by simply dragging it onto an
+  existing connection — the edge highlights with an accent stroke + ⊕ hint
+  while the node hovers over it and is replaced by source→node→target on
+  drop, and ONE Ctrl/Cmd+Z undoes the move + splice together; previously
+  this took delete edge → draw two connections by hand (top carried
+  proposal from the previous iteration, premise re-verified).
+- **Issue/PR**: #969
+- **Outcome**: done — eligibility computed at drag start (single-node drag,
+  not Start/End/Group, zero connected edges — an already-wired node is never
+  re-wired by a stray drag); the rendered edge paths are sampled once at
+  drag start via `getTotalLength`/`getPointAtLength` (flow coords, exact for
+  bezier; edges can't move mid-drag since the dragged node is unwired), and
+  each drag frame hit-tests the cached points against the node rect. Best
+  match rides a new transient `dragSpliceTargetEdgeId` store field (untracked,
+  `edgeInsertRequest` pattern); DeletableEdge highlights itself + shows a
+  non-interactive ⊕ at the midpoint. New store action
+  `spliceNodeIntoEdge(nodeId, edgeId)` replaces the edge with
+  source→node→target in one set() (outer handles preserved, re-checks
+  eligibility). The drag-stop single-undo sealing now captures edges too, so
+  move + splice restore with one undo. No schema/persistence change, no new
+  locale strings (visual affordance only). Browser E2E via `ccwf canvas` +
+  headless Chromium on the 8-node daily-dev sample: 14/14 checks green
+  (highlight during hover, splice on drop with original edge gone and both
+  new edges wired, single-undo restores edge AND pre-drag position, wired
+  node drag never highlights/splices, zero page errors). `pnpm build` +
+  `pnpm check` green. Issue #969 could not be locked (no `gh`, no MCP lock
+  tool — known limitation, noted in the issue). Found adjacent bug while
+  testing: `ccwf canvas` silently shows an empty canvas for `{meta, workflow}`
+  wrapper files (handlers read raw JSON without unwrapping) — filed as a
+  follow-up idea issue.
+- **Next proposals**:
+  - Fix `ccwf canvas` to unwrap `{meta, workflow}` wrapper files (its own
+    up-front validation accepts them, then the webview gets the raw wrapper
+    and falls back to an empty canvas + Start Menu).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): drag-splice in the VSCode extension host
+    (highlight, drop, undo, wired-node guard, multi-select drag guard);
+    edge ⊕ insert (simple + dialog types, cancel paths, undo, ja locale
+    tooltip); edge-drop dialog create (all four dialogs, cancel path,
+    collapsed palette auto-expand, sub-agent-flow and Codex-beta gating);
+    palette filter; arrow-key nudge; Esc panel dismissal; F8 / Shift+F8
+    problem cycling; inline group rename; Ungroup; Group selection; Save as
+    Image from the VSCode extension host; Copy as Markdown; `render_workflow`
+    via MCP Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Insert a node into an existing connection (edge splice)
 - **User value**: a user can now insert a node into the middle of an existing
   connection in two clicks — select the edge, click its new ⊕ button, pick a

--- a/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
+++ b/packages/vscode/src/webview/src/components/WorkflowEditor.tsx
@@ -42,6 +42,7 @@ import ReactFlow, {
   type Connection,
   Controls,
   type DefaultEdgeOptions,
+  type Edge,
   type EdgeTypes,
   MiniMap,
   type Node,
@@ -232,6 +233,37 @@ const buildNodePickerEntries = (opts: {
         ] satisfies CanvasContextMenuEntry[])
       : []),
   ];
+};
+
+/** Points sampled per edge path for the drag-splice hit test. */
+const SPLICE_PATH_SAMPLES = 24;
+
+/** Sample every rendered edge path in flow coordinates for the drag-splice
+ *  hit test (drag an unwired node onto a connection). The edge SVG lives
+ *  inside the viewport transform, so path-space coordinates ARE flow
+ *  coordinates, and `getPointAtLength` is exact for any edge shape — no
+ *  bezier math re-derivation. Edges cannot move during an eligible drag
+ *  (the dragged node is unwired), so sampling once at drag start is safe. */
+const sampleEdgePathPoints = (
+  edges: Edge[]
+): { id: string; points: { x: number; y: number }[] }[] => {
+  const sampled: { id: string; points: { x: number; y: number }[] }[] = [];
+  for (const edge of edges) {
+    if (edge.id.includes('"')) continue;
+    const path = document.querySelector<SVGPathElement>(
+      `[data-testid="rf__edge-${edge.id}"] .react-flow__edge-path`
+    );
+    if (!path) continue;
+    const total = path.getTotalLength();
+    if (!Number.isFinite(total) || total <= 0) continue;
+    const points: { x: number; y: number }[] = [];
+    for (let i = 0; i <= SPLICE_PATH_SAMPLES; i++) {
+      const p = path.getPointAtLength((total * i) / SPLICE_PATH_SAMPLES);
+      points.push({ x: p.x, y: p.y });
+    }
+    sampled.push({ id: edge.id, points });
+  }
+  return sampled;
 };
 
 /** In-window mirror of the last copied/cut selection. The context menu's
@@ -463,8 +495,18 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
     [setSelectedNodeId]
   );
 
-  // Save pre-drag snapshot for undo/redo (ref to avoid re-renders)
+  // Save pre-drag snapshot for undo/redo (ref to avoid re-renders). Edges are
+  // captured too so a drag-splice (edge replaced on drop) seals into the same
+  // single undo entry as the move.
   const preDragNodesRef = useRef<Node[] | null>(null);
+  const preDragEdgesRef = useRef<Edge[] | null>(null);
+
+  // Drag-splice: eligibility + cached edge-path samples for the current drag
+  // (drag an unwired node onto a connection to splice it in)
+  const dragSpliceRef = useRef<{
+    nodeId: string;
+    sampledEdges: { id: string; points: { x: number; y: number }[] }[];
+  } | null>(null);
 
   // Arrow-key nudge bursts pause undo tracking like drags do; the timer
   // seals the burst into a single undo entry once the keys go idle
@@ -474,31 +516,84 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   });
 
   // Pause undo/redo tracking during node drag to record only the final position
-  const handleNodeDragStart = useCallback(() => {
-    // A pending nudge-burst resume must not fire mid-drag and re-enable
-    // tracking — the drag-stop handler resumes for both
-    if (nudgeBurstRef.current.timer !== null) {
-      window.clearTimeout(nudgeBurstRef.current.timer);
-      nudgeBurstRef.current.timer = null;
-      nudgeBurstRef.current.active = false;
+  const handleNodeDragStart = useCallback(
+    (_event: React.MouseEvent, node: Node, draggedNodes: Node[]) => {
+      // A pending nudge-burst resume must not fire mid-drag and re-enable
+      // tracking — the drag-stop handler resumes for both
+      if (nudgeBurstRef.current.timer !== null) {
+        window.clearTimeout(nudgeBurstRef.current.timer);
+        nudgeBurstRef.current.timer = null;
+        nudgeBurstRef.current.active = false;
+      }
+      const { nodes: allNodes, edges: allEdges } = useWorkflowStore.getState();
+      preDragNodesRef.current = allNodes;
+      preDragEdgesRef.current = allEdges;
+      useWorkflowStore.temporal.getState().pause();
+
+      // Drag-splice eligibility: only a single, fully unwired, non-structural
+      // node can be dropped onto a connection — an already-wired node is
+      // never re-wired by a stray drag
+      const isSpliceable =
+        draggedNodes.length === 1 &&
+        node.type !== 'start' &&
+        node.type !== 'end' &&
+        node.type !== 'group' &&
+        !allEdges.some((e) => e.source === node.id || e.target === node.id);
+      dragSpliceRef.current = isSpliceable
+        ? { nodeId: node.id, sampledEdges: sampleEdgePathPoints(allEdges) }
+        : null;
+    },
+    []
+  );
+
+  // While an eligible node is dragged, hit-test its rect against the cached
+  // edge-path samples and mark the closest overlapped edge as the splice
+  // target (transient store field — DeletableEdge highlights itself)
+  const handleNodeDrag = useCallback((_event: React.MouseEvent, node: Node) => {
+    const splice = dragSpliceRef.current;
+    if (!splice || splice.nodeId !== node.id) return;
+    const x = node.positionAbsolute?.x ?? node.position.x;
+    const y = node.positionAbsolute?.y ?? node.position.y;
+    const w = node.width ?? 150;
+    const h = node.height ?? 48;
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+    let best: { id: string; dist: number } | null = null;
+    for (const edge of splice.sampledEdges) {
+      for (const p of edge.points) {
+        if (p.x < x || p.x > x + w || p.y < y || p.y > y + h) continue;
+        const dist = (p.x - cx) ** 2 + (p.y - cy) ** 2;
+        if (!best || dist < best.dist) best = { id: edge.id, dist };
+      }
     }
-    preDragNodesRef.current = useWorkflowStore.getState().nodes;
-    useWorkflowStore.temporal.getState().pause();
+    useWorkflowStore.getState().setDragSpliceTargetEdgeId(best ? best.id : null);
   }, []);
 
-  // Handle node drag stop (group containment logic + record single undo entry)
+  // Handle node drag stop (group containment + drag-splice + record single undo entry)
   const handleNodeDragStop = useCallback(
     (_event: React.MouseEvent, node: Node) => {
+      const spliceTargetEdgeId = useWorkflowStore.getState().dragSpliceTargetEdgeId;
+      const spliceNodeId = dragSpliceRef.current?.nodeId ?? null;
+      dragSpliceRef.current = null;
+      useWorkflowStore.getState().setDragSpliceTargetEdgeId(null);
+
       onNodeDragStop(node);
+      // Dropped onto a connection: replace it with source→node→target while
+      // temporal tracking is still paused, so move + splice seal together
+      if (spliceTargetEdgeId && spliceNodeId === node.id) {
+        useWorkflowStore.getState().spliceNodeIntoEdge(node.id, spliceTargetEdgeId);
+      }
       const preDragNodes = preDragNodesRef.current;
-      if (preDragNodes) {
-        const currentNodes = useWorkflowStore.getState().nodes;
+      const preDragEdges = preDragEdgesRef.current;
+      if (preDragNodes && preDragEdges) {
+        const { nodes: currentNodes, edges: currentEdges } = useWorkflowStore.getState();
         // Temporarily revert to pre-drag state, then resume tracking and apply final state
         // This makes zundo record a single undo entry: pre-drag → post-drag
-        useWorkflowStore.setState({ nodes: preDragNodes });
+        useWorkflowStore.setState({ nodes: preDragNodes, edges: preDragEdges });
         useWorkflowStore.temporal.getState().resume();
-        useWorkflowStore.setState({ nodes: currentNodes });
+        useWorkflowStore.setState({ nodes: currentNodes, edges: currentEdges });
         preDragNodesRef.current = null;
+        preDragEdgesRef.current = null;
       } else {
         useWorkflowStore.temporal.getState().resume();
       }
@@ -1548,6 +1643,7 @@ export const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           onConnectStart={handleConnectStart}
           onConnectEnd={handleConnectEnd}
           onNodeDragStart={handleNodeDragStart}
+          onNodeDrag={handleNodeDrag}
           onNodeDragStop={handleNodeDragStop}
           onNodeClick={handleNodeClick}
           onEdgeClick={() => syncSelectedNodeId(null)}

--- a/packages/vscode/src/webview/src/components/edges/DeletableEdge.tsx
+++ b/packages/vscode/src/webview/src/components/edges/DeletableEdge.tsx
@@ -51,6 +51,10 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
   const { t } = useTranslation();
   const { setEdges } = useReactFlow();
 
+  // Highlight this edge while an eligible dragged node hovers over it
+  // (drag an unwired node onto a connection to splice it in)
+  const isSpliceTarget = useWorkflowStore((state) => state.dragSpliceTargetEdgeId === id);
+
   // Calculate bezier curve path and center coordinates
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
@@ -86,7 +90,37 @@ export const DeletableEdge: React.FC<EdgeProps> = ({
   return (
     <>
       {/* Base edge */}
-      <BaseEdge path={edgePath} style={style} markerEnd={markerEnd} />
+      <BaseEdge
+        path={edgePath}
+        style={
+          isSpliceTarget ? { ...style, stroke: 'var(--vscode-focusBorder)', strokeWidth: 4 } : style
+        }
+        markerEnd={markerEnd}
+      />
+
+      {/* Drop-target hint: non-interactive ⊕ at the midpoint while an
+          eligible dragged node hovers over this edge */}
+      {isSpliceTarget && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: 'none',
+              width: '18px',
+              height: '18px',
+              borderRadius: '50%',
+              backgroundColor: 'var(--vscode-focusBorder)',
+              color: 'var(--vscode-button-foreground)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Plus size={12} strokeWidth={3} />
+          </div>
+        </EdgeLabelRenderer>
+      )}
 
       {/* Buttons rendered in HTML layer (outside SVG) to avoid animation flicker */}
       {selected && (

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -206,6 +206,11 @@ interface WorkflowStore {
     clientY: number;
     flowPosition: { x: number; y: number };
   } | null;
+  /** The edge an eligible dragged node is currently hovering over (drag an
+   *  unwired node onto a connection to splice it in). Set by WorkflowEditor
+   *  during the drag so DeletableEdge can highlight the drop target; cleared
+   *  on drop/cancel. Transient UI state — not tracked in undo history. */
+  dragSpliceTargetEdgeId: string | null;
 
   // Guided Tour player state (reads steps from activeWorkflow.tour)
   isTourActive: boolean;
@@ -307,6 +312,14 @@ interface WorkflowStore {
    *  when the edge no longer exists (e.g. the canvas changed while a
    *  creation dialog was open). */
   insertNodeOnEdge: (node: Node, edgeId: string) => void;
+  setDragSpliceTargetEdgeId: (edgeId: string | null) => void;
+  /** Splice an EXISTING node into an edge (drag an unwired node onto a
+   *  connection): the edge is replaced by source→node and node→target in one
+   *  set() — outer handles preserved, the node's own handles resolve to
+   *  React Flow's first-handle default. No-op unless both the node and the
+   *  edge still exist and the node has no connected edges (the eligibility
+   *  guard — an already-wired node is never re-wired by a stray drag). */
+  spliceNodeIntoEdge: (nodeId: string, edgeId: string) => void;
   /** Duplicate a configured node (fresh id, +40/+40 offset, same parent group,
    *  deep-copied data; edges are not copied). Duplicating a group also copies
    *  its child nodes and the edges fully inside the group. Start/End excluded. */
@@ -625,6 +638,7 @@ export const useWorkflowStore = create<WorkflowStore>()(
       pendingConnection: null,
       paletteDialogRequest: null,
       edgeInsertRequest: null,
+      dragSpliceTargetEdgeId: null,
       isTourActive: false,
       tourStepIndex: 0,
       highlightedGroupNodeId: null,
@@ -1013,6 +1027,41 @@ export const useWorkflowStore = create<WorkflowStore>()(
 
       setPendingConnection: (pending) => {
         set({ pendingConnection: pending });
+      },
+
+      setDragSpliceTargetEdgeId: (edgeId) => {
+        if (get().dragSpliceTargetEdgeId === edgeId) return;
+        set({ dragSpliceTargetEdgeId: edgeId });
+      },
+
+      spliceNodeIntoEdge: (nodeId: string, edgeId: string) => {
+        const node = get().nodes.find((n) => n.id === nodeId);
+        const edge = get().edges.find((e) => e.id === edgeId);
+        if (!node || !edge) return;
+        // Eligibility re-check at splice time: only a fully unwired node may
+        // be spliced, and never into an edge touching itself
+        const hasEdges = get().edges.some((e) => e.source === nodeId || e.target === nodeId);
+        if (hasEdges || edge.source === nodeId || edge.target === nodeId) return;
+        const remainingEdges = get().edges.filter((e) => e.id !== edgeId);
+        set({
+          edges: addEdge(
+            {
+              source: nodeId,
+              sourceHandle: null,
+              target: edge.target,
+              targetHandle: edge.targetHandle ?? null,
+            },
+            addEdge(
+              {
+                source: edge.source,
+                sourceHandle: edge.sourceHandle ?? null,
+                target: nodeId,
+                targetHandle: null,
+              },
+              remainingEdges
+            )
+          ),
+        });
       },
 
       setEdgeInsertRequest: (request) => {


### PR DESCRIPTION
## Summary

A user who click-adds a node from the palette (which lands unwired) can now wire it into the flow by simply dragging it onto an existing connection: the edge highlights with an accent stroke and a ⊕ hint while the node hovers over it, and on drop the edge is replaced by source→node→target. A single Ctrl/Cmd+Z undoes the move and the splice together. Previously this took delete edge → draw two connections by hand.

Closes #969

## Changes

- **`workflow-store.ts`**: new transient `dragSpliceTargetEdgeId` field (untracked by undo/canvas revision, same pattern as `edgeInsertRequest`) and a `spliceNodeIntoEdge(nodeId, edgeId)` action that replaces the edge with source→node and node→target in one `set()` (outer handles preserved), re-checking eligibility at splice time.
- **`WorkflowEditor.tsx`**: eligibility computed at drag start (single-node drag, not Start/End/Group, zero connected edges — an already-wired node is never re-wired by a stray drag); rendered edge paths are sampled once at drag start (`getTotalLength`/`getPointAtLength`, flow coords, exact for bezier), and each drag frame hit-tests the cached points against the node rect. The drag-stop single-undo sealing now captures edges too, so move + splice restore with one undo.
- **`DeletableEdge.tsx`**: highlights itself (accent stroke, width 4) and shows a non-interactive ⊕ at the midpoint while it is the drop target.

No schema or persistence change; no new locale strings (visual affordance only).

## Testing

- `pnpm build` + `pnpm check` green from the repo root.
- Browser E2E via `ccwf canvas` + headless Chromium on the 8-node daily-dev sample — 14/14 checks green: edge highlights during hover; splice on drop (same node count, edge count +1, original edge gone, both new edges wired to the dropped node); single undo restores the original edge AND the pre-drag node position; dragging a wired node never highlights or splices; zero page errors.

## Changeset

`minor` for `cc-wf-studio` (`.changeset/drag-splice-node-onto-edge.md`).

## Follow-up found while testing

`ccwf canvas` silently shows an empty canvas for `{meta, workflow}` wrapper files (the canvas handlers serve raw parsed JSON without unwrapping, while the command's own up-front validation accepts wrappers) — filed as a separate idea issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114ZgHf4dWCWDZeiugz76Br

---
_Generated by [Claude Code](https://claude.ai/code/session_0114ZgHf4dWCWDZeiugz76Br)_