### PR TITLE
feat(cli): live-reload canvas on external workflow file changes

### DIFF
--- a/.changeset/canvas-live-reload.md
+++ b/.changeset/canvas-live-reload.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': minor
+---
+
+`ccwf canvas` now live-reloads the open canvas when the workflow file changes on disk (e.g. an AI agent editing it via `ccwf mcp --file`, or a text editor), instead of going stale and clobbering the external edit on the next save. The canvas's own saves and mid-write invalid JSON are filtered out, so no spurious reloads occur.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -17,6 +17,52 @@ Entry format:
 
 ---
 
+## 2026-07-25 — `ccwf canvas` live-reloads on external file changes
+- **User value**: a user with an open canvas no longer gets a stale view —
+  and no longer clobbers the file on their next save — when an external
+  process (an AI agent via `ccwf mcp --file`, a text editor, `git checkout`)
+  modifies the workflow JSON; the canvas reloads automatically (top carried
+  proposal, premise re-verified: `handlers.ts` read the file only at boot /
+  explicit load and `SAVE_WORKFLOW` wrote unconditionally).
+- **Issue/PR**: #977
+- **Outcome**: done — reused `preview/watcher.ts` (debounced `fs.watch`,
+  new optional `logLabel`); `startCanvasServer` handle gains `broadcast()`
+  over its open sockets; `createCanvasHandlers` gains `loadExternalChange()`
+  which drops echoes by comparing contents against the last load/save/push
+  (`lastKnownContents` — also guards platforms with null watch filenames,
+  where sibling writes like exported PNGs trigger events), skips mid-write
+  invalid JSON with a server-side warning (next event retries), and
+  refreshes `{meta, workflow}` wrapper meta so a later save keeps the new
+  meta; watcher armed in `commands/canvas.ts`, closed on shutdown, banner
+  mentions live-reload. Webview untouched — it already applies unsolicited
+  `LOAD_WORKFLOW` pushes. E2E via WS harness against the built CLI: 8/8
+  (boot, external edit push, no self-save echo, invalid-JSON ignored,
+  recovery push, wrapper-meta survival, new-file starter, external creation
+  of a new file). `pnpm build` + `pnpm check` green. Security check from
+  last round done first: the 2 high advisories (postcss, brace-expansion)
+  are dev-only build-chain deps (vite, @vscode/vsce) unreachable in shipped
+  artifacts; moderate @hono/node-server (via MCP SDK) is Windows
+  `serve-static`, unused by the stdio MCP server — no actionable interrupt.
+  Issue #977 could not be locked (no `gh`, no MCP lock tool — known
+  limitation, noted in the issue).
+- **Next proposals**:
+  - The reload replaces unsaved canvas edits when an external write lands;
+    consider a lightweight "file changed on disk" toast with keep/reload
+    choice instead of an unconditional swap (needs a small webview message).
+  - Mirror the shortcut cheat sheet in the README/docs (carried).
+  - Manual E2E queue (carried): drag-splice in the VSCode extension host
+    (highlight, drop, undo, wired-node guard, multi-select drag guard);
+    edge ⊕ insert (simple + dialog types, cancel paths, undo, ja locale
+    tooltip); edge-drop dialog create (all four dialogs, cancel path,
+    collapsed palette auto-expand, sub-agent-flow and Codex-beta gating);
+    palette filter; arrow-key nudge; Esc panel dismissal; F8 / Shift+F8
+    problem cycling; inline group rename; Ungroup; Group selection; Save as
+    Image from the VSCode extension host; Copy as Markdown; `render_workflow`
+    via MCP Inspector; problems badge; shortcut cheat sheet; problem-node
+    markers; problems panel click-to-jump; auto layout; node search cycling;
+    align/distribute + context menu + copy/cut/paste; localized Claude API
+    dialog in ja/ko/zh; `validate_workflow` via MCP Inspector.
+
 ## 2026-07-25 — Malformed workflow JSON errors point at the offending line
 - **User value**: a user who feeds `ccwf` a malformed workflow JSON file now
   sees the offending line with a caret pointing at the exact spot (plus

--- a/packages/cli/src/canvas/handlers.ts
+++ b/packages/cli/src/canvas/handlers.ts
@@ -69,6 +69,16 @@ export interface CanvasHandlersOptions {
   allowMissing?: boolean;
 }
 
+export interface CanvasHandlers extends CanvasServerHandlers {
+  /**
+   * Re-read the workflow after a filesystem change event. Returns `null`
+   * when the change should NOT be pushed to the canvas: the event is an
+   * echo of the canvas's own save, the file is missing, or it does not
+   * parse (e.g. an external writer is mid-write — a later event retries).
+   */
+  loadExternalChange(): Promise<Workflow | null>;
+}
+
 /**
  * Minimal workflow for new-file mode — Start and End nodes only, matching
  * the webview's own `createEmptyWorkflow` starter shape.
@@ -134,7 +144,7 @@ function isCanvasUnsupported(type: string): boolean {
   return UNSUPPORTED_PREFIXES.some((prefix) => type.startsWith(prefix));
 }
 
-export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServerHandlers {
+export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasHandlers {
   const workflowAbsPath = path.resolve(options.workflowPath);
   const workflowId = path.basename(workflowAbsPath, '.json');
   const workflowDisplayName = workflowId;
@@ -147,6 +157,13 @@ export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServ
   // Cached so browser reloads before the first save keep the same workflow
   // id instead of minting a fresh starter each time.
   let starterWorkflow: Workflow | undefined;
+
+  // Exact file contents the canvas is already showing — last load, last save,
+  // or last pushed external change. The file watcher fires for our own writes
+  // (and, on platforms that report null filenames, for sibling files like
+  // exported PNGs); comparing contents lets loadExternalChange drop those
+  // echoes instead of pushing a reload that wipes unsaved canvas edits.
+  let lastKnownContents: string | undefined;
 
   async function readWorkflowFromDisk() {
     let raw: string;
@@ -161,10 +178,36 @@ export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServ
     }
     const document = parseWorkflowDocument(raw, workflowAbsPath);
     wrapperMeta = document.wrapperMeta;
+    lastKnownContents = raw;
     return migrateWorkflow(document.workflow);
   }
 
   return {
+    async loadExternalChange() {
+      let raw: string;
+      try {
+        raw = await fs.readFile(workflowAbsPath, 'utf-8');
+      } catch {
+        // Deleted or transiently unreadable (atomic-rename window) — keep the
+        // canvas as-is; a follow-up event fires once the file is back.
+        return null;
+      }
+      if (raw === lastKnownContents) {
+        return null;
+      }
+      try {
+        const document = parseWorkflowDocument(raw, workflowAbsPath);
+        wrapperMeta = document.wrapperMeta;
+        lastKnownContents = raw;
+        return migrateWorkflow(document.workflow);
+      } catch (error) {
+        console.warn(
+          `[ccwf canvas] Ignoring file change (not a valid workflow yet): ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`
+        );
+        return null;
+      }
+    },
+
     async onMessage(raw, send) {
       const message = (raw ?? {}) as IncomingMessage;
       const type = typeof message.type === 'string' ? message.type : '';
@@ -256,6 +299,7 @@ export function createCanvasHandlers(options: CanvasHandlersOptions): CanvasServ
                 ? save.workflow
                 : { meta: wrapperMeta, workflow: save.workflow };
             const contents = `${JSON.stringify(document, null, 2)}\n`;
+            lastKnownContents = contents;
             await fs.writeFile(workflowAbsPath, contents, 'utf-8');
             const payload: SaveSuccessPayload = {
               filePath: workflowAbsPath,

--- a/packages/cli/src/canvas/server.ts
+++ b/packages/cli/src/canvas/server.ts
@@ -63,6 +63,8 @@ export interface CanvasServerHandle {
   sessionId: string;
   /** URL the user should open in their browser (`http://host:port/<sessionId>/`). */
   url: string;
+  /** Send a message to every connected WebSocket (e.g. a file-change reload). */
+  broadcast(payload: unknown): void;
   /** Shut down the HTTP server, close all open WebSockets, and resolve. */
   close(): Promise<void>;
 }
@@ -258,6 +260,14 @@ export async function startCanvasServer(
     port,
     sessionId,
     url: `http://${displayHost}:${port}/${sessionId}/`,
+    broadcast(payload) {
+      const data = JSON.stringify(payload);
+      for (const socket of openSockets) {
+        if (socket.readyState === socket.OPEN) {
+          socket.send(data);
+        }
+      }
+    },
     async close() {
       for (const socket of openSockets) {
         socket.close();

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { createCanvasHandlers } from '../canvas/handlers.js';
 import { startCanvasServer } from '../canvas/server.js';
+import { watchWorkflowFile } from '../preview/watcher.js';
 import { reachabilityNote } from '../utils/host-warning.js';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
 import { formatServerStartError } from '../utils/server-start-error.js';
@@ -157,12 +158,31 @@ export function registerCanvasCommand(program: Command): void {
           bootstrapConfig: { locale: process.env.LANG?.split('.')[0] ?? 'en' },
         });
 
+        // Live-reload: when something else writes the workflow file (an AI
+        // agent via `ccwf mcp --file`, a text editor, git …), push the fresh
+        // workflow to every open canvas instead of letting it go stale and
+        // clobber the edit on the next save. Self-write echoes and mid-write
+        // parse failures are filtered inside loadExternalChange.
+        const watcher = watchWorkflowFile({
+          filePath: workflowAbsPath,
+          logLabel: '[ccwf canvas]',
+          onChange: () => {
+            void handlers.loadExternalChange().then((workflow) => {
+              if (workflow) {
+                server.broadcast({ type: 'LOAD_WORKFLOW', payload: { workflow } });
+                console.log('[ccwf canvas] Workflow file changed on disk — canvas reloaded.');
+              }
+            });
+          },
+        });
+
         const banner = [
           `ccwf canvas server listening at ${server.url}`,
           `  workflow: ${workflowAbsPath}${isNewFile ? ' (new file — created on first save)' : ''}`,
           `  bind:     ${server.host}:${server.port}`,
           '',
           'Save buttons in the canvas will write back to the workflow file.',
+          'External changes to the file reload the open canvas automatically.',
           reachabilityNote(server.host),
           'Press Ctrl+C to stop.',
         ].join('\n');
@@ -180,6 +200,7 @@ export function registerCanvasCommand(program: Command): void {
           if (shuttingDown) return;
           shuttingDown = true;
           process.stdout.write(`\nReceived ${signal}, shutting down ccwf canvas…\n`);
+          watcher.close();
           try {
             await server.close();
           } catch (error) {

--- a/packages/cli/src/preview/watcher.ts
+++ b/packages/cli/src/preview/watcher.ts
@@ -19,6 +19,8 @@ export interface WorkflowWatcherOptions {
   debounceMs?: number;
   /** Invoked after each debounced change. */
   onChange(): void;
+  /** Prefix for warning logs. Defaults to `[ccwf preview]`. */
+  logLabel?: string;
 }
 
 export interface WorkflowWatcherHandle {
@@ -78,7 +80,7 @@ export function watchWorkflowFile(options: WorkflowWatcherOptions): WorkflowWatc
       // Watching is a best-effort optimisation; if the directory is gone, just
       // log and stop trying.
       console.warn(
-        `[ccwf preview] Failed to watch ${dir}: ${error instanceof Error ? error.message : String(error)}`
+        `${options.logLabel ?? '[ccwf preview]'} Failed to watch ${dir}: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   };


### PR DESCRIPTION
## Summary

`ccwf canvas` now watches the workflow file and live-reloads every open canvas when the file changes on disk — e.g. an AI agent editing it via `ccwf mcp --file`, a text editor, or `git checkout`. Previously the canvas silently went stale and the next in-canvas save clobbered the external edit.

Closes #977

## Changes

- **`canvas/server.ts`**: the server handle gains `broadcast(payload)` over its already-tracked open WebSockets.
- **`canvas/handlers.ts`**: `createCanvasHandlers` returns a `CanvasHandlers` with `loadExternalChange()` — re-reads the file on a watch event and returns `null` (skip) for: echoes of the canvas's own save or already-pushed content (tracked as `lastKnownContents`, which also guards platforms where `fs.watch` reports `null` filenames and sibling writes like exported PNGs fire events), missing/transiently unreadable files (atomic-rename window), and mid-write invalid JSON (server-side warning; the writer's next event retries). A successful external read also refreshes the `{meta, workflow}` wrapper meta so a later save preserves the *new* meta.
- **`commands/canvas.ts`**: arms the shared watcher, broadcasts `LOAD_WORKFLOW` on genuine changes, closes the watcher on shutdown, and mentions live-reload in the startup banner.
- **`preview/watcher.ts`**: gains an optional `logLabel` so its warning says `[ccwf canvas]` when reused there (default unchanged for `ccwf preview`).

No webview changes needed — the webview already applies unsolicited `LOAD_WORKFLOW` pushes (`Toolbar.tsx` message listener; same push used at boot).

## Testing

- E2E against the built CLI via a WebSocket harness emulating the webview channel, 8/8 checks: boot load; external edit pushes `LOAD_WORKFLOW`; own save produces `SAVE_SUCCESS` with **no** echo reload; invalid-JSON write ignored; recovery write pushes reload; `{meta, workflow}` wrapper meta from an external change survives the next save; new-file mode boots the starter; external creation of the not-yet-existing file pushes the real workflow.
- `pnpm build` + `pnpm check` green from the repo root.

## Release

- Changeset included: `@cc-wf-studio/cli` **minor** (`canvas-live-reload.md`).

## Notes

- Known tradeoff (logged as a next-iteration proposal in `docs/progress-log.md`): an external write replaces unsaved in-canvas edits; a keep/reload toast would need a small webview message and is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TM3WdvZeeN8vgLxsLLZ9p

---
_Generated by [Claude Code](https://claude.ai/code/session_016TM3WdvZeeN8vgLxsLLZ9p)_