### PR TITLE
fix(cli): unwrap {meta, workflow} wrapper files in ccwf canvas

### DIFF
--- a/.changeset/ccwf-canvas-wrapper-unwrap.md
+++ b/.changeset/ccwf-canvas-wrapper-unwrap.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": patch
+---
+
+Fix `ccwf canvas` showing an empty canvas for `{meta, workflow}` wrapper files — the canvas now unwraps them like every other subcommand, and saving writes the wrapper back so `meta` is preserved.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,45 @@ Entry format:
 
 ---
 
+## 2026-07-24 — Fix `ccwf canvas` empty canvas for {meta, workflow} wrapper files
+- **User value**: a user who runs `ccwf canvas` on a `{meta, workflow}`
+  wrapper file (the format `ccwf export` and the bundled samples produce)
+  no longer gets a silently empty canvas with the Start Menu — the workflow
+  loads, and saving writes the wrapper back so `meta` is preserved instead
+  of silently discarded (top carried proposal from the previous iteration,
+  premise re-verified in code: `readWorkflowFromDisk` did raw
+  `JSON.parse` + `migrateWorkflow` with no unwrap while the command's
+  up-front validation accepted the wrapper).
+- **Issue/PR**: #971
+- **Outcome**: done — `parseWorkflowSource` in `load-workflow.ts` refactored
+  into an exported `parseWorkflowDocument` returning `{ workflow,
+  wrapperMeta? }`; canvas handlers now read through it (same unwrap +
+  error messages as every other subcommand) and remember `wrapperMeta` so
+  SAVE_WORKFLOW writes `{ meta, workflow }` back when the source was
+  wrapped, plain files stay plain. A malformed file now surfaces as a
+  LOAD_FAILED error envelope instead of an empty canvas. `ccwf preview`
+  checked: already loads via `loadWorkflowFromFile`, not affected. Browser
+  E2E via `ccwf canvas` + headless Chromium: wrapper sample renders 8/8
+  nodes + 8 edges (previously empty), nudge + Ctrl+S round-trip keeps the
+  wrapper and `meta.id`, plain file still renders and saves without a
+  wrapper being added, zero page errors (10/10 checks). `pnpm build` +
+  `pnpm check` green. Issue #971 could not be locked (no `gh`, no MCP lock
+  tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): drag-splice in the VSCode extension host
+    (highlight, drop, undo, wired-node guard, multi-select drag guard);
+    edge ⊕ insert (simple + dialog types, cancel paths, undo, ja locale
+    tooltip); edge-drop dialog create (all four dialogs, cancel path,
+    collapsed palette auto-expand, sub-agent-flow and Codex-beta gating);
+    palette filter; arrow-key nudge; Esc panel dismissal; F8 / Shift+F8
+    problem cycling; inline group rename; Ungroup; Group selection; Save as
+    Image from the VSCode extension host; Copy as Markdown; `render_workflow`
+    via MCP Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Drag an unwired node onto a connection to splice it in
 - **User value**: a user who click-adds a node from the palette (which lands
   unwired) can now wire it into the flow by simply dragging it onto an

--- a/packages/cli/src/canvas/handlers.ts
+++ b/packages/cli/src/canvas/handlers.ts
@@ -14,6 +14,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { type Workflow, migrateWorkflow } from '@cc-wf-studio/core';
+import { parseWorkflowDocument } from '../utils/load-workflow.js';
 import type { CanvasServerHandlers } from './server.js';
 
 // Local shape declarations for the message envelopes the webview expects.
@@ -100,10 +101,16 @@ export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServ
   const workflowId = path.basename(workflowAbsPath, '.json');
   const workflowDisplayName = workflowId;
 
