### PR TITLE
improvement(cli): launch the agent with the workflow skill already invoked

### DIFF
--- a/.changeset/run-launch-invokes-skill.md
+++ b/.changeset/run-launch-invokes-skill.md
@@ -1,0 +1,5 @@
+---
+'@cc-wf-studio/cli': patch
+---
+
+`ccwf run --launch` now spawns the agent CLI with the exported skill already invoked, so the workflow starts running instead of opening an empty session. Supported for claude-code, codex, copilot and gemini, each with the invocation it understands.

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -18,6 +18,40 @@ Entry format:
 
 ---
 
+## 2026-07-25 — `ccwf run --launch` starts the agent with the skill invoked
+- **User value**: a user running `ccwf run <file> --launch` now lands in an
+  agent session that is already executing the workflow, instead of an empty
+  session plus a printed hint telling them to type the slash command
+  themselves — one command from workflow JSON to the workflow running.
+- **Issue/PR**: #984
+- **Outcome**: done — `AgentLauncher` (`packages/cli/src/utils/agent-launchers.ts`)
+  gained `invokeSkill` (per-agent skill phrase: `/name` for Claude Code and
+  Copilot, `$name` for Codex, bare `name` for Gemini) and `promptArgs`
+  (per-agent argv for an inline initial prompt), so `run.ts` spawns
+  `bin promptArgs(invokeSkill(slashName))` instead of `bin []`. The session
+  stays interactive (`stdio: 'inherit'`, exit-code propagation unchanged) and
+  no permission-bypass flags are passed — `ccwf tour` keeps its own argv map
+  precisely because it adds `--allow-all-tools` for its one-shot edit, and its
+  behaviour is unchanged (verified). The "Next: … run `/x`" hint now prints
+  only when no launch happens (plain `run`, unsupported agent, binary missing)
+  rather than alongside a launch that already typed it; the binary-missing
+  warning stopped hardcoding `/name` for every agent and uses the agent's own
+  phrase. Docs updated in `packages/cli/README.md` and the bundled
+  `ccwf-cli/SKILL.md`, which both still claimed launch was "claude-code only".
+  E2E against the built CLI with stub agent binaries: all four launchable
+  agents receive the right argv (`[/x]`, `[$x]`, `[-i /x]`, `[-i x]`), plain
+  `run` still prints the hint, unsupported agent (cursor) and missing binary
+  both warn + fall back to the hint with exit 0, and `ccwf tour` still passes
+  its 3-arg Copilot invocation.
+- **Next proposals**:
+  - `ccwf run --agent <bogus>` throws a raw commander stack trace instead of
+    the clean `error: …` line the other failure paths print
+    (`asSupportedAgent` in `packages/cli/src/commands/export.ts` throws a
+    plain `Error` that no handler in `run.ts`/`export.ts` catches).
+  - `ccwf run --launch` inherits the export's `--overwrite`/conflict
+    behaviour but gives no way to launch against files already exported
+    earlier (a `--launch`-only "skip export if unchanged" path).
+
 ## 2026-07-25 — `ccwf export` / `run` refuse to write an invalid workflow
 - **User value**: a user exporting or running a broken workflow no longer
   silently gets broken skill files — the same error list `ccwf validate`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -152,11 +152,14 @@ ccwf run ./my-workflow.json                                    # same files as e
 ccwf run ./my-workflow.json --agent cursor                     # forwarded to export
 ```
 
-`ccwf run` is a thin wrapper over `ccwf export` (same flags: `--agent`, `--cwd`, `--overwrite`, `--no-validate` — including the schema check that refuses to write files for an invalid workflow). It adds an agent-specific "next step" line to stdout. With `--launch` (best-effort, claude-code only for now) it also walks `PATH` for the `claude` binary and spawns it in the output directory — when the binary is missing or a different agent is selected, the spawn is skipped and a warning is printed.
+`ccwf run` is a thin wrapper over `ccwf export` (same flags: `--agent`, `--cwd`, `--overwrite`, `--no-validate` — including the schema check that refuses to write files for an invalid workflow). It adds an agent-specific "next step" line to stdout.
+
+With `--launch` it goes one step further: it walks `PATH` for the agent's CLI binary and spawns it in the output directory **with the exported skill already invoked** — so the workflow starts running instead of leaving you at an empty session. Supported for `claude-code`, `codex`, `copilot` and `gemini` (the agents with a headless CLI); each gets the invocation it understands (`/name`, `$name`, or the bare skill name). The session stays interactive and the agent's normal permission prompts still apply. When the binary is missing or the selected agent has no CLI, the spawn is skipped and the "next step" hint is printed instead.
 
 ```sh
-ccwf run ./my-workflow.json --launch        # write + spawn claude
-ccwf run ./my-workflow.json --agent cursor  # write only (cursor launch not yet wired)
+ccwf run ./my-workflow.json --launch                # write + launch claude, skill already invoked
+ccwf run ./my-workflow.json --launch --agent codex  # same, in Codex CLI
+ccwf run ./my-workflow.json --agent cursor          # write only (cursor has no CLI to launch)
 ```
 
 ### `ccwf preview`

--- a/packages/cli/skills/ccwf-cli/SKILL.md
+++ b/packages/cli/skills/ccwf-cli/SKILL.md
@@ -144,11 +144,12 @@ Use `export` (rather than `run`) when the user wants the *files only* — e.g. c
 
 ### `ccwf run <file> [--agent <name>] [--launch]`
 
-Same file output as `ccwf export` — including the schema check that refuses to write anything for an invalid workflow (`--no-validate` to override) — plus a "next step" hint on stdout. `--launch` additionally spawns the `claude` binary in the output directory (best-effort, claude-code agent only).
+Same file output as `ccwf export` — including the schema check that refuses to write anything for an invalid workflow (`--no-validate` to override) — plus a "next step" hint on stdout. `--launch` instead spawns the agent's CLI in the output directory **with the exported skill already invoked**, so the workflow starts running (best-effort; `claude-code`, `codex`, `copilot`, `gemini`). The session stays interactive and permission prompts still apply.
 
 ```bash
-ccwf run ./my-workflow.json --launch          # write + spawn claude
-ccwf run ./my-workflow.json --agent cursor    # write only (cursor launch not yet wired)
+ccwf run ./my-workflow.json --launch                # write + launch claude, skill already invoked
+ccwf run ./my-workflow.json --launch --agent codex  # same, in Codex CLI
+ccwf run ./my-workflow.json --agent cursor          # write only (cursor has no CLI to launch)
 ```
 
 Use `run`:
@@ -240,7 +241,7 @@ Use this as a lookup when the user describes intent in natural language. If the 
 
 - **`ccwf preview` URLs include a per-session UUID** so two concurrent preview sessions don't collide. The server itself only binds to the loopback interface (`127.0.0.1`) by default, so external machines can't reach it; the UUID is a path key, not a credential.
 - **Auto-shutdown**: `preview` and `canvas` shut themselves down 30 seconds after the last viewer tab closes. The countdown only starts once at least one viewer has connected, so a `preview` that nobody opens stays up. Use `--keep-alive` for multi-tab or LAN scenarios.
-- **`ccwf run --launch` requires `claude` on PATH**. If it's missing, the command warns and exits cleanly after writing the files — that's not an error condition.
+- **`ccwf run --launch` requires the agent's CLI on PATH** (`claude`, `codex`, `copilot`, `gemini`). If it's missing, the command warns, prints the "next step" hint, and exits cleanly after writing the files — that's not an error condition.
 - **`ccwf canvas` is experimental** and missing Slack / Claude API / MCP / external-IDE export. If the user needs any of those, fall back to the VSCode extension.
 - **Workflow file location**: when the user doesn't specify a path, look first under `.vscode/workflows/*.json` from the workspace root. If multiple workflows exist, list them and ask.
 - **Validation before execution**: if the workflow is hand-edited or AI-authored in the same session, run `ccwf validate` before `ccwf run` / `ccwf export` to catch shape errors early.

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,10 +1,11 @@
 /**
  * `ccwf run <file>` — for now, a thin wrapper over `ccwf export`.
  *
- * Today this just calls `runExport` and appends a "next step" hint pointing
- * the user at Claude Code (or the chosen agent). In a later phase, `run` will
- * spawn `claude` itself and let the agent perform the skill export +
- * execution. The contract for `<file>` and the flags (`--agent`, `--cwd`,
+ * Today this calls `runExport` and then either prints a "next step" hint
+ * pointing the user at the chosen agent, or — with `--launch` — spawns that
+ * agent's CLI with the exported skill already invoked, so the workflow starts
+ * running from the same command. The contract for `<file>` and the flags
+ * (`--agent`, `--cwd`,
  * `--overwrite`, `--no-validate`) is intentionally identical to `ccwf export`
  * so the future change is backward-compatible — including the schema check
  * that refuses to write files for an invalid workflow.
@@ -81,7 +82,7 @@ export function registerRunCommand(program: Command): void {
     )
     .option(
       '--launch',
-      `After writing files, also spawn the agent CLI interactively (best-effort; supported for ${Object.keys(LAUNCHABLE_AGENTS).join(', ')}).`,
+      `After writing files, spawn the agent CLI with the exported skill already invoked (best-effort; supported for ${Object.keys(LAUNCHABLE_AGENTS).join(', ')}).`,
       false
     )
     .option(
@@ -101,45 +102,64 @@ export function registerRunCommand(program: Command): void {
 
         reportExportOutcome(result);
 
-        const hint = NEXT_STEP_HINTS[agent](result.slashName);
-        // Each hint ends in its own period; no trailing dot here.
-        process.stdout.write(`\nNext: in ${result.rootDir}, ${hint}\n`);
+        /**
+         * The "type this yourself" hint only makes sense when we are not
+         * about to type it for the user — so it is printed for a plain `run`
+         * and for every path where the launch is skipped.
+         */
+        const printNextStepHint = () => {
+          const hint = NEXT_STEP_HINTS[agent](result.slashName);
+          // Each hint ends in its own period; no trailing dot here.
+          process.stdout.write(`\nNext: in ${result.rootDir}, ${hint}\n`);
+        };
 
-        if (options.launch) {
-          const launcher = LAUNCHABLE_AGENTS[agent];
-          if (!launcher) {
-            process.stderr.write(
-              `warn: --launch is not supported for --agent ${agent} (no headless CLI). Skipping launch.\n`
-            );
-            return;
-          }
-          const bin = await findBinaryInPath(launcher.bin);
-          if (!bin) {
-            process.stderr.write(
-              `warn: --launch requested but \`${launcher.bin}\` was not found on PATH. Files were written; please launch ${launcher.label} manually and run /${result.slashName}.\n`
-            );
-            return;
-          }
-          process.stdout.write(`\nLaunching: ${bin} (cwd ${result.rootDir})\n`);
-          const child = spawn(bin, [], {
-            cwd: result.rootDir,
-            stdio: 'inherit',
-            shell: false,
-          });
-          await new Promise<void>((resolve) => {
-            child.on('exit', (code) => {
-              if (typeof code === 'number' && code !== 0) {
-                process.exitCode = code;
-              }
-              resolve();
-            });
-            child.on('error', (error) => {
-              process.stderr.write(`error: failed to launch ${launcher.bin}: ${error.message}\n`);
-              process.exitCode = 1;
-              resolve();
-            });
-          });
+        if (!options.launch) {
+          printNextStepHint();
+          return;
         }
+
+        const launcher = LAUNCHABLE_AGENTS[agent];
+        if (!launcher) {
+          process.stderr.write(
+            `warn: --launch is not supported for --agent ${agent} (no headless CLI). Skipping launch.\n`
+          );
+          printNextStepHint();
+          return;
+        }
+        const invocation = launcher.invokeSkill(result.slashName);
+        const bin = await findBinaryInPath(launcher.bin);
+        if (!bin) {
+          process.stderr.write(
+            `warn: --launch requested but \`${launcher.bin}\` was not found on PATH. Files were written; please launch ${launcher.label} manually and run \`${invocation}\`.\n`
+          );
+          printNextStepHint();
+          return;
+        }
+        // Hand the skill invocation to the agent as its opening prompt, so the
+        // workflow starts running instead of dropping the user at an empty
+        // session. The session stays interactive afterwards (stdio inherited,
+        // no permission-bypass flags).
+        process.stdout.write(
+          `\nLaunching: ${bin} (cwd ${result.rootDir}) — invoking \`${invocation}\`\n`
+        );
+        const child = spawn(bin, launcher.promptArgs(invocation), {
+          cwd: result.rootDir,
+          stdio: 'inherit',
+          shell: false,
+        });
+        await new Promise<void>((resolve) => {
+          child.on('exit', (code) => {
+            if (typeof code === 'number' && code !== 0) {
+              process.exitCode = code;
+            }
+            resolve();
+          });
+          child.on('error', (error) => {
+            process.stderr.write(`error: failed to launch ${launcher.bin}: ${error.message}\n`);
+            process.exitCode = 1;
+            resolve();
+          });
+        });
       } catch (error) {
         if (error instanceof WorkflowInvalidError) {
           reportWorkflowInvalid(error);

--- a/packages/cli/src/utils/agent-launchers.ts
+++ b/packages/cli/src/utils/agent-launchers.ts
@@ -3,18 +3,52 @@
  * IDE-only agents (antigravity / cursor / roo-code) have no headless CLI and
  * are intentionally excluded — `--launch` / `ccwf tour` skip them.
  *
- * Shared by `ccwf run --launch` (opens the agent interactively, no prompt)
- * and `ccwf tour` (spawns the agent with an inline prompt) so both commands
- * agree on which agents are launchable and what their binary is called.
+ * Shared by `ccwf run --launch` (spawns the agent with the exported skill
+ * already invoked) and `ccwf tour` (spawns the agent with an inline tour
+ * prompt) so both commands agree on which agents are launchable, what their
+ * binary is called, and how an inline prompt is passed to it.
+ *
+ * `ccwf tour` keeps its own argv map on top of this one: it adds
+ * `--allow-all-tools` for Copilot because the tour is a one-shot file edit,
+ * whereas `run --launch` stays a normal interactive session and must not
+ * bypass the agent's permission prompts.
  */
 export interface AgentLauncher {
   label: string;
   bin: string;
+  /**
+   * How a user invokes an exported skill in this agent, given the skill's
+   * slash name — Claude Code / Copilot use `/name`, Codex uses `$name`,
+   * Gemini takes the bare name. Mirrors the `Next:` hints in `run`.
+   */
+  invokeSkill: (slashName: string) => string;
+  /** argv that spawns this agent with `prompt` as its initial input. */
+  promptArgs: (prompt: string) => string[];
 }
 
 export const LAUNCHABLE_AGENTS: Record<string, AgentLauncher> = {
-  'claude-code': { label: 'Claude Code', bin: 'claude' },
-  codex: { label: 'Codex CLI', bin: 'codex' },
-  copilot: { label: 'Copilot CLI', bin: 'copilot' },
-  gemini: { label: 'Gemini CLI', bin: 'gemini' },
+  'claude-code': {
+    label: 'Claude Code',
+    bin: 'claude',
+    invokeSkill: (slash) => `/${slash}`,
+    promptArgs: (prompt) => [prompt],
+  },
+  codex: {
+    label: 'Codex CLI',
+    bin: 'codex',
+    invokeSkill: (slash) => `$${slash}`,
+    promptArgs: (prompt) => [prompt],
+  },
+  copilot: {
+    label: 'Copilot CLI',
+    bin: 'copilot',
+    invokeSkill: (slash) => `/${slash}`,
+    promptArgs: (prompt) => ['-i', prompt],
+  },
+  gemini: {
+    label: 'Gemini CLI',
+    bin: 'gemini',
+    invokeSkill: (slash) => slash,
+    promptArgs: (prompt) => ['-i', prompt],
+  },
 };


### PR DESCRIPTION
## Summary

`ccwf run <file> --launch` now spawns the agent CLI **with the exported skill already invoked**, so the user lands in a session that is executing the workflow. Previously `--launch` spawned the binary with no arguments (`spawn(bin, [], …)`) and printed a hint telling the user to type the slash command themselves — one command short of actually running anything.

Closes #984

## Changes

- **`packages/cli/src/utils/agent-launchers.ts`**: `AgentLauncher` gains two per-agent members — `invokeSkill(slashName)` (the phrase that invokes an exported skill: `/name` for Claude Code and Copilot, `$name` for Codex, the bare name for Gemini — the same mapping the `Next:` hints already encoded) and `promptArgs(prompt)` (argv for an inline initial prompt).
- **`packages/cli/src/commands/run.ts`**: spawns `bin promptArgs(invokeSkill(result.slashName))`. The session stays interactive — `stdio: 'inherit'`, exit-code propagation and the `error:` path are unchanged, and **no permission-bypass flags** are passed.
- The `Next: … run \`/x\`` hint now prints only when no launch happens (plain `run`, unsupported agent, binary not on PATH) instead of alongside a launch that already typed it.
- The binary-missing warning stopped hardcoding `/<name>` for every agent and now uses that agent's own invocation phrase.
- Docs: `packages/cli/README.md` and the bundled `ccwf-cli/SKILL.md`, both of which still described `--launch` as "claude-code only for now" although four agents have been launchable.

`ccwf tour` deliberately keeps its own argv map: it adds `--allow-all-tools` for Copilot because the tour is a one-shot file edit, whereas `run --launch` is an ordinary interactive session. That asymmetry is now documented where the launchers live; tour's behaviour is unchanged and was regression-checked.

## Testing

E2E against the built CLI with stub agent binaries that echo their argv:

| case | result |
|---|---|
| `--launch` claude-code / codex / copilot / gemini | argv `[/x]`, `[$x]`, `[-i /x]`, `[-i x]` — correct per agent |
| plain `run` (no `--launch`) | `Next:` hint still printed |
| `--launch --agent cursor` (no headless CLI) | warns, falls back to the hint, exit 0 |
| `--launch` with the binary off PATH | warns with the agent's own phrase, falls back to the hint, exit 0 |
| `ccwf tour --agent copilot` | unchanged 3-arg invocation (`-i`, prompt, `--allow-all-tools`) |

`pnpm build` + `pnpm check` green from the repo root.

## Release

Changeset included: `@cc-wf-studio/cli` **patch** (`run-launch-invokes-skill.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011mccdTH8Wdr9cv2HhS2Cxa)_