### PR TITLE
feat(cli): validate workflows before ccwf export/run write files

### DIFF
--- a/.changeset/export-validates-before-writing.md
+++ b/.changeset/export-validates-before-writing.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': minor
+---
+
+`ccwf export` / `ccwf run` now schema-validate the workflow before writing any file, reporting the same errors as `ccwf validate` and exiting 1; `--no-validate` skips the check

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -18,6 +18,49 @@ Entry format:
 
 ---
 
+## 2026-07-25 — `ccwf export` / `run` refuse to write an invalid workflow
+- **User value**: a user exporting or running a broken workflow no longer
+  silently gets broken skill files — the same error list `ccwf validate`
+  prints goes to stderr and **nothing is written** (exit 1), with
+  `--no-validate` as the deliberate escape hatch.
+- **Issue/PR**: #980
+- **Outcome**: done — premise re-verified and found **half-stale**: the
+  issue's second half (wire `collectIgnoredFieldWarnings` into export) had
+  already shipped meanwhile as `collectAgentCompatibilityWarnings`, so only
+  the validation gate remained and that is what this iteration built. New
+  `packages/cli/src/utils/validation-report.ts` owns the shared
+  `formatValidationError` (moved out of `validate.ts`, so validate/export/run
+  print byte-identical lines), a `WorkflowInvalidError`, `assertWorkflowValid`
+  and `reportWorkflowInvalid`. The gate sits right after the load in all
+  three export entry points (`runExport`, `previewExport`, `planForAgents`)
+  — i.e. before planning, before the conflict check, before any write — so
+  `--dry-run` and multi-agent runs behave identically. `--no-validate` added
+  to both `export` and `run` (commander's negated-boolean default stays
+  `true`); `--json` reports the failure as
+  `{ ok: false, file, agent | agents, valid: false, errors }`. Validation
+  now runs *before* compatibility warnings, matching `validate.ts`, whose
+  own comment already noted warnings are only meaningful for a schema-valid
+  workflow. Docs updated in `packages/cli/README.md` and the bundled
+  `ccwf-cli` SKILL.md. E2E against the built CLI, 12/12: baseline validate;
+  invalid export refused with 0 files written; `--no-validate` writes;
+  valid export unchanged; invalid `--dry-run`; invalid `--json` single and
+  multi agent; `run` refused and `run --no-validate`; `--agent all` invalid
+  (nothing written) and valid (10 files, 7 agents); `--dry-run --json`.
+  `pnpm build` + `pnpm check` green. No interrupts this round: `auto-dev` CI
+  green at `f4d4428` (CI + Security Scan), no `ci-failure`/`bug` issues.
+  Guard step also closed #977 (its PR #978 had merged after that session
+  ended). Issue #980 could not be locked (no `gh`, no MCP lock tool — known
+  limitation).
+- **Next proposals**:
+  - `ccwf canvas`'s save path writes without validating too — the canvas can
+    persist a workflow the CLI would now refuse to export; consider the same
+    gate (or a non-blocking problems push) there.
+  - The MCP `export_workflow` tool shares none of this gate; check whether it
+    should reuse `assertWorkflowValid` so agent-driven exports fail the same
+    way.
+  - Carried: canvas live-reload replaces unsaved in-canvas edits — a
+    keep/reload toast would need a small webview message.
+
 ## 2026-07-25 — `ccwf canvas` live-reloads on external file changes
 - **User value**: a user with an open canvas no longer gets a stale view —
   and no longer clobbers the file on their next save — when an external

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,8 +21,8 @@ pnpm add -D @cc-wf-studio/cli
 | `ccwf render <file>` | Print a Mermaid + execution-instructions Markdown bundle to stdout (or a file with `-o <path>`). `<file>` may be `-` to read the workflow JSON from stdin. `--agent <name>` phrases the execution instructions for that target agent and reports its target-compatibility warnings. |
 | `ccwf validate <paths...>` | Schema-check workflow JSON files — any mix of files and directories (searched recursively for `*.json`); `-` reads workflow JSON from stdin. Exit 0/1 (2 on unreadable files). `--json` for machine-readable output. `--agent <name>` (repeatable, or `all`) also preflights target compatibility; add `--strict` to turn those warnings into exit 1 for CI. |
 | `ccwf mcp --file <file>` | Run the cc-wf-studio stdio MCP server in-process against `<file>`. |
