### PR TITLE
feat(cli): let ccwf canvas create a brand-new workflow file

### DIFF
--- a/.changeset/brave-canvas-new-file.md
+++ b/.changeset/brave-canvas-new-file.md
@@ -1,0 +1,5 @@
+---
+"@cc-wf-studio/cli": minor
+---
+
+`ccwf canvas <file>` now starts a brand-new workflow when `<file>` does not exist: the canvas opens with a Start→End starter and the file is created on first save. A missing parent directory or a directory path still fails with a clear error.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,51 @@ Entry format:
 
 ---
 
+## 2026-07-24 — `ccwf canvas` can start a brand-new workflow file
+- **User value**: a user can now begin a workflow from the terminal with
+  `ccwf canvas new.json` — the canvas opens with a Start→End starter (name
+  derived from the filename) and the file is created on first save;
+  previously the command refused with `error: File not found`, so the only
+  way to start a workflow was the VSCode extension or hand-writing a JSON
+  skeleton.
+- **Issue/PR**: #973
+- **Outcome**: done — `canvas.ts` stats the path first: ENOENT with an
+  existing parent directory enters new-file mode (a missing parent stays a
+  hard error — that's almost always a typo — and a directory path gets its
+  own clear error); existing files keep the up-front parse validation.
+  `createCanvasHandlers` gains `allowMissing`: `readWorkflowFromDisk`
+  returns a cached Start→End starter (same shape as the webview's
+  `createEmptyWorkflow`) on ENOENT, so browser reloads before the first
+  save keep the same workflow id; SAVE_WORKFLOW already created the file
+  via `fs.writeFile`, unchanged. Banner notes "(new file — created on
+  first save)". Browser E2E via `ccwf canvas` + headless Chromium: 12/12
+  checks (starter renders 2 nodes, file absent before save, toolbar Save
+  creates a plain 2-node workflow named after the file, reload after save
+  re-reads from disk, existing-sample regression renders 8 nodes, both
+  error paths exit 2 with friendly messages, zero page errors).
+  `pnpm build` + `pnpm check` green. Issue #973 could not be locked (no
+  `gh`, no MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Malformed workflow JSON errors surface the raw `JSON.parse` message
+    (byte offset, no line/column) — add a line/col (+ caret snippet)
+    translator in `load-workflow.ts` so every `ccwf` command benefits.
+  - `ccwf canvas` doesn't watch the file: external edits (e.g. an AI agent
+    via `ccwf mcp --file`) go stale in the open canvas and a later save
+    clobbers them — `ccwf preview` already has the watcher pattern.
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): drag-splice in the VSCode extension host
+    (highlight, drop, undo, wired-node guard, multi-select drag guard);
+    edge ⊕ insert (simple + dialog types, cancel paths, undo, ja locale
+    tooltip); edge-drop dialog create (all four dialogs, cancel path,
+    collapsed palette auto-expand, sub-agent-flow and Codex-beta gating);
+    palette filter; arrow-key nudge; Esc panel dismissal; F8 / Shift+F8
+    problem cycling; inline group rename; Ungroup; Group selection; Save as
+    Image from the VSCode extension host; Copy as Markdown; `render_workflow`
+    via MCP Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — Fix `ccwf canvas` empty canvas for {meta, workflow} wrapper files
 - **User value**: a user who runs `ccwf canvas` on a `{meta, workflow}`
   wrapper file (the format `ccwf export` and the bundled samples produce)

--- a/packages/cli/src/canvas/handlers.ts
+++ b/packages/cli/src/canvas/handlers.ts
@@ -13,7 +13,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { type Workflow, migrateWorkflow } from '@cc-wf-studio/core';
+import { NodeType, type Workflow, migrateWorkflow } from '@cc-wf-studio/core';
 import { parseWorkflowDocument } from '../utils/load-workflow.js';
 import type { CanvasServerHandlers } from './server.js';
 
