### PR TITLE
improvement(cli): point at the offending line for malformed workflow JSON

### DIFF
--- a/.changeset/tidy-eyes-shout.md
+++ b/.changeset/tidy-eyes-shout.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': patch
+---
+
+Malformed workflow JSON errors now point at the offending line with a caret snippet and line/column, instead of a raw byte offset

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,51 @@ Entry format:
 
 ---
 
+## 2026-07-25 — Malformed workflow JSON errors point at the offending line
+- **User value**: a user who feeds `ccwf` a malformed workflow JSON file now
+  sees the offending line with a caret pointing at the exact spot (plus
+  line/column), instead of a raw V8 message — which on Node 20 is just a
+  byte offset and even on Node 22 gives only `(line L column C)` with no
+  visible context (top carried proposal from the previous iteration,
+  premise re-verified: `parseWorkflowDocument` surfaced `error.message`
+  verbatim).
+- **Issue/PR**: #975
+- **Outcome**: done — `describeJsonParseError` in `load-workflow.ts`:
+  recovers the location from V8's message (`(line L column C)` on Node 22+;
+  on Node 20 re-derives line/column from `at position N` — derivation
+  verified to match V8's own line/col for the same input), strips the
+  position boilerplate down to a one-line reason, and renders a ±1-line
+  caret snippet; minified single-line files get a `…`-windowed 100-char
+  slice centered on the column so the caret stays visible; messages with no
+  recoverable position (tiny inputs, `Unexpected end of JSON input`) fall
+  through unchanged. Every subcommand benefits (`validate`, `render`,
+  `export`, `run`, `tour`, `preview`, `canvas` incl. its LOAD_FAILED
+  envelope) since all parse via `parseWorkflowDocument`. E2E on built CLI:
+  large/minified/tiny/truncated fixtures + valid-file control — caret exact,
+  windows correct, fallbacks intact, exit codes stable (2 / 1). `pnpm
+  build` + `pnpm check` green. Issue #975 could not be locked (no `gh`, no
+  MCP lock tool — known limitation, noted in the issue).
+- **Next proposals**:
+  - Security-interrupt check first next round: the push response reported
+    5 Dependabot alerts on the default branch (2 high) — assess whether any
+    is actionable (real, reachable dependency) before inventing.
+  - `ccwf canvas` doesn't watch the file: external edits (e.g. an AI agent
+    via `ccwf mcp --file`) go stale in the open canvas and a later save
+    clobbers them — `ccwf preview` already has the watcher pattern (carried).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): drag-splice in the VSCode extension host
+    (highlight, drop, undo, wired-node guard, multi-select drag guard);
+    edge ⊕ insert (simple + dialog types, cancel paths, undo, ja locale
+    tooltip); edge-drop dialog create (all four dialogs, cancel path,
+    collapsed palette auto-expand, sub-agent-flow and Codex-beta gating);
+    palette filter; arrow-key nudge; Esc panel dismissal; F8 / Shift+F8
+    problem cycling; inline group rename; Ungroup; Group selection; Save as
+    Image from the VSCode extension host; Copy as Markdown; `render_workflow`
+    via MCP Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-24 — `ccwf canvas` can start a brand-new workflow file
 - **User value**: a user can now begin a workflow from the terminal with
   `ccwf canvas new.json` — the canvas opens with a Start→End starter (name

--- a/packages/cli/src/utils/load-workflow.ts
+++ b/packages/cli/src/utils/load-workflow.ts
@@ -37,6 +37,104 @@ export interface WorkflowDocument {
   wrapperMeta?: unknown;
 }
 
+interface JsonErrorLocation {
+  /** 1-based line number of the parse error. */
+  line: number;
+  /** 1-based column number of the parse error. */
+  column: number;
+}
+
+/**
+ * Recover the error location from a V8 `JSON.parse` message. Node 22+ appends
+ * "at position N (line L column C)"; Node 20 only "at position N", so the
+ * line/column is re-derived from the position there; very short inputs get the
+ * whole text inlined with no location at all.
+ */
+function locateJsonError(detail: string, raw: string): JsonErrorLocation | undefined {
+  const lineCol = /\(line (\d+) column (\d+)\)/.exec(detail);
+  if (lineCol) {
+    return { line: Number(lineCol[1]), column: Number(lineCol[2]) };
+  }
+  const positionMatch = /at position (\d+)/.exec(detail);
+  if (!positionMatch) {
+    return undefined;
+  }
+  const position = Math.min(Number(positionMatch[1]), raw.length);
+  let line = 1;
+  let lineStart = 0;
+  for (let i = 0; i < position; i++) {
+    if (raw.charCodeAt(i) === 10 /* \n */) {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, column: position - lineStart + 1 };
+}
+
+/** Widest slice of the offending line shown in a snippet (minified files can be one huge line). */
+const SNIPPET_MAX_WIDTH = 100;
+
+function renderCaretSnippet(raw: string, location: JsonErrorLocation): string {
+  const lines = raw.split('\n').map((line) => line.replace(/\r$/, '').replace(/\t/g, ' '));
+  const errorIndex = location.line - 1;
+  if (errorIndex < 0 || errorIndex >= lines.length) {
+    return '';
+  }
+  const first = Math.max(0, errorIndex - 1);
+  const last = Math.min(lines.length - 1, errorIndex + 1);
+  const gutterWidth = String(last + 1).length;
+
+  const column = Math.max(1, location.column);
+  const errorLine = lines[errorIndex];
+  const windowStart =
+    errorLine.length > SNIPPET_MAX_WIDTH
+      ? Math.max(
+          0,
+          Math.min(
+            column - 1 - Math.floor(SNIPPET_MAX_WIDTH / 2),
+            errorLine.length - SNIPPET_MAX_WIDTH
+          )
+        )
+      : 0;
+  const clip = (line: string): string => {
+    const sliced = line.slice(windowStart, windowStart + SNIPPET_MAX_WIDTH);
+    const prefix = windowStart > 0 ? '…' : '';
+    const suffix = windowStart + SNIPPET_MAX_WIDTH < line.length ? '…' : '';
+    return `${prefix}${sliced}${suffix}`;
+  };
+
+  const rows: string[] = [];
+  for (let i = first; i <= last; i++) {
+    const marker = i === errorIndex ? '>' : ' ';
+    rows.push(`${marker} ${String(i + 1).padStart(gutterWidth)} | ${clip(lines[i])}`);
+    if (i === errorIndex) {
+      const caretOffset =
+        Math.min(column - 1 - windowStart, SNIPPET_MAX_WIDTH - 1) + (windowStart > 0 ? 1 : 0);
+      rows.push(`  ${' '.repeat(gutterWidth)} | ${' '.repeat(Math.max(0, caretOffset))}^`);
+    }
+  }
+  return rows.join('\n');
+}
+
+/**
+ * Turn a raw `JSON.parse` failure into a message that points at the offending
+ * line with a caret. Falls back to the raw V8 message when no location can be
+ * recovered from it.
+ */
+function describeJsonParseError(raw: string, sourceLabel: string, detail: string): string {
+  const location = locateJsonError(detail, raw);
+  if (!location) {
+    return `Invalid JSON in ${sourceLabel}: ${detail}`;
+  }
+  const reason =
+    detail
+      .replace(/\s*(?:in|after) JSON at position \d+(?:\s*\(line \d+ column \d+\))?/, '')
+      .trim() || detail;
+  const header = `Invalid JSON in ${sourceLabel}: ${reason} (line ${location.line}, column ${location.column})`;
+  const snippet = renderCaretSnippet(raw, location);
+  return snippet === '' ? header : `${header}\n${snippet}`;
+}
+
 /**
  * Parse a raw JSON string into a workflow, unwrapping the `{ meta, workflow }`
  * wrapper that sample/share files use. Callers that write the file back (e.g.
@@ -48,7 +146,7 @@ export function parseWorkflowDocument(raw: string, sourceLabel: string): Workflo
     parsed = JSON.parse(raw);
   } catch (error) {
     throw new WorkflowLoadError(
-      `Invalid JSON in ${sourceLabel}: ${error instanceof Error ? error.message : String(error)}`
+      describeJsonParseError(raw, sourceLabel, error instanceof Error ? error.message : String(error))
     );
   }
   if (looksLikeWorkflow(parsed)) {


### PR DESCRIPTION
## Summary

A user who feeds `ccwf` a malformed workflow JSON file now sees the offending line with a caret pointing at the exact spot (plus line/column), instead of a raw V8 `JSON.parse` message — which on Node 20 is just a byte offset ("at position 2554") and even on Node 22 shows only `(line 179 column 19)` with no visible context.

Closes #975

## What changed

- `packages/cli/src/utils/load-workflow.ts`: new `describeJsonParseError` used by `parseWorkflowDocument`:
  - recovers the location from V8's message — `(line L column C)` on Node 22+, and on Node 20 re-derives line/column from `at position N` (derivation verified to match V8's own line/col for the same input)
  - strips the position boilerplate down to a one-line reason and renders a ±1-line caret snippet
  - minified single-line files get a `…`-windowed 100-char slice centered on the error column so the caret stays visible
  - messages with no recoverable position (V8's short-input format, `Unexpected end of JSON input`) fall through unchanged
- Every subcommand benefits automatically (`validate`, `render`, `export`, `run`, `tour`, `preview`, `canvas` incl. its `LOAD_FAILED` envelope) — they all parse via `parseWorkflowDocument`.

Example output:

```
error: Invalid JSON in /path/wf.json: Expected double-quoted property name (line 180, column 19)
  179 |     {
> 180 |       "id": "n25",,
      |                   ^
  181 |       "type": "prompt",
```

## Testing

- E2E on the built CLI: large multi-line, minified single-line, tiny, and truncated malformed fixtures + a valid-file control — caret position exact, window markers correct, fallbacks intact, exit codes stable (2 for load errors, 1 for validation errors).
- Node 20 path verified by comparing the position→line/column derivation against V8's own values for the same document.
- `pnpm build` + `pnpm check` green.

## Release

- Changeset: `@cc-wf-studio/cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3yDDzcDHoschBStLSmixu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3yDDzcDHoschBStLSmixu)_