-| `ccwf export <file>` | Materialise the workflow as agent-skill files for one or more target agents (`--agent <name>`, repeatable, or `--agent all`; default `claude-code`). Multi-agent runs are atomic: any conflict aborts before anything is written. `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
-| `ccwf run <file>` | `ccwf export` + a "next step" hint. `--launch` additionally spawns Claude Code when available. |
+| `ccwf export <file>` | Materialise the workflow as agent-skill files for one or more target agents (`--agent <name>`, repeatable, or `--agent all`; default `claude-code`). Invalid workflows are rejected before anything is written (`--no-validate` to override). Multi-agent runs are atomic: any conflict aborts before anything is written. `--dry-run` previews the planned files without writing. `--json` for machine-readable output (works with `--dry-run` too). |
+| `ccwf run <file>` | `ccwf export` + a "next step" hint (same schema check and `--no-validate` escape hatch). `--launch` additionally spawns Claude Code when available. |
 | `ccwf preview <file>` | Open a read-only viewer (Mermaid + per-node Markdown panes) in a local browser. Auto-reloads when the file changes. |
 | `ccwf canvas <file>` | (Experimental) Open the **full editable** cc-wf-studio canvas in a local browser. Saves write back to the same file. |
 | `ccwf samples list` / `ccwf samples copy <id>` | Discover the bundled example workflows and copy one locally to preview, export, or run. |
@@ -104,9 +104,12 @@ ccwf export ./my-workflow.json --overwrite                     # replace files w
 ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
 ccwf export ./my-workflow.json --json                          # machine-readable result on stdout
 ccwf export ./my-workflow.json --dry-run --json                # machine-readable plan preview
+ccwf export ./my-workflow.json --no-validate                   # export even if the schema check fails
 ```
 
 Re-running an export is idempotent: existing files whose content already matches are reported as up to date and skipped. Only files with *different* content are conflicts that require `--overwrite`.
+
+The workflow is schema-checked first: if it fails validation, the same error list `ccwf validate` prints goes to stderr, **nothing is written**, and the exit code is 1 — a broken workflow can no longer become broken skill files. `--no-validate` skips the check and exports anyway (escape hatch for forward-compatible files written by a newer version). The check runs on every path, including `--dry-run` and multi-agent runs; with `--json` the failure is reported as `{ "ok": false, "file", "agent" | "agents", "valid": false, "errors": [...] }`.
 
 `--agent` is repeatable (de-duped, first-mention order) and accepts `all` to expand to every supported target. With more than one agent the run is **atomic**: every agent's plan is checked against the disk first, and any conflict (without `--overwrite`) aborts the whole export before a single file is written (conflict lines are prefixed `[agent]`). Per-agent summaries are `[agent]`-prefixed, followed by a total line; target-compatibility warnings print as `warning: [agent] …`. With exactly one agent, all output is identical to earlier single-agent versions.
 
@@ -149,7 +152,7 @@ ccwf run ./my-workflow.json                                    # same files as e
 ccwf run ./my-workflow.json --agent cursor                     # forwarded to export
 ```
 
-`ccwf run` is a thin wrapper over `ccwf export` (same flags: `--agent`, `--cwd`, `--overwrite`). It adds an agent-specific "next step" line to stdout. With `--launch` (best-effort, claude-code only for now) it also walks `PATH` for the `claude` binary and spawns it in the output directory — when the binary is missing or a different agent is selected, the spawn is skipped and a warning is printed.
+`ccwf run` is a thin wrapper over `ccwf export` (same flags: `--agent`, `--cwd`, `--overwrite`, `--no-validate` — including the schema check that refuses to write files for an invalid workflow). It adds an agent-specific "next step" line to stdout. With `--launch` (best-effort, claude-code only for now) it also walks `PATH` for the `claude` binary and spawns it in the output directory — when the binary is missing or a different agent is selected, the spawn is skipped and a warning is printed.
 
 ```sh
 ccwf run ./my-workflow.json --launch        # write + spawn claude

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -115,7 +115,10 @@ ccwf export ./my-workflow.json --overwrite                     # replace files w
 ccwf export ./my-workflow.json --dry-run                       # preview the plan, write nothing
 ccwf export ./my-workflow.json --json                          # machine-readable result on stdout
 ccwf export ./my-workflow.json --dry-run --json                # machine-readable plan preview
