### PR TITLE
fix(webview): parse CRLF agent frontmatter

### DIFF
--- a/.changeset/parse-crlf-agent-frontmatter.md
+++ b/.changeset/parse-crlf-agent-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"cc-wf-studio": patch
+---
+
+Parse Windows CRLF agent files without dropping their frontmatter fields during sub-agent import.

--- a/packages/vscode/src/webview/src/utils/agent-frontmatter.test.ts
+++ b/packages/vscode/src/webview/src/utils/agent-frontmatter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentFrontmatter } from './agent-frontmatter';
+
+const LF_AGENT = `---
+name: code-reviewer
+description: Reviews code for correctness
+model: opus
+tools: Read, Grep, Glob
+---
+You are a senior code reviewer.
+
+Run git diff first.`;
+
+describe('parseAgentFrontmatter line endings', () => {
+  it('parses CRLF agent files identically to LF files', () => {
+    const crlfAgent = LF_AGENT.replace(/\n/g, '\r\n');
+
+    expect(parseAgentFrontmatter(crlfAgent)).toEqual(parseAgentFrontmatter(LF_AGENT));
+  });
+
+  it('preserves original line endings when there is no frontmatter', () => {
+    const crlfBody = 'plain body\r\nsecond line';
+
+    expect(parseAgentFrontmatter(crlfBody)).toEqual({ frontmatter: {}, body: crlfBody });
+  });
+});

--- a/packages/vscode/src/webview/src/utils/agent-frontmatter.ts
+++ b/packages/vscode/src/webview/src/utils/agent-frontmatter.ts
@@ -6,7 +6,8 @@ export function parseAgentFrontmatter(content: string): {
   frontmatter: Record<string, string | undefined>;
   body: string;
 } {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  const normalizedContent = content.replace(/\r\n?/g, '\n');
+  const match = normalizedContent.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) {
     return { frontmatter: {}, body: content };
   }


### PR DESCRIPTION
## Summary

Fixes #1031 by normalizing CRLF and lone-CR line endings before matching and parsing agent frontmatter.

A Windows-authored `.claude/agents/*.md` now produces the same frontmatter and body as its LF equivalent, so imported sub-agents retain their selected model, tools, description, and clean agent definition.

The no-frontmatter fallback still returns the original content unchanged, including its original line endings.

## Validation

- Added a focused regression proving LF and CRLF agent files parse identically.
- Added a boundary regression proving plain CRLF body content remains untouched when no frontmatter is present.
- Focused and complete webview test run: `2 passed`.
- Built `@cc-wf-studio/core` and the production webview bundle successfully.
- Biome 2.4.4 check passes for both changed files.

## Branching

This PR targets `auto-dev`, matching the issue's feature-track instruction. The QA-track PR #1032 remains separate; this PR carries only the focused fixed-behavior regression needed for the feature change.