@@ -61,6 +61,44 @@ interface IncomingMessage {
 export interface CanvasHandlersOptions {
   /** Absolute path to the workflow JSON the user passed to `ccwf canvas`. */
   workflowPath: string;
+  /**
+   * New-file mode: the path did not exist when the command started. Loads
+   * serve a Start→End starter workflow instead of failing, and the first
+   * save creates the file.
+   */
+  allowMissing?: boolean;
+}
+
+/**
+ * Minimal workflow for new-file mode — Start and End nodes only, matching
+ * the webview's own `createEmptyWorkflow` starter shape.
+ */
+function createStarterWorkflow(name: string): Workflow {
+  const now = new Date();
+  return {
+    id: `workflow-${Date.now()}`,
+    name,
+    version: '1.0.0',
+    createdAt: now,
+    updatedAt: now,
+    nodes: [
+      {
+        id: 'start-node-default',
+        name: 'Start',
+        type: NodeType.Start,
+        position: { x: 100, y: 200 },
+        data: { label: 'Start' },
+      },
+      {
+        id: 'end-node-default',
+        name: 'End',
+        type: NodeType.End,
+        position: { x: 600, y: 200 },
+        data: { label: 'End' },
+      },
+    ],
+    connections: [],
+  };
 }
 
 // Heuristic: any message type that starts with one of these prefixes is
@@ -106,8 +144,21 @@ export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServ
   // so saves write the wrapper back instead of silently discarding it.
   let wrapperMeta: unknown;
 
+  // Cached so browser reloads before the first save keep the same workflow
+  // id instead of minting a fresh starter each time.
+  let starterWorkflow: Workflow | undefined;
+
   async function readWorkflowFromDisk() {
-    const raw = await fs.readFile(workflowAbsPath, 'utf-8');
+    let raw: string;
+    try {
+      raw = await fs.readFile(workflowAbsPath, 'utf-8');
+    } catch (error) {
+      if (options.allowMissing && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+        starterWorkflow ??= createStarterWorkflow(workflowDisplayName);
+        return starterWorkflow;
+      }
+      throw error;
+    }
     const document = parseWorkflowDocument(raw, workflowAbsPath);
     wrapperMeta = document.wrapperMeta;
     return migrateWorkflow(document.workflow);

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -19,6 +19,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import type { Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -96,18 +97,53 @@ export function registerCanvasCommand(program: Command): void {
     .description(
       'Open the full editable cc-wf-studio canvas for <file> in a local browser (experimental). Saves write back to the same file.'
     )
-    .argument('<file>', 'Path to a workflow JSON file.')
+    .argument(
+      '<file>',
+      'Path to a workflow JSON file. If it does not exist yet, the canvas opens a new Start→End starter workflow and creates the file on first save.'
+    )
     .option('--port <number>', 'Preferred port (default: ephemeral / 0).')
     .option('--host <address>', 'Bind host. Default 127.0.0.1; do not change for public networks.')
     .action(async (file: string, options: CanvasOptions) => {
       let portOption = 0;
       try {
-        // Validate the file is parseable JSON up-front so the user gets a clear
-        // error instead of a confused empty canvas in the browser.
-        await loadWorkflowFromFile(file);
+        const workflowAbsPath = path.resolve(file);
+        let isNewFile = false;
+        let stat: Stats | undefined;
+        try {
+          stat = await fs.stat(workflowAbsPath);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw error;
+          }
+          // New-file mode — but a missing parent directory is almost always a
+          // path typo, so keep that a hard error instead of a silent new file.
+          const parentDir = path.dirname(workflowAbsPath);
+          let parentIsDirectory = false;
+          try {
+            parentIsDirectory = (await fs.stat(parentDir)).isDirectory();
+          } catch {
+            // fall through to the error below
+          }
+          if (!parentIsDirectory) {
+            throw new WorkflowLoadError(
+              `Directory not found: ${parentDir}\nCreate it first, or check the path for a typo.`
+            );
+          }
+          isNewFile = true;
+        }
+        if (stat) {
+          if (stat.isDirectory()) {
+            throw new WorkflowLoadError(
+              `${workflowAbsPath} is a directory — pass a workflow JSON file.`
+            );
+          }
+          // Validate the file is parseable JSON up-front so the user gets a
+          // clear error instead of a confused empty canvas in the browser.
+          await loadWorkflowFromFile(file);
+        }
 
         const webviewDistDir = await resolveWebviewDistDir();
-        const handlers = createCanvasHandlers({ workflowPath: file });
+        const handlers = createCanvasHandlers({ workflowPath: file, allowMissing: isNewFile });
         portOption = options.port ? Number(options.port) : 0;
         if (Number.isNaN(portOption)) {
           process.stderr.write(`error: --port must be a number, got '${options.port}'\n`);
@@ -123,7 +159,7 @@ export function registerCanvasCommand(program: Command): void {
 
         const banner = [
           `ccwf canvas server listening at ${server.url}`,
-          `  workflow: ${path.resolve(file)}`,
+          `  workflow: ${workflowAbsPath}${isNewFile ? ' (new file — created on first save)' : ''}`,
           `  bind:     ${server.host}:${server.port}`,
           '',
           'Save buttons in the canvas will write back to the workflow file.',


### PR DESCRIPTION
Closes #973

## What

`ccwf canvas <file>` now starts a brand-new workflow when `<file>` does not exist: the canvas opens with a Start→End starter workflow (name derived from the filename) and the file is created on the first save. Previously the command refused with `error: File not found`, so the only way to begin a workflow was the VSCode extension or hand-writing a JSON skeleton.

## How

- `packages/cli/src/commands/canvas.ts`: stats the path up front. ENOENT with an existing parent directory enters new-file mode; a missing parent directory stays a hard error (`Directory not found: … check the path for a typo`) since that is almost always a path typo, and a directory path gets its own clear error. Existing files keep the up-front parse validation unchanged. The banner marks the workflow line with "(new file — created on first save)".
- `packages/cli/src/canvas/handlers.ts`: `createCanvasHandlers` gains an `allowMissing` option. `readWorkflowFromDisk` returns a Start→End starter workflow (same shape as the webview's own `createEmptyWorkflow`) on ENOENT in new-file mode; the starter is cached so browser reloads before the first save keep the same workflow id. `SAVE_WORKFLOW` already creates the file via `fs.writeFile` — unchanged.
- No schema or persistence change. `ccwf preview` (read-only) intentionally still requires an existing file.

## Testing

- Browser E2E via `ccwf canvas` + headless Chromium, 12/12 checks green:
  - new file: banner note present, starter renders exactly Start + End, file absent before save, toolbar Save creates a plain 2-node workflow named after the file, reload after save re-reads from disk, zero page errors
  - existing sample file regression: renders all 8 nodes, no new-file note, zero page errors
  - error paths: missing parent directory and directory-as-argument both exit 2 with friendly messages
- `pnpm build` + `pnpm check` green
- Changeset: minor bump for `@cc-wf-studio/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2UePaaNTtfDLHLAufDLBi

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2UePaaNTtfDLHLAufDLBi)_