+ccwf export ./my-workflow.json --no-validate                   # export even if the schema check fails
 ```
+
+The workflow is schema-checked before anything is planned or written: on failure the same error list `ccwf validate` prints goes to stderr, no file is written, and the exit code is 1 (`--json`: `{ ok: false, file, agent | agents, valid: false, errors }`). This runs on every path, `--dry-run` and multi-agent included. Pass `--no-validate` only when you deliberately want to export a file the current schema rejects — normally, fix the workflow instead.
 
 Re-running an export is idempotent: existing files whose content already matches are skipped as up to date; only files with different content require `--overwrite`.
 
@@ -141,7 +144,7 @@ Use `export` (rather than `run`) when the user wants the *files only* — e.g. c
 
 ### `ccwf run <file> [--agent <name>] [--launch]`
 
-Same file output as `ccwf export`, plus a "next step" hint on stdout. `--launch` additionally spawns the `claude` binary in the output directory (best-effort, claude-code agent only).
+Same file output as `ccwf export` — including the schema check that refuses to write anything for an invalid workflow (`--no-validate` to override) — plus a "next step" hint on stdout. `--launch` additionally spawns the `claude` binary in the output directory (best-effort, claude-code agent only).
 
 ```bash
 ccwf run ./my-workflow.json --launch          # write + spawn claude

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -15,6 +15,10 @@
  * the run is atomic across agents (any conflict without `--overwrite`
  * aborts before anything is written), human lines are `[agent]`-prefixed,
  * and JSON payloads carry `resultsByAgent` instead of the single-agent keys.
+ *
+ * Every path schema-validates the workflow first and refuses to write a
+ * single file when it fails (`--no-validate` opts out), so a broken workflow
+ * can no longer materialise as broken skill files.
  */
 
 import * as fs from 'node:fs/promises';
@@ -31,6 +35,11 @@ import {
 } from '@cc-wf-studio/core';
 import { Command, InvalidArgumentError } from 'commander';
 import { WorkflowLoadError, loadWorkflowFromFile } from '../utils/load-workflow.js';
+import {
+  WorkflowInvalidError,
+  assertWorkflowValid,
+  reportWorkflowInvalid,
+} from '../utils/validation-report.js';
 
 const CLAUDE_CODE_AGENT = 'claude-code' as const;
 export const SUPPORTED_AGENTS = WORKFLOW_TARGET_AGENTS;