+  // When the source file wraps the workflow as `{ meta, workflow }` (the
+  // format `ccwf export` and the bundled samples produce), remember the meta
+  // so saves write the wrapper back instead of silently discarding it.
+  let wrapperMeta: unknown;
+
   async function readWorkflowFromDisk() {
     const raw = await fs.readFile(workflowAbsPath, 'utf-8');
-    const parsed = JSON.parse(raw);
-    return migrateWorkflow(parsed);
+    const document = parseWorkflowDocument(raw, workflowAbsPath);
+    wrapperMeta = document.wrapperMeta;
+    return migrateWorkflow(document.workflow);
   }
 
   return {
@@ -193,7 +200,11 @@ export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServ
             return;
           }
           try {
-            const contents = `${JSON.stringify(save.workflow, null, 2)}\n`;
+            const document =
+              wrapperMeta === undefined
+                ? save.workflow
+                : { meta: wrapperMeta, workflow: save.workflow };
+            const contents = `${JSON.stringify(document, null, 2)}\n`;
             await fs.writeFile(workflowAbsPath, contents, 'utf-8');
             const payload: SaveSuccessPayload = {
               filePath: workflowAbsPath,

--- a/packages/cli/src/utils/load-workflow.ts
+++ b/packages/cli/src/utils/load-workflow.ts
@@ -31,7 +31,18 @@ function looksLikeWorkflow(value: unknown): value is Workflow {
   );
 }
 
-function parseWorkflowSource(raw: string, sourceLabel: string): Workflow {
+export interface WorkflowDocument {
+  workflow: Workflow;
+  /** Set when the source wraps the workflow as `{ meta, workflow }` and carries a `meta` value. */
+  wrapperMeta?: unknown;
+}
+
+/**
+ * Parse a raw JSON string into a workflow, unwrapping the `{ meta, workflow }`
+ * wrapper that sample/share files use. Callers that write the file back (e.g.
+ * `ccwf canvas` save) can use `wrapperMeta` to preserve the wrapper on save.
+ */
+export function parseWorkflowDocument(raw: string, sourceLabel: string): WorkflowDocument {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -41,7 +52,7 @@ function parseWorkflowSource(raw: string, sourceLabel: string): Workflow {
     );
   }
   if (looksLikeWorkflow(parsed)) {
-    return parsed;
+    return { workflow: parsed };
   }
   // Sample/share files wrap the workflow: { meta: {...}, workflow: {...} }
   const wrapped =
@@ -49,11 +60,16 @@ function parseWorkflowSource(raw: string, sourceLabel: string): Workflow {
       ? (parsed as { workflow?: unknown }).workflow
       : undefined;
   if (looksLikeWorkflow(wrapped)) {
-    return wrapped;
+    const meta = (parsed as { meta?: unknown }).meta;
+    return meta === undefined ? { workflow: wrapped } : { workflow: wrapped, wrapperMeta: meta };
   }
   throw new WorkflowLoadError(
     `${sourceLabel} does not look like a workflow file: expected a top-level "nodes" array or a { meta, workflow } wrapper`
   );
+}
+
+function parseWorkflowSource(raw: string, sourceLabel: string): Workflow {
+  return parseWorkflowDocument(raw, sourceLabel).workflow;
 }
 
 export async function loadWorkflowFromFile(filePath: string): Promise<{


### PR DESCRIPTION
## Summary

`ccwf canvas my-flow.json` on a `{meta, workflow}` wrapper file (the format `ccwf export` and the bundled samples produce, and every other `ccwf` subcommand accepts) started without error — the command's up-front validation goes through `loadWorkflowFromFile`, which unwraps — but the canvas server's own `readWorkflowFromDisk` did a raw `JSON.parse` + `migrateWorkflow` with no unwrap. The webview received the raw wrapper, failed to apply it, and silently fell back to an empty canvas with the Start Menu.

Closes #971

## Changes

- `packages/cli/src/utils/load-workflow.ts`: refactored the private `parseWorkflowSource` into an exported `parseWorkflowDocument` that returns `{ workflow, wrapperMeta? }` — same JSON/shape error messages, now capturing the wrapper's `meta` when present. `parseWorkflowSource` remains as a thin wrapper for the existing file/stdin loaders (no behavior change for them).
- `packages/cli/src/canvas/handlers.ts`: `readWorkflowFromDisk` now loads through `parseWorkflowDocument`, so the canvas unwraps wrapper files exactly like every other subcommand, and a malformed file surfaces as a `LOAD_FAILED` error envelope instead of an empty canvas. It remembers `wrapperMeta`, and `SAVE_WORKFLOW` writes `{ meta, workflow }` back when the source was wrapped — `meta` (sample id, tags, difficulty…) is preserved instead of silently discarded. Plain workflow files keep saving plain.
- `ccwf preview` checked for the same discrepancy: it already loads via `loadWorkflowFromFile`, not affected.

## Verification

- Browser E2E via `ccwf canvas` + headless Chromium:
  - Wrapper sample (`daily-dev-with-branch-sample.en.json`): 8/8 nodes + 8 edges render (previously an empty canvas); node nudge + Ctrl+S round-trip keeps the `{meta, workflow}` shape and `meta.id`; zero page errors — 7/7 checks.
  - Plain (unwrapped) copy of the same workflow: renders, and saving does not add a wrapper — 3/3 checks.
- `pnpm build` + `pnpm check` green from the repo root.

## Release

- Changeset included: `@cc-wf-studio/cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UZBXRff7xsBgGPkJDp8DL

---
_Generated by [Claude Code](https://claude.ai/code/session_012UZBXRff7xsBgGPkJDp8DL)_