### PR TITLE
feat(canvas): save with Ctrl/Cmd+S and guard unsaved edits on tab close

### DIFF
--- a/.changeset/canvas-save-shortcut-unsaved-guard.md
+++ b/.changeset/canvas-save-shortcut-unsaved-guard.md
@@ -1,0 +1,6 @@
+---
+'cc-wf-studio': patch
+'@cc-wf-studio/cli': patch
+---
+
+Save the canvas with Ctrl/Cmd+S, warn before a browser tab with unsaved edits is closed, and show the workflow name plus a dirty marker in the tab title

--- a/docs/progress-log.md
+++ b/docs/progress-log.md
@@ -18,6 +18,46 @@ Entry format:
 
 ---
 
+## 2026-07-25 — Ctrl/Cmd+S saves, and the canvas warns before losing edits
+- **User value**: a user editing in `ccwf canvas` can now press Ctrl/Cmd+S to
+  save instead of getting the browser's "Save page…" dialog, and no longer
+  silently loses unsaved edits by closing the tab — the canvas warns first,
+  and the tab title carries the workflow name plus a `●` dirty marker so
+  several open canvases stay distinguishable.
+- **Issue/PR**: #988
+- **Outcome**: done — but the shape changed once the premise was tested.
+  `hasUnsavedChanges()` (workflow-store), which the issue assumed could drive
+  the guard, is **defeated by its own data source**: `App.tsx` re-serializes
+  the live canvas into `activeWorkflow` on every edit via
+  `updateActiveWorkflowMetadata`, so the canvas and its "saved" baseline never
+  diverge and the function returns `false` no matter how much has changed.
+  That also meant the pre-existing "loading a sample discards your changes"
+  confirm (App.tsx) had been silently inert. Replaced it with revision-based
+  tracking built on the fingerprint the canvas-revision counter already
+  maintains (`hasUnsavedCanvasChanges` / `markCanvasSaved` /
+  `subscribeToUnsavedChanges`), with the baseline re-captured on
+  load-from-disk and on successful save; the dead `hasUnsavedChanges` was
+  removed. Because it reuses the content fingerprint, undoing back to the
+  saved state reports clean again rather than staying dirty forever.
+  The shortcut lives in `Toolbar.tsx` so it goes through the same save path as
+  the button (name + schema validation, same error surface) and deliberately
+  still fires while a text field has focus — that is exactly when the browser
+  would otherwise hijack the key. Title uses the workflow name, not the file
+  name: the canvas boot payload (`INITIAL_STATE`) carries no file name, and
+  plumbing one would have meant changing the shared message contract.
+  Verified for real against `ccwf canvas` driven by headless Chromium: clean
+  on load, dirty after a node drag (marker + unload guard), clean again after
+  Ctrl+Z, Ctrl+S writes the file, clean again after save.
+- **Next proposals**:
+  - Plumb the opened file name through `INITIAL_STATE` so the canvas tab title
+    can show `foo.json` rather than the workflow name.
+  - Entering Sub-Agent flow editing swaps the canvas wholesale, so it reads as
+    dirty until the next save; a per-canvas baseline would fix that.
+  - The VSCode webview has no equivalent guard — closing the panel with
+    unsaved edits still discards them silently.
+
+---
+
 ## 2026-07-25 — `ccwf run --launch` starts the agent with the skill invoked
 - **User value**: a user running `ccwf run <file> --launch` now lands in an
   agent session that is already executing the workflow, instead of an empty

--- a/packages/vscode/src/webview/src/App.tsx
+++ b/packages/vscode/src/webview/src/App.tsx
@@ -48,6 +48,7 @@ import { Tour } from './components/Tour';
 import { TourPanel } from './components/TourPanel';
 import { WorkflowEditor } from './components/WorkflowEditor';
 import { useCollapsiblePanel } from './hooks/useCollapsiblePanel';
+import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard';
 import { useIsCompactMode } from './hooks/useWindowWidth';
 import { useTranslation } from './i18n/i18n-context';
 import { vscode } from './main';
@@ -55,7 +56,11 @@ import { generateTour } from './services/vscode-bridge';
 import { deserializeWorkflow, serializeWorkflow } from './services/workflow-service';
 import { useCommentaryStore } from './stores/commentary-store';
 import { useRefinementStore } from './stores/refinement-store';
-import { getCanvasRevision, hasUnsavedChanges, useWorkflowStore } from './stores/workflow-store';
+import {
+  getCanvasRevision,
+  hasUnsavedCanvasChanges,
+  useWorkflowStore,
+} from './stores/workflow-store';
 import type { RefinementChatState } from './types/refinement-chat-state';
 import { computeWorkflowDiff, type WorkflowDiffSummary } from './utils/workflow-diff';
 
@@ -258,6 +263,10 @@ const App: React.FC = () => {
   } = useCollapsiblePanel();
   const isCompact = useIsCompactMode();
 
+  // Warn before a browser tab with unsaved canvas edits is closed, and keep the
+  // tab title in sync with the workflow name / dirty state.
+  useUnsavedChangesGuard();
+
   // Edge-drop create for dialog-based node types: the palette owns the
   // creation dialogs but unmounts while collapsed — expand it so it can
   // pick up the pending dialog request from the store.
@@ -317,7 +326,7 @@ const App: React.FC = () => {
   };
 
   const handleLoadSample = useCallback((sampleId: string) => {
-    if (hasUnsavedChanges()) {
+    if (hasUnsavedCanvasChanges()) {
       setPendingLoadSampleId(sampleId);
       setShowUnsavedConfirmForSample(true);
     } else {

--- a/packages/vscode/src/webview/src/components/Toolbar.tsx
+++ b/packages/vscode/src/webview/src/components/Toolbar.tsx
@@ -56,7 +56,7 @@ import {
 } from '../services/workflow-service';
 import { useCommentaryStore } from '../stores/commentary-store';
 import { useRefinementStore } from '../stores/refinement-store';
-import { useWorkflowStore } from '../stores/workflow-store';
+import { markCanvasSaved, useWorkflowStore } from '../stores/workflow-store';
 import { captureCanvasPng } from '../utils/canvas-image';
 import { EditableNameField } from './common/EditableNameField';
 import { ProcessingOverlay } from './common/ProcessingOverlay';
@@ -317,6 +317,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
       // Save if validation passes
       await saveWorkflow(workflow);
+      markCanvasSaved();
       console.log('Workflow saved successfully:', workflowName);
     } catch (error) {
       // Translate error messages
@@ -338,6 +339,32 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       setIsSaving(false);
     }
   };
+
+  // Ctrl/Cmd+S saves, the way every other editor does. Registered here so the
+  // shortcut goes through the exact same path as the Save button — name
+  // validation, schema validation and the toolbar's error surface included.
+  // Unlike the canvas shortcuts in WorkflowEditor this deliberately still
+  // fires while a text field has focus: in the browser canvas the alternative
+  // is the browser hijacking the key with its "Save page…" dialog, which is
+  // never what the user meant.
+  const saveShortcutRef = useRef({ save: handleSave, isSaving });
+  useEffect(() => {
+    saveShortcutRef.current = { save: handleSave, isSaving };
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== 's') return;
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
+      event.preventDefault();
+      // A save is already in flight — the button is disabled in that state too.
+      if (saveShortcutRef.current.isSaving) return;
+      void saveShortcutRef.current.save();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   // Copy the current workflow as the same Markdown bundle `ccwf render`
   // (format md) prints: title + description + Mermaid diagram + execution
@@ -439,6 +466,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           });
           // Set as active workflow to preserve conversation history
           setActiveWorkflow(workflow);
+          // The canvas now mirrors the file on disk — this is the clean baseline
+          // the unsaved-changes guard measures later edits against.
+          markCanvasSaved();
         }
       } else if (message.type === 'FILE_PICKER_CANCELLED') {
         // User cancelled file picker - reset loading state

--- a/packages/vscode/src/webview/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/packages/vscode/src/webview/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -65,6 +65,7 @@ export const KeyboardShortcutsDialog: React.FC<KeyboardShortcutsDialogProps> = (
     {
       title: t('shortcuts.section.editing'),
       rows: [
+        { label: t('shortcuts.save'), combos: [[mod, 'S']] },
         { label: t('shortcuts.undo'), combos: [[mod, 'Z']] },
         {
           label: t('shortcuts.redo'),

--- a/packages/vscode/src/webview/src/hooks/useUnsavedChangesGuard.ts
+++ b/packages/vscode/src/webview/src/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,48 @@
+/**
+ * Claude Code Workflow Studio - Unsaved Changes Guard Hook
+ *
+ * The canvas is explicit-save (see `ccwf canvas` in
+ * packages/cli/src/commands/canvas.ts — there is no auto-save), so closing a
+ * browser tab mid-edit used to discard the work without a word. This hook:
+ *   - warns via `beforeunload` while the canvas is dirty
+ *   - reflects the workflow name plus a dirty marker in `document.title`, so
+ *     several open canvas tabs stay distinguishable
+ *
+ * Both effects are meaningful only in the browser canvas: the VSCode webview
+ * never fires `beforeunload` when its panel is disposed, and the editor owns
+ * its own tab label — there they are simply inert.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import {
+  hasUnsavedCanvasChanges,
+  subscribeToUnsavedChanges,
+  useWorkflowStore,
+} from '../stores/workflow-store';
+
+const TITLE_SUFFIX = 'cc-wf-studio';
+const DIRTY_MARKER = '● ';
+
+export function useUnsavedChangesGuard(): void {
+  const isDirty = useSyncExternalStore(subscribeToUnsavedChanges, hasUnsavedCanvasChanges);
+  const workflowName = useWorkflowStore((state) => state.workflowName);
+
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      // The browser supplies its own wording; preventDefault (plus the legacy
+      // returnValue, still required by older engines) is what triggers it.
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isDirty]);
+
+  useEffect(() => {
+    const name = workflowName || 'workflow';
+    document.title = `${isDirty ? DIRTY_MARKER : ''}${name} — ${TITLE_SUFFIX}`;
+  }, [isDirty, workflowName]);
+}

--- a/packages/vscode/src/webview/src/i18n/translation-keys.ts
+++ b/packages/vscode/src/webview/src/i18n/translation-keys.ts
@@ -441,6 +441,7 @@ export interface WebviewTranslationKeys {
   'shortcuts.section.editing': string;
   'shortcuts.section.canvas': string;
   'shortcuts.section.mouse': string;
+  'shortcuts.save': string;
   'shortcuts.undo': string;
   'shortcuts.redo': string;
   'shortcuts.copy': string;

--- a/packages/vscode/src/webview/src/i18n/translations/en.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/en.ts
@@ -461,6 +461,7 @@ export const enWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.section.editing': 'Editing',
   'shortcuts.section.canvas': 'Canvas',
   'shortcuts.section.mouse': 'Mouse',
+  'shortcuts.save': 'Save workflow',
   'shortcuts.undo': 'Undo',
   'shortcuts.redo': 'Redo',
   'shortcuts.copy': 'Copy selection',

--- a/packages/vscode/src/webview/src/i18n/translations/ja.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ja.ts
@@ -459,6 +459,7 @@ export const jaWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.section.editing': '編集',
   'shortcuts.section.canvas': 'キャンバス',
   'shortcuts.section.mouse': 'マウス',
+  'shortcuts.save': 'ワークフローを保存',
   'shortcuts.undo': '元に戻す',
   'shortcuts.redo': 'やり直す',
   'shortcuts.copy': '選択範囲をコピー',

--- a/packages/vscode/src/webview/src/i18n/translations/ko.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/ko.ts
@@ -458,6 +458,7 @@ export const koWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.section.editing': '편집',
   'shortcuts.section.canvas': '캔버스',
   'shortcuts.section.mouse': '마우스',
+  'shortcuts.save': '워크플로우 저장',
   'shortcuts.undo': '실행 취소',
   'shortcuts.redo': '다시 실행',
   'shortcuts.copy': '선택 항목 복사',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-CN.ts
@@ -445,6 +445,7 @@ export const zhCNWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.section.editing': '编辑',
   'shortcuts.section.canvas': '画布',
   'shortcuts.section.mouse': '鼠标',
+  'shortcuts.save': '保存工作流',
   'shortcuts.undo': '撤销',
   'shortcuts.redo': '重做',
   'shortcuts.copy': '复制所选内容',

--- a/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
+++ b/packages/vscode/src/webview/src/i18n/translations/zh-TW.ts
@@ -447,6 +447,7 @@ export const zhTWWebviewTranslations: WebviewTranslationKeys = {
   'shortcuts.section.editing': '編輯',
   'shortcuts.section.canvas': '畫布',
   'shortcuts.section.mouse': '滑鼠',
+  'shortcuts.save': '儲存工作流程',
   'shortcuts.undo': '復原',
   'shortcuts.redo': '重做',
   'shortcuts.copy': '複製所選內容',

--- a/packages/vscode/src/webview/src/stores/workflow-store.ts
+++ b/packages/vscode/src/webview/src/stores/workflow-store.ts
@@ -2397,71 +2397,52 @@ export function getCanvasRevision(): number {
   return _canvasRevision;
 }
 
-/**
- * Check if the current canvas has unsaved changes compared to activeWorkflow
- *
- * @returns true if there are unsaved changes
- */
-export function hasUnsavedChanges(): boolean {
-  const { nodes, edges, activeWorkflow, workflowName } = useWorkflowStore.getState();
+// ============================================================================
+// Unsaved-Changes Tracking
+// ============================================================================
+// The canvas is dirty when its content fingerprint (or the workflow name) has
+// drifted from the one captured at the last load-from-disk or save.
+//
+// This deliberately does NOT compare the canvas against `activeWorkflow`:
+// App.tsx re-serializes the live canvas into `activeWorkflow` on every edit
+// (updateActiveWorkflowMetadata), so the two never diverge and any such
+// comparison reports "clean" no matter how much has been edited.
+//
+// Reusing `_prevFingerprint` means undoing back to the saved state reports
+// clean again, rather than staying dirty forever.
 
-  // If no activeWorkflow, check if canvas is in default state (only Start + End nodes)
-  if (!activeWorkflow) {
-    // Check if we have more than the default Start and End nodes
-    if (nodes.length !== 2) return true;
+let _savedFingerprint = _prevFingerprint;
+let _savedName = _initialState.workflowName;
+let _isDirty = false;
+const _dirtyListeners = new Set<() => void>();
 
-    const hasStart = nodes.some((n) => n.type === 'start');
-    const hasEnd = nodes.some((n) => n.type === 'end');
-    if (!hasStart || !hasEnd) return true;
+function refreshDirtyState(workflowName: string): void {
+  const next = _prevFingerprint !== _savedFingerprint || workflowName !== _savedName;
+  if (next === _isDirty) return;
+  _isDirty = next;
+  for (const listener of _dirtyListeners) listener();
+}
 
-    // Check if there are any edges
-    if (edges.length > 0) return true;
+// Registered after the revision subscription above, so `_prevFingerprint` is
+// already up to date by the time this runs.
+useWorkflowStore.subscribe((state) => refreshDirtyState(state.workflowName));
 
-    // Check if workflow name is changed from default
-    if (workflowName !== 'my-workflow') return true;
+/** True when the canvas holds edits that have not been written to the file. */
+export function hasUnsavedCanvasChanges(): boolean {
+  return _isDirty;
+}
 
-    return false;
-  }
+/** Record the current canvas as the on-disk state — call after a load or save. */
+export function markCanvasSaved(): void {
+  _savedFingerprint = _prevFingerprint;
+  _savedName = useWorkflowStore.getState().workflowName;
+  refreshDirtyState(_savedName);
+}
 
-  // Compare node count
-  if (nodes.length !== activeWorkflow.nodes.length) return true;
-
-  // Compare edge count
-  if (edges.length !== activeWorkflow.connections.length) return true;
-
-  // Compare workflow name
-  if (workflowName !== activeWorkflow.name) return true;
-
-  // Compare node IDs and positions
-  for (const node of nodes) {
-    const savedNode = activeWorkflow.nodes.find((n) => n.id === node.id);
-    if (!savedNode) return true;
-
-    // Check position
-    if (savedNode.position.x !== node.position.x || savedNode.position.y !== node.position.y) {
-      return true;
-    }
-
-    // Check data (simple JSON comparison for non-function properties)
-    const currentData = JSON.stringify(node.data || {});
-    const savedData = JSON.stringify(savedNode.data || {});
-    if (currentData !== savedData) return true;
-  }
-
-  // Compare edge connections
-  for (const edge of edges) {
-    const savedEdge = activeWorkflow.connections.find((c) => c.id === edge.id);
-    if (!savedEdge) return true;
-
-    if (
-      savedEdge.from !== edge.source ||
-      savedEdge.to !== edge.target ||
-      savedEdge.fromPort !== (edge.sourceHandle || 'default') ||
-      savedEdge.toPort !== (edge.targetHandle || 'default')
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+/** Subscribe to dirty-state flips (the `useSyncExternalStore` contract). */
+export function subscribeToUnsavedChanges(listener: () => void): () => void {
+  _dirtyListeners.add(listener);
+  return () => {
+    _dirtyListeners.delete(listener);
+  };
 }


### PR DESCRIPTION
Closes #988

## User value

A user editing in `ccwf canvas` can now press **Ctrl/Cmd+S** to save — instead of the browser hijacking the shortcut with its "Save page…" dialog — and no longer silently loses unsaved edits by closing the tab: the canvas warns first. The tab title carries the workflow name plus a `●` dirty marker, so several open canvases stay distinguishable.

## The premise changed once it was tested

Issue #988 assumed the existing `hasUnsavedChanges()` (workflow-store) could drive the guard. It can't — **it is defeated by its own data source**:

`App.tsx` re-serializes the live canvas into `activeWorkflow` on every edit via `updateActiveWorkflowMetadata`, and `hasUnsavedChanges()` compares the canvas *against* `activeWorkflow`. The two therefore never diverge, and the function returns `false` no matter how much has been edited. A browser check confirmed this: dragging a node left the canvas reported as clean.

Consequence beyond this feature: the pre-existing "loading a sample discards your changes" confirm in `App.tsx` had been **silently inert** — it is now switched to the working tracker and fires again.

## What changed

- **`stores/workflow-store.ts`** — revision-based dirty tracking built on the content fingerprint the canvas-revision counter already maintains: `hasUnsavedCanvasChanges()`, `markCanvasSaved()`, `subscribeToUnsavedChanges()`. Because it reuses that fingerprint, undoing back to the saved state reports *clean* again instead of staying dirty forever. The dead `hasUnsavedChanges` is removed (it had no remaining callers).
- **`hooks/useUnsavedChangesGuard.ts`** (new) — `beforeunload` warning while dirty + `document.title` sync, subscribed via `useSyncExternalStore`. Both are inert in the VSCode webview by design (panel disposal never fires `beforeunload`; the editor owns its tab label).
- **`components/Toolbar.tsx`** — the Ctrl/Cmd+S listener lives here so it goes through the exact same path as the Save button (name + schema validation, same error surface), and re-captures the clean baseline on load-from-disk and on successful save.
- **`KeyboardShortcutsDialog` + i18n** — `shortcuts.save` added to the cheat sheet and all 5 locales (en/ja/ko/zh-CN/zh-TW).

## Deliberate decisions

- **The shortcut still fires while a text field has focus**, unlike the canvas shortcuts in `WorkflowEditor`. That is precisely when the browser would otherwise steal the key with "Save page…", and saving is safe regardless of focus.
- **Title uses the workflow name, not the file name.** The canvas boot payload (`INITIAL_STATE`) carries no file name, and plumbing one would have meant changing the shared webview message contract — out of scope for a webview-only change. Logged as a follow-up.
- Baseline is *not* re-captured on MCP apply or AI-refinement apply: those are visual-only and nothing is written to disk, so dirty is the correct state.

## Verification

Manual E2E was run for real against `ccwf canvas` driven by headless Chromium (not just a build check). All assertions passed:

| Step | Expected | Result |
|---|---|---|
| On load | clean, no marker, no unload guard | ✅ |
| After node drag | `●` marker + unload guard fires | ✅ |
| After Ctrl+Z back to saved state | clean again | ✅ |
| Ctrl+S | workflow file written to disk | ✅ |
| After save | clean, guard silent | ✅ |

`pnpm build && pnpm check` both pass from the repo root. Not exercised here: the VSCode Extension Development Host (no display in this environment) — the guard is inert there by design, and the shortcut reuses the unchanged toolbar save path.

## Changeset

`patch` for `cc-wf-studio` and `@cc-wf-studio/cli` (both bundle the webview).

---
_Generated by [Claude Code](https://claude.ai/code/session_016H1hdYypPrr7DfahRhfunP)_