@@ -46,6 +55,8 @@ export interface ExportRunOptions {
   overwrite: boolean;
   /** Output root. Defaults to `process.cwd()`. */
   cwd?: string;
+  /** Schema-validate before planning/writing. Defaults to `true` (`--no-validate` clears it). */
+  validate?: boolean;
 }
 
 export interface ExportRunResult {
@@ -190,14 +201,21 @@ async function classifyPlan(
  * target-compatibility warnings as a real export, and classify the planned
  * files against the disk — but never write.
  *
- * Throws `WorkflowLoadError` for `<file>` issues, like `runExport`.
+ * Throws `WorkflowLoadError` for `<file>` issues and `WorkflowInvalidError`
+ * for schema failures, like `runExport`.
  */
 export async function previewExport(
   options: Omit<ExportRunOptions, 'overwrite'>,
   emitWarnings = true
 ): Promise<ExportPreviewResult> {
-  const { workflow } = await loadWorkflowFromFile(options.file);
+  const { workflow, absolutePath } = await loadWorkflowFromFile(options.file);
   const rootDir = path.resolve(options.cwd ?? process.cwd());
+
+  // Validate before anything else: compatibility warnings are only meaningful
+  // for a schema-valid workflow, and a dry run must predict the real run.
+  if (options.validate !== false) {
+    assertWorkflowValid(workflow, absolutePath);
+  }
 
   const warnings = collectAgentCompatibilityWarnings(workflow, options.agent);
   if (emitWarnings) {
@@ -251,17 +269,23 @@ function previewNote(status: PlannedFileStatus, overwrite: boolean): string {
 /**
  * Shared implementation invoked by both `ccwf export` and `ccwf run`.
  *
- * Throws `WorkflowLoadError` for `<file>` issues and `ExportConflictError`
- * on a write conflict (without `--overwrite`) — callers render those via
- * their usual error paths (`reportExportConflict` for the historical
- * stderr + exit 1 behaviour).
+ * Throws `WorkflowLoadError` for `<file>` issues, `WorkflowInvalidError` when
+ * the workflow fails schema validation (unless `validate: false`), and
+ * `ExportConflictError` on a write conflict (without `--overwrite`) —
+ * callers render those via their usual error paths (`reportExportConflict`
+ * for the historical stderr + exit 1 behaviour).
  */
 export async function runExport(
   options: ExportRunOptions,
   emitWarnings = true
 ): Promise<ExportRunResult> {
-  const { workflow } = await loadWorkflowFromFile(options.file);
+  const { workflow, absolutePath } = await loadWorkflowFromFile(options.file);
   const rootDir = path.resolve(options.cwd ?? process.cwd());
+
+  // Before planning, so an invalid workflow never reaches the filesystem.
+  if (options.validate !== false) {
+    assertWorkflowValid(workflow, absolutePath);
+  }
 
   const warnings = collectAgentCompatibilityWarnings(workflow, options.agent);
   if (emitWarnings) {
@@ -366,10 +390,14 @@ async function planForAgents(
   file: string,
   agents: SupportedAgent[],
   cwd: string | undefined,
-  emitWarnings: boolean
+  emitWarnings: boolean,
+  validate = true
 ): Promise<{ slashName: string; rootDir: string; bundles: AgentPlanBundle[] }> {
-  const { workflow } = await loadWorkflowFromFile(file);
+  const { workflow, absolutePath } = await loadWorkflowFromFile(file);
   const rootDir = path.resolve(cwd ?? process.cwd());
+  if (validate) {
+    assertWorkflowValid(workflow, absolutePath);
+  }
   const bundles: AgentPlanBundle[] = agents.map((agent) => ({
     agent,
     warnings: collectAgentCompatibilityWarnings(workflow, agent),
@@ -398,7 +426,13 @@ async function previewMultiExport(
   agents: SupportedAgent[],
   options: CommanderExportOptions
 ): Promise<void> {
-  const { rootDir, bundles } = await planForAgents(file, agents, options.cwd, !options.json);
+  const { rootDir, bundles } = await planForAgents(
+    file,
+    agents,
+    options.cwd,
+    !options.json,
+    options.validate
+  );
   const classified: { bundle: AgentPlanBundle; entries: ClassifiedPlanEntry[] }[] = [];
   for (const bundle of bundles) {
     classified.push({ bundle, entries: await classifyPlan(rootDir, bundle.plan) });
@@ -469,7 +503,8 @@ async function runMultiExport(
     file,
     agents,
     options.cwd,
-    !options.json
+    !options.json,
+    options.validate
   );
 
   // Same contract as the single-agent run: --overwrite skips classification
@@ -599,6 +634,8 @@ interface CommanderExportOptions {
   dryRun: boolean;
   json: boolean;
   cwd?: string;
+  /** Commander sets this to `false` when `--no-validate` is passed. */
+  validate: boolean;
 }
 
 function toRootRelative(rootDir: string, absPaths: string[]): string[] {
@@ -664,6 +701,10 @@ export function registerExportCommand(program: Command): void {
       '--cwd <dir>',
       'Output root. Defaults to process.cwd(). Useful for tests / scripted runs.'
     )
+    .option(
+      '--no-validate',
+      'Skip the schema check and export even if the workflow is invalid (escape hatch for forward-compatible files).'
+    )
     .action(async (file: string, options: CommanderExportOptions) => {
       const agents = options.agent ?? [CLAUDE_CODE_AGENT];
       const singleAgent = agents.length === 1 ? agents[0] : undefined;
@@ -685,6 +726,7 @@ export function registerExportCommand(program: Command): void {
               file,
               agent: singleAgent,
               cwd: options.cwd,
+              validate: options.validate,
             },
             !options.json
           );
@@ -702,6 +744,7 @@ export function registerExportCommand(program: Command): void {
             agent: singleAgent,
             overwrite: options.overwrite,
             cwd: options.cwd,
+            validate: options.validate,
           },
           !options.json
         );
@@ -721,6 +764,19 @@ export function registerExportCommand(program: Command): void {
 
         reportExportOutcome(result);
       } catch (error) {
+        if (error instanceof WorkflowInvalidError) {
+          if (options.json) {
+            printJson({
+              ok: false,
+              file: error.sourceLabel,
+              ...(singleAgent === undefined ? { agents } : { agent: singleAgent }),
+              valid: false,
+              errors: error.errors,
+            });
+            process.exit(1);
+          }
+          reportWorkflowInvalid(error);
+        }
         if (error instanceof ExportConflictError) {
           if (options.json) {
             printJson({

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,8 +5,9 @@
  * the user at Claude Code (or the chosen agent). In a later phase, `run` will
  * spawn `claude` itself and let the agent perform the skill export +
  * execution. The contract for `<file>` and the flags (`--agent`, `--cwd`,
- * `--overwrite`) is intentionally identical to `ccwf export` so the future
- * change is backward-compatible.
+ * `--overwrite`, `--no-validate`) is intentionally identical to `ccwf export`
+ * so the future change is backward-compatible — including the schema check
+ * that refuses to write files for an invalid workflow.
  */
 
 import { spawn } from 'node:child_process';
@@ -14,6 +15,7 @@ import { Command } from 'commander';
 import { LAUNCHABLE_AGENTS } from '../utils/agent-launchers.js';
 import { findBinaryInPath } from '../utils/find-binary.js';
 import { WorkflowLoadError } from '../utils/load-workflow.js';
+import { WorkflowInvalidError, reportWorkflowInvalid } from '../utils/validation-report.js';
 import {
   ExportConflictError,
   asSupportedAgent,
@@ -27,6 +29,8 @@ interface CommanderRunOptions {
   overwrite: boolean;
   cwd?: string;
   launch: boolean;
+  /** Commander sets this to `false` when `--no-validate` is passed. */
+  validate: boolean;
 }
 
 /**
@@ -80,6 +84,10 @@ export function registerRunCommand(program: Command): void {
       `After writing files, also spawn the agent CLI interactively (best-effort; supported for ${Object.keys(LAUNCHABLE_AGENTS).join(', ')}).`,
       false
     )
+    .option(
+      '--no-validate',
+      'Skip the schema check and run even if the workflow is invalid (escape hatch for forward-compatible files).'
+    )
     .action(async (file: string, options: CommanderRunOptions) => {
       try {
         const agent = asSupportedAgent(options.agent);
@@ -88,6 +96,7 @@ export function registerRunCommand(program: Command): void {
           agent,
           overwrite: options.overwrite,
           cwd: options.cwd,
+          validate: options.validate,
         });
 
         reportExportOutcome(result);
@@ -132,6 +141,9 @@ export function registerRunCommand(program: Command): void {
           });
         }
       } catch (error) {
+        if (error instanceof WorkflowInvalidError) {
+          reportWorkflowInvalid(error);
+        }
         if (error instanceof ExportConflictError) {
           reportExportConflict(error);
         }

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -38,6 +38,7 @@ import {
   loadWorkflowFromFile,
   loadWorkflowFromStdin,
 } from '../utils/load-workflow.js';
+import { formatValidationError } from '../utils/validation-report.js';
 import {
   SUPPORTED_AGENTS,
   type SupportedAgent,
@@ -66,11 +67,6 @@ type FileReport =
       valid: false;
       loadError: string;
     };
-
-function formatError(err: ValidationError): string {
-  const fieldSuffix = err.field ? ` (field: ${err.field})` : '';
-  return `  - [${err.code}] ${err.message}${fieldSuffix}`;
-}
 
 const SKIPPED_DIR_NAMES = new Set(['node_modules']);
 
@@ -182,7 +178,7 @@ function printHumanReport(report: FileReport, agents: SupportedAgent[]): void {
   } else {
     process.stderr.write(`✗ ${report.file} has ${report.errors.length} error(s):\n`);
     for (const err of report.errors) {
-      process.stderr.write(`${formatError(err)}\n`);
+      process.stderr.write(`${formatValidationError(err)}\n`);
     }
   }
 }

--- a/packages/cli/src/utils/validation-report.ts
+++ b/packages/cli/src/utils/validation-report.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared schema-validation reporting for the subcommands that consume a
+ * workflow file.
+ *
+ * `ccwf validate` has always printed a `  - [CODE] message (field: x)` line
+ * per error; `ccwf export` / `ccwf run` gate their writes on the same check,
+ * so the formatter lives here and every command prints identical lines.
+ */
+
+import { type ValidationError, type Workflow, validateAIGeneratedWorkflow } from '@cc-wf-studio/core';
+
+/** One human-readable line for a single validation error. */
+export function formatValidationError(err: ValidationError): string {
+  const fieldSuffix = err.field ? ` (field: ${err.field})` : '';
+  return `  - [${err.code}] ${err.message}${fieldSuffix}`;
+}
+
+/**
+ * Thrown by the export path when the workflow fails schema validation and
+ * `--no-validate` was not passed. Carries everything the caller needs to
+ * render the failure (human or JSON) and exit 1.
+ */
+export class WorkflowInvalidError extends Error {
+  /** Every schema error, in validator order. */
+  readonly errors: ValidationError[];
+  /** Absolute path (or `<stdin>`) the workflow came from. */
+  readonly sourceLabel: string;
+
+  constructor(errors: ValidationError[], sourceLabel: string) {
+    super(`${sourceLabel} has ${errors.length} validation error(s).`);
+    this.name = 'WorkflowInvalidError';
+    this.errors = errors;
+    this.sourceLabel = sourceLabel;
+  }
+}
+
+/**
+ * Throw {@link WorkflowInvalidError} unless `workflow` passes schema
+ * validation. Called before anything is planned or written, so an invalid
+ * workflow can never leave half-broken skill files behind.
+ */
+export function assertWorkflowValid(workflow: Workflow, sourceLabel: string): void {
+  const result = validateAIGeneratedWorkflow(workflow);
+  if (!result.valid) {
+    throw new WorkflowInvalidError(result.errors, sourceLabel);
+  }
+}
+
+/**
+ * Print a validation failure the way `ccwf validate` prints it, plus the line
+ * explaining that nothing was written, then exit 1.
+ */
+export function reportWorkflowInvalid(error: WorkflowInvalidError): never {
+  process.stderr.write(`✗ ${error.sourceLabel} has ${error.errors.length} error(s):\n`);
+  for (const err of error.errors) {
+    process.stderr.write(`${formatValidationError(err)}\n`);
+  }
+  process.stderr.write(
+    'error: refusing to write files for an invalid workflow. Fix the errors above (see `ccwf validate`), or pass --no-validate to export anyway.\n'
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

`ccwf export` and `ccwf run` now schema-check the workflow **before anything is planned or written**. An invalid workflow is reported with the exact error list `ccwf validate` prints, no file is written, and the exit code is 1 — previously a workflow missing an End node (or with dangling connections) exported to broken skill files without a word.

Closes #980

## Scope note — the issue was half-stale

The issue asked for two things. Its second half — wiring `collectIgnoredFieldWarnings` into the export path — **already shipped on `auto-dev`** in the meantime as `collectAgentCompatibilityWarnings` (`export.ts`, `validate.ts`, `render`). Only the validation gate was still missing, so that is what this PR builds; the issue's "zero callers" bullet no longer holds, its user-value statement does.

## Changes

- **`packages/cli/src/utils/validation-report.ts`** (new): `formatValidationError` (moved out of `validate.ts`, so validate/export/run print byte-identical error lines), `WorkflowInvalidError`, `assertWorkflowValid`, `reportWorkflowInvalid`.
- **`commands/export.ts`**: the gate sits right after the load in all three entry points — `runExport`, `previewExport`, `planForAgents` — i.e. before planning, before the conflict check, before any write, so `--dry-run` and multi-agent runs behave identically to a real run. New `--no-validate` flag (`ExportRunOptions.validate`, default `true`). With `--json` the failure is `{ ok: false, file, agent | agents, valid: false, errors }`.
- **`commands/run.ts`**: same `--no-validate` flag, forwards it, renders `WorkflowInvalidError` through the shared reporter.
- **`commands/validate.ts`**: uses the shared formatter; output unchanged.
- Docs: `packages/cli/README.md` and the bundled `ccwf-cli` SKILL.md.

Validation now runs *before* compatibility warnings — matching `validate.ts`, whose existing comment already noted warnings are only meaningful for a schema-valid workflow.

## Testing

E2E against the built CLI, 12/12: baseline `validate`; invalid export refused with 0 files written; `--no-validate` writes; valid export unchanged; invalid `--dry-run`; invalid `--json` single- and multi-agent; `run` refused and `run --no-validate`; `--agent all` invalid (nothing written) and valid (10 files across 7 agents); `--dry-run --json`.

`pnpm build` + `pnpm check` green from the repo root.

## Release

Changeset included: `@cc-wf-studio/cli` **minor** (`export-validates-before-writing.md`).

## Notes

Logged as next-iteration proposals in `docs/progress-log.md`: the `ccwf canvas` save path and the MCP `export_workflow` tool still write without this gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_015eohuCVRnWSeqA3qk5Bs